### PR TITLE
NDRS-399: Fix metrics

### DIFF
--- a/node/src/app/cli.rs
+++ b/node/src/app/cli.rs
@@ -18,6 +18,7 @@ use casper_node::{
     reactor::{initializer, joiner, validator, Runner},
     utils::WithDir,
 };
+use prometheus::Registry;
 
 // Note: The docstring on `Cli` is the help shown when calling the binary with `--help`.
 #[derive(Debug, StructOpt)]
@@ -140,9 +141,13 @@ impl Cli {
                 // performance reasons.
                 let mut rng = ChaCha20Rng::from_entropy();
 
-                let mut initializer_runner = Runner::<initializer::Reactor, _>::new(
+                // The metrics are shared across all reactors.
+                let registry = Registry::new();
+
+                let mut initializer_runner = Runner::<initializer::Reactor, _>::with_metrics(
                     WithDir::new(root.clone(), validator_config),
                     &mut rng,
+                    &registry,
                 )
                 .await?;
                 initializer_runner.run(&mut rng).await;
@@ -154,9 +159,12 @@ impl Cli {
                     bail!("failed to initialize successfully");
                 }
 
-                let mut joiner_runner =
-                    Runner::<joiner::Reactor<_>, _>::new(WithDir::new(root, initializer), &mut rng)
-                        .await?;
+                let mut joiner_runner = Runner::<joiner::Reactor<_>, _>::with_metrics(
+                    WithDir::new(root, initializer),
+                    &mut rng,
+                    &registry,
+                )
+                .await?;
                 joiner_runner.run(&mut rng).await;
 
                 info!("finished joining");
@@ -164,7 +172,8 @@ impl Cli {
                 let config = joiner_runner.into_inner().into_validator_config().await;
 
                 let mut validator_runner =
-                    Runner::<validator::Reactor<_>, _>::new(config, &mut rng).await?;
+                    Runner::<validator::Reactor<_>, _>::with_metrics(config, &mut rng, &registry)
+                        .await?;
                 validator_runner.run(&mut rng).await;
             }
         }

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -176,6 +176,9 @@ where
 struct RunnerMetrics {
     /// Total number of events processed.
     events: IntCounter,
+
+    /// Handle to the metrics registry, in case we need to unregister.
+    registry: Registry,
 }
 
 impl RunnerMetrics {
@@ -184,7 +187,18 @@ impl RunnerMetrics {
         let events = IntCounter::new("runner_events", "total event count")?;
         registry.register(Box::new(events.clone()))?;
 
-        Ok(RunnerMetrics { events })
+        Ok(RunnerMetrics {
+            events,
+            registry: registry.clone(),
+        })
+    }
+}
+
+impl Drop for RunnerMetrics {
+    fn drop(&mut self) {
+        self.registry
+            .unregister(Box::new(self.events.clone()))
+            .expect("did not expect deregistering metrics to fail")
     }
 }
 


### PR DESCRIPTION
Every reactor runner used to come with its own metrics registry, which mean that metrics were not reported properly when going from one reactor to the next.

This PR changes the interface of the runner, making it possible to share a preconstructed registry for metrics that is shared across initializer, joiner and validator.

This requires properly deregistering metrics when dropping a runner/shared component, which is done only for the runner. Should someone attempt to drop and recreate a contract runtime at some point, this will need to be added to the contract runtime metrics as well. For now this is not an issue though and it will be apparent quickly during development, as it will cause a panic when creating the follow-up reactor.