### PR TITLE
EE-1043: step function

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1894,7 +1894,6 @@ where
                 return Ok(StepResult::Serialization(error));
             }
         };
-        println!("slashed_validators {:?}", slashed_validators);
 
         let slash_args = runtime_args! {"validator_public_keys" => slashed_validators};
 
@@ -1902,6 +1901,58 @@ where
             DirectSystemContractCall::Slash,
             auction_module.clone(),
             slash_args,
+            &mut named_keys,
+            Default::default(),
+            base_key,
+            &system_account,
+            authorization_keys.clone(),
+            BlockTime::default(),
+            deploy_hash,
+            gas_limit,
+            step_request.protocol_version,
+            correlation_id,
+            Rc::clone(&tracking_copy),
+            Phase::Session,
+            protocol_data,
+            SystemContractCache::clone(&self.system_contract_cache),
+        );
+
+        if execution_result.has_precondition_failure() {
+            return Ok(StepResult::PreconditionError);
+        }
+
+        let distribute_args = runtime_args! {}; // TODO: distribute args?
+
+        let (_, execution_result): (Option<()>, ExecutionResult) = executor.exec_system_contract(
+            DirectSystemContractCall::DistributeRewards,
+            auction_module.clone(),
+            distribute_args,
+            &mut named_keys,
+            Default::default(),
+            base_key,
+            &system_account,
+            authorization_keys.clone(),
+            BlockTime::default(),
+            deploy_hash,
+            gas_limit,
+            step_request.protocol_version,
+            correlation_id,
+            Rc::clone(&tracking_copy),
+            Phase::Session,
+            protocol_data,
+            SystemContractCache::clone(&self.system_contract_cache),
+        );
+
+        if execution_result.has_precondition_failure() {
+            return Ok(StepResult::PreconditionError);
+        }
+
+        let run_auction_args = runtime_args! {};
+
+        let (_, execution_result): (Option<()>, ExecutionResult) = executor.exec_system_contract(
+            DirectSystemContractCall::RunAuction,
+            auction_module.clone(),
+            run_auction_args,
             &mut named_keys,
             Default::default(),
             base_key,

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -10,6 +10,7 @@ pub mod genesis;
 pub mod op;
 pub mod query;
 pub mod run_genesis_request;
+pub mod step;
 pub mod system_contract_cache;
 mod transfer;
 pub mod upgrade;

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1947,30 +1947,33 @@ where
             return Ok(StepResult::PreconditionError);
         }
 
-        let run_auction_args = runtime_args! {};
+        if step_request.run_auction {
+            let run_auction_args = runtime_args! {};
 
-        let (_, execution_result): (Option<()>, ExecutionResult) = executor.exec_system_contract(
-            DirectSystemContractCall::RunAuction,
-            auction_module.clone(),
-            run_auction_args,
-            &mut named_keys,
-            Default::default(),
-            base_key,
-            &system_account,
-            authorization_keys.clone(),
-            BlockTime::default(),
-            deploy_hash,
-            gas_limit,
-            step_request.protocol_version,
-            correlation_id,
-            Rc::clone(&tracking_copy),
-            Phase::Session,
-            protocol_data,
-            SystemContractCache::clone(&self.system_contract_cache),
-        );
+            let (_, execution_result): (Option<()>, ExecutionResult) = executor
+                .exec_system_contract(
+                    DirectSystemContractCall::RunAuction,
+                    auction_module.clone(),
+                    run_auction_args,
+                    &mut named_keys,
+                    Default::default(),
+                    base_key,
+                    &system_account,
+                    authorization_keys.clone(),
+                    BlockTime::default(),
+                    deploy_hash,
+                    gas_limit,
+                    step_request.protocol_version,
+                    correlation_id,
+                    Rc::clone(&tracking_copy),
+                    Phase::Session,
+                    protocol_data,
+                    SystemContractCache::clone(&self.system_contract_cache),
+                );
 
-        if execution_result.has_precondition_failure() {
-            return Ok(StepResult::PreconditionError);
+            if execution_result.has_precondition_failure() {
+                return Ok(StepResult::PreconditionError);
+            }
         }
 
         let effects = tracking_copy.borrow().effect();

--- a/execution_engine/src/core/engine_state/step.rs
+++ b/execution_engine/src/core/engine_state/step.rs
@@ -1,0 +1,60 @@
+use std::vec::Vec;
+
+use casper_types::{ProtocolVersion, U512};
+
+use crate::shared::newtypes::Blake2bHash;
+
+#[derive(Debug)]
+pub struct SlashItem {
+    pub validator_id: Vec<u8>,
+    pub value: U512,
+}
+
+impl SlashItem {
+    pub fn new(validator_id: Vec<u8>, value: U512) -> Self {
+        Self {
+            validator_id,
+            value,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RewardItem {
+    pub validator_id: Vec<u8>,
+    pub value: U512,
+}
+
+impl RewardItem {
+    pub fn new(validator_id: Vec<u8>, value: U512) -> Self {
+        Self {
+            validator_id,
+            value,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct StepRequest {
+    pub parent_state_hash: Blake2bHash,
+    pub protocol_version: ProtocolVersion,
+
+    pub slash_items: Vec<SlashItem>,
+    pub reward_items: Vec<RewardItem>,
+}
+
+impl StepRequest {
+    pub fn new(
+        parent_state_hash: Blake2bHash,
+        protocol_version: ProtocolVersion,
+        slash_items: Vec<SlashItem>,
+        reward_items: Vec<RewardItem>,
+    ) -> Self {
+        Self {
+            parent_state_hash,
+            protocol_version,
+            slash_items,
+            reward_items,
+        }
+    }
+}

--- a/execution_engine/src/core/engine_state/step.rs
+++ b/execution_engine/src/core/engine_state/step.rs
@@ -41,6 +41,7 @@ pub struct StepRequest {
 
     pub slash_items: Vec<SlashItem>,
     pub reward_items: Vec<RewardItem>,
+    pub run_auction: bool,
 }
 
 impl StepRequest {
@@ -49,12 +50,14 @@ impl StepRequest {
         protocol_version: ProtocolVersion,
         slash_items: Vec<SlashItem>,
         reward_items: Vec<RewardItem>,
+        run_auction: bool,
     ) -> Self {
         Self {
             parent_state_hash,
             protocol_version,
             slash_items,
             reward_items,
+            run_auction,
         }
     }
 

--- a/execution_engine/src/core/engine_state/step.rs
+++ b/execution_engine/src/core/engine_state/step.rs
@@ -11,15 +11,11 @@ use uint::static_assertions::_core::fmt::Formatter;
 #[derive(Debug)]
 pub struct SlashItem {
     pub validator_id: Vec<u8>,
-    pub value: U512,
 }
 
 impl SlashItem {
-    pub fn new(validator_id: Vec<u8>, value: U512) -> Self {
-        Self {
-            validator_id,
-            value,
-        }
+    pub fn new(validator_id: Vec<u8>) -> Self {
+        Self { validator_id }
     }
 }
 

--- a/execution_engine/src/core/execution/executor.rs
+++ b/execution_engine/src/core/execution/executor.rs
@@ -280,7 +280,9 @@ impl Executor {
         T: FromBytes + CLTyped,
     {
         match direct_system_contract_call {
-            DirectSystemContractCall::Slash => {
+            DirectSystemContractCall::Slash
+            | DirectSystemContractCall::RunAuction
+            | DirectSystemContractCall::DistributeRewards => {
                 if protocol_data.auction() != base_key.into_seed() {
                     panic!(
                         "{} should only be called with the auction contract",
@@ -584,6 +586,8 @@ impl Executor {
 
 pub enum DirectSystemContractCall {
     Slash,
+    RunAuction,
+    DistributeRewards,
     FinalizePayment,
     CreatePurse,
     Transfer,
@@ -593,6 +597,8 @@ impl DirectSystemContractCall {
     fn entry_point_name(&self) -> &str {
         match self {
             DirectSystemContractCall::Slash => "slash",
+            DirectSystemContractCall::RunAuction => "run_auction",
+            DirectSystemContractCall::DistributeRewards => "distribute_rewards",
             DirectSystemContractCall::FinalizePayment => "finalize_payment",
             DirectSystemContractCall::CreatePurse => "create",
             DirectSystemContractCall::Transfer => "transfer",
@@ -615,7 +621,9 @@ impl DirectSystemContractCall {
     {
         let entry_point_name = self.entry_point_name();
         let result = match self {
-            DirectSystemContractCall::Slash => runtime.call_host_auction(
+            DirectSystemContractCall::Slash
+            | DirectSystemContractCall::RunAuction
+            | DirectSystemContractCall::DistributeRewards => runtime.call_host_auction(
                 protocol_version,
                 entry_point_name,
                 named_keys,

--- a/grpc/server/protobuf/casper/ipc.proto
+++ b/grpc/server/protobuf/casper/ipc.proto
@@ -494,7 +494,6 @@ message StepRequest {
 
 message SlashItem{
     bytes validator_id = 1;
-    casper.state.BigInt value = 2;
 }
 
 message RewardItem {

--- a/grpc/server/protobuf/casper/ipc.proto
+++ b/grpc/server/protobuf/casper/ipc.proto
@@ -502,31 +502,20 @@ message RewardItem {
     casper.state.BigInt value = 2;
 }
 
-message NoStepOp {}
-
 message StepResponse {
-    message SlashResult {
-        oneof slash_result {
-            // effects of slashing are committed automatically, so commit result is returned in the success case
+    message StepError {
+        string message = 1;
+    }
+
+    message StepResult {
+        oneof step_result {
             CommitResult success = 1;
             RootNotFound missing_parent = 2;
-            SlashError error = 3;
-            NoStepOp no_op = 4;
+            StepError error =3;
         }
     }
 
-    message DistributeRewardsResult {
-        oneof distribute_rewards_result {
-            // effects of rewards distribution are committed automatically, so commit result is returned in the success case
-            CommitResult success = 1;
-            RootNotFound missing_parent = 2;
-            DistibuteRewardsError error = 3;
-            NoStepOp no_op = 4;
-        }
-    }
-
-    SlashResult slash_result = 1;
-    DistributeRewardsResult distribute_rewards_result = 2;
+    StepResult step_result = 1;
 }
 
 // Definition of the service.

--- a/grpc/server/protobuf/casper/ipc.proto
+++ b/grpc/server/protobuf/casper/ipc.proto
@@ -482,6 +482,53 @@ message RunGenesisRequest {
 
 // --- END PROOF-OF-STAKE SERVICE DEFINITION --- //
 
+
+message StepRequest {
+    bytes parent_state_hash = 1;
+    casper.state.ProtocolVersion protocol_version = 2;
+
+    repeated SlashItem slash_items = 3;
+    repeated RewardItem reward_items = 4;
+//    RunAuctionRequest run_auction_request = 5;
+}
+
+message SlashItem{
+    bytes validator_id = 1;
+    casper.state.BigInt value = 2;
+}
+
+message RewardItem {
+    bytes validator_id = 1;
+    casper.state.BigInt value = 2;
+}
+
+message NoStepOp {}
+
+message StepResponse {
+    message SlashResult {
+        oneof slash_result {
+            // effects of slashing are committed automatically, so commit result is returned in the success case
+            CommitResult success = 1;
+            RootNotFound missing_parent = 2;
+            SlashError error = 3;
+            NoStepOp no_op = 4;
+        }
+    }
+
+    message DistributeRewardsResult {
+        oneof distribute_rewards_result {
+            // effects of rewards distribution are committed automatically, so commit result is returned in the success case
+            CommitResult success = 1;
+            RootNotFound missing_parent = 2;
+            DistibuteRewardsError error = 3;
+            NoStepOp no_op = 4;
+        }
+    }
+
+    SlashResult slash_result = 1;
+    DistributeRewardsResult distribute_rewards_result = 2;
+}
+
 // Definition of the service.
 // ExecutionEngine implements server part while Consensus implements client part.
 service ExecutionEngineService {
@@ -496,4 +543,6 @@ service ExecutionEngineService {
     rpc distribute_rewards(DistributeRewardsRequest) returns (DistributeRewardsResponse) {}
     rpc slash(SlashRequest) returns (SlashResponse) {}
     rpc unbond_payout(UnbondPayoutRequest) returns (UnbondPayoutResponse) {}
+    // auction endpoint
+    rpc step(StepRequest) returns (StepResponse) {}
 }

--- a/grpc/server/protobuf/casper/ipc.proto
+++ b/grpc/server/protobuf/casper/ipc.proto
@@ -489,7 +489,7 @@ message StepRequest {
 
     repeated SlashItem slash_items = 3;
     repeated RewardItem reward_items = 4;
-//    RunAuctionRequest run_auction_request = 5;
+    bool run_auction = 5;
 }
 
 message SlashItem{

--- a/grpc/server/src/engine_server/mappings/ipc/mod.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/mod.rs
@@ -11,5 +11,6 @@ mod genesis_account;
 mod genesis_config;
 mod query_request;
 mod run_genesis_request;
+mod step;
 mod upgrade_request;
 mod wasm_costs;

--- a/grpc/server/src/engine_server/mappings/ipc/step.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/step.rs
@@ -118,3 +118,5 @@ impl From<StepRequest> for ipc::StepRequest {
         result
     }
 }
+
+// impl From<Vec<SlashItem>> for ipc::

--- a/grpc/server/src/engine_server/mappings/ipc/step.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/step.rs
@@ -84,11 +84,14 @@ impl TryFrom<ipc::StepRequest> for StepRequest {
             ret
         };
 
+        let run_auction = pb_step_request.get_run_auction();
+
         Ok(StepRequest::new(
             parent_state_hash,
             protocol_version,
             slash_items,
             reward_items,
+            run_auction,
         ))
     }
 }

--- a/grpc/server/src/engine_server/mappings/ipc/step.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/step.rs
@@ -1,0 +1,120 @@
+use std::convert::{TryFrom, TryInto};
+
+use casper_execution_engine::core::engine_state::step::{RewardItem, SlashItem, StepRequest};
+use casper_types::U512;
+
+use crate::engine_server::{
+    ipc,
+    mappings::{MappingError, ParsingError},
+};
+
+impl TryFrom<ipc::SlashItem> for SlashItem {
+    type Error = MappingError;
+
+    fn try_from(pb_slash_item: ipc::SlashItem) -> Result<Self, Self::Error> {
+        let validator_id = pb_slash_item
+            .get_validator_id()
+            .try_into()
+            .map_err(|_| MappingError::Parsing(ParsingError("validator_id".to_string())))?;
+        let value: U512 = pb_slash_item.get_value().clone().try_into()?;
+        Ok(SlashItem::new(validator_id, value))
+    }
+}
+
+impl From<SlashItem> for ipc::SlashItem {
+    fn from(slash_item: SlashItem) -> Self {
+        let mut result = ipc::SlashItem::new();
+        result.set_validator_id(slash_item.validator_id);
+        result.set_value(slash_item.value.into());
+        result
+    }
+}
+
+impl TryFrom<ipc::RewardItem> for RewardItem {
+    type Error = MappingError;
+
+    fn try_from(pb_reward_item: ipc::RewardItem) -> Result<Self, Self::Error> {
+        let validator_id = pb_reward_item
+            .get_validator_id()
+            .try_into()
+            .map_err(|_| MappingError::Parsing(ParsingError("validator_id".to_string())))?;
+        let value: U512 = pb_reward_item.get_value().clone().try_into()?;
+
+        Ok(RewardItem::new(validator_id, value))
+    }
+}
+
+impl From<RewardItem> for ipc::RewardItem {
+    fn from(reward_item: RewardItem) -> Self {
+        let mut result = ipc::RewardItem::new();
+        result.set_validator_id(reward_item.validator_id);
+        result.set_value(reward_item.value.into());
+        result
+    }
+}
+
+impl TryFrom<ipc::StepRequest> for StepRequest {
+    type Error = MappingError;
+
+    fn try_from(mut pb_step_request: ipc::StepRequest) -> Result<Self, Self::Error> {
+        let parent_state_hash = pb_step_request
+            .get_parent_state_hash()
+            .try_into()
+            .map_err(|_| MappingError::InvalidStateHash("parent_state_hash".to_string()))?;
+
+        let protocol_version = pb_step_request.take_protocol_version().into();
+
+        let slash_items = {
+            let mut ret: Vec<SlashItem> = vec![];
+            for item in pb_step_request.take_slash_items().into_iter() {
+                let slash_item: SlashItem = item
+                    .try_into()
+                    .map_err(|_| MappingError::Parsing(ParsingError("slash_items".to_string())))?;
+                ret.push(slash_item);
+            }
+            ret
+        };
+
+        let reward_items = {
+            let mut ret: Vec<RewardItem> = vec![];
+            for item in pb_step_request.take_reward_items().into_iter() {
+                let reward_item: RewardItem = item
+                    .try_into()
+                    .map_err(|_| MappingError::Parsing(ParsingError("reward_items".to_string())))?;
+                ret.push(reward_item);
+            }
+            ret
+        };
+
+        Ok(StepRequest::new(
+            parent_state_hash,
+            protocol_version,
+            slash_items,
+            reward_items,
+        ))
+    }
+}
+
+impl From<StepRequest> for ipc::StepRequest {
+    fn from(step_request: StepRequest) -> Self {
+        let mut result = ipc::StepRequest::new();
+        result.set_parent_state_hash(step_request.parent_state_hash.to_vec());
+        result.set_protocol_version(step_request.protocol_version.into());
+
+        result.set_slash_items(
+            step_request
+                .slash_items
+                .into_iter()
+                .map(|item| item.into())
+                .collect(),
+        );
+        result.set_reward_items(
+            step_request
+                .reward_items
+                .into_iter()
+                .map(|item| item.into())
+                .collect(),
+        );
+        result
+    }
+}

--- a/grpc/server/src/engine_server/mappings/ipc/step.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/step.rs
@@ -16,8 +16,7 @@ impl TryFrom<ipc::SlashItem> for SlashItem {
             .get_validator_id()
             .try_into()
             .map_err(|_| MappingError::Parsing(ParsingError("validator_id".to_string())))?;
-        let value: U512 = pb_slash_item.get_value().clone().try_into()?;
-        Ok(SlashItem::new(validator_id, value))
+        Ok(SlashItem::new(validator_id))
     }
 }
 
@@ -25,7 +24,6 @@ impl From<SlashItem> for ipc::SlashItem {
     fn from(slash_item: SlashItem) -> Self {
         let mut result = ipc::SlashItem::new();
         result.set_validator_id(slash_item.validator_id);
-        result.set_value(slash_item.value.into());
         result
     }
 }

--- a/grpc/server/src/engine_server/mappings/state/mod.rs
+++ b/grpc/server/src/engine_server/mappings/state/mod.rs
@@ -2,7 +2,7 @@
 //! defined in protobuf/io/casperlabs/casper/consensus/state.proto
 
 mod account;
-mod big_int;
+pub(crate) mod big_int;
 mod cl_type;
 mod cl_value;
 mod contract;

--- a/grpc/server/src/engine_server/mod.rs
+++ b/grpc/server/src/engine_server/mod.rs
@@ -52,7 +52,8 @@ use self::{
     ipc::{
         BidStateRequest, BidStateResponse, CommitRequest, CommitResponse, DistributeRewardsRequest,
         DistributeRewardsResponse, ExecuteResponse, GenesisResponse, QueryResponse, SlashRequest,
-        SlashResponse, UnbondPayoutRequest, UnbondPayoutResponse, UpgradeRequest, UpgradeResponse,
+        SlashResponse, StepRequest, StepResponse, UnbondPayoutRequest, UnbondPayoutResponse,
+        UpgradeRequest, UpgradeResponse,
     },
     ipc_grpc::{ExecutionEngineService, ExecutionEngineServiceServer},
     mappings::{ParsingError, TransformMap},
@@ -399,6 +400,14 @@ where
         _request_options: RequestOptions,
         _unbond_payout_request: UnbondPayoutRequest,
     ) -> SingleResponse<UnbondPayoutResponse> {
+        SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()))
+    }
+
+    fn step(
+        &self,
+        _request_options: RequestOptions,
+        _step_request: StepRequest,
+    ) -> SingleResponse<StepResponse> {
         SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()))
     }
 }

--- a/grpc/test_support/src/internal/mod.rs
+++ b/grpc/test_support/src/internal/mod.rs
@@ -23,7 +23,7 @@ use super::DEFAULT_ACCOUNT_INITIAL_BALANCE;
 pub use additive_map_diff::AdditiveMapDiff;
 pub use deploy_item_builder::DeployItemBuilder;
 pub use execute_request_builder::ExecuteRequestBuilder;
-pub use step_request_builder::{StepItem, StepRequestBuilder};
+pub use step_request_builder::{SlashItem, StepRequestBuilder};
 pub use upgrade_request_builder::UpgradeRequestBuilder;
 pub use wasm_test_builder::{
     InMemoryWasmTestBuilder, LmdbWasmTestBuilder, WasmTestBuilder, WasmTestResult,

--- a/grpc/test_support/src/internal/mod.rs
+++ b/grpc/test_support/src/internal/mod.rs
@@ -2,6 +2,7 @@ mod additive_map_diff;
 mod deploy_item_builder;
 pub mod exec_with_return;
 mod execute_request_builder;
+mod step_request_builder;
 mod upgrade_request_builder;
 pub mod utils;
 mod wasm_test_builder;
@@ -22,6 +23,7 @@ use super::DEFAULT_ACCOUNT_INITIAL_BALANCE;
 pub use additive_map_diff::AdditiveMapDiff;
 pub use deploy_item_builder::DeployItemBuilder;
 pub use execute_request_builder::ExecuteRequestBuilder;
+pub use step_request_builder::{StepItem, StepRequestBuilder};
 pub use upgrade_request_builder::UpgradeRequestBuilder;
 pub use wasm_test_builder::{
     InMemoryWasmTestBuilder, LmdbWasmTestBuilder, WasmTestBuilder, WasmTestResult,

--- a/grpc/test_support/src/internal/step_request_builder.rs
+++ b/grpc/test_support/src/internal/step_request_builder.rs
@@ -2,40 +2,63 @@ use casper_engine_grpc_server::engine_server::{ipc, state};
 use casper_types::{ProtocolVersion, U512};
 
 #[derive(Debug)]
-pub struct StepItem {
+pub struct SlashItem {
+    validator_id: Vec<u8>,
+}
+
+impl SlashItem {
+    pub fn new(validator_id: Vec<u8>) -> Self {
+        SlashItem { validator_id }
+    }
+}
+
+impl Default for SlashItem {
+    fn default() -> Self {
+        SlashItem {
+            validator_id: Default::default(),
+        }
+    }
+}
+
+impl From<SlashItem> for ipc::SlashItem {
+    fn from(slash_item: SlashItem) -> Self {
+        let mut item = ipc::SlashItem::new();
+        item.set_validator_id(slash_item.validator_id);
+        item
+    }
+}
+
+#[derive(Debug)]
+pub struct RewardItem {
     validator_id: Vec<u8>,
     value: U512,
 }
 
-impl StepItem {
+#[allow(dead_code)]
+impl RewardItem {
     pub fn new(validator_id: Vec<u8>, value: U512) -> Self {
-        StepItem {
+        RewardItem {
             validator_id,
             value,
         }
     }
-
-    pub fn as_slash_item(self) -> ipc::SlashItem {
-        let mut item = ipc::SlashItem::new();
-        item.set_validator_id(self.validator_id);
-        item.set_value(self.value.into());
-        item
-    }
-
-    pub fn as_reward_item(self) -> ipc::RewardItem {
-        let mut item = ipc::RewardItem::new();
-        item.set_validator_id(self.validator_id);
-        item.set_value(self.value.into());
-        item
-    }
 }
 
-impl Default for StepItem {
+impl Default for RewardItem {
     fn default() -> Self {
-        StepItem {
+        RewardItem {
             validator_id: Default::default(),
             value: Default::default(),
         }
+    }
+}
+
+impl From<RewardItem> for ipc::RewardItem {
+    fn from(reward_item: RewardItem) -> Self {
+        let mut item = ipc::RewardItem::new();
+        item.set_validator_id(reward_item.validator_id);
+        item.set_value(reward_item.value.into());
+        item
     }
 }
 

--- a/grpc/test_support/src/internal/step_request_builder.rs
+++ b/grpc/test_support/src/internal/step_request_builder.rs
@@ -1,0 +1,94 @@
+use casper_engine_grpc_server::engine_server::{ipc, state};
+use casper_types::{ProtocolVersion, U512};
+
+#[derive(Debug)]
+pub struct StepItem {
+    validator_id: Vec<u8>,
+    value: U512,
+}
+
+impl StepItem {
+    pub fn new(validator_id: Vec<u8>, value: U512) -> Self {
+        StepItem {
+            validator_id,
+            value,
+        }
+    }
+
+    pub fn as_slash_item(self) -> ipc::SlashItem {
+        let mut item = ipc::SlashItem::new();
+        item.set_validator_id(self.validator_id);
+        item.set_value(self.value.into());
+        item
+    }
+
+    pub fn as_reward_item(self) -> ipc::RewardItem {
+        let mut item = ipc::RewardItem::new();
+        item.set_validator_id(self.validator_id);
+        item.set_value(self.value.into());
+        item
+    }
+}
+
+impl Default for StepItem {
+    fn default() -> Self {
+        StepItem {
+            validator_id: Default::default(),
+            value: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct StepRequestBuilder {
+    parent_state_hash: Vec<u8>,
+    protocol_version: state::ProtocolVersion,
+    slash_items: Vec<ipc::SlashItem>,
+    reward_items: Vec<ipc::RewardItem>,
+}
+
+impl StepRequestBuilder {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn with_parent_state_hash(mut self, parent_state_hash: Vec<u8>) -> Self {
+        self.parent_state_hash = parent_state_hash;
+        self
+    }
+
+    pub fn with_protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
+        self.protocol_version = protocol_version.into();
+        self
+    }
+
+    pub fn with_slash_item(mut self, slash_item: ipc::SlashItem) -> Self {
+        self.slash_items.push(slash_item);
+        self
+    }
+
+    pub fn with_reward_item(mut self, reward_item: ipc::RewardItem) -> Self {
+        self.reward_items.push(reward_item);
+        self
+    }
+
+    pub fn build(self) -> ipc::StepRequest {
+        let mut request = ipc::StepRequest::new();
+        request.set_parent_state_hash(self.parent_state_hash);
+        request.set_protocol_version(self.protocol_version);
+        request.set_slash_items(self.slash_items.into());
+        request.set_reward_items(self.reward_items.into());
+        request
+    }
+}
+
+impl Default for StepRequestBuilder {
+    fn default() -> Self {
+        StepRequestBuilder {
+            parent_state_hash: Default::default(),
+            protocol_version: Default::default(),
+            slash_items: Default::default(),
+            reward_items: Default::default(),
+        }
+    }
+}

--- a/grpc/test_support/src/internal/step_request_builder.rs
+++ b/grpc/test_support/src/internal/step_request_builder.rs
@@ -68,6 +68,7 @@ pub struct StepRequestBuilder {
     protocol_version: state::ProtocolVersion,
     slash_items: Vec<ipc::SlashItem>,
     reward_items: Vec<ipc::RewardItem>,
+    run_auction: bool,
 }
 
 impl StepRequestBuilder {
@@ -95,12 +96,18 @@ impl StepRequestBuilder {
         self
     }
 
+    pub fn with_run_auction(mut self, run_auction: bool) -> Self {
+        self.run_auction = run_auction;
+        self
+    }
+
     pub fn build(self) -> ipc::StepRequest {
         let mut request = ipc::StepRequest::new();
         request.set_parent_state_hash(self.parent_state_hash);
         request.set_protocol_version(self.protocol_version);
         request.set_slash_items(self.slash_items.into());
         request.set_reward_items(self.reward_items.into());
+        request.set_run_auction(self.run_auction);
         request
     }
 }
@@ -112,6 +119,7 @@ impl Default for StepRequestBuilder {
             protocol_version: Default::default(),
             slash_items: Default::default(),
             reward_items: Default::default(),
+            run_auction: true,
         }
     }
 }

--- a/grpc/test_support/src/internal/wasm_test_builder.rs
+++ b/grpc/test_support/src/internal/wasm_test_builder.rs
@@ -24,7 +24,8 @@ use casper_execution_engine::{
     core::{
         engine_state::{
             execute_request::ExecuteRequest, execution_result::ExecutionResult,
-            run_genesis_request::RunGenesisRequest, EngineConfig, EngineState, SYSTEM_ACCOUNT_ADDR,
+            run_genesis_request::RunGenesisRequest, step::StepRequest, EngineConfig, EngineState,
+            SYSTEM_ACCOUNT_ADDR,
         },
         execution,
     },
@@ -478,6 +479,10 @@ where
 
         self.upgrade_responses.push(upgrade_response.clone());
         self
+    }
+
+    pub fn step(&mut self, mut _step_request: StepRequest) -> &mut Self {
+        unreachable!()
     }
 
     /// Expects a successful run and caches transformations

--- a/grpc/tests/src/test/mod.rs
+++ b/grpc/tests/src/test/mod.rs
@@ -7,6 +7,7 @@ mod explorer;
 mod groups;
 mod manage_groups;
 mod regression;
+mod step;
 mod system_contracts;
 mod upgrade;
 mod wasmless_transfer;

--- a/grpc/tests/src/test/step.rs
+++ b/grpc/tests/src/test/step.rs
@@ -1,4 +1,8 @@
-use casper_engine_test_support::internal::{InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST};
+use casper_engine_test_support::internal::{
+    InMemoryWasmTestBuilder, StepItem, StepRequestBuilder, DEFAULT_RUN_GENESIS_REQUEST,
+};
+use casper_types::{bytesrepr::ToBytes, ProtocolVersion, U512};
+
 // use casper_execution_engine::core::engine_state::step::StepRequest;
 
 /*
@@ -35,15 +39,19 @@ fn should_slash() {
         how to determine success?
             check auction contract state after slash; victim should be gone and all others
             should still exist.
-
-        TODO: check Michal's existing tests of slash to figure out how it is meant to work
     */
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
-    // let step_request = //todo: make a request builder;
-    // builder.step(step_request);
-    unreachable!()
+    let validator_id = casper_types::PublicKey::Ed25519([42; 32])
+        .to_bytes()
+        .expect("should serialize to bytes");
+    let step_request = StepRequestBuilder::new()
+        .with_parent_state_hash(builder.get_post_state_hash())
+        .with_protocol_version(ProtocolVersion::V1_0_0)
+        .with_slash_item(StepItem::new(validator_id, U512::from(1000)).as_slash_item())
+        .build();
+    builder.step(step_request);
 }
 
 /// Should be able to apply slashing per era.

--- a/grpc/tests/src/test/step.rs
+++ b/grpc/tests/src/test/step.rs
@@ -1,0 +1,77 @@
+/*
+TODO's:
+* add new endpoint, request, and response to ipc.proto engine state service
+** what should request / response contain?
+*** set up similar to exec / deploy w/ oneof's
+*** add Slashing first & wire all the way thru, should be easy to add more variants thereafter
+* add new step function, domain request & response types to EE engine_state
+* add From mappings for ipc / domain types in grpc host
+* implement call to auction slashing in EE function; self commit afterwards.
+* iterate until should_slash test passes
+
+* Implement should_run_auction test; iterate to success
+* Implement should_distribute_rewards test; iterate to success
+* create a separate EE ticket to track this portion of the work and submit a PR.
+
+* Complete wire up of ContractRuntime & BlockExecutor on ndrs-307 story and cut a
+    second PR based on the first.
+*/
+
+/// Should be able to apply slashing per era.
+#[ignore]
+#[test]
+fn should_slash() {
+    /*
+        get a builder & do genesis plus some number of commits to build up state
+            how much min state is necessary before being able to slash?
+                maybe genesis + 1 block / post state hash is all that is necessary; verify
+            should be able to just assert era 2 as to the EE era is just an arg
+        slash a validator
+            add a .step(...) function to the test builder
+            check the auction contract validator set before slash and pick a victim
+        how to determine success?
+            check auction contract state after slash; victim should be gone and all others
+            should still exist.
+
+        TODO: check Michal's existing tests of slash to figure out how it is meant to work
+    */
+}
+
+/// Should be able to apply slashing per era.
+#[ignore]
+#[test]
+fn should_run_auction() {
+    /*
+        get a builder & do genesis plus some number of commits to build up state
+            how much min state is necessary before being able to auction?
+                maybe genesis + 1 block / post state hash is all that is necessary; verify
+            should be able to just assert era 2 as to the EE era is just an arg
+        run auction in such a way to force a new winning bidder / new validator to be included
+            upgrade .step(...) function on test builder to support auction
+            check the auction contract validator set before auction
+        how to determine success?
+            check auction contract state after auction; new winning bidder should be present
+
+        TODO: check Michal's existing tests of run_auction to figure out how it is meant to work
+    */
+}
+
+/// Should be able to distribute rewards per era.
+#[ignore]
+#[test]
+fn should_distribute_rewards() {
+    /*
+        get a builder & do genesis plus some number of commits to build up state
+            how much min state is necessary before being able to distro rewards?
+                maybe genesis + 1 block / post state hash is all that is necessary; verify
+            should be able to just assert era 2 as to the EE era is just an arg
+        distribute rewards a validator
+            upgrade .step(...) function on test builder to support reward distro
+            determine what state is available pre-reward distro to serve as control set
+        how to determine success?
+            determine what state is available post-reward distro to compare against previous state
+                and what the expected final resting state is; may not be able to do this
+                until henry's new logic completely lands in which case, allow test to pass
+                but add TODO! and link to Henry's ticket.
+    */
+}

--- a/grpc/tests/src/test/step.rs
+++ b/grpc/tests/src/test/step.rs
@@ -1,3 +1,6 @@
+use casper_engine_test_support::internal::{InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST};
+// use casper_execution_engine::core::engine_state::step::StepRequest;
+
 /*
 TODO's:
 * add new endpoint, request, and response to ipc.proto engine state service
@@ -35,6 +38,12 @@ fn should_slash() {
 
         TODO: check Michal's existing tests of slash to figure out how it is meant to work
     */
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    // let step_request = //todo: make a request builder;
+    // builder.step(step_request);
+    unreachable!()
 }
 
 /// Should be able to apply slashing per era.


### PR DESCRIPTION
This PR adds a single step function to combine multiple `auction` activities into a single call to the contract-runtime / execution engine / grpc / test_support; et al.

https://casperlabs.atlassian.net/browse/EE-1043

Waiting on several other PR's (distribute rewards, switch block changes, genesis validators / slashing bug fix) to merge for integration, final pass, and clean up of obsoleted method stubs. 