### PR TITLE
NO-TICKET: Add some INFO log messages for equivocations.

### DIFF
--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -5,7 +5,7 @@ pub(crate) use vertex::{Dependency, SignedWireVote, Vertex, WireVote};
 
 use rand::{CryptoRng, Rng};
 use thiserror::Error;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use crate::{
     components::consensus::{
@@ -124,6 +124,7 @@ impl<C: Context> Highway<C> {
         validators: Validators<C::ValidatorId>,
         params: Params,
     ) -> Highway<C> {
+        info!(?validators, "creating Highway instance {:?}", instance_id);
         let state = State::new(validators.iter().map(Validator::weight), params);
         Highway {
             instance_id,

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -27,7 +27,7 @@ use itertools::Itertools;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use thiserror::Error;
-use tracing::error;
+use tracing::{error, info};
 
 use crate::{
     components::consensus::{
@@ -270,6 +270,7 @@ impl<C: Context> State<C> {
 
     pub(crate) fn add_evidence(&mut self, evidence: Evidence<C>) {
         let idx = evidence.perpetrator();
+        info!(?evidence, "marking validator #{} as faulty", idx.0);
         self.evidence.insert(idx, evidence);
     }
 


### PR DESCRIPTION
Logs whenever we detect (or receive evidence of) an equivocation. Since this only lists the validator _index_, I also added a log entry at the beginning of each era that lists that era's validator ID - validator index mapping.