### PR TITLE
NDRS-429: Fix joining process.

### DIFF
--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -219,7 +219,11 @@ impl BlockExecutor {
         finalized_block: FinalizedBlock,
     ) -> Effects<Event> {
         let deploy_hashes = SmallVec::from_slice(finalized_block.proto_block().deploys());
-
+        let err_message = format!(
+            "deploy for block in era={} and height={} is expected to exist in the storage",
+            finalized_block.era_id(),
+            finalized_block.height()
+        );
         // Get all deploys in order they appear in the finalized block.
         effect_builder
             .get_deploys_from_storage(deploy_hashes)
@@ -228,9 +232,7 @@ impl BlockExecutor {
                 deploys: result
                     .into_iter()
                     // Assumes all deploys are present
-                    .map(|maybe_deploy| {
-                        maybe_deploy.expect("deploy is expected to exist in the storage")
-                    })
+                    .map(|maybe_deploy| maybe_deploy.expect(&err_message))
                     .collect(),
             })
     }

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -219,11 +219,9 @@ impl BlockExecutor {
         finalized_block: FinalizedBlock,
     ) -> Effects<Event> {
         let deploy_hashes = SmallVec::from_slice(finalized_block.proto_block().deploys());
-        let err_message = format!(
-            "deploy for block in era={} and height={} is expected to exist in the storage",
-            finalized_block.era_id(),
-            finalized_block.height()
-        );
+        let era_id = finalized_block.era_id();
+        let height = finalized_block.height();
+
         // Get all deploys in order they appear in the finalized block.
         effect_builder
             .get_deploys_from_storage(deploy_hashes)
@@ -232,7 +230,7 @@ impl BlockExecutor {
                 deploys: result
                     .into_iter()
                     // Assumes all deploys are present
-                    .map(|maybe_deploy| maybe_deploy.expect(&err_message))
+                    .map(|maybe_deploy| maybe_deploy.unwrap_or_else(|| panic!("deploy for block in era={} and height={} is expected to exist in the storage", era_id, height)))
                     .collect(),
             })
     }

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -14,7 +14,7 @@ use crate::{
         EffectExt, Effects,
     },
     small_network::NodeId,
-    types::{Deploy, Timestamp},
+    types::Deploy,
     utils::Source,
 };
 
@@ -174,17 +174,6 @@ fn is_valid(deploy: &Deploy, chainspec: Chainspec) -> bool {
             deploy_header = %deploy.header(),
             max_ttl = %chainspec.genesis.deploy_config.max_ttl,
             "deploy ttl excessive"
-        );
-        return false;
-    }
-
-    let now = Timestamp::now();
-    if now > deploy.header().expires() {
-        warn!(
-            deploy_hash = %deploy.id(),
-            deploy_header = %deploy.header(),
-            %now,
-            "deploy expired"
         );
         return false;
     }

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -88,8 +88,6 @@ enum State {
         /// During synchronization we might see new eras being created.
         /// Track the highest height and wait until it's handled by consensus.
         highest_block_seen: u64,
-        /// Indicates whether we have downloaded whole available linear chain.
-        is_done: bool,
     },
     /// Synchronizing done.
     Done,
@@ -130,7 +128,6 @@ impl State {
             linear_chain_block: Box::new(None),
             current_block: Box::new(None),
             highest_block_seen: 0,
-            is_done: false,
         }
     }
 
@@ -434,6 +431,7 @@ where
                         // We have synchronized all, currently existing, descendants of trusted
                         // hash.
                         self.mark_done();
+                        info!("Finished synchronizing descendants of the trusted hash.");
                         Effects::new()
                     }
                     Some(peer) => fetch_block_at_height(effect_builder, peer, block_height),


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-429

This PR fixes problems with the synchronization process. There were a couple of them:
- ignored incoming `GetResponse` for `Deploy`
- once added it was routed directly to `Fetcher` instead of `DeployAcceptor` (it resulted in deploys not being persisted in storage while their dependency was considered resolved)
- TTL check on deploy dependencies.

I will port those commits to `charlie-*` branch later.

Tested on blocks with and without deploys in both `SyncingTrustedHash` and `SyncingDescendnts` phases.