### PR TITLE
NO-TICKET: support account hash as client arg

### DIFF
--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -20,7 +20,7 @@ use casper_node::{
 use casper_types::{
     account::AccountHash,
     bytesrepr::{self, ToBytes},
-    AccessRights, CLType, CLValue, Key, NamedArg, RuntimeArgs, URef, U128, U256, U512,
+    AccessRights, CLType, CLTyped, CLValue, Key, NamedArg, RuntimeArgs, URef, U128, U256, U512,
 };
 
 use crate::common;
@@ -98,6 +98,10 @@ pub(super) mod show_arg_examples {
         println!(
             "key_uref_name:key='{}'",
             Key::URef(URef::new(array, AccessRights::NONE)).to_formatted_string()
+        );
+        println!(
+            "account_hash_name:account_hash='{}'",
+            AccountHash::new(array).to_formatted_string()
         );
         println!(
             "uref_name:uref='{}'",
@@ -315,6 +319,7 @@ pub(super) mod arg_simple {
             ("unit", CLType::Unit),
             ("string", CLType::String),
             ("key", CLType::Key),
+            ("account_hash", AccountHash::cl_type()),
             ("uref", CLType::URef),
         ];
         static ref SUPPORTED_LIST: String = {
@@ -408,6 +413,7 @@ pub(super) mod arg_simple {
             t if t == SUPPORTED_TYPES[10].0 => SUPPORTED_TYPES[10].1.clone(),
             t if t == SUPPORTED_TYPES[11].0 => SUPPORTED_TYPES[11].1.clone(),
             t if t == SUPPORTED_TYPES[12].0 => SUPPORTED_TYPES[12].1.clone(),
+            t if t == SUPPORTED_TYPES[13].0 => SUPPORTED_TYPES[13].1.clone(),
             _ => panic!(
                 "unknown variant {}, expected one of {}",
                 parts[1], *SUPPORTED_LIST
@@ -480,6 +486,16 @@ pub(super) mod arg_simple {
                     .unwrap_or_else(|error| panic!("can't parse {} as Key: {:?}", value, error));
                 CLValue::from_t(key).unwrap()
             }
+            CLType::FixedList(ty, 32) => match *ty {
+                CLType::U8 => {
+                    let account_hash =
+                        AccountHash::from_formatted_str(value).unwrap_or_else(|error| {
+                            panic!("can't parse {} as AccountHash: {:?}", value, error)
+                        });
+                    CLValue::from_t(account_hash).unwrap()
+                }
+                _ => unreachable!(),
+            },
             CLType::URef => {
                 let uref = URef::from_formatted_str(value)
                     .unwrap_or_else(|error| panic!("can't parse {} as URef: {:?}", value, error));

--- a/client/src/query_state.rs
+++ b/client/src/query_state.rs
@@ -27,7 +27,7 @@ mod key {
     const ARG_HELP: &str =
         "The base key for the query.  This must be a properly formatted account hash, contract \
         address hash or URef.  The format for each respectively is \
-        \"account-account_hash-<HEX STRING>\", \"hash-<HEX STRING>\" and \
+        \"account-hash-<HEX STRING>\", \"hash-<HEX STRING>\" and \
         \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
 
     pub(super) fn arg() -> Arg<'static, 'static> {

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -16,7 +16,7 @@ pub const UREF_ADDR_LENGTH: usize = 32;
 /// The number of bytes in a serialized [`URef`] where the [`AccessRights`] are not `None`.
 pub const UREF_SERIALIZED_LENGTH: usize = UREF_ADDR_LENGTH + ACCESS_RIGHTS_SERIALIZED_LENGTH;
 
-const PREFIX: &str = "uref-";
+const FORMATTED_STRING_PREFIX: &str = "uref-";
 
 /// The address of a [`URef`](types::URef) (unforgeable reference) on the network.
 pub type URefAddr = [u8; UREF_ADDR_LENGTH];
@@ -111,7 +111,7 @@ impl URef {
         self.1.is_addable()
     }
 
-    /// Formats the address and access rights of the [`URef`] in an unique way that could be used as
+    /// Formats the address and access rights of the [`URef`] in a unique way that could be used as
     /// a name when storing the given `URef` in a global state.
     pub fn to_formatted_string(&self) -> String {
         // Extract bits as numerical value, with no flags marked as 0.
@@ -120,16 +120,16 @@ impl URef {
         // be represented as maximum of 3 octal digits.
         format!(
             "{}{}-{:03o}",
-            PREFIX,
+            FORMATTED_STRING_PREFIX,
             base16::encode_lower(&self.addr()),
             access_rights_bits
         )
     }
 
-    /// Parses a string formatted as per `Self::as_string()` into a `URef`.
+    /// Parses a string formatted as per `Self::to_formatted_string()` into a `URef`.
     pub fn from_formatted_str(input: &str) -> Result<Self, FromStrError> {
         let remainder = input
-            .strip_prefix(PREFIX)
+            .strip_prefix(FORMATTED_STRING_PREFIX)
             .ok_or_else(|| FromStrError::InvalidPrefix)?;
         let parts = remainder.splitn(2, '-').collect::<Vec<_>>();
         if parts.len() != 2 {


### PR DESCRIPTION
This PR adds support for passing `AccountHash`es as args in client subcommands such as `put-deploy`.  While we want to continue support for users dealing with the `AccountHash` type, the client should treat this as a non-complex arg type to make it simpler for users to pass.

@henrytill & @mpapierski - please note that this PR changes the prefix for a formatted `AccountHash` from `account-account_hash` to `account-hash`.  This can be reverted if we really require the longer prefix.