### PR TITLE
NO-TICKET: Add some log messages when not sending a confirmation.

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -231,12 +231,7 @@ impl<C: Context> ActiveValidator<C> {
             return false;
         }
         // If it's not a proposal, the sender is faulty, or we are, don't send a confirmation.
-        if vote.creator == self.vidx
-            || self.is_faulty(state)
-            || state.has_evidence(vote.creator)
-            || state.leader(vote.timestamp) != vote.creator
-            || vote.timestamp != state::round_id(vote.timestamp, vote.round_exp)
-        {
+        if vote.creator == self.vidx || self.is_faulty(state) || !state.is_correct_proposal(vote) {
             return false;
         }
         if let Some(vote) = self.latest_vote(state) {

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -458,6 +458,13 @@ impl<C: Context> State<C> {
         vote.timestamp + vote.round_len() * self.params.reward_delay()
     }
 
+    /// Returns `true` if this is a proposal and the creator is not faulty.
+    pub(super) fn is_correct_proposal(&self, vote: &Vote<C>) -> bool {
+        !self.has_evidence(vote.creator)
+            && self.leader(vote.timestamp) == vote.creator
+            && vote.timestamp == round_id(vote.timestamp, vote.round_exp)
+    }
+
     /// Returns the hash of the message with the given sequence number from the creator of `hash`,
     /// or `None` if the sequence number is higher than that of the vote with `hash`.
     fn find_in_swimlane<'a>(&'a self, hash: &'a C::Hash, seq_number: u64) -> Option<&'a C::Hash> {


### PR DESCRIPTION
Adds some logging to `should_send_confirmation` to address [this comment](https://github.com/CasperLabs/casper-node/pull/283#discussion_r495886951).