### PR TITLE
NDRS-414: Only vote in eras younger than the node process.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -93,6 +93,7 @@ pub(crate) struct EraSupervisor<I, R: Rng + CryptoRng + ?Sized> {
     validator_stakes: Vec<(PublicKey, Motes)>,
     current_era: EraId,
     chainspec: Chainspec,
+    node_start_time: Timestamp,
 }
 
 impl<I, R: Rng + CryptoRng + ?Sized> Debug for EraSupervisor<I, R> {
@@ -128,6 +129,7 @@ where
             current_era: EraId(0),
             validator_stakes: validator_stakes.clone(),
             chainspec: chainspec.clone(),
+            node_start_time: Timestamp::now(),
         };
 
         let results = era_supervisor.new_era(
@@ -238,16 +240,14 @@ where
             start_time + self.highway_config().era_duration,
         );
 
-        // Activate the era if it is still ongoing based on its minimum duration, and if we are one
-        // of the validators.
+        // Activate the era if this node was already running when the era began, it is still
+        // ongoing based on its minimum duration, and we are one of the validators.
         let our_id = self.public_signing_key;
-        let min_end_time = start_time
-            + self
-                .highway_config()
-                .era_duration
-                .max(params.min_round_len() * params.end_height());
-        let should_activate =
-            min_end_time >= timestamp && validators.iter().any(|v| *v.id() == our_id);
+        let era_rounds_len = params.min_round_len() * params.end_height();
+        let min_end_time = start_time + self.highway_config().era_duration.max(era_rounds_len);
+        let should_activate = self.node_start_time < start_time
+            && min_end_time >= timestamp
+            && validators.iter().any(|v| *v.id() == our_id);
 
         let mut highway = HighwayProtocol::<I, HighwayContext>::new(
             self.instance_id(post_state_hash, start_height),

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -50,8 +50,8 @@ impl TestChain {
             })
             .collect();
         // TODO: This is duplicated. Remove the `HighwayConfig` field.
-        chainspec.genesis.timestamp = Timestamp::now();
-        chainspec.genesis.highway_config.genesis_era_start_timestamp = Timestamp::now();
+        chainspec.genesis.timestamp = Timestamp::now() + 30000.into();
+        chainspec.genesis.highway_config.genesis_era_start_timestamp = chainspec.genesis.timestamp;
 
         TestChain {
             keys,
@@ -179,7 +179,7 @@ async fn run_validator_network() {
     };
 
     // Wait for all nodes to agree on one era.
-    net.settle_on(&mut rng, is_in_era(1), Duration::from_secs(60))
+    net.settle_on(&mut rng, is_in_era(1), Duration::from_secs(90))
         .await;
 
     net.settle_on(&mut rng, is_in_era(2), Duration::from_secs(60))

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -50,6 +50,7 @@ impl TestChain {
             })
             .collect();
         // TODO: This is duplicated. Remove the `HighwayConfig` field.
+        // Make the genesis timestamp 30 seconds from now, to allow for all validators to start up.
         chainspec.genesis.timestamp = Timestamp::now() + 30000.into();
         chainspec.genesis.highway_config.genesis_era_start_timestamp = chainspec.genesis.timestamp;
 


### PR DESCRIPTION
This prevents accidental equivocations when restarting a node:
If the current process is younger than the era, we know that before the restart, we certainly haven't cast any votes yet, so it is safe to vote.

@arcolife will make a separate PR to update the `run-dev.sh` script and add a few seconds to the genesis timestamp.

https://casperlabs.atlassian.net/browse/NDRS-414