### PR TITLE
NDRS-385: Fix no `NewPeer` event bug.

### DIFF
--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -382,6 +382,13 @@ impl<R: Rng + CryptoRng + ?Sized> reactor::Reactor<R> for Reactor<R> {
                     rng,
                     Event::Consensus(consensus::Event::MessageReceived { sender, msg }),
                 ),
+                Message::AddressGossiper(message) => {
+                    let event = Event::AddressGossiper(gossiper::Event::MessageReceived {
+                        sender,
+                        message,
+                    });
+                    self.dispatch_event(effect_builder, rng, event)
+                }
                 other => {
                     warn!(?other, "network announcement ignored.");
                     Effects::new()


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-385

Another case of `AddressGossiper` event not being handled.


After this change, I can see 3 nodes being signaled:
```
➜  casperlabs-node git:(master) ✗ cat /tmp/node-4.log | grep "New peer connected"
Sep 16 18:17:57.697 TRACE crank{ev=24}:dispatch events{ev=25}: [casper_node::components::linear_chain_sync linear_chain_sync.rs:262] New peer connected; peer_id=d08d..eb93
Sep 16 18:17:58.474 TRACE crank{ev=270}:dispatch events{ev=271}: [casper_node::components::linear_chain_sync linear_chain_sync.rs:262] New peer connected; peer_id=eb7d..ef6b
Sep 16 18:17:58.502 TRACE crank{ev=336}:dispatch events{ev=337}: [casper_node::components::linear_chain_sync linear_chain_sync.rs:262] New peer connected; peer_id=a54f..1c83
```