### PR TITLE
NDRS-{345-346}: A workaround for a timing issue

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -18,7 +18,7 @@ use crate::{
             self, BlockExecutorRequest, BlockValidationRequest, DeployBufferRequest,
             NetworkRequest, StorageRequest,
         },
-        EffectBuilder, Effects,
+        EffectBuilder, EffectExt, Effects,
     },
     protocol::Message,
     types::{ProtoBlock, Timestamp},
@@ -181,7 +181,11 @@ where
         let mut handling_es = self.handling_wrapper(effect_builder, rng);
         match event {
             Event::Timer { era_id, timestamp } => handling_es.handle_timer(era_id, timestamp),
-            Event::MessageReceived { sender, msg } => handling_es.handle_message(sender, msg),
+            Event::MessageReceived { sender, msg } => {
+                let mut effects = effect_builder.announce_message_in_era(msg.era_id).ignore();
+                effects.extend(handling_es.handle_message(sender, msg));
+                effects
+            }
             Event::NewProtoBlock {
                 era_id,
                 proto_block,

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -69,7 +69,7 @@ impl EraId {
 
 impl Display for EraId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "EraId({})", self.0)
+        write!(f, "{:?}", self.0)
     }
 }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -90,7 +90,7 @@ use casper_types::Key;
 
 use crate::{
     components::{
-        consensus::BlockContext,
+        consensus::{BlockContext, EraId},
         fetcher::FetchResult,
         small_network::GossipedAddress,
         storage::{DeployHashes, DeployHeaderResults, DeployResults, StorageType, Value},
@@ -833,6 +833,20 @@ impl<REv> EffectBuilder<REv> {
         self.0
             .schedule(
                 ConsensusAnnouncement::Orphaned(proto_block),
+                QueueKind::Regular,
+            )
+            .await
+    }
+
+    /// Announce that we received a message in a given era
+    /// TODO: Remove when proper linear chain syncing is in place
+    pub(crate) async fn announce_message_in_era(self, era_id: EraId)
+    where
+        REv: From<ConsensusAnnouncement>,
+    {
+        self.0
+            .schedule(
+                ConsensusAnnouncement::GotMessageInEra(era_id),
                 QueueKind::Regular,
             )
             .await

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -6,7 +6,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use crate::{
-    components::small_network::GossipedAddress,
+    components::{consensus::EraId, small_network::GossipedAddress},
     types::{Block, Deploy, Item, ProtoBlock},
     utils::Source,
 };
@@ -119,6 +119,9 @@ pub enum ConsensusAnnouncement {
     Orphaned(ProtoBlock),
     /// A linear chain block has been handled.
     Handled(u64),
+    /// TODO: this is only for purposes of detecting incomplete linear chain synchronization,
+    /// remove when proper syncing is implemented
+    GotMessageInEra(EraId),
 }
 
 impl Display for ConsensusAnnouncement {
@@ -138,6 +141,9 @@ impl Display for ConsensusAnnouncement {
                 "Linear chain block has been handled by consensus, height={}",
                 height
             ),
+            ConsensusAnnouncement::GotMessageInEra(era_id) => {
+                write!(formatter, "message in era {:?} received", era_id)
+            }
         }
     }
 }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -456,17 +456,17 @@ impl<R: Rng + CryptoRng + ?Sized> reactor::Reactor<R> for Reactor<R> {
                         linear_chain_sync::Event::BlockHandled(height),
                     ),
                 ),
-                    ConsensusAnnouncement::GotMessageInEra(era_id) => {
-                        // note if the era id is later than the latest we've received so far
-                        if self
-                            .latest_received_era_id
-                            .map(|lreid| era_id > lreid)
-                            .unwrap_or(true)
-                        {
-                            self.latest_received_era_id = Some(era_id);
-                        }
-                        Effects::new()
+                ConsensusAnnouncement::GotMessageInEra(era_id) => {
+                    // note if the era id is later than the latest we've received so far
+                    if self
+                        .latest_received_era_id
+                        .map(|lreid| era_id > lreid)
+                        .unwrap_or(true)
+                    {
+                        self.latest_received_era_id = Some(era_id);
                     }
+                    Effects::new()
+                }
                 other => {
                     warn!("Ignoring consensus announcement {}", other);
                     Effects::new()

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -597,6 +597,8 @@ impl<R: Rng + CryptoRng + ?Sized> reactor::Reactor<R> for Reactor<R> {
                     ConsensusAnnouncement::Orphaned(block) => {
                         reactor_event_dispatch(deploy_buffer::Event::OrphanedProtoBlock(block))
                     }
+                    // Only interesting for the joiner
+                    ConsensusAnnouncement::GotMessageInEra(_era_id) => Effects::new(),
                     ConsensusAnnouncement::Handled(_) => {
                         debug!("Ignoring `Handled` announcement in `validator` reactor.");
                         Effects::new()

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -485,6 +485,10 @@ impl Block {
         self.header.height()
     }
 
+    pub(crate) fn era_id(&self) -> EraId {
+        self.header.era_id()
+    }
+
     pub(crate) fn is_genesis_child(&self) -> bool {
         self.header.era_id == EraId(0) && self.header.height == 0
     }

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -16,6 +16,7 @@ run_node() {
     LOGFILE=/tmp/node-${ID}.log
     rm -rf ${STORAGE_DIR}
     rm -f ${LOGFILE}
+    rm -f ${LOGFILE}.stderr
     mkdir -p ${STORAGE_DIR}
 
     if [ $1 -ne 1 ]


### PR DESCRIPTION
This is Mateusz's code from #223 plus a workaround for the issue where the validators switch eras while the joiner is synchronizing.

The workaround causes the joiner to detect whether other validators are in the era it will be able to join or in a later one, and panic if the latter is the case. A great part of the linear chain will be synchronized already, though - so the node's owner should be able to join after restarting the node with a more up-to-date trusted hash.