### PR TITLE
NO-TICK: offset timestamp in run-dev.sh by 30 seconds

### DIFF
--- a/run-dev.sh
+++ b/run-dev.sh
@@ -7,8 +7,10 @@ set -eu
 BASEDIR=$(readlink -f $(dirname $0))
 CHAINSPEC=$(mktemp -t chainspec_XXXXXXXX --suffix .toml)
 TRUSTED_HASH="${TRUSTED_HASH:-}"
-TIMESTAMP="${GENESIS_TIMESTAMP:-$(date '+%s000')}"
+OFFSET="${OFFSET:-30}"
+TIMESTAMP=${GENESIS_TIMESTAMP:-$(date '+%s000' -d "+$OFFSET sec")}
 echo "GENESIS_TIMESTAMP="$TIMESTAMP
+date -d @$(echo "$TIMESTAMP/1000" | bc)
 
 run_node() {
     ID=$1


### PR DESCRIPTION
```
╰─ OFFSET=50 ./run-dev.sh
GENESIS_TIMESTAMP=1600862573000
Wed Sep 23 17:32:53 IST 2020
...
```

@afck Default's to 30. Ref https://github.com/CasperLabs/casper-node/pull/260