### PR TITLE
[charlie] proposed enhancement: api-server incoming deploy rate limiting

### DIFF
--- a/node/src/components/api_server.rs
+++ b/node/src/components/api_server.rs
@@ -98,10 +98,10 @@ impl TicketCounterHandle {
     fn acquire_ticket(&self) -> bool {
         if self.0.fetch_sub(1, Ordering::SeqCst) <= 0 {
             self.0.fetch_add(1, Ordering::SeqCst);
-            return false;
+            false
+        } else {
+            true
         }
-
-        return true;
     }
 
     /// Increase the amount of available tickets by `amount`, up to `limit`.
@@ -228,7 +228,7 @@ where
 {
     // If we're exceeding the acceptable rate of incoming deploys, return an HTTP 429.
     if !ticket_counter.acquire_ticket() {
-        let error_reply = format!("Deploy rate limit exceeded.",);
+        let error_reply = "Deploy rate limit exceeded.";
         let json = reply::json(&error_reply);
         return Ok(reply::with_status(json, StatusCode::TOO_MANY_REQUESTS));
     }

--- a/node/src/components/api_server/config.rs
+++ b/node/src/components/api_server/config.rs
@@ -12,6 +12,12 @@ pub struct Config {
 
     /// Port to bind to. Use 0 for a random port.
     pub bind_port: u16,
+
+    /// Maximum number of deploys per second accepted.
+    pub accepted_deploy_rate_limit: u32,
+
+    /// Allow exceeding the deploy rate for short bursts following periods of inactivity.
+    pub accepted_deploy_burst_limit: u32,
 }
 
 impl Config {
@@ -20,6 +26,8 @@ impl Config {
         Config {
             bind_interface: Ipv4Addr::LOCALHOST.into(),
             bind_port: 0,
+            accepted_deploy_rate_limit: 50,
+            accepted_deploy_burst_limit: 1000,
         }
     }
 }

--- a/resources/charlie/config-example.toml
+++ b/resources/charlie/config-example.toml
@@ -74,6 +74,11 @@ bind_interface = '0.0.0.0'
 # Port to bind to.  Use 0 for a random port.
 bind_port = 7777
 
+# Maximum number of deploys to accept on average.
+accepted_deploy_rate_limit = 50
+
+# Allow exceeding deploy rate for short bursts following periods of inactivity by this many deploys.
+accepted_deploy_burst_limit = 1000
 
 # ===============================================
 # Configuration options for the storage component

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -75,6 +75,12 @@ bind_interface = '127.0.0.1'
 # Port to bind to.  Use 0 for a random port.
 bind_port = 7777
 
+# Maximum number of deploys to accept on average.
+accepted_deploy_rate_limit = 50
+
+# Allow exceeding deploy rate for short bursts following periods of inactivity by this many deploys.
+accepted_deploy_burst_limit = 1000
+
 
 # ===============================================
 # Configuration options for the storage component


### PR DESCRIPTION
Untested (but compiling :)) fix that introduces rate limiting for incoming deploys.

Based on a ticketing system, numbers are tweakable through the configuration.

Someone who has been on the front lines should give this a whirl locally.