### PR TITLE
NDRS-388: derive `DataSize` on all reactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ name = "datasize"
 version = "0.1.0"
 dependencies = [
  "datasize_derive",
+ "fake_instant",
  "futures 0.3.5",
  "smallvec 1.4.2",
  "tokio 0.2.22",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "datasize"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93de26b919316206b20672da2dee5a73c257e25956a017a2456b76cded7146a1"
+checksum = "0f1292b90d99c504eddae27e8cd709f040c30357095ba63b30d20d1601b3b446"
 dependencies = [
  "datasize_derive",
  "fake_instant",
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "datasize_derive"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f39aa3c8d02084919760b6478b95ddfbe3e0ac71d227cf97cfa149d34123478"
+checksum = "2f498ec2d61e8710f1fd214ea84e8dc6b791ba4ac3fe2b5e4b8ca17b75f0ee61"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "chrono",
  "criterion",
  "csv",
+ "datasize",
  "hex",
  "hex_fmt",
  "hostname",
@@ -543,6 +544,7 @@ dependencies = [
  "casper-types",
  "chrono",
  "csv",
+ "datasize",
  "derive_more",
  "derp",
  "directories",
@@ -619,6 +621,7 @@ dependencies = [
  "bitflags 1.2.1",
  "blake2",
  "criterion",
+ "datasize",
  "failure",
  "hex_fmt",
  "num-derive",
@@ -999,6 +1002,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "datasize"
+version = "0.1.0"
+dependencies = [
+ "datasize_derive",
+ "futures 0.3.5",
+ "smallvec 1.4.2",
+ "tokio 0.2.22",
+]
+
+[[package]]
+name = "datasize_derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.21",
+ "quote 1.0.7",
+ "syn 1.0.41",
+]
+
+[[package]]
 name = "derivative"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,7 +1028,7 @@ checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -1017,7 +1039,7 @@ checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -1381,7 +1403,7 @@ checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -1443,7 +1465,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "synstructure",
 ]
 
@@ -1592,7 +1614,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2598,7 +2620,7 @@ checksum = "6f09b9841adb6b5e1f89ef7087ea636e0fd94b2851f887c1e3eb5d5f8228fab3"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2838,7 +2860,7 @@ checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -3052,7 +3074,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "version_check",
 ]
 
@@ -3799,7 +3821,7 @@ checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -3821,7 +3843,7 @@ checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -4033,7 +4055,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -4077,9 +4099,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
@@ -4094,7 +4116,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "unicode-xid 0.2.1",
 ]
 
@@ -4233,7 +4255,7 @@ checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -4414,7 +4436,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -4656,7 +4678,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -5176,7 +5198,7 @@ dependencies = [
  "log 0.4.11",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "wasm-bindgen-shared",
 ]
 
@@ -5210,7 +5232,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5353,6 +5375,6 @@ checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "datasize"
-version = "0.1.0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93de26b919316206b20672da2dee5a73c257e25956a017a2456b76cded7146a1"
 dependencies = [
  "datasize_derive",
  "fake_instant",
@@ -1014,7 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "datasize_derive"
-version = "0.1.0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f39aa3c8d02084919760b6478b95ddfbe3e0ac71d227cf97cfa149d34123478"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -16,7 +16,7 @@ base16 = "0.2.1"
 blake2 = "0.8.1"
 casper-types = { version = "0.6.0", path = "../types", package = "casper-types", features = ["std", "gens"] }
 chrono = "0.4.10"
-datasize = "0.1.1"
+datasize = "0.2.0"
 csv = "1.1.3"
 hex = "0.4.2"
 hex_fmt = "0.3.0"

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -16,6 +16,7 @@ base16 = "0.2.1"
 blake2 = "0.8.1"
 casper-types = { version = "0.6.0", path = "../types", package = "casper-types", features = ["std", "gens"] }
 chrono = "0.4.10"
+datasize = "0.1.1"
 csv = "1.1.3"
 hex = "0.4.2"
 hex_fmt = "0.3.0"
@@ -44,8 +45,6 @@ uint = "0.8.3"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 wabt = "0.10.0"
 wasmi = "0.6.2"
-
-datasize = { path = "../../datasize/datasize" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -45,6 +45,8 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 wabt = "0.10.0"
 wasmi = "0.6.2"
 
+datasize = { path = "../../datasize/datasize" }
+
 [dev-dependencies]
 assert_matches = "1.3.0"
 criterion = "0.3.3"

--- a/execution_engine/src/core/engine_state/executable_deploy_item.rs
+++ b/execution_engine/src/core/engine_state/executable_deploy_item.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Debug, Display, Formatter};
 
+use datasize::DataSize;
 use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +13,7 @@ use casper_types::{
 use super::error;
 use crate::{core::execution, shared::account::Account};
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, DataSize, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum ExecutableDeployItem {
     ModuleBytes {
         #[serde(with = "serde_bytes")]

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -1,5 +1,6 @@
 use std::{fmt, iter};
 
+use datasize::DataSize;
 use num_traits::Zero;
 use rand::{
     distributions::{Distribution, Standard},
@@ -65,7 +66,7 @@ impl GenesisResult {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(DataSize, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GenesisAccount {
     /// Assumed to be a system account if `public_key` is not specified.
     public_key: Option<PublicKey>,

--- a/execution_engine/src/shared/motes.rs
+++ b/execution_engine/src/shared/motes.rs
@@ -1,5 +1,6 @@
 use std::{fmt, iter::Sum};
 
+use datasize::DataSize;
 use num::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +8,9 @@ use casper_types::U512;
 
 use crate::shared::gas::Gas;
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(
+    DataSize, Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize,
+)]
 pub struct Motes(U512);
 
 impl Motes {

--- a/execution_engine/src/shared/wasm_costs.rs
+++ b/execution_engine/src/shared/wasm_costs.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use datasize::DataSize;
 use pwasm_utils::rules::{InstructionType, Metering, Set};
 use rand::{distributions::Standard, prelude::*, Rng};
 use serde::{Deserialize, Serialize};
@@ -10,7 +11,7 @@ const NUM_FIELDS: usize = 10;
 pub const WASM_COSTS_SERIALIZED_LENGTH: usize = NUM_FIELDS * U32_SERIALIZED_LENGTH;
 
 // Taken (partially) from parity-ethereum
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct WasmCosts {
     /// Default opcode cost
     pub regular: u32,

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -85,7 +85,12 @@ warp-json-rpc = "0.1.6"
 wasmi = "0.6.2"
 sd-notify = "0.1.1"
 
-datasize = { path = "../../datasize/datasize", features = ["futures-types", "smallvec-types", "tokio-types"] }
+datasize = { path = "../../datasize/datasize", features = [
+    "fake_clock-types",
+    "futures-types",
+    "smallvec-types",
+    "tokio-types",
+] }
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -85,6 +85,8 @@ warp-json-rpc = "0.1.6"
 wasmi = "0.6.2"
 sd-notify = "0.1.1"
 
+datasize = { path = "../../datasize/datasize", features = ["futures-types", "smallvec-types", "tokio-types"] }
+
 [dev-dependencies]
 assert_matches = "1.3.0"
 fake_instant = "0.4.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,6 +23,12 @@ casper-execution-engine = { path = "../execution_engine" }
 casper-types = { version = "0.6.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 csv = "1.1.3"
+datasize = { version = "0.1.1", features = [
+    "fake_clock-types",
+    "futures-types",
+    "smallvec-types",
+    "tokio-types",
+] }
 derive_more = "0.99.7"
 derp = "0.0.14"
 directories = "2.0.2"
@@ -84,13 +90,6 @@ warp = "0.2.4"
 warp-json-rpc = "0.1.6"
 wasmi = "0.6.2"
 sd-notify = "0.1.1"
-
-datasize = { path = "../../datasize/datasize", features = [
-    "fake_clock-types",
-    "futures-types",
-    "smallvec-types",
-    "tokio-types",
-] }
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,7 +23,7 @@ casper-execution-engine = { path = "../execution_engine" }
 casper-types = { version = "0.6.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 csv = "1.1.3"
-datasize = { version = "0.1.1", features = [
+datasize = { version = "0.2.0", features = [
     "fake_clock-types",
     "futures-types",
     "smallvec-types",

--- a/node/src/components/api_server.rs
+++ b/node/src/components/api_server.rs
@@ -16,6 +16,7 @@ pub mod rpcs;
 
 use std::{convert::Infallible, fmt::Debug, net::SocketAddr};
 
+use datasize::DataSize;
 use futures::{future, join};
 use hyper::Server;
 use lazy_static::lazy_static;
@@ -76,7 +77,7 @@ impl<REv> ReactorEventT for REv where
 {
 }
 
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub(crate) struct ApiServer {}
 
 impl ApiServer {

--- a/node/src/components/api_server/config.rs
+++ b/node/src/components/api_server/config.rs
@@ -1,9 +1,10 @@
 use std::net::{IpAddr, Ipv4Addr};
 
+use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 /// API server configuration.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(DataSize, Debug, Deserialize, Serialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct Config {

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -5,6 +5,7 @@ use std::{
     fmt::{Debug, Display},
 };
 
+use datasize::DataSize;
 use derive_more::From;
 use itertools::Itertools;
 use rand::{CryptoRng, Rng};
@@ -163,7 +164,7 @@ pub struct State {
     pre_state_hash: Digest,
 }
 
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 struct ExecutedBlockSummary {
     hash: BlockHash,
     post_state_hash: Digest,
@@ -172,7 +173,7 @@ struct ExecutedBlockSummary {
 type BlockHeight = u64;
 
 /// The Block executor component.
-#[derive(Debug, Default)]
+#[derive(DataSize, Debug, Default)]
 pub(crate) struct BlockExecutor {
     genesis_post_state_hash: Digest,
     /// A mapping from proto block to executed block's ID and post-state hash, to allow

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -14,6 +14,7 @@ use std::{
     fmt::Debug,
 };
 
+use datasize::DataSize;
 use derive_more::{Display, From};
 use rand::{CryptoRng, Rng};
 use smallvec::{smallvec, SmallVec};
@@ -47,8 +48,8 @@ pub enum Event<T, I> {
 /// State of the current process of block validation.
 ///
 /// Tracks whether or not there are deploys still missing and who is interested in the final result.
-#[derive(Debug)]
-struct BlockValidationState<T> {
+#[derive(DataSize, Debug)]
+pub(crate) struct BlockValidationState<T> {
     /// The deploys that have not yet been "crossed off" the list of potential misses.
     missing_deploys: HashSet<DeployHash>,
     /// A list of responders that are awaiting an answer.
@@ -56,7 +57,7 @@ struct BlockValidationState<T> {
 }
 
 /// Block validator.
-#[derive(Debug, Default)]
+#[derive(DataSize, Debug, Default)]
 pub(crate) struct BlockValidator<T, I> {
     /// State of validation of a specific block.
     validation_states: HashMap<T, BlockValidationState<T>>,

--- a/node/src/components/block_validator/keyed_counter.rs
+++ b/node/src/components/block_validator/keyed_counter.rs
@@ -6,12 +6,14 @@ use std::{
     ops::{AddAssign, SubAssign},
 };
 
+use datasize::DataSize;
+
 /// A key-counter.
 ///
 /// Allows tracking a counter for any key `K`.
 ///
 /// Any counter that is set to `0` will not use any memory.
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub(super) struct KeyedCounter<K>(HashMap<K, usize>);
 
 impl<K> KeyedCounter<K> {

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -14,6 +14,7 @@ mod error;
 
 use std::fmt::{self, Display, Formatter};
 
+use datasize::DataSize;
 use derive_more::From;
 use rand::{CryptoRng, Rng};
 use semver::Version;
@@ -62,7 +63,7 @@ impl Display for Event {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(DataSize, Debug, Serialize, Deserialize)]
 pub struct ChainspecInfo {
     // Name of the chainspec.
     name: String,
@@ -85,7 +86,7 @@ impl From<ChainspecLoader> for ChainspecInfo {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, DataSize, Debug, Serialize, Deserialize)]
 pub(crate) struct ChainspecLoader {
     chainspec: Chainspec,
     // If `Some`, we're finished.  The value of the bool indicates success (true) or not.

--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use csv::ReaderBuilder;
+use datasize::DataSize;
 use num_traits::Zero;
 #[cfg(test)]
 use rand::Rng;
@@ -26,7 +27,7 @@ use crate::{
     utils::Loadable,
 };
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, DataSize, Debug, PartialEq, Eq, Serialize, Deserialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub(crate) struct DeployConfig {
@@ -71,7 +72,7 @@ impl DeployConfig {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, DataSize, Debug, PartialEq, Eq, Serialize, Deserialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub(crate) struct HighwayConfig {
@@ -156,12 +157,14 @@ impl Loadable for Vec<GenesisAccount> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, DataSize, PartialEq, Eq, Serialize, Deserialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub(crate) struct GenesisConfig {
     pub(crate) name: String,
     pub(crate) timestamp: Timestamp,
+    // We don't have an implementation for the semver version type, we skip it for now
+    #[data_size(skip)]
     pub(crate) protocol_version: Version,
     pub(crate) mint_installer_bytes: Vec<u8>,
     pub(crate) pos_installer_bytes: Vec<u8>,
@@ -264,14 +267,15 @@ impl GenesisConfig {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, DataSize, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ActivationPoint {
     pub(crate) rank: u64,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, DataSize, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct UpgradePoint {
     pub(crate) activation_point: ActivationPoint,
+    #[data_size(skip)]
     pub(crate) protocol_version: Version,
     pub(crate) upgrade_installer_bytes: Option<Vec<u8>>,
     pub(crate) upgrade_installer_args: Option<Vec<u8>>,
@@ -322,7 +326,7 @@ impl UpgradePoint {
 /// A collection of configuration settings describing the state of the system at genesis and
 /// upgrades to basic system functionality (including system contracts and gas costs) occurring
 /// after genesis.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, DataSize, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Chainspec {
     pub(crate) genesis: GenesisConfig,
     pub(crate) upgrades: Vec<UpgradePoint>,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -8,6 +8,7 @@ mod protocols;
 mod tests;
 mod traits;
 
+use datasize::DataSize;
 use std::fmt::{self, Debug, Display, Formatter};
 
 use crate::{
@@ -32,7 +33,7 @@ use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 use traits::NodeIdT;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(DataSize, Clone, Serialize, Deserialize)]
 pub struct ConsensusMessage {
     era_id: EraId,
     payload: Vec<u8>,
@@ -45,7 +46,7 @@ impl ConsensusMessage {
 }
 
 /// Consensus component event.
-#[derive(Debug, From)]
+#[derive(DataSize, Debug, From)]
 pub enum Event<I> {
     /// An incoming network message.
     MessageReceived { sender: I, msg: ConsensusMessage },

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -1,9 +1,10 @@
+use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 use crate::{crypto::asymmetric_key::SecretKey, utils::External};
 
 /// Consensus configuration.
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(DataSize, Debug, Deserialize, Serialize, Default, Clone)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct Config {

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -1,12 +1,13 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
 use anyhow::Error;
+use datasize::DataSize;
 use rand::{CryptoRng, Rng};
 
 use crate::{components::consensus::traits::ConsensusValueT, types::Timestamp};
 
 /// Information about the context in which a new block is created.
-#[derive(Clone, Eq, PartialEq, Debug, Ord, PartialOrd)]
+#[derive(Clone, DataSize, Eq, PartialEq, Debug, Ord, PartialOrd)]
 pub struct BlockContext {
     timestamp: Timestamp,
     height: u64,

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -17,6 +17,7 @@ use blake2::{
     VarBlake2b,
 };
 use casper_types::U512;
+use datasize::DataSize;
 use fmt::Display;
 use num_traits::AsPrimitive;
 use rand::{CryptoRng, Rng};
@@ -55,7 +56,9 @@ const BLOCK_REWARD: u64 = 1_000_000_000_000;
 // TODO: This needs to be in sync with AUCTION_DELAY/booking_duration_millis. (Already duplicated!)
 const RETAIN_ERAS: u64 = 4;
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    DataSize, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct EraId(pub(crate) u64);
 
 impl EraId {
@@ -77,14 +80,18 @@ impl Display for EraId {
     }
 }
 
-pub(crate) struct Era<I, R: Rng + CryptoRng + ?Sized> {
+pub struct Era<I, R: Rng + CryptoRng + ?Sized> {
     /// The consensus protocol instance.
     consensus: Box<dyn ConsensusProtocol<I, ProtoBlock, PublicKey, R>>,
     /// The height of this era's first block.
     start_height: u64,
 }
 
-pub(crate) struct EraSupervisor<I, R: Rng + CryptoRng + ?Sized> {
+#[derive(DataSize)]
+pub struct EraSupervisor<I, R>
+where
+    R: Rng + CryptoRng + ?Sized,
+{
     /// A map of active consensus protocols.
     /// A value is a trait so that we can run different consensus protocol instances per era.
     active_eras: HashMap<EraId, Era<I, R>>,

--- a/node/src/components/consensus/highway_core/state/block.rs
+++ b/node/src/components/consensus/highway_core/state/block.rs
@@ -1,9 +1,14 @@
+use datasize::DataSize;
+
 use super::State;
 use crate::components::consensus::traits::Context;
 
 /// A block: Chains of blocks are the consensus values in the CBC Casper sense.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct Block<C: Context> {
+#[derive(Clone, DataSize, Debug, Eq, PartialEq)]
+pub(crate) struct Block<C>
+where
+    C: Context,
+{
     /// The total number of ancestors, i.e. the height in the blockchain.
     pub(crate) height: u64,
     /// The payload, e.g. a list of transactions.

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -3,10 +3,11 @@ use std::{
     hash::Hash,
 };
 
+use datasize::DataSize;
 use rand::{CryptoRng, Rng};
 use serde::{de::DeserializeOwned, Serialize};
 
-pub(crate) trait NodeIdT: Clone + Debug + Send + Eq + Hash + 'static {}
+pub trait NodeIdT: Clone + Debug + Send + Eq + Hash + 'static {}
 impl<I> NodeIdT for I where I: Clone + Debug + Send + Eq + Hash + 'static {}
 
 /// A validator identifier.
@@ -42,7 +43,7 @@ pub(crate) trait ValidatorSecret {
 // parameter. Split this up or replace the derives with explicit implementations.
 pub(crate) trait Context: Clone + Debug + Eq + Ord + Hash {
     /// The consensus value type, e.g. a list of transactions.
-    type ConsensusValue: ConsensusValueT;
+    type ConsensusValue: ConsensusValueT + DataSize;
     /// Unique identifiers for validators.
     type ValidatorId: ValidatorIdT;
     /// A validator's secret signing key.

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -9,6 +9,7 @@ use std::{
     time::Instant,
 };
 
+use datasize::DataSize;
 use derive_more::From;
 use lmdb::DatabaseFlags;
 use prometheus::{self, Histogram, HistogramOpts, Registry};
@@ -36,6 +37,7 @@ use crate::{
 };
 
 /// The contract runtime components.
+#[derive(DataSize)]
 pub(crate) struct ContractRuntime {
     engine_state: Arc<EngineState<LmdbGlobalState>>,
     metrics: Arc<ContractRuntimeMetrics>,

--- a/node/src/components/contract_runtime/config.rs
+++ b/node/src/components/contract_runtime/config.rs
@@ -1,3 +1,4 @@
+use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 use casper_execution_engine::shared::utils;
@@ -6,7 +7,7 @@ const DEFAULT_MAX_GLOBAL_STATE_SIZE: usize = 805_306_368_000; // 750 GiB
 const DEFAULT_USE_SYSTEM_CONTRACTS: bool = false;
 
 /// Contract runtime configuration.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, DataSize, Debug, Deserialize, Serialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct Config {

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -3,6 +3,7 @@ mod event;
 
 use std::fmt::Debug;
 
+use datasize::DataSize;
 use rand::{CryptoRng, Rng};
 use semver::Version;
 use tracing::{debug, error, warn};
@@ -39,7 +40,7 @@ impl<REv> ReactorEventT for REv where
 ///
 /// It validates a new `Deploy` as far as possible, stores it if valid, then announces the newly-
 /// accepted `Deploy`.
-#[derive(Debug, Default)]
+#[derive(DataSize, Debug, Default)]
 pub(crate) struct DeployAcceptor {}
 
 impl DeployAcceptor {

--- a/node/src/components/deploy_buffer.rs
+++ b/node/src/components/deploy_buffer.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::{self, Display, Formatter},
 };
 
+use datasize::DataSize;
 use derive_more::From;
 use rand::{CryptoRng, Rng};
 use semver::Version;
@@ -76,7 +77,7 @@ impl Display for Event {
 }
 
 /// Deploy buffer.
-#[derive(Debug, Clone)]
+#[derive(DataSize, Debug, Clone)]
 pub(crate) struct DeployBuffer {
     block_max_deploy_count: usize,
     collected_deploys: HashMap<DeployHash, DeployHeader>,

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -3,6 +3,7 @@ mod tests;
 
 use std::{collections::HashMap, fmt::Debug, time::Duration};
 
+use datasize::DataSize;
 use rand::{CryptoRng, Rng};
 use smallvec::smallvec;
 use tracing::{debug, error};
@@ -158,8 +159,11 @@ pub trait ItemFetcher<T: Item + 'static> {
 }
 
 /// The component which fetches an item from local storage or asks a peer if it's not in storage.
-#[derive(Debug)]
-pub(crate) struct Fetcher<T: Item + 'static> {
+#[derive(DataSize, Debug)]
+pub(crate) struct Fetcher<T>
+where
+    T: Item + 'static,
+{
     get_from_peer_timeout: Duration,
     responders: HashMap<T::Id, HashMap<NodeId, Vec<FetchResponder<T>>>>,
 }

--- a/node/src/components/fetcher/event.rs
+++ b/node/src/components/fetcher/event.rs
@@ -6,9 +6,10 @@ use crate::{
     small_network::NodeId,
     utils::Source,
 };
+use datasize::DataSize;
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum FetchResult<T: Item> {
+#[derive(Clone, DataSize, Debug, PartialEq)]
+pub enum FetchResult<T> {
     FromStorage(Box<T>),
     FromPeer(Box<T>, NodeId),
 }

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -5,15 +5,15 @@ mod gossip_table;
 mod message;
 mod tests;
 
+use datasize::DataSize;
+use futures::FutureExt;
+use rand::{CryptoRng, Rng};
+use smallvec::smallvec;
 use std::{
     collections::HashSet,
     fmt::{self, Debug, Formatter},
     time::Duration,
 };
-
-use futures::FutureExt;
-use rand::{CryptoRng, Rng};
-use smallvec::smallvec;
 use tracing::{debug, error};
 
 use crate::{
@@ -91,10 +91,16 @@ pub(crate) fn get_deploy_from_storage<T: Item + 'static, REv: ReactorEventT<T>>(
 
 /// The component which gossips to peers and handles incoming gossip messages from peers.
 #[allow(clippy::type_complexity)]
-pub(crate) struct Gossiper<T: Item + 'static, REv: ReactorEventT<T>> {
+#[derive(DataSize)]
+pub(crate) struct Gossiper<T, REv>
+where
+    T: Item + 'static,
+    REv: ReactorEventT<T>,
+{
     table: GossipTable<T::Id>,
     gossip_timeout: Duration,
     get_from_peer_timeout: Duration,
+    #[data_size(skip)] // Not well supported by datasize.
     get_from_holder:
         Box<dyn Fn(EffectBuilder<REv>, T::Id, NodeId) -> Effects<Event<T>> + Send + 'static>,
 }

--- a/node/src/components/gossiper/config.rs
+++ b/node/src/components/gossiper/config.rs
@@ -1,3 +1,4 @@
+use datasize::DataSize;
 use serde::{
     de::{Deserializer, Error as SerdeError, Unexpected},
     Deserialize, Serialize,
@@ -15,7 +16,7 @@ const DEFAULT_GOSSIP_REQUEST_TIMEOUT_SECS: u64 = 10;
 const DEFAULT_GET_REMAINDER_TIMEOUT_SECS: u64 = 60;
 
 /// Configuration options for gossiping.
-#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
 pub struct Config {
     /// Target number of peers to infect with a given piece of data.
     infection_target: u8,

--- a/node/src/components/gossiper/gossip_table.rs
+++ b/node/src/components/gossiper/gossip_table.rs
@@ -106,12 +106,10 @@ pub(crate) struct GossipTable<T> {
     current: HashMap<T, State>,
     /// Data IDs for which gossiping is complete.  The map's values are the times after which the
     /// relevant entries can be removed.
-    #[data_size(skip)] // Conditional redefinition of `Instant` prevents us from counting this.
     finished: HashMap<T, Instant>,
     /// Data IDs for which gossiping has been paused (likely due to detecting that the data was not
     /// correct as per our current knowledge).  Such data could later be decided as still requiring
     /// to be gossiped, so we retain the `State` part here in order to resume gossiping.
-    #[data_size(skip)] // Conditional redefinition of `Instant` prevents us from counting this.
     paused: HashMap<T, (State, Instant)>,
     /// See `Config::infection_target`.
     infection_target: usize,

--- a/node/src/components/gossiper/gossip_table.rs
+++ b/node/src/components/gossiper/gossip_table.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use datasize::DataSize;
 #[cfg(test)]
 use fake_instant::FakeClock as Instant;
 use tracing::warn;
@@ -42,8 +43,8 @@ pub(crate) struct ShouldGossip {
     pub(crate) is_already_held: bool,
 }
 
-#[derive(Debug, Default)]
-struct State {
+#[derive(DataSize, Debug, Default)]
+pub(crate) struct State {
     /// The peers excluding us which hold the data.
     holders: HashSet<NodeId>,
     /// Whether we hold the full data locally yet or not.
@@ -99,16 +100,18 @@ impl State {
     }
 }
 
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub(crate) struct GossipTable<T> {
     /// Data IDs for which gossiping is still ongoing.
     current: HashMap<T, State>,
     /// Data IDs for which gossiping is complete.  The map's values are the times after which the
     /// relevant entries can be removed.
+    #[data_size(skip)] // Conditional redefinition of `Instant` prevents us from counting this.
     finished: HashMap<T, Instant>,
     /// Data IDs for which gossiping has been paused (likely due to detecting that the data was not
     /// correct as per our current knowledge).  Such data could later be decided as still requiring
     /// to be gossiped, so we retain the `State` part here in order to resume gossiping.
+    #[data_size(skip)] // Conditional redefinition of `Instant` prevents us from counting this.
     paused: HashMap<T, (State, Instant)>,
     /// See `Config::infection_target`.
     infection_target: usize,

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -4,6 +4,7 @@ use std::{
     marker::PhantomData,
 };
 
+use datasize::DataSize;
 use derive_more::From;
 use futures::FutureExt;
 use rand::{CryptoRng, Rng};
@@ -69,7 +70,7 @@ impl<I: Display> Display for Event<I> {
     }
 }
 
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub(crate) struct LinearChain<I> {
     /// A temporary workaround.
     linear_chain: Vec<Block>,

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -25,6 +25,8 @@
 
 mod event;
 
+use datasize::DataSize;
+
 use super::{fetcher::FetchResult, storage::Storage, Component};
 use crate::{
     effect::{self, EffectBuilder, EffectExt, EffectOptionExt, Effects},
@@ -59,7 +61,7 @@ impl<I, REv> ReactorEventT<I> for REv where
 {
 }
 
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 enum State {
     /// No syncing of the linear chain configured.
     None,
@@ -149,7 +151,7 @@ impl State {
     }
 }
 
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub(crate) struct LinearChainSync<I> {
     // Set of peers that we can requests block from.
     peers: Vec<I>,

--- a/node/src/components/metrics.rs
+++ b/node/src/components/metrics.rs
@@ -23,6 +23,7 @@
 //!    prevent any actual logic depending on them. If a counter is being increment as a metric and
 //!    also required for busines logic, a second counter should be kept in the component's state.
 
+use datasize::DataSize;
 use prometheus::{Encoder, Registry, TextEncoder};
 use rand::{CryptoRng, Rng};
 use tracing::error;
@@ -33,9 +34,10 @@ use crate::{
 };
 
 /// The metrics component.
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub(crate) struct Metrics {
     /// Metrics registry used to answer metrics queries.
+    #[data_size(skip)] // Actual implementation is just a wrapper around an `Arc`.
     registry: Registry,
 }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -50,6 +50,7 @@ use std::{
 };
 
 use anyhow::Context;
+use datasize::DataSize;
 use futures::{
     future::{select, BoxFuture, Either},
     stream::{SplitSink, SplitStream},
@@ -94,13 +95,18 @@ pub use error::Error;
 /// The key fingerprint found on TLS certificates.
 pub(crate) type NodeId = KeyFingerprint;
 
-#[derive(Debug)]
-struct OutgoingConnection<P> {
+#[derive(DataSize, Debug)]
+pub(crate) struct OutgoingConnection<P> {
+    #[data_size(skip)] // Unfortunately, there is no way to inspect an `UnboundedSender`.
     sender: UnboundedSender<Message<P>>,
     peer_address: SocketAddr,
 }
 
-pub(crate) struct SmallNetwork<REv: 'static, P> {
+#[derive(DataSize)]
+pub(crate) struct SmallNetwork<REv, P>
+where
+    REv: 'static,
+{
     /// Server certificate.
     certificate: Arc<TlsCert>,
     /// Server secret key.

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 use std::net::{Ipv4Addr, SocketAddr};
-
 use std::time::Duration;
 
+use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
@@ -35,7 +35,7 @@ impl Default for Config {
 }
 
 /// Small network configuration.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(DataSize, Debug, Clone, Deserialize, Serialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct Config {

--- a/node/src/components/small_network/gossiped_address.rs
+++ b/node/src/components/small_network/gossiped_address.rs
@@ -3,12 +3,15 @@ use std::{
     net::SocketAddr,
 };
 
+use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 use crate::types::{Item, Tag};
 
 /// Used to gossip our public listening address to peers.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+#[derive(
+    Copy, Clone, DataSize, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug,
+)]
 pub struct GossipedAddress {
     /// Our public listening address.
     address: SocketAddr,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -16,6 +16,7 @@ use std::{
     sync::Arc,
 };
 
+use datasize::DataSize;
 use futures::TryFutureExt;
 use rand::{CryptoRng, Rng};
 use semver::Version;
@@ -490,8 +491,12 @@ impl<B: Value + 'static, D: Value + Item + 'static> StorageType for InMemStorage
 }
 
 // Concrete type of `Storage` backed by LMDB stores.
-#[derive(Debug)]
-pub struct LmdbStorage<B: Value, D: Value> {
+#[derive(DataSize, Debug)]
+pub struct LmdbStorage<B, D>
+where
+    B: Value,
+    D: Value,
+{
     block_store: Arc<LmdbStore<B, BlockMetadata>>,
     deploy_store: Arc<LmdbStore<D, DeployMetadata<B>>>,
     chainspec_store: Arc<LmdbChainspecStore>,

--- a/node/src/components/storage/config.rs
+++ b/node/src/components/storage/config.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use datasize::DataSize;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 #[cfg(test)]
@@ -20,7 +21,7 @@ const DEFAULT_MAX_CHAINSPEC_STORE_SIZE: usize = 1_073_741_824; // 1 GiB
 const DEFAULT_TEST_MAX_DB_SIZE: usize = 52_428_800; // 50 MiB
 
 /// On-disk storage configuration.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct Config {

--- a/node/src/components/storage/lmdb_store.rs
+++ b/node/src/components/storage/lmdb_store.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Debug, marker::PhantomData, path::Path};
 
+use datasize::DataSize;
 use lmdb::{
     self, Cursor, Database, DatabaseFlags, Environment, EnvironmentFlags, Transaction, WriteFlags,
 };
@@ -19,9 +20,14 @@ enum Tag {
 }
 
 /// LMDB version of a store.
-#[derive(Debug)]
-pub(super) struct LmdbStore<V: Value, M> {
+#[derive(DataSize, Debug)]
+pub struct LmdbStore<V, M>
+where
+    V: Value,
+{
+    #[data_size(skip)] // Just a pointer to an external C lib
     env: Environment,
+    #[data_size(skip)] // Just a pointer to an external C lib
     db: Database,
     _phantom: PhantomData<(V, M)>,
 }

--- a/node/src/crypto/asymmetric_key.rs
+++ b/node/src/crypto/asymmetric_key.rs
@@ -9,6 +9,7 @@ use std::{
     path::Path,
 };
 
+use datasize::DataSize;
 use derp::{Der, Tag};
 use ed25519_dalek::{self as ed25519, ExpandedSecretKey};
 use hex_fmt::HexFmt;
@@ -53,11 +54,13 @@ const SECP256K1_PEM_SECRET_KEY_TAG: &str = "EC PRIVATE KEY";
 const SECP256K1_PEM_PUBLIC_KEY_TAG: &str = "PUBLIC KEY";
 
 /// A secret or private asymmetric key.
-#[derive(Serialize, Deserialize)]
+#[derive(DataSize, Serialize, Deserialize)]
 pub enum SecretKey {
     /// Ed25519 secret key.
+    #[data_size(skip)] // Manually verified to have no data on the heap.
     Ed25519(ed25519::SecretKey),
     /// secp256k1 secret key.
+    #[data_size(skip)] // Manually verified to have no data on the heap.
     #[serde(with = "secp256k1_secret_key_serde")]
     Secp256k1(k256::SecretKey),
 }
@@ -412,12 +415,14 @@ mod secp256k1_secret_key_serde {
 }
 
 /// A public asymmetric key.
-#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, DataSize, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PublicKey {
     /// Ed25519 public key.
+    #[data_size(skip)] // Manually verified to have no data on the heap.
     Ed25519(ed25519::PublicKey),
     /// secp256k1 public key.
     #[serde(with = "secp256k1_public_key_serde")]
+    #[data_size(skip)] // Manually verified to have no data on the heap.
     Secp256k1(k256::PublicKey),
 }
 
@@ -860,7 +865,7 @@ mod big_array {
 }
 
 /// A signature of given data.
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, DataSize, Serialize, Deserialize)]
 pub enum Signature {
     /// Ed25519 signature.
     //
@@ -870,6 +875,7 @@ pub enum Signature {
     Ed25519(#[serde(with = "big_array::BigArray")] [u8; ed25519::SIGNATURE_LENGTH]),
     /// secp256k1 signature.
     #[serde(with = "secp256k1_signature_serde")]
+    #[data_size(skip)] // Manually verified to have no data on the heap.
     Secp256k1(Secp256k1Signature),
 }
 

--- a/node/src/crypto/hash.rs
+++ b/node/src/crypto/hash.rs
@@ -10,6 +10,7 @@ use blake2::{
     digest::{Input, VariableOutput},
     VarBlake2b,
 };
+use datasize::DataSize;
 use hex_fmt::HexFmt;
 #[cfg(test)]
 use rand::Rng;
@@ -23,7 +24,9 @@ use super::Error;
 use crate::testing::TestRng;
 
 /// The hash digest; a wrapped `u8` array.
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Default)]
+#[derive(
+    Copy, Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Default,
+)]
 pub struct Digest([u8; Digest::LENGTH]);
 
 impl Digest {

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -70,6 +70,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use datasize::DataSize;
 use futures::{channel::oneshot, future::BoxFuture, FutureExt};
 use semver::Version;
 use smallvec::{smallvec, SmallVec};
@@ -136,6 +137,7 @@ type Multiple<T> = SmallVec<[T; 2]>;
 
 /// A responder satisfying a request.
 #[must_use]
+#[derive(DataSize)]
 pub struct Responder<T>(Option<oneshot::Sender<T>>);
 
 impl<T: 'static + Send> Responder<T> {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -9,6 +9,7 @@ use std::{
     net::SocketAddr,
 };
 
+use datasize::DataSize;
 use semver::Version;
 
 use casper_execution_engine::{
@@ -619,7 +620,7 @@ impl<I: Display> Display for LinearChainRequest<I> {
     }
 }
 
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 #[must_use]
 /// Consensus component requests.
 pub enum ConsensusRequest {

--- a/node/src/logging.rs
+++ b/node/src/logging.rs
@@ -3,6 +3,7 @@
 use std::{fmt, io};
 
 use ansi_term::{Color, Style};
+use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use tracing::{Event, Level, Subscriber};
@@ -18,7 +19,7 @@ use tracing_subscriber::{
 };
 
 /// Logging configuration.
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(DataSize, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LoggingConfig {
     /// Output format for log.
@@ -43,7 +44,7 @@ impl LoggingConfig {
 /// Logging output format.
 ///
 /// Defaults to "text"".
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(DataSize, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LoggingFormat {
     /// Text format.

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -34,6 +34,7 @@ use std::{
     mem,
 };
 
+use datasize::DataSize;
 use futures::{future::BoxFuture, FutureExt};
 use prometheus::{self, IntCounter, Registry};
 use rand::{CryptoRng, Rng};
@@ -59,8 +60,10 @@ pub type Scheduler<Ev> = WeightedRoundRobin<Ev, QueueKind>;
 /// The event queue handle is how almost all parts of the application interact with the reactor
 /// outside of the normal event loop. It gives different parts a chance to schedule messages that
 /// stem from things like external IO.
-#[derive(Debug)]
-pub struct EventQueueHandle<REv: 'static>(&'static Scheduler<REv>);
+#[derive(DataSize, Debug)]
+pub struct EventQueueHandle<REv>(&'static Scheduler<REv>)
+where
+    REv: 'static;
 
 // Implement `Clone` and `Copy` manually, as `derive` will make it depend on `R` and `Ev` otherwise.
 impl<REv> Clone for EventQueueHandle<REv> {

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::{self, Display, Formatter};
 
+use datasize::DataSize;
 use derive_more::From;
 use prometheus::Registry;
 use rand::{CryptoRng, Rng};
@@ -94,7 +95,7 @@ pub enum Error {
 }
 
 /// Initializer node reactor.
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub struct Reactor {
     pub(super) config: validator::Config,
     pub(super) chainspec_loader: ChainspecLoader,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::{self, Display, Formatter};
 
+use datasize::DataSize;
+
 use block_executor::BlockExecutor;
 use consensus::EraSupervisor;
 use deploy_acceptor::DeployAcceptor;
@@ -250,7 +252,11 @@ impl Display for Event {
 }
 
 /// Joining node reactor.
-pub struct Reactor<R: Rng + CryptoRng + ?Sized> {
+#[derive(DataSize)]
+pub struct Reactor<R>
+where
+    R: Rng + CryptoRng + ?Sized,
+{
     pub(super) net: SmallNetwork<Event, Message>,
     pub(super) address_gossiper: Gossiper<GossipedAddress, Event>,
     pub(super) config: validator::Config,
@@ -267,6 +273,8 @@ pub struct Reactor<R: Rng + CryptoRng + ?Sized> {
     // Effects consensus component returned during creation.
     // In the `joining` phase we don't want to handle it,
     // so we carry them forward to the `validator` reactor.
+    #[data_size(skip)]
+    // Unfortunately, we have no way of inspecting the future and its heap allocations at all.
     pub(super) init_consensus_effects: Effects<consensus::Event<NodeId>>,
     // Handles request for linear chain block by height.
     pub(super) block_by_height_fetcher: Fetcher<BlockByHeight>,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -9,6 +9,7 @@ mod tests;
 
 use std::fmt::{self, Display, Formatter};
 
+use datasize::DataSize;
 use derive_more::From;
 use fmt::Debug;
 use prometheus::Registry;
@@ -257,8 +258,11 @@ pub struct ValidatorInitConfig<R: Rng + CryptoRng + ?Sized> {
 }
 
 /// Validator node reactor.
-#[derive(Debug)]
-pub struct Reactor<R: Rng + CryptoRng + ?Sized> {
+#[derive(DataSize, Debug)]
+pub struct Reactor<R>
+where
+    R: Rng + CryptoRng + ?Sized,
+{
     metrics: Metrics,
     net: SmallNetwork<Event, Message>,
     address_gossiper: Gossiper<GossipedAddress, Event>,

--- a/node/src/reactor/validator/config.rs
+++ b/node/src/reactor/validator/config.rs
@@ -1,3 +1,4 @@
+use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -6,7 +7,7 @@ use crate::{
 };
 
 /// Root configuration.
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(DataSize, Debug, Default, Deserialize, Serialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct Config {

--- a/node/src/tls.rs
+++ b/node/src/tls.rs
@@ -32,6 +32,7 @@ use std::{
 };
 
 use anyhow::Context;
+use datasize::DataSize;
 use hex_fmt::HexFmt;
 use nid::Nid;
 use openssl::{
@@ -79,7 +80,7 @@ const SIGNATURE_DIGEST: Nid = Nid::SHA512;
 type SslResult<T> = Result<T, ErrorStack>;
 
 /// SHA512 hash.
-#[derive(Copy, Clone, Deserialize, Serialize)]
+#[derive(Copy, Clone, DataSize, Deserialize, Serialize)]
 struct Sha512(#[serde(with = "big_array::BigArray")] [u8; Sha512::SIZE]);
 
 impl Sha512 {
@@ -129,7 +130,7 @@ impl Sha512 {
 }
 
 /// Certificate fingerprint.
-#[derive(Copy, Clone, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Copy, Clone, DataSize, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub(crate) struct CertFingerprint(Sha512);
 
 impl Debug for CertFingerprint {
@@ -139,7 +140,7 @@ impl Debug for CertFingerprint {
 }
 
 /// Public key fingerprint.
-#[derive(Copy, Clone, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Copy, Clone, DataSize, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct KeyFingerprint(Sha512);
 
 impl Debug for KeyFingerprint {
@@ -177,9 +178,10 @@ impl Debug for Signature {
 /// TLS certificate.
 ///
 /// Thin wrapper around `X509` enabling things like Serde serialization and fingerprint caching.
-#[derive(Clone)]
+#[derive(Clone, DataSize)]
 pub struct TlsCert {
     /// The wrapped x509 certificate.
+    #[data_size(skip)] // Skip OpenSSL type.
     x509: X509,
 
     /// Cached certificate fingerprint.

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -9,6 +9,7 @@ use std::{
     hash::Hash,
 };
 
+use datasize::DataSize;
 use hex::FromHexError;
 use hex_fmt::{HexFmt, HexList};
 #[cfg(test)]
@@ -63,7 +64,18 @@ pub trait BlockLike: Eq + Hash {
 
 /// A cryptographic hash identifying a `ProtoBlock`.
 #[derive(
-    Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug, Default,
+    Copy,
+    Clone,
+    DataSize,
+    Ord,
+    PartialOrd,
+    Eq,
+    PartialEq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Debug,
+    Default,
 )]
 pub struct ProtoBlockHash(Digest);
 
@@ -99,7 +111,7 @@ impl Display for ProtoBlockHash {
 ///
 /// The word "proto" does _not_ refer to "protocol" or "protobuf"! It is just a prefix to highlight
 /// that this comes before a block in the linear, executed, finalized blockchain is produced.
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ProtoBlock {
     hash: ProtoBlockHash,
     deploys: Vec<DeployHash>,
@@ -169,7 +181,7 @@ impl BlockLike for ProtoBlock {
 }
 
 /// System transactions like slashing and rewards.
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SystemTransaction {
     /// A validator has equivocated and should be slashed.
     Slash(PublicKey),
@@ -215,7 +227,7 @@ impl Display for SystemTransaction {
 
 /// The piece of information that will become the content of a future block after it was finalized
 /// and before execution happened yet.
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FinalizedBlock {
     proto_block: ProtoBlock,
     timestamp: Timestamp,
@@ -321,7 +333,9 @@ impl Display for FinalizedBlock {
 }
 
 /// A cryptographic hash identifying a [`Block`](struct.Block.html).
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
+#[derive(
+    Copy, Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug,
+)]
 pub struct BlockHash(Digest);
 
 impl BlockHash {
@@ -355,7 +369,7 @@ impl AsRef<[u8]> for BlockHash {
 }
 
 /// The header portion of a [`Block`](struct.Block.html).
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
 pub struct BlockHeader {
     parent_hash: BlockHash,
     global_state_hash: Digest,
@@ -465,7 +479,7 @@ impl Display for BlockHeader {
 
 /// A proto-block after execution, with the resulting post-state-hash.  This is the core component
 /// of the Casper linear blockchain.
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(DataSize, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Block {
     hash: BlockHash,
     header: BlockHeader,

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -7,6 +7,7 @@ use std::{
     iter::FromIterator,
 };
 
+use datasize::DataSize;
 use hex::FromHexError;
 use itertools::Itertools;
 #[cfg(test)]
@@ -77,7 +78,18 @@ impl From<TryFromSliceError> for Error {
 
 /// The cryptographic hash of a [`Deploy`](struct.Deploy.html).
 #[derive(
-    Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug, Default,
+    Copy,
+    Clone,
+    DataSize,
+    Ord,
+    PartialOrd,
+    Eq,
+    PartialEq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Debug,
+    Default,
 )]
 pub struct DeployHash(Digest);
 
@@ -112,7 +124,7 @@ impl AsRef<[u8]> for DeployHash {
 }
 
 /// The header portion of a [`Deploy`](struct.Deploy.html).
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
 pub struct DeployHeader {
     account: PublicKey,
     timestamp: Timestamp,
@@ -184,7 +196,7 @@ impl Display for DeployHeader {
 }
 
 /// A struct containing a signature and the public key of the signer.
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
 pub struct Approval {
     signer: PublicKey,
     signature: Signature,
@@ -209,7 +221,7 @@ impl Display for Approval {
 }
 
 /// A deploy; an item containing a smart contract along with the requester's signature(s).
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, DataSize, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 pub struct Deploy {
     hash: DeployHash,
     header: DeployHeader,

--- a/node/src/types/node_config.rs
+++ b/node/src/types/node_config.rs
@@ -1,3 +1,4 @@
+use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 use crate::{utils::External, Chainspec};
@@ -6,7 +7,7 @@ const DEFAULT_CHAINSPEC_CONFIG_PATH: &str = "chainspec.toml";
 const DEFAULT_BLOCK_MAX_DEPLOY_COUNT: u32 = 3;
 
 /// Node configuration.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(DataSize, Debug, Deserialize, Serialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct NodeConfig {

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -6,6 +6,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use datasize::DataSize;
 use derive_more::{Add, AddAssign, From, Shl, Shr, Sub, SubAssign};
 #[cfg(test)]
 use rand::Rng;
@@ -16,7 +17,19 @@ use crate::testing::TestRng;
 
 /// A timestamp type, representing a concrete moment in time.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash, Shr, Shl,
+    DataSize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Hash,
+    Shr,
+    Shl,
 )]
 pub struct Timestamp(u64);
 
@@ -25,6 +38,7 @@ pub struct Timestamp(u64);
     Debug,
     Clone,
     Copy,
+    DataSize,
     PartialEq,
     Eq,
     PartialOrd,

--- a/node/src/utils/external.rs
+++ b/node/src/utils/external.rs
@@ -8,6 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use datasize::DataSize;
 use openssl::{
     pkey::{PKey, Private},
     x509::X509,
@@ -39,7 +40,7 @@ lazy_static::lazy_static! {
 /// An `External` also always provides a default, which will always result in an error when `load`
 /// is called. Should the underlying type `T` implement `Default`, the `with_default` can be
 /// used instead.
-#[derive(Clone, Eq, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, DataSize, Eq, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum External<T> {
     /// Value that should be loaded from an external path.

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -15,6 +15,7 @@ base16 = { version = "0.2.1", default-features = false }
 bitflags = "1"
 blake2 = { version = "0.8.1", default-features = false }
 # TODO: Replace failure with thiserror once no_std support is landed https://github.com/dtolnay/thiserror/pull/64
+datasize = { version = "0.1.1" }
 failure = { version = "0.1.6", default-features = false, features = ["failure_derive"] }
 hex_fmt = "0.3.0"
 num-derive = { version = "0.3.0", default-features = false }
@@ -24,8 +25,6 @@ proptest = { version = "0.10.0", optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-big-array = "0.3.0"
 uint = { version = "0.8.3", default-features = false }
-
-datasize = { path = "../../datasize/datasize" }
 
 [dev-dependencies]
 bincode = "1.3.1"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -25,6 +25,8 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde-big-array = "0.3.0"
 uint = { version = "0.8.3", default-features = false }
 
+datasize = { path = "../../datasize/datasize" }
+
 [dev-dependencies]
 bincode = "1.3.1"
 criterion = "0.3.3"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -15,7 +15,7 @@ base16 = { version = "0.2.1", default-features = false }
 bitflags = "1"
 blake2 = { version = "0.8.1", default-features = false }
 # TODO: Replace failure with thiserror once no_std support is landed https://github.com/dtolnay/thiserror/pull/64
-datasize = { version = "0.1.1" }
+datasize = { version = "0.2.0", default-features = false }
 failure = { version = "0.1.6", default-features = false, features = ["failure_derive"] }
 hex_fmt = "0.3.0"
 num-derive = { version = "0.3.0", default-features = false }

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -7,6 +7,7 @@ use core::{
     fmt::{Debug, Display, Formatter},
 };
 
+use datasize::DataSize;
 use failure::Fail;
 use serde::{Deserialize, Serialize};
 
@@ -181,7 +182,7 @@ pub type AccountHashBytes = [u8; ACCOUNT_HASH_LENGTH];
 
 /// A newtype wrapping a [`AccountHashBytes`] which is the raw bytes of
 /// the AccountHash, a hash of Public Key and Algorithm
-#[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
+#[derive(DataSize, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
 pub struct AccountHash(AccountHashBytes);
 
 impl AccountHash {

--- a/types/src/public_key.rs
+++ b/types/src/public_key.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use core::{cmp, fmt};
 
+use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -22,7 +23,7 @@ mod big_array {
     big_array! { BigArray; super::SECP256K1_PUBLIC_KEY_LENGTH }
 }
 
-#[derive(Copy, Clone, Serialize, Deserialize)]
+#[derive(Copy, Clone, DataSize, Serialize, Deserialize)]
 pub struct Secp256k1Bytes(#[serde(with = "big_array::BigArray")] [u8; SECP256K1_PUBLIC_KEY_LENGTH]);
 
 impl Secp256k1Bytes {
@@ -89,7 +90,7 @@ impl ToBytes for Secp256k1Bytes {
 }
 
 /// Simplified raw data type
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(DataSize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum PublicKey {
     /// Ed25519 public key.
     Ed25519([u8; ED25519_PUBLIC_KEY_LENGTH]),

--- a/types/src/uint.rs
+++ b/types/src/uint.rs
@@ -25,6 +25,7 @@ mod macro_code {
     use uint::construct_uint;
 
     construct_uint! {
+        #[derive(datasize::DataSize)]
         pub struct U512(8);
     }
     construct_uint! {


### PR DESCRIPTION
This adds a derivation of `DataSize` on all reactors and the related types. Some changes to visibility were necessary due to types now showing up in `trait` bounds.

This PR has been deliberately separated from the actual memory usage statistics to make reviews easier.