### PR TITLE
NDRS-417: Fix relative storage path bug for node storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ dist
 # End of https://www.toptal.com/developers/gitignore/api/rust,node
 
 resources/production/*.wasm
+resources/node-storage/*
 
 # CLion
 .idea/

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -30,7 +30,7 @@ use crate::{
         ConditionCheckReactor, TestRng,
     },
     types::{Deploy, DeployHash, Tag},
-    utils::Loadable,
+    utils::{Loadable, WithDir},
 };
 
 const TIMEOUT: Duration = Duration::from_secs(1);
@@ -117,7 +117,7 @@ impl reactor::Reactor<TestRng> for Reactor {
         let network = NetworkController::create_node(event_queue, rng);
 
         let (storage_config, _storage_tempdir) = storage::Config::default_for_tests();
-        let storage = Storage::new(&storage_config).unwrap();
+        let storage = Storage::new(WithDir::new(_storage_tempdir.path(), storage_config)).unwrap();
 
         let deploy_acceptor = DeployAcceptor::new();
         let deploy_fetcher = Fetcher::<Deploy>::new(config);

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -124,8 +124,8 @@ impl reactor::Reactor<TestRng> for Reactor {
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
         let network = NetworkController::create_node(event_queue, rng);
 
-        let (storage_config, _storage_tempdir) = storage::Config::default_for_tests();
-        let storage = Storage::new(WithDir::new(_storage_tempdir.path(), storage_config)).unwrap();
+        let (storage_config, storage_tempdir) = storage::Config::default_for_tests();
+        let storage = Storage::new(WithDir::new(storage_tempdir.path(), storage_config)).unwrap();
 
         let deploy_acceptor = DeployAcceptor::new();
         let deploy_gossiper = Gossiper::new_for_partial_items(config, get_deploy_from_storage);
@@ -135,7 +135,7 @@ impl reactor::Reactor<TestRng> for Reactor {
             storage,
             deploy_acceptor,
             deploy_gossiper,
-            _storage_tempdir,
+            _storage_tempdir: storage_tempdir,
         };
 
         let effects = Effects::new();

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -32,7 +32,7 @@ use crate::{
         ConditionCheckReactor, TestRng,
     },
     types::{Deploy, Tag},
-    utils::Loadable,
+    utils::{Loadable, WithDir},
 };
 
 /// Top-level event for the reactor.
@@ -125,7 +125,7 @@ impl reactor::Reactor<TestRng> for Reactor {
         let network = NetworkController::create_node(event_queue, rng);
 
         let (storage_config, _storage_tempdir) = storage::Config::default_for_tests();
-        let storage = Storage::new(&storage_config).unwrap();
+        let storage = Storage::new(WithDir::new(_storage_tempdir.path(), storage_config)).unwrap();
 
         let deploy_acceptor = DeployAcceptor::new();
         let deploy_gossiper = Gossiper::new_for_partial_items(config, get_deploy_from_storage);

--- a/node/src/components/storage/config.rs
+++ b/node/src/components/storage/config.rs
@@ -28,7 +28,7 @@ pub struct Config {
     ///
     /// If the folder doesn't exist, it and any required parents will be created.
     ///
-    /// If unset via the configuration file, the value must be provided via the CLI. 
+    /// If unset via the configuration file, the value must be provided via the CLI.
     path: PathBuf,
     /// The maximum size of the database to use for the block store.
     ///

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -126,12 +126,12 @@ impl<RNG: Rng + CryptoRng + ?Sized> reactor::Reactor<RNG> for Reactor {
             .node
             .chainspec_config_path
             .clone()
-            .load(root)
+            .load(root.clone())
             .map_err(|err| Error::ConfigError(err.to_string()))?;
 
         let effect_builder = EffectBuilder::new(event_queue);
 
-        let storage = Storage::new(&config.storage)?;
+        let storage = Storage::new(WithDir::new(&root, config.storage.clone()))?;
         let contract_runtime =
             ContractRuntime::new(&config.storage, config.contract_runtime, registry)?;
         let (chainspec_loader, chainspec_effects) =

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -16,6 +16,7 @@ use std::{
 
 use lazy_static::lazy_static;
 use libc::{c_long, sysconf, _SC_PAGESIZE};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
 
@@ -161,7 +162,7 @@ pub fn read_file_to_string<P: AsRef<Path>>(filename: P) -> Result<String, ReadFi
 /// With-directory context.
 ///
 /// Associates a type with a "working directory".
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct WithDir<T> {
     path: PathBuf,
     value: T,

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -16,7 +16,6 @@ use std::{
 
 use lazy_static::lazy_static;
 use libc::{c_long, sysconf, _SC_PAGESIZE};
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
 
@@ -162,7 +161,7 @@ pub fn read_file_to_string<P: AsRef<Path>>(filename: P) -> Result<String, ReadFi
 /// With-directory context.
 ///
 /// Associates a type with a "working directory".
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub struct WithDir<T> {
     path: PathBuf,
     value: T,

--- a/resources/charlie/config-example.toml
+++ b/resources/charlie/config-example.toml
@@ -84,10 +84,8 @@ bind_port = 7777
 # or read by the storage component will exist.
 #
 # If the folder doesn't exist, it and any required parents will be created.
-#
-# If unset, defaults to:
-#   /root/.local/share/casper-node
-# path = 'node-storage'
+# If unset, the value must be supplied via the CLI.
+path = '/root/.local/share/casper-node'
 
 # Optional maximum size of the database to use for the block store.
 #

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -86,7 +86,7 @@ bind_port = 7777
 #
 # If the folder doesn't exist, it and any required parents will be created.
 #
-# If unset, the path must be supplied as an argument via the CLI:
+# If unset, the path must be supplied as an argument via the CLI.
 path = '../node-storage'
 
 # Optional maximum size of the database to use for the block store.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -81,18 +81,12 @@ bind_port = 7777
 # ===============================================
 [storage]
 
-# Optional path (absolute, or relative to this config.toml) to the folder where any files created
+# Path (absolute, or relative to this config.toml) to the folder where any files created
 # or read by the storage component will exist.
 #
 # If the folder doesn't exist, it and any required parents will be created.
 #
-# If unset, defaults to:
-# * Linux: `$XDG_DATA_HOME/casper-node` or `$HOME/.local/share/casper-node`, e.g.
-#   /home/alice/.local/share/casper-node
-# * macOS: `$HOME/Library/Application Support/io.CasperLabs.casper-node`, e.g.
-#   /Users/Alice/Library/Application Support/io.CasperLabs.casper-node
-# * Windows: `{FOLDERID_RoamingAppData}\CasperLabs\casper-node\data` e.g.
-#   C:\Users\Alice\AppData\Roaming\CasperLabs\casper-node\data
+# If unset, the path must be supplied as an argument via the CLI:
 path = '../node-storage'
 
 # Optional maximum size of the database to use for the block store.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -32,7 +32,7 @@ format = "text"
 
 # Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
 # consensus messages.
-secret_key_path = 'secret_key.pem'
+secret_key_path = '../secret_key.pem'
 
 
 # ====================================
@@ -93,7 +93,7 @@ bind_port = 7777
 #   /Users/Alice/Library/Application Support/io.CasperLabs.casper-node
 # * Windows: `{FOLDERID_RoamingAppData}\CasperLabs\casper-node\data` e.g.
 #   C:\Users\Alice\AppData\Roaming\CasperLabs\casper-node\data
-#path = 'node-storage'
+path = '../node-storage'
 
 # Optional maximum size of the database to use for the block store.
 #

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -32,7 +32,7 @@ format = "text"
 
 # Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
 # consensus messages.
-secret_key_path = '../secret_key.pem'
+secret_key_path = 'secret_key.pem'
 
 
 # ====================================


### PR DESCRIPTION
Updated the storage configuration by wrapping the `WithDir` struct around it to preserve the directory-context of the `config.toml` file.