### PR TITLE
NO-TICKET: impl Display for Validators

### DIFF
--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -124,7 +124,7 @@ impl<C: Context> Highway<C> {
         validators: Validators<C::ValidatorId>,
         params: Params,
     ) -> Highway<C> {
-        info!(?validators, "creating Highway instance {:?}", instance_id);
+        info!(%validators, "creating Highway instance {:?}", instance_id);
         let state = State::new(validators.iter().map(Validator::weight), params);
         Highway {
             instance_id,

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    fmt,
     hash::Hash,
     iter::FromIterator,
     ops::{Add, Index, IndexMut},
@@ -94,6 +95,16 @@ impl<VID: Ord + Hash + Clone, W: Into<Weight>> FromIterator<(VID, W)> for Valida
             index_by_id,
             validators,
         }
+    }
+}
+
+impl<VID: Ord + Hash + fmt::Debug> fmt::Display for Validators<VID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Validators: index, ID, weight")?;
+        for (i, val) in self.validators.iter().enumerate() {
+            writeln!(f, "{:3}, {:?}, {}", i, val.id(), val.weight().0)?
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This looks like:
```
Sep 24 11:36:18.296 INFO  [casper_node::components::consensus::highway_core::highway highway.rs:127] creating Highway instance 5a0bfdc4d05ebaf245ee3e823200c8fe08509c00ef465c335f410f3aa8b46f44; validators=Validators: index, ID, weight
  0, PublicKey::Ed25519(449c5f751e465adabc9885fe8f33b522ab2c069997148e4b65fddde9c4440d31), 300000000000000
  1, PublicKey::Ed25519(8f5a3ee4c1221686fcdbe6c0b6168acb24025c5485f59f7c4039ffc444fb7509), 400000000000000
  2, PublicKey::Ed25519(b3feeec1d91c7c2f070052315258eeaaf7c24029a80a1aea285814e9f9a20d36), 200000000000000
  3, PublicKey::Ed25519(f60bce2bb1059c41910eac1e7ee6c3ef4c8fcc63a901eb9603c1524cadfb0c18), 500000000000000
  4, PublicKey::Secp256k1(0248509e67db3127f82d5224c5c18eac00f96d1edeadbadc8eb2c8606227b56873), 100000000000001
```

Not ideal, but at the point where we're currently logging that, the validator ID is still generic. At least it should make it easy to find a validator's index.