### PR TITLE
Add collected memory usage to metrics

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt::Debug};
+use std::{any::Any, collections::BTreeMap, fmt::Debug};
 
 use anyhow::Error;
 use datasize::DataSize;
@@ -80,6 +80,11 @@ pub(crate) enum ConsensusProtocolResult<I, C: ConsensusValueT, VID> {
 
 /// An API for a single instance of the consensus.
 pub(crate) trait ConsensusProtocol<I, C: ConsensusValueT, VID, R: Rng + CryptoRng + ?Sized> {
+    /// Upcasts consensus protocol into `dyn Any`.
+    ///
+    /// Typically called on a boxed trait object for downcasting afterwards.
+    fn as_any(&self) -> &dyn Any;
+
     /// Handles an incoming message (like NewVote, RequestDependency).
     fn handle_message(
         &mut self,

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -22,7 +22,7 @@ use fmt::Display;
 use num_traits::AsPrimitive;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
-use tracing::{error, info, trace};
+use tracing::{error, info, trace, warn};
 
 use casper_execution_engine::shared::motes::Motes;
 
@@ -80,11 +80,45 @@ impl Display for EraId {
     }
 }
 
-pub struct Era<I, R: Rng + CryptoRng + ?Sized> {
+pub struct Era<I, R>
+where
+    R: Rng + CryptoRng + ?Sized,
+{
     /// The consensus protocol instance.
     consensus: Box<dyn ConsensusProtocol<I, ProtoBlock, PublicKey, R>>,
     /// The height of this era's first block.
     start_height: u64,
+}
+
+impl<I, R> DataSize for Era<I, R>
+where
+    R: Rng + CryptoRng + ?Sized,
+    I: 'static,
+{
+    const IS_DYNAMIC: bool = true;
+
+    const STATIC_HEAP_SIZE: usize = 0;
+
+    #[inline]
+    fn estimate_heap_size(&self) -> usize {
+        // `DataSize` cannot be made object safe due its use of associated constants. We implement
+        // it manually here, downcasting the consensus protocol as a workaround.
+
+        let consensus_heap_size = {
+            let any_ref = self.consensus.as_any();
+
+            if let Some(highway) = any_ref.downcast_ref::<HighwayProtocol<I, HighwayContext>>() {
+                highway.estimate_heap_size()
+            } else {
+                warn!(
+                    "could not downcast consensus protocol to HighwayProtocol<I, HighwayContext> to determine heap allocation size"
+                );
+                0
+            }
+        };
+
+        consensus_heap_size + self.start_height.estimate_heap_size()
+    }
 }
 
 #[derive(DataSize)]

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -1,4 +1,5 @@
 use std::{
+    any::Any,
     collections::{BTreeMap, HashMap},
     fmt::Debug,
     iter,
@@ -312,7 +313,7 @@ where
         self.highway.deactivate_validator()
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -282,7 +282,6 @@ where
         Ok(self.process_av_effects(effects))
     }
 
-    /// Marks `value` as valid.
     fn resolve_validity(
         &mut self,
         value: &C::ConsensusValue,
@@ -309,7 +308,6 @@ where
         }
     }
 
-    /// Turns this instance into a passive observer, that does not create any new vertices.
     fn deactivate_validator(&mut self) {
         self.highway.deactivate_validator()
     }

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -136,6 +136,9 @@ pub trait Reactor<R: Rng + CryptoRng + ?Sized>: Sized {
     fn is_stopped(&mut self) -> bool {
         false
     }
+
+    /// Instructs the reactor to update performance metrics, if any.
+    fn update_metrics(&mut self) {}
 }
 
 /// A drop-like trait for `async` compatible drop-and-wait.

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -309,8 +309,8 @@ where
             let now = Instant::now();
 
             // We update metrics on the first very event as well to get a good baseline.
-            if self.event_count == 0
-                || now.duration_since(self.last_metrics) >= self.event_metrics_min_delay
+            if now.duration_since(self.last_metrics) >= self.event_metrics_min_delay
+                || self.event_count == 0
             {
                 self.reactor.update_metrics();
                 self.last_metrics = now;

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -316,6 +316,9 @@ impl<R: Rng + CryptoRng + ?Sized> reactor::Reactor<R> for Reactor<R> {
 
         let metrics = Metrics::new(registry.clone());
 
+        // Temporary memory metrics.
+        // TODO
+
         let effect_builder = EffectBuilder::new(event_queue);
         let (net, net_effects) = SmallNetwork::new(event_queue, config.network, true)?;
 
@@ -344,26 +347,25 @@ impl<R: Rng + CryptoRng + ?Sized> reactor::Reactor<R> for Reactor<R> {
             init_consensus_effects,
         ));
 
-        Ok((
-            Reactor {
-                metrics,
-                net,
-                address_gossiper,
-                storage,
-                contract_runtime,
-                api_server,
-                chainspec_loader,
-                consensus,
-                deploy_acceptor,
-                deploy_fetcher,
-                deploy_gossiper,
-                deploy_buffer,
-                block_executor,
-                proto_block_validator,
-                linear_chain,
-            },
-            effects,
-        ))
+        let reactor = Reactor {
+            metrics,
+            net,
+            address_gossiper,
+            storage,
+            contract_runtime,
+            api_server,
+            chainspec_loader,
+            consensus,
+            deploy_acceptor,
+            deploy_fetcher,
+            deploy_gossiper,
+            deploy_buffer,
+            block_executor,
+            proto_block_validator,
+            linear_chain,
+        };
+        error!("MEMORY METRICS: {:?}", reactor.estimate_heap_size());
+        Ok((reactor, effects))
     }
 
     fn dispatch_event(

--- a/node/src/reactor/validator/memory_metrics.rs
+++ b/node/src/reactor/validator/memory_metrics.rs
@@ -202,6 +202,7 @@ impl MemoryMetrics {
 
         debug!(%total,
                %duration_s,
+               %metrics,
                %net,
                %address_gossiper,
                %storage,

--- a/node/src/reactor/validator/memory_metrics.rs
+++ b/node/src/reactor/validator/memory_metrics.rs
@@ -1,5 +1,5 @@
 use datasize::DataSize;
-use prometheus::{exponential_buckets, Histogram, HistogramOpts, IntGauge, Registry};
+use prometheus::{self, Histogram, HistogramOpts, IntGauge, Registry};
 use rand::{CryptoRng, Rng};
 use tracing::debug;
 
@@ -97,7 +97,7 @@ impl MemoryMetrics {
                 "time taken to estimate memory usage, in seconds",
             )
             //  Create buckets from one nanosecond to eight seconds.
-            .buckets(exponential_buckets(0.000_000_004, 2.0, 32)?),
+            .buckets(prometheus::exponential_buckets(0.000_000_004, 2.0, 32)?),
         )?;
 
         registry.register(Box::new(mem_total.clone()))?;

--- a/node/src/reactor/validator/memory_metrics.rs
+++ b/node/src/reactor/validator/memory_metrics.rs
@@ -1,0 +1,273 @@
+use datasize::DataSize;
+use prometheus::{exponential_buckets, Histogram, HistogramOpts, IntGauge, Registry};
+use rand::{CryptoRng, Rng};
+
+use super::Reactor;
+use tracing::debug;
+
+/// Metrics for memory usage.
+#[derive(Debug)]
+pub(super) struct MemoryMetrics {
+    /// Total estimated heap memory usage.
+    mem_total: IntGauge,
+
+    /// Estimated heap memory usage of metrics component.
+    mem_metrics: IntGauge,
+    /// Estimated heap memory usage of network component.
+    mem_net: IntGauge,
+    /// Estimated heap memory usage of address gossiper component.
+    mem_address_gossiper: IntGauge,
+    /// Estimated heap memory usage of storage component.
+    mem_storage: IntGauge,
+    /// Estimated heap memory usage of contract runtime component.
+    mem_contract_runtime: IntGauge,
+    /// Estimated heap memory usage of api server component.
+    mem_api_server: IntGauge,
+    /// Estimated heap memory usage of chainspec loader component.
+    mem_chainspec_loader: IntGauge,
+    /// Estimated heap memory usage of consensus component.
+    mem_consensus: IntGauge,
+    /// Estimated heap memory usage of deploy acceptor component.
+    mem_deploy_acceptor: IntGauge,
+    /// Estimated heap memory usage of deploy fetcher component.
+    mem_deploy_fetcher: IntGauge,
+    /// Estimated heap memory usage of deploy gossiper component.
+    mem_deploy_gossiper: IntGauge,
+    /// Estimated heap memory usage of deploy buffer component.
+    mem_deploy_buffer: IntGauge,
+    /// Estimated heap memory usage of block executor component.
+    mem_block_executor: IntGauge,
+    /// Estimated heap memory usage of block validator component.
+    mem_proto_block_validator: IntGauge,
+    /// Estimated heap memory usage of linear chain component.
+    mem_linear_chain: IntGauge,
+
+    /// Histogram detailing how long it took to measure memory usage.
+    mem_estimator_runtime_s: Histogram,
+
+    /// Instance of registry to unregister from when being dropped.
+    registry: Registry,
+}
+
+impl MemoryMetrics {
+    /// Initializes a new set of memory metrics.
+    pub(super) fn new(registry: Registry) -> Result<Self, prometheus::Error> {
+        let mem_total = IntGauge::new("mem_total", "total memory usage in bytes")?;
+        let mem_metrics = IntGauge::new("mem_metrics", "metrics memory usage in bytes")?;
+        let mem_net = IntGauge::new("mem_net", "net memory usage in bytes")?;
+        let mem_address_gossiper = IntGauge::new(
+            "mem_address_gossiper",
+            "address_gossiper memory usage in bytes",
+        )?;
+        let mem_storage = IntGauge::new("mem_storage", "storage memory usage in bytes")?;
+        let mem_contract_runtime = IntGauge::new(
+            "mem_contract_runtime",
+            "contract_runtime memory usage in bytes",
+        )?;
+        let mem_api_server = IntGauge::new("mem_api_server", "api_server memory usage in bytes")?;
+        let mem_chainspec_loader = IntGauge::new(
+            "mem_chainspec_loader",
+            "chainspec_loader memory usage in bytes",
+        )?;
+        let mem_consensus = IntGauge::new("mem_consensus", "consensus memory usage in bytes")?;
+        let mem_deploy_acceptor = IntGauge::new(
+            "mem_deploy_acceptor",
+            "deploy_acceptor memory usage in bytes",
+        )?;
+        let mem_deploy_fetcher =
+            IntGauge::new("mem_deploy_fetcher", "deploy_fetcher memory usage in bytes")?;
+        let mem_deploy_gossiper = IntGauge::new(
+            "mem_deploy_gossiper",
+            "deploy_gossiper memory usage in bytes",
+        )?;
+        let mem_deploy_buffer =
+            IntGauge::new("mem_deploy_buffer", "deploy_buffer memory usage in bytes")?;
+        let mem_block_executor =
+            IntGauge::new("mem_block_executor", "block_executor memory usage in bytes")?;
+        let mem_proto_block_validator = IntGauge::new(
+            "mem_proto_block_validator",
+            "proto_block_validator memory usage in bytes",
+        )?;
+        let mem_linear_chain =
+            IntGauge::new("mem_linear_chain", "linear_chain memory usage in bytes")?;
+
+        let mem_estimator_runtime_s = Histogram::with_opts(
+            HistogramOpts::new(
+                "mem_estimator_runtime_s",
+                "time taken to estimate memory usage, in seconds",
+            )
+            //  Create buckets from one nanosecond to four seconds.
+            .buckets(exponential_buckets(0.000_000_001, 2.0, 32)?),
+        )?;
+
+        registry.register(Box::new(mem_total.clone()))?;
+        registry.register(Box::new(mem_metrics.clone()))?;
+        registry.register(Box::new(mem_net.clone()))?;
+        registry.register(Box::new(mem_address_gossiper.clone()))?;
+        registry.register(Box::new(mem_storage.clone()))?;
+        registry.register(Box::new(mem_contract_runtime.clone()))?;
+        registry.register(Box::new(mem_api_server.clone()))?;
+        registry.register(Box::new(mem_chainspec_loader.clone()))?;
+        registry.register(Box::new(mem_consensus.clone()))?;
+        registry.register(Box::new(mem_deploy_acceptor.clone()))?;
+        registry.register(Box::new(mem_deploy_fetcher.clone()))?;
+        registry.register(Box::new(mem_deploy_gossiper.clone()))?;
+        registry.register(Box::new(mem_deploy_buffer.clone()))?;
+        registry.register(Box::new(mem_block_executor.clone()))?;
+        registry.register(Box::new(mem_proto_block_validator.clone()))?;
+        registry.register(Box::new(mem_linear_chain.clone()))?;
+        registry.register(Box::new(mem_estimator_runtime_s.clone()))?;
+
+        Ok(MemoryMetrics {
+            mem_total,
+            mem_metrics,
+            mem_net,
+            mem_address_gossiper,
+            mem_storage,
+            mem_contract_runtime,
+            mem_api_server,
+            mem_chainspec_loader,
+            mem_consensus,
+            mem_deploy_acceptor,
+            mem_deploy_fetcher,
+            mem_deploy_gossiper,
+            mem_deploy_buffer,
+            mem_block_executor,
+            mem_proto_block_validator,
+            mem_linear_chain,
+            mem_estimator_runtime_s,
+            registry,
+        })
+    }
+
+    /// Estimates memory usage and updates metrics.
+    pub(super) fn estimate<R>(&self, reactor: &Reactor<R>)
+    where
+        R: CryptoRng + Rng + ?Sized,
+    {
+        let timer = self.mem_estimator_runtime_s.start_timer();
+
+        let metrics = reactor.metrics.estimate_heap_size() as i64;
+        let net = reactor.net.estimate_heap_size() as i64;
+        let address_gossiper = reactor.address_gossiper.estimate_heap_size() as i64;
+        let storage = reactor.storage.estimate_heap_size() as i64;
+        let contract_runtime = reactor.contract_runtime.estimate_heap_size() as i64;
+        let api_server = reactor.api_server.estimate_heap_size() as i64;
+        let chainspec_loader = reactor.chainspec_loader.estimate_heap_size() as i64;
+        let consensus = reactor.consensus.estimate_heap_size() as i64;
+        let deploy_acceptor = reactor.deploy_acceptor.estimate_heap_size() as i64;
+        let deploy_fetcher = reactor.deploy_fetcher.estimate_heap_size() as i64;
+        let deploy_gossiper = reactor.deploy_gossiper.estimate_heap_size() as i64;
+        let deploy_buffer = reactor.deploy_buffer.estimate_heap_size() as i64;
+        let block_executor = reactor.block_executor.estimate_heap_size() as i64;
+        let proto_block_validator = reactor.proto_block_validator.estimate_heap_size() as i64;
+
+        let linear_chain = reactor.linear_chain.estimate_heap_size() as i64;
+
+        let total = metrics
+            + net
+            + address_gossiper
+            + storage
+            + contract_runtime
+            + api_server
+            + chainspec_loader
+            + consensus
+            + deploy_acceptor
+            + deploy_fetcher
+            + deploy_gossiper
+            + deploy_buffer
+            + block_executor
+            + proto_block_validator
+            + linear_chain;
+
+        self.mem_total.set(total);
+        self.mem_metrics.set(metrics);
+        self.mem_net.set(net);
+        self.mem_address_gossiper.set(address_gossiper);
+        self.mem_storage.set(storage);
+        self.mem_contract_runtime.set(contract_runtime);
+        self.mem_api_server.set(api_server);
+        self.mem_chainspec_loader.set(chainspec_loader);
+        self.mem_consensus.set(consensus);
+        self.mem_deploy_acceptor.set(deploy_acceptor);
+        self.mem_deploy_fetcher.set(deploy_fetcher);
+        self.mem_deploy_gossiper.set(deploy_gossiper);
+        self.mem_deploy_buffer.set(deploy_buffer);
+        self.mem_block_executor.set(block_executor);
+        self.mem_proto_block_validator.set(proto_block_validator);
+        self.mem_linear_chain.set(linear_chain);
+
+        // Stop the timer explicitly, don't count logging.
+        drop(timer);
+
+        debug!(%total,
+               %net,
+               %address_gossiper,
+               %storage,
+               %contract_runtime,
+               %api_server,
+               %chainspec_loader,
+               %consensus,
+               %deploy_acceptor,
+               %deploy_fetcher,
+               %deploy_gossiper,
+               %deploy_buffer,
+               %block_executor,
+               %proto_block_validator,
+               %linear_chain,
+               "Collected new set of memory metrics.");
+    }
+}
+
+impl Drop for MemoryMetrics {
+    fn drop(&mut self) {
+        self.registry
+            .unregister(Box::new(self.mem_total.clone()))
+            .expect("did not expect deregistering mem_total, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_metrics.clone()))
+            .expect("did not expect deregistering mem_metrics, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_net.clone()))
+            .expect("did not expect deregistering mem_net, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_address_gossiper.clone()))
+            .expect("did not expect deregistering mem_address_gossiper, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_storage.clone()))
+            .expect("did not expect deregistering mem_storage, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_contract_runtime.clone()))
+            .expect("did not expect deregistering mem_contract_runtime, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_api_server.clone()))
+            .expect("did not expect deregistering mem_api_server, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_chainspec_loader.clone()))
+            .expect("did not expect deregistering mem_chainspec_loader, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_consensus.clone()))
+            .expect("did not expect deregistering mem_consensus, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_deploy_acceptor.clone()))
+            .expect("did not expect deregistering mem_deploy_acceptor, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_deploy_fetcher.clone()))
+            .expect("did not expect deregistering mem_deploy_fetcher, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_deploy_gossiper.clone()))
+            .expect("did not expect deregistering mem_deploy_gossiper, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_deploy_buffer.clone()))
+            .expect("did not expect deregistering mem_deploy_buffer, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_block_executor.clone()))
+            .expect("did not expect deregistering mem_block_executor, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_proto_block_validator.clone()))
+            .expect("did not expect deregistering mem_proto_block_validator, to fail");
+        self.registry
+            .unregister(Box::new(self.mem_linear_chain.clone()))
+            .expect("did not expect deregistering mem_linear_chain, to fail");
+    }
+}

--- a/node/src/reactor/validator/memory_metrics.rs
+++ b/node/src/reactor/validator/memory_metrics.rs
@@ -1,9 +1,9 @@
 use datasize::DataSize;
 use prometheus::{exponential_buckets, Histogram, HistogramOpts, IntGauge, Registry};
 use rand::{CryptoRng, Rng};
+use tracing::debug;
 
 use super::Reactor;
-use tracing::debug;
 
 /// Metrics for memory usage.
 #[derive(Debug)]

--- a/node/src/reactor/validator/memory_metrics.rs
+++ b/node/src/reactor/validator/memory_metrics.rs
@@ -96,8 +96,8 @@ impl MemoryMetrics {
                 "mem_estimator_runtime_s",
                 "time taken to estimate memory usage, in seconds",
             )
-            //  Create buckets from one nanosecond to four seconds.
-            .buckets(exponential_buckets(0.000_000_001, 2.0, 32)?),
+            //  Create buckets from one nanosecond to eight seconds.
+            .buckets(exponential_buckets(0.000_000_004, 2.0, 32)?),
         )?;
 
         registry.register(Box::new(mem_total.clone()))?;

--- a/node/src/reactor/validator/memory_metrics.rs
+++ b/node/src/reactor/validator/memory_metrics.rs
@@ -198,9 +198,10 @@ impl MemoryMetrics {
         self.mem_linear_chain.set(linear_chain);
 
         // Stop the timer explicitly, don't count logging.
-        drop(timer);
+        let duration_s = timer.stop_and_record();
 
         debug!(%total,
+               %duration_s,
                %net,
                %address_gossiper,
                %storage,

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -9,8 +9,8 @@ CHAINSPEC=$(mktemp -t chainspec_XXXXXXXX --suffix .toml)
 TRUSTED_HASH="${TRUSTED_HASH:-}"
 OFFSET="${OFFSET:-30}"
 TIMESTAMP=${GENESIS_TIMESTAMP:-$(date '+%s000' -d "+$OFFSET sec")}
-echo "GENESIS_TIMESTAMP="$TIMESTAMP
-date -d @$(echo "$TIMESTAMP/1000" | bc)
+echo "GENESIS_TIMESTAMP=${TIMESTAMP}"
+date -d @$(($TIMESTAMP/1000))
 
 # Build the node first, so that `sleep` in the loop has an effect.
 cargo build -p casper-node

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -21,9 +21,8 @@ sed -i "s/^\([[:alnum:]_]*timestamp\) = .*/\1 = ${TIMESTAMP}/" ${CHAINSPEC}
 sed -i 's|\.\./\.\.|'"$BASEDIR"'|' ${CHAINSPEC}
 sed -i 's|accounts\.csv|'"$BASEDIR"'/resources/local/accounts.csv|' ${CHAINSPEC}
 
-ARGS="$@"
 # If no nodes defined, start all.
-NODES="${ARGS:-1 2 3 4 5}"
+NODES="${@:-1 2 3 4 5}"
 
 run_node() {
     ID=$1
@@ -85,10 +84,8 @@ run_node() {
     sleep 1;
 }
 
-for i in 1 2 3 4 5; do
-    case "$NODES" in
-        *"$i"*) run_node $i
-    esac
+for i in $NODES; do
+    run_node $i
 done;
 
 echo "Test network starting."

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -7,10 +7,12 @@ set -eu
 BASEDIR=$(readlink -f $(dirname $0))
 CHAINSPEC=$(mktemp -t chainspec_XXXXXXXX --suffix .toml)
 TRUSTED_HASH="${TRUSTED_HASH:-}"
+
+# Generate a genesis timestamp 30 seconds into the future, unless explicity given a different one.
 OFFSET="${OFFSET:-30}"
 TIMESTAMP=${GENESIS_TIMESTAMP:-$(date '+%s000' -d "+$OFFSET sec")}
-echo "GENESIS_TIMESTAMP=${TIMESTAMP}"
-date -d @$(($TIMESTAMP/1000))
+
+echo "GENESIS_TIMESTAMP=${TIMESTAMP}  [$(date -d @$(($TIMESTAMP/1000)))]"
 
 # Build the node first, so that `sleep` in the loop has an effect.
 cargo build -p casper-node


### PR DESCRIPTION
Initiates a collection of memory usage metrics roughly every 30 seconds, which are also logged.

In passing, fixes a bug where twice as many events as should be were counted.