### PR TITLE
NO-TICKET: fix bug in client

### DIFF
--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -735,15 +735,17 @@ pub(super) fn apply_common_creation_options<'a, 'b>(subcommand: App<'a, 'b>) -> 
         )
 }
 
-pub(super) fn construct_deploy(
-    matches: &ArgMatches<'_>,
-    session: ExecutableDeployItem,
-) -> PutDeployParams {
+pub(super) fn show_arg_examples_and_exit_if_required(matches: &ArgMatches<'_>) {
     // If we printed the arg examples, exit the process.
     if show_arg_examples::get(matches) {
         process::exit(0);
     }
+}
 
+pub(super) fn construct_deploy(
+    matches: &ArgMatches<'_>,
+    session: ExecutableDeployItem,
+) -> PutDeployParams {
     let secret_key = common::secret_key::get(matches);
     let timestamp = timestamp::get(matches);
     let ttl = ttl::get(matches);

--- a/client/src/deploy/put.rs
+++ b/client/src/deploy/put.rs
@@ -31,6 +31,8 @@ impl<'a, 'b> ClientCommand<'a, 'b> for PutDeploy {
     }
 
     fn run(matches: &ArgMatches<'_>) {
+        creation_common::show_arg_examples_and_exit_if_required(matches);
+
         let node_address = common::node_address::get(matches);
         let session = creation_common::parse_session_info(matches);
         let params = creation_common::construct_deploy(matches, session);

--- a/client/src/deploy/transfer.rs
+++ b/client/src/deploy/transfer.rs
@@ -179,6 +179,8 @@ impl<'a, 'b> ClientCommand<'a, 'b> for Transfer {
     }
 
     fn run(matches: &ArgMatches<'_>) {
+        creation_common::show_arg_examples_and_exit_if_required(matches);
+
         let node_address = common::node_address::get(matches);
 
         let transfer_args = create_transfer_args(matches)


### PR DESCRIPTION
This fixes an issue in the client where if the `--show-arg-examples` flag is passed, it should be evaluated before any other args so the help output can be displayed and the app can exit.

Without this, we were trying to parse other args, some of which are required.  It should be valid to only require these if `--show-arg-examples` is not present. 