### PR TITLE
Updated deploy_acceptor for chain name warning

### DIFF
--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -155,7 +155,7 @@ fn is_valid(deploy: &Deploy, chainspec: Chainspec) -> bool {
         );
         return false;
     }
-    
+
     if deploy.header().chain_name() != chainspec.genesis.name {
         warn!(
             deploy_hash = %deploy.id(),

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -146,12 +146,22 @@ impl<REv: ReactorEventT, R: Rng + CryptoRng + ?Sized> Component<REv, R> for Depl
 }
 
 fn is_valid(deploy: &Deploy, chainspec: Chainspec) -> bool {
+    if deploy.header().chain_name().is_empty() {
+        warn!(
+            deploy_hash = %deploy.id(),
+            deploy_header = %deploy.header(),
+            chain_name = %chainspec.genesis.name,
+            "chain-name is required"
+        );
+        return false;
+    }
+    
     if deploy.header().chain_name() != chainspec.genesis.name {
         warn!(
             deploy_hash = %deploy.id(),
             deploy_header = %deploy.header(),
             chain_name = %chainspec.genesis.name,
-            "invalid chain identifier"
+            "[{}] is an invalid chain identifier", deploy.header().chain_name(),
         );
         return false;
     }


### PR DESCRIPTION
A simple change the deploy_acceptor component to explicitly log the invalid chain-name that is supplied via the client. Additionally, expanded the deploy_acceptor to consider the case where no chain-name is specified and log a warning message for that case as well. 