### PR TITLE
NDRS-430: Put slashing and reward information in the switch block only.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -33,10 +33,6 @@ use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 use traits::NodeIdT;
 
-// We use one trillion as a block reward unit because it's large enough to allow precise
-// fractions, and small enough for many block rewards to fit into a u64.
-pub(crate) const BLOCK_REWARD: u64 = 1_000_000_000_000;
-
 #[derive(DataSize, Clone, Serialize, Deserialize)]
 pub struct ConsensusMessage {
     era_id: EraId,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -25,13 +25,17 @@ use crate::{
     types::{ProtoBlock, Timestamp},
 };
 pub use config::Config;
-pub(crate) use consensus_protocol::BlockContext;
+pub(crate) use consensus_protocol::{BlockContext, EraEnd};
 use derive_more::From;
 pub(crate) use era_supervisor::{EraId, EraSupervisor};
 use hex_fmt::HexFmt;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 use traits::NodeIdT;
+
+// We use one trillion as a block reward unit because it's large enough to allow precise
+// fractions, and small enough for many block rewards to fit into a u64.
+pub(crate) const BLOCK_REWARD: u64 = 1_000_000_000_000;
 
 #[derive(DataSize, Clone, Serialize, Deserialize)]
 pub struct ConsensusMessage {

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -40,7 +40,7 @@ impl BlockContext {
     deserialize = "VID: Ord + Deserialize<'de>",
 ))]
 pub struct EraEnd<VID> {
-    /// The set of newly detected equivocators.
+    /// The set of equivocators.
     pub(crate) equivocators: Vec<VID>,
     /// Rewards for finalization of earlier blocks.
     ///

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, fmt::Debug};
 use anyhow::Error;
 use datasize::DataSize;
 use rand::{CryptoRng, Rng};
+use serde::{Deserialize, Serialize};
 
 use crate::{components::consensus::traits::ConsensusValueT, types::Timestamp};
 
@@ -32,6 +33,22 @@ impl BlockContext {
     }
 }
 
+/// Equivocation and reward information to be included in the terminal finalized block.
+#[derive(Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "VID: Ord + Serialize",
+    deserialize = "VID: Ord + Deserialize<'de>",
+))]
+pub struct EraEnd<VID> {
+    /// The set of newly detected equivocators.
+    pub(crate) equivocators: Vec<VID>,
+    /// Rewards for finalization of earlier blocks.
+    ///
+    /// This is a measure of the value of each validator's contribution to consensus, in
+    /// fractions of the configured maximum block reward.
+    pub(crate) rewards: BTreeMap<VID, u64>,
+}
+
 /// A finalized block. All nodes are guaranteed to see the same sequence of blocks, and to agree
 /// about all the information contained in this type, as long as the total weight of faulty
 /// validators remains below the threshold.
@@ -39,19 +56,13 @@ impl BlockContext {
 pub(crate) struct FinalizedBlock<C: ConsensusValueT, VID> {
     /// The finalized value.
     pub(crate) value: C,
-    /// The set of newly detected equivocators.
-    pub(crate) new_equivocators: Vec<VID>,
-    /// Rewards for finalization of earlier blocks.
-    ///
-    /// This is a measure of the value of each validator's contribution to consensus, in
-    /// fractions of the configured maximum block reward.
-    pub(crate) rewards: BTreeMap<VID, u64>,
     /// The timestamp at which this value was proposed.
     pub(crate) timestamp: Timestamp,
     /// The relative height in this instance of the protocol.
     pub(crate) height: u64,
-    /// Whether this is a terminal block, i.e. the last one to be finalized.
-    pub(crate) terminal: bool,
+    /// If this is a terminal block, i.e. the last one to be finalized, this includes reward and
+    /// equivocator information.
+    pub(crate) era_end: Option<EraEnd<VID>>,
     /// Proposer of this value
     pub(crate) proposer: VID,
 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -238,7 +238,6 @@ where
         let ftt = validators.total_weight()
             * u64::from(self.highway_config().finality_threshold_percent)
             / 100;
-        // The number of rounds after which a block reward is paid out.
         // TODO: The initial round length should be the observed median of the switch block.
         let params = Params::new(
             0, // TODO: get a proper seed.
@@ -396,7 +395,7 @@ where
             trace!("executed block in old era {}", block_header.era_id().0);
             return effects;
         }
-        if block_header.era_end().is_some() {
+        if block_header.switch_block() {
             // TODO: Learn the new weights from contract (validator rotation).
             let validator_stakes = self.era_supervisor.validator_stakes.clone();
             self.era_supervisor

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -16,7 +16,6 @@ use blake2::{
     digest::{Input, VariableOutput},
     VarBlake2b,
 };
-use casper_types::U512;
 use datasize::DataSize;
 use fmt::Display;
 use num_traits::AsPrimitive;
@@ -25,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, info, trace};
 
 use casper_execution_engine::shared::motes::Motes;
+use casper_types::{auction::BLOCK_REWARD, U512};
 
 use crate::{
     components::{
@@ -37,7 +37,7 @@ use crate::{
             highway_core::{highway::Params, validators::Validators},
             protocols::highway::{HighwayContext, HighwayProtocol, HighwaySecret},
             traits::NodeIdT,
-            Config, ConsensusMessage, Event, ReactorEventT, BLOCK_REWARD,
+            Config, ConsensusMessage, Event, ReactorEventT,
         },
     },
     crypto::{

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -1,5 +1,3 @@
-use tracing::error;
-
 use super::Horizon;
 use crate::{
     components::consensus::{
@@ -29,11 +27,10 @@ pub(crate) fn compute_rewards<C: Context>(state: &State<C>, bhash: &C::Hash) -> 
         for (vidx, r) in compute_rewards_for(state, panorama, proposal_hash).enumerate() {
             match rewards[vidx].checked_add(*r) {
                 Some(sum) => rewards[vidx] = sum,
-                None => {
-                    let r0 = rewards[vidx];
-                    error!("rewards for {:?}, {} + {}, saturate u64", vidx, r0, r);
-                    rewards[vidx] = u64::MAX;
-                }
+                None => panic!(
+                    "rewards for {:?}, {} + {}, overflow u64",
+                    vidx, rewards[vidx], r
+                ),
             }
         }
         prev_block = state.block(proposal_hash);

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -25,8 +25,8 @@ pub(crate) fn compute_rewards<C: Context>(state: &State<C>, bhash: &C::Hash) -> 
     let panorama = &payout_vote.panorama;
     let mut rewards = ValidatorMap::from(vec![0u64; panorama.len()]);
     let mut prev_block = payout_block;
-    while let Some(prop_hash) = prev_block.parent() {
-        for (vidx, r) in compute_rewards_for(state, panorama, prop_hash).enumerate() {
+    while let Some(proposal_hash) = prev_block.parent() {
+        for (vidx, r) in compute_rewards_for(state, panorama, proposal_hash).enumerate() {
             match rewards[vidx].checked_add(*r) {
                 Some(sum) => rewards[vidx] = sum,
                 None => {

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -36,7 +36,7 @@ pub(crate) fn compute_rewards<C: Context>(state: &State<C>, bhash: &C::Hash) -> 
                 }
             }
         }
-        prev_block = state.block(prop_hash);
+        prev_block = state.block(proposal_hash);
     }
     rewards
 }

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -14,14 +14,7 @@ pub(crate) use weight::Weight;
 pub(super) use panorama::{Observation, Panorama};
 pub(super) use vote::Vote;
 
-use std::{
-    borrow::Borrow,
-    cmp::Ordering,
-    collections::{BTreeMap, BTreeSet, HashMap},
-    convert::identity,
-    iter,
-    ops::RangeBounds,
-};
+use std::{borrow::Borrow, cmp::Ordering, collections::HashMap, convert::identity, iter};
 
 use itertools::Itertools;
 use rand::{Rng, SeedableRng};
@@ -97,8 +90,6 @@ pub(crate) struct State<C: Context> {
     votes: HashMap<C::Hash, Vote<C>>,
     /// All blocks, by hash.
     blocks: HashMap<C::Hash, Block<C>>,
-    /// All block hashes, by the earliest time at which rewards for the blocks' rounds can be paid.
-    reward_index: BTreeMap<Timestamp, BTreeSet<C::Hash>>,
     /// Evidence to prove a validator malicious, by index.
     evidence: HashMap<ValidatorIndex, Evidence<C>>,
     /// The full panorama, corresponding to the complete protocol state.
@@ -130,7 +121,6 @@ impl<C: Context> State<C> {
             cumulative_w,
             votes: HashMap::new(),
             blocks: HashMap::new(),
-            reward_index: BTreeMap::new(),
             evidence: HashMap::new(),
             panorama,
         }
@@ -220,17 +210,6 @@ impl<C: Context> State<C> {
         self.opt_block(hash).expect("block hash must exist")
     }
 
-    /// Returns an iterator over all hashes of blocks whose earliest timestamp for reward payout is
-    /// in the specified range.
-    pub(crate) fn rewards_range<RB>(&self, range: RB) -> impl Iterator<Item = &C::Hash>
-    where
-        RB: RangeBounds<Timestamp>,
-    {
-        self.reward_index
-            .range(range)
-            .flat_map(|(_, blocks)| blocks)
-    }
-
     /// Returns the complete protocol state's latest panorama.
     pub(crate) fn panorama(&self) -> &Panorama<C> {
         &self.panorama
@@ -259,10 +238,6 @@ impl<C: Context> State<C> {
         let (vote, opt_value) = Vote::new(swvote, fork_choice.as_ref(), self);
         if let Some(value) = opt_value {
             let block = Block::new(fork_choice, value, self);
-            self.reward_index
-                .entry(self.reward_time(&vote))
-                .or_default()
-                .insert(hash.clone());
             self.blocks.insert(hash.clone(), block);
         }
         self.votes.insert(hash, vote);
@@ -453,11 +428,6 @@ impl<C: Context> State<C> {
         self.panorama[wvote.creator] = new_obs;
     }
 
-    /// Returns the earliest time at which rewards for a block introduced by this vote can be paid.
-    pub(super) fn reward_time(&self, vote: &Vote<C>) -> Timestamp {
-        vote.timestamp + vote.round_len() * self.params.reward_delay()
-    }
-
     /// Returns the hash of the message with the given sequence number from the creator of `hash`,
     /// or `None` if the sequence number is higher than that of the vote with `hash`.
     fn find_in_swimlane<'a>(&'a self, hash: &'a C::Hash, seq_number: u64) -> Option<&'a C::Hash> {
@@ -488,27 +458,6 @@ impl<C: Context> State<C> {
             next = vote.previous();
             Some((current, vote))
         })
-    }
-
-    /// Returns a vector of validator indexes that equivocated between block
-    /// identified by `fhash` and its parent.
-    pub(super) fn get_new_equivocators(&self, fhash: &C::Hash) -> Vec<ValidatorIndex> {
-        let cvote = self.vote(fhash);
-        let mut equivocators: Vec<ValidatorIndex> = Vec::new();
-        let fblock = self.block(fhash);
-        let empty_panorama = Panorama::new(self.validator_count());
-        let pvpanorama = fblock
-            .parent()
-            .map(|pvhash| &self.vote(pvhash).panorama)
-            .unwrap_or(&empty_panorama);
-        for (vid, obs) in cvote.panorama.enumerate() {
-            // If validator is faulty in candidate's panorama but not in its
-            // parent, it means it's a "new" equivocator.
-            if obs.is_faulty() && !pvpanorama.get(vid).is_faulty() {
-                equivocators.push(vid)
-            }
-        }
-        equivocators
     }
 }
 

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -459,6 +459,20 @@ impl<C: Context> State<C> {
             Some((current, vote))
         })
     }
+
+    /// Returns an iterator over all hashes of ancestors of the block `bhash`, excluding `bhash`
+    /// itself. Panics if `bhash` is not the hash of a known block.
+    pub(crate) fn ancestor_hashes<'a>(
+        &'a self,
+        bhash: &'a C::Hash,
+    ) -> impl Iterator<Item = &'a C::Hash> {
+        let mut next = self.block(bhash).parent();
+        iter::from_fn(move || {
+            let current = next?;
+            next = self.block(current).parent();
+            Some(current)
+        })
+    }
 }
 
 /// Returns the round length, given the round exponent.

--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -6,7 +6,6 @@ pub(crate) struct Params {
     seed: u64,
     block_reward: u64,
     reduced_block_reward: u64,
-    reward_delay: u64,
     min_round_exp: u8,
     init_round_exp: u8,
     end_height: u64,
@@ -25,9 +24,6 @@ impl Params {
     ///   rewards in a `u64`.
     /// * `reduced_block_reward`: The reduced block reward that is paid out even if the heaviest
     ///   summit does not exceed half the total weight.
-    /// * `reward_delay`: The delay after which rewards are calculated. Rewards for a round in which
-    ///   a block B was proposed are paid out in the first block whose timestamp greater than
-    ///   `reward_delay * t` after B's timestamp, where `t` is the round length of B itself.
     /// * `min_round_exp`: The minimum round exponent. `1 << min_round_exp` milliseconds is the
     ///   minimum round length.
     /// * `end_height`, `end_timestamp`: The last block will be the first one that has at least the
@@ -37,7 +33,6 @@ impl Params {
         seed: u64,
         block_reward: u64,
         reduced_block_reward: u64,
-        reward_delay: u64,
         min_round_exp: u8,
         end_height: u64,
         end_timestamp: Timestamp,
@@ -50,7 +45,6 @@ impl Params {
             seed,
             block_reward,
             reduced_block_reward,
-            reward_delay,
             min_round_exp,
             init_round_exp: min_round_exp, // TODO: The median seen by previous era's switch block?
             end_height,
@@ -72,12 +66,6 @@ impl Params {
     /// exceed half the total weight. This is at most `block_reward`.
     pub(crate) fn reduced_block_reward(&self) -> u64 {
         self.reduced_block_reward
-    }
-
-    /// Returns the delay after which rewards for a block are paid out, in multiples of the round
-    /// length of that block.
-    pub(crate) fn reward_delay(&self) -> u64 {
-        self.reward_delay
     }
 
     /// Returns the minimum round exponent. `1 << self.min_round_exp()` milliseconds is the minimum

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -7,10 +7,7 @@ use rand::{CryptoRng, Rng, RngCore};
 use super::*;
 use crate::{
     components::consensus::{
-        highway_core::{
-            highway::Dependency,
-            highway_testing::{TEST_BLOCK_REWARD, TEST_REWARD_DELAY},
-        },
+        highway_core::{highway::Dependency, highway_testing::TEST_BLOCK_REWARD},
         traits::ValidatorSecret,
     },
     testing::TestRng,
@@ -110,7 +107,6 @@ impl State<TestContext> {
             seed,
             TEST_BLOCK_REWARD,
             TEST_BLOCK_REWARD / 5,
-            TEST_REWARD_DELAY,
             4,
             u64::MAX,
             Timestamp::from(u64::MAX),

--- a/node/src/components/consensus/tests/consensus_des_testing.rs
+++ b/node/src/components/consensus/tests/consensus_des_testing.rs
@@ -134,7 +134,10 @@ where
         &mut self.validator
     }
 
-    pub(crate) fn new_equivocators<I: Iterator<Item = ValidatorId>>(&mut self, equivocators: I) {
+    pub(crate) fn new_equivocators<I>(&mut self, equivocators: I)
+    where
+        I: IntoIterator<Item = ValidatorId>,
+    {
         self.equivocators_seen.extend(equivocators);
     }
 

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -9,9 +9,7 @@ mod status_feed;
 mod timestamp;
 
 pub use block::{Block, BlockHash, BlockHeader};
-pub(crate) use block::{
-    BlockByHeight, BlockLike, FinalizedBlock, ProtoBlock, ProtoBlockHash, SystemTransaction,
-};
+pub(crate) use block::{BlockByHeight, BlockLike, FinalizedBlock, ProtoBlock, ProtoBlockHash};
 pub use deploy::{Approval, Deploy, DeployHash, DeployHeader, Error as DeployError};
 pub use item::{Item, Tag};
 pub use node_config::NodeConfig;

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -19,19 +19,23 @@ use serde_json::{json, Value as JsonValue};
 use thiserror::Error;
 
 use super::{Item, Tag, Timestamp};
+#[cfg(test)]
 use crate::{
-    components::{consensus::EraId, storage::Value},
+    components::consensus::BLOCK_REWARD,
+    crypto::asymmetric_key::{self, SecretKey},
+    testing::TestRng,
+};
+use crate::{
+    components::{
+        consensus::{self, EraId},
+        storage::Value,
+    },
     crypto::{
         asymmetric_key::{PublicKey, Signature},
         hash::{self, Digest},
     },
     types::DeployHash,
     utils::DisplayIter,
-};
-#[cfg(test)]
-use crate::{
-    crypto::asymmetric_key::{self, SecretKey},
-    testing::TestRng,
 };
 
 /// Error returned from constructing or validating a `Block`.
@@ -180,48 +184,18 @@ impl BlockLike for ProtoBlock {
     }
 }
 
-/// System transactions like slashing and rewards.
-#[derive(Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum SystemTransaction {
-    /// A validator has equivocated and should be slashed.
-    Slash(PublicKey),
-    /// Block reward information, in trillionths (10^-12) of the total reward for one block.
-    /// This includes the delegator reward.
-    Rewards(BTreeMap<PublicKey, u64>),
-}
+/// Equivocation and reward information to be included in the terminal finalized block.
+pub type EraEnd = consensus::EraEnd<PublicKey>;
 
-impl SystemTransaction {
-    /// Generates a random instance using a `TestRng`.
-    #[cfg(test)]
-    pub fn random(rng: &mut TestRng) -> Self {
-        if rng.gen() {
-            SystemTransaction::Slash(PublicKey::random(rng))
-        } else {
-            let count = rng.gen_range(2, 11);
-            let rewards = iter::repeat_with(|| {
-                let public_key = PublicKey::random(rng);
-                let amount = rng.gen();
-                (public_key, amount)
-            })
-            .take(count)
-            .collect();
-            SystemTransaction::Rewards(rewards)
-        }
-    }
-}
-
-impl Display for SystemTransaction {
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            SystemTransaction::Slash(public_key) => write!(formatter, "slash {}", public_key),
-            SystemTransaction::Rewards(rewards) => {
-                let rewards = rewards
-                    .iter()
-                    .map(|(public_key, amount)| format!("{}: {}", public_key, amount))
-                    .collect::<Vec<_>>();
-                write!(formatter, "rewards [{}]", DisplayIter::new(rewards.iter()))
-            }
-        }
+impl Display for EraEnd {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let slashings = DisplayIter::new(&self.equivocators);
+        let rewards = DisplayIter::new(
+            self.rewards
+                .iter()
+                .map(|(public_key, amount)| format!("{}: {}", public_key, amount)),
+        );
+        write!(f, "era end: slash {}, reward {}", slashings, rewards)
     }
 }
 
@@ -231,8 +205,7 @@ impl Display for SystemTransaction {
 pub struct FinalizedBlock {
     proto_block: ProtoBlock,
     timestamp: Timestamp,
-    system_transactions: Vec<SystemTransaction>,
-    switch_block: bool,
+    era_end: Option<EraEnd>,
     era_id: EraId,
     height: u64,
     proposer: PublicKey,
@@ -242,8 +215,7 @@ impl FinalizedBlock {
     pub(crate) fn new(
         proto_block: ProtoBlock,
         timestamp: Timestamp,
-        system_transactions: Vec<SystemTransaction>,
-        switch_block: bool,
+        era_end: Option<EraEnd>,
         era_id: EraId,
         height: u64,
         proposer: PublicKey,
@@ -251,8 +223,7 @@ impl FinalizedBlock {
         FinalizedBlock {
             proto_block,
             timestamp,
-            system_transactions,
-            switch_block,
+            era_end,
             era_id,
             height,
             proposer,
@@ -267,11 +238,6 @@ impl FinalizedBlock {
     /// The timestamp from when the proto block was proposed.
     pub(crate) fn timestamp(&self) -> Timestamp {
         self.timestamp
-    }
-
-    /// Instructions for system transactions like slashing and rewards.
-    pub(crate) fn system_transactions(&self) -> &Vec<SystemTransaction> {
-        &self.system_transactions
     }
 
     /// Returns the ID of the era this block belongs to.
@@ -295,21 +261,13 @@ impl From<BlockHeader> for FinalizedBlock {
     fn from(header: BlockHeader) -> Self {
         let proto_block = ProtoBlock::new(header.deploy_hashes().clone(), header.random_bit);
 
-        let timestamp = header.timestamp();
-        let switch_block = header.switch_block;
-        let era_id = header.era_id;
-        let height = header.height;
-        let proposer = header.proposer;
-        let system_transactions = header.system_transactions;
-
         FinalizedBlock {
             proto_block,
-            timestamp,
-            system_transactions,
-            switch_block,
-            era_id,
-            height,
-            proposer,
+            timestamp: header.timestamp,
+            era_end: header.era_end,
+            era_id: header.era_id,
+            height: header.height,
+            proposer: header.proposer,
         }
     }
 }
@@ -318,17 +276,19 @@ impl Display for FinalizedBlock {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
-            "finalized {}block {:10} in era {:?}, height {}, deploys {:10}, random bit {}, \
-            timestamp {}, system_transactions: [{}]",
-            if self.switch_block { "switch " } else { "" },
+            "finalized block {:10} in era {:?}, height {}, deploys {:10}, random bit {}, \
+            timestamp {}",
             HexFmt(self.proto_block.hash().inner()),
             self.era_id,
             self.height,
             HexList(&self.proto_block.deploys),
             self.proto_block.random_bit,
-            self.timestamp(),
-            DisplayIter::new(self.system_transactions().iter())
-        )
+            self.timestamp,
+        )?;
+        if let Some(ee) = &self.era_end {
+            write!(formatter, ", era_end: {}", ee)?;
+        }
+        Ok(())
     }
 }
 
@@ -376,9 +336,8 @@ pub struct BlockHeader {
     body_hash: Digest,
     deploy_hashes: Vec<DeployHash>,
     random_bit: bool,
-    switch_block: bool,
+    era_end: Option<EraEnd>,
     timestamp: Timestamp,
-    system_transactions: Vec<SystemTransaction>,
     era_id: EraId,
     height: u64,
     proposer: PublicKey,
@@ -405,11 +364,6 @@ impl BlockHeader {
         &self.deploy_hashes
     }
 
-    /// Returns `true` if this is the last block of an era.
-    pub fn switch_block(&self) -> bool {
-        self.switch_block
-    }
-
     /// A random bit needed for initializing a future era.
     pub fn random_bit(&self) -> bool {
         self.random_bit
@@ -420,9 +374,9 @@ impl BlockHeader {
         self.timestamp
     }
 
-    /// Instructions for system transactions like slashing and rewards.
-    pub fn system_transactions(&self) -> &Vec<SystemTransaction> {
-        &self.system_transactions
+    /// Returns reward and slashing information if this is the era's last block.
+    pub fn era_end(&self) -> Option<&EraEnd> {
+        self.era_end.as_ref()
     }
 
     /// Era ID in which this block was created.
@@ -464,16 +418,18 @@ impl Display for BlockHeader {
         write!(
             formatter,
             "block header parent hash {}, post-state hash {}, body hash {}, deploys [{}], \
-            random bit {}, switch block {}, timestamp {}, system_transactions [{}]",
+            random bit {}, timestamp {}",
             self.parent_hash.inner(),
             self.global_state_hash,
             self.body_hash,
             DisplayIter::new(self.deploy_hashes.iter()),
             self.random_bit,
-            self.switch_block,
             self.timestamp,
-            DisplayIter::new(self.system_transactions.iter()),
-        )
+        )?;
+        if let Some(ee) = &self.era_end {
+            write!(formatter, ", era_end: {}", ee)?;
+        }
+        Ok(())
     }
 }
 
@@ -507,9 +463,8 @@ impl Block {
             body_hash,
             deploy_hashes: finalized_block.proto_block.deploys,
             random_bit: finalized_block.proto_block.random_bit,
-            switch_block: finalized_block.switch_block,
+            era_end: finalized_block.era_end,
             timestamp: finalized_block.timestamp,
-            system_transactions: finalized_block.system_transactions,
             era_id,
             height,
             proposer: finalized_block.proposer,
@@ -583,11 +538,26 @@ impl Block {
 
         // TODO - make Timestamp deterministic.
         let timestamp = Timestamp::now();
-        let system_transactions_count = rng.gen_range(1, 11);
-        let system_transactions = iter::repeat_with(|| SystemTransaction::random(rng))
-            .take(system_transactions_count)
-            .collect();
-        let switch_block = rng.gen_bool(0.1);
+        let era_end = if rng.gen_bool(0.1) {
+            let equivocators_count = rng.gen_range(0, 5);
+            let rewards_count = rng.gen_range(0, 5);
+            Some(EraEnd {
+                equivocators: iter::repeat_with(|| {
+                    PublicKey::from(&SecretKey::new_ed25519(rng.gen()))
+                })
+                .take(equivocators_count)
+                .collect(),
+                rewards: iter::repeat_with(|| {
+                    let pub_key = PublicKey::from(&SecretKey::new_ed25519(rng.gen()));
+                    let reward = rng.gen_range(1, BLOCK_REWARD + 1);
+                    (pub_key, reward)
+                })
+                .take(rewards_count)
+                .collect(),
+            })
+        } else {
+            None
+        };
         let era = rng.gen_range(0, 5);
         let secret_key: SecretKey = SecretKey::new_ed25519(rng.gen());
         let public_key = PublicKey::from(&secret_key);
@@ -595,8 +565,7 @@ impl Block {
         let finalized_block = FinalizedBlock::new(
             proto_block,
             timestamp,
-            system_transactions,
-            switch_block,
+            era_end,
             EraId(era),
             era * 10 + rng.gen_range(0, 10),
             public_key,
@@ -623,7 +592,7 @@ impl Display for Block {
         write!(
             formatter,
             "executed block {}, parent hash {}, post-state hash {}, body hash {}, deploys [{}], \
-            random bit {}, timestamp {}, era_id {}, height {}, system_transactions [{}], proofs count {}",
+            random bit {}, timestamp {}, era_id {}, height {}, proofs count {}",
             self.hash.inner(),
             self.header.parent_hash.inner(),
             self.header.global_state_hash,
@@ -633,9 +602,12 @@ impl Display for Block {
             self.header.timestamp,
             self.header.era_id.0,
             self.header.height,
-            DisplayIter::new(self.header.system_transactions.iter()),
             self.proofs.len()
-        )
+        )?;
+        if let Some(ee) = &self.header.era_end {
+            write!(formatter, ", era_end: {}", ee)?;
+        }
+        Ok(())
     }
 }
 
@@ -716,45 +688,49 @@ mod json {
     }
 
     #[derive(Serialize, Deserialize)]
-    enum JsonSystemTransaction {
-        Slash(String),
-        Rewards(BTreeMap<String, u64>),
+    struct JsonEraEnd {
+        equivocators: Vec<String>,
+        rewards: BTreeMap<String, u64>,
     }
 
-    impl From<&SystemTransaction> for JsonSystemTransaction {
-        fn from(txn: &SystemTransaction) -> Self {
-            match txn {
-                SystemTransaction::Slash(public_key) => {
-                    JsonSystemTransaction::Slash(public_key.to_hex())
-                }
-                SystemTransaction::Rewards(map) => JsonSystemTransaction::Rewards(
-                    map.iter()
-                        .map(|(public_key, amount)| (public_key.to_hex(), *amount))
-                        .collect(),
-                ),
+    impl From<&EraEnd> for JsonEraEnd {
+        fn from(era_end: &EraEnd) -> Self {
+            JsonEraEnd {
+                equivocators: era_end.equivocators.iter().map(PublicKey::to_hex).collect(),
+                rewards: era_end
+                    .rewards
+                    .iter()
+                    .map(|(pub_key, amount)| (pub_key.to_hex(), *amount))
+                    .collect(),
             }
         }
     }
 
-    impl TryFrom<JsonSystemTransaction> for SystemTransaction {
+    impl TryFrom<JsonEraEnd> for EraEnd {
         type Error = Error;
 
-        fn try_from(json_txn: JsonSystemTransaction) -> Result<Self, Self::Error> {
-            match json_txn {
-                JsonSystemTransaction::Slash(hex_public_key) => Ok(SystemTransaction::Slash(
-                    PublicKey::from_hex(&hex_public_key)
-                        .map_err(|error| Error::DecodeFromJson(Box::new(error)))?,
-                )),
-                JsonSystemTransaction::Rewards(json_map) => {
-                    let mut map = BTreeMap::new();
-                    for (hex_public_key, amount) in json_map.iter() {
-                        let public_key = PublicKey::from_hex(&hex_public_key)
-                            .map_err(|error| Error::DecodeFromJson(Box::new(error)))?;
-                        let _ = map.insert(public_key, *amount);
-                    }
-                    Ok(SystemTransaction::Rewards(map))
-                }
-            }
+        fn try_from(era_end: JsonEraEnd) -> Result<Self, Self::Error> {
+            let equivocators = era_end
+                .equivocators
+                .into_iter()
+                .map(|pub_key_str| {
+                    PublicKey::from_hex(pub_key_str)
+                        .map_err(|error| Error::DecodeFromJson(Box::new(error)))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let rewards = era_end
+                .rewards
+                .into_iter()
+                .map(|(pub_key_str, amount): (String, u64)| {
+                    PublicKey::from_hex(pub_key_str)
+                        .map_err(|error| Error::DecodeFromJson(Box::new(error)))
+                        .map(|pub_key| (pub_key, amount))
+                })
+                .collect::<Result<BTreeMap<_, _>, _>>()?;
+            Ok(EraEnd {
+                equivocators,
+                rewards,
+            })
         }
     }
 
@@ -765,9 +741,8 @@ mod json {
         body_hash: String,
         deploy_hashes: Vec<String>,
         random_bit: bool,
-        switch_block: bool,
         timestamp: Timestamp,
-        system_transactions: Vec<JsonSystemTransaction>,
+        era_end: Option<JsonEraEnd>,
         era_id: EraId,
         height: u64,
         proposer: String,
@@ -785,9 +760,8 @@ mod json {
                     .map(|deploy_hash| hex::encode(deploy_hash.as_ref()))
                     .collect(),
                 random_bit: header.random_bit,
-                switch_block: header.switch_block,
                 timestamp: header.timestamp,
-                system_transactions: header.system_transactions.iter().map(Into::into).collect(),
+                era_end: header.era_end.as_ref().map(JsonEraEnd::from),
                 era_id: header.era_id,
                 height: header.height,
                 proposer: header.proposer.to_hex(),
@@ -799,12 +773,6 @@ mod json {
         type Error = Error;
 
         fn try_from(header: JsonBlockHeader) -> Result<Self, Self::Error> {
-            let mut system_transactions = vec![];
-            for json_txn in header.system_transactions {
-                let txn = json_txn.try_into()?;
-                system_transactions.push(txn);
-            }
-
             let mut deploy_hashes = vec![];
             for hex_deploy_hash in header.deploy_hashes.iter() {
                 let hash = Digest::from_hex(&hex_deploy_hash)
@@ -826,9 +794,8 @@ mod json {
                     .map_err(|error| Error::DecodeFromJson(Box::new(error)))?,
                 deploy_hashes,
                 random_bit: header.random_bit,
-                switch_block: header.switch_block,
                 timestamp: header.timestamp,
-                system_transactions,
+                era_end: header.era_end.map(EraEnd::try_from).transpose()?,
                 era_id: header.era_id,
                 height: header.height,
                 proposer,

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -18,13 +18,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use thiserror::Error;
 
-use super::{Item, Tag, Timestamp};
 #[cfg(test)]
-use crate::{
-    components::consensus::BLOCK_REWARD,
-    crypto::asymmetric_key::{self, SecretKey},
-    testing::TestRng,
-};
+use casper_types::auction::BLOCK_REWARD;
+
+use super::{Item, Tag, Timestamp};
 use crate::{
     components::{
         consensus::{self, EraId},
@@ -36,6 +33,11 @@ use crate::{
     },
     types::DeployHash,
     utils::DisplayIter,
+};
+#[cfg(test)]
+use crate::{
+    crypto::asymmetric_key::{self, SecretKey},
+    testing::TestRng,
 };
 
 /// Error returned from constructing or validating a `Block`.

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -379,6 +379,11 @@ impl BlockHeader {
         self.era_end.as_ref()
     }
 
+    /// Returns `true` if this block is the last one in the current era.
+    pub fn switch_block(&self) -> bool {
+        self.era_end.is_some()
+    }
+
     /// Era ID in which this block was created.
     pub fn era_id(&self) -> EraId {
         self.era_id

--- a/types/src/auction/constants.rs
+++ b/types/src/auction/constants.rs
@@ -19,6 +19,10 @@ pub const INITIAL_ERA_ID: EraId = 0;
 /// Default lock period for new bid entries represented in eras.
 pub const DEFAULT_LOCKED_FUNDS_PERIOD: EraId = 15;
 
+/// We use one trillion as a block reward unit because it's large enough to allow precise
+/// fractions, and small enough for many block rewards to fit into a u64.
+pub const BLOCK_REWARD: u64 = 1_000_000_000_000;
+
 /// Named constant for `amount`.
 pub const ARG_AMOUNT: &str = "amount";
 /// Named constant for `delegation_rate`.


### PR DESCRIPTION
This removes `SystemTransactions` and replaces them with an `EraEnd` struct that contains a list of validators to be slashed, and a map of rewards. This will only be contained in the last block of each era (switch block).

The `compute_rewards_test` was updated: Rewards are always applied to all ancestors of the payout block, which in production will be the switch block.

To make the test easier to read, the rewards for individual ancestors are also verified.

Quora in reward calculation apply only to level-1 summits, and don't include the faulty validators. Such a summit finalizes the block if and only if it has > 50% of the weight, regardless of the already known faulty validators. This was incorrect in `compute_rewards_for`.

https://casperlabs.atlassian.net/browse/NDRS-430