### PR TITLE
NDRS-425: allow stored blocks to be mutated to append signatures

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -170,7 +170,6 @@ where
             },
             Event::NewFinalitySignature(block_hash, signature) => {
                 effect_builder
-                .clone()
                     .get_block_from_storage(block_hash)
                     .then(move |maybe_block| match maybe_block {
                         Some(mut block) => {

--- a/node/src/components/storage/lmdb_store.rs
+++ b/node/src/components/storage/lmdb_store.rs
@@ -101,7 +101,10 @@ impl<V: Value, M: Send + Sync> Store for LmdbStore<V, M> {
             self.db,
             &serialized_id,
             &serialized_value,
-            WriteFlags::NO_OVERWRITE,
+            // TODO - this should be changed back to `WriteFlags::NO_OVERWRITE` once the mutable
+            //        data (i.e. blocks' proofs) are handled via metadata as per deploys'
+            //        execution results.
+            WriteFlags::default(),
         ) {
             Ok(()) => true,
             Err(lmdb::Error::KeyExist) => false,


### PR DESCRIPTION
This is a quick fix to allow signatures to be appended to blocks.

The plan was to handle signatures as block-related metadata, keeping the immutable parts of the block separate from the mutable parts, hence avoiding deserializing and re-serializing the whole block every time a new signature is appended.

With the upcoming CEP-0003 work, it's probably worth dwelling a pause on spending effort to do that work on the existing storage and block types, in case the effort is wasted.