### PR TITLE
NO-TICK: Cache only the minimal set of data.

### DIFF
--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -30,7 +30,7 @@ use crate::{
 #[derive(Copy, Clone, DataSize, Debug, PartialEq, Eq, Serialize, Deserialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
-pub(crate) struct DeployConfig {
+pub struct DeployConfig {
     pub(crate) max_payment_cost: Motes,
     pub(crate) max_ttl: TimeDiff,
     pub(crate) max_dependencies: u8,
@@ -160,7 +160,7 @@ impl Loadable for Vec<GenesisAccount> {
 #[derive(Clone, DataSize, PartialEq, Eq, Serialize, Deserialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
-pub(crate) struct GenesisConfig {
+pub struct GenesisConfig {
     pub(crate) name: String,
     pub(crate) timestamp: Timestamp,
     // We don't have an implementation for the semver version type, we skip it for now

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -20,6 +20,8 @@ use crate::{
 
 pub use event::Event;
 
+use super::chainspec_loader::DeployConfig;
+
 /// A helper trait constraining `DeployAcceptor` compatible reactor events.
 pub trait ReactorEventT:
     From<Event> + From<DeployAcceptorAnnouncement<NodeId>> + From<StorageRequest<Storage>> + Send
@@ -34,19 +36,36 @@ impl<REv> ReactorEventT for REv where
 {
 }
 
+#[derive(Debug, Clone)]
+pub struct DeployAcceptorConfig {
+    chain_name: String,
+    deploy_config: DeployConfig,
+}
+
+impl From<Chainspec> for DeployAcceptorConfig {
+    fn from(c: Chainspec) -> Self {
+        DeployAcceptorConfig {
+            chain_name: c.genesis.name,
+            deploy_config: c.genesis.deploy_config,
+        }
+    }
+}
+
 /// The `DeployAcceptor` is the component which handles all new `Deploy`s immediately after they're
 /// received by this node, regardless of whether they were provided by a peer or a client.
 ///
 /// It validates a new `Deploy` as far as possible, stores it if valid, then announces the newly-
 /// accepted `Deploy`.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct DeployAcceptor {
-    chainspecs: HashMap<Version, Chainspec>,
+    cached_deploy_configs: HashMap<Version, DeployAcceptorConfig>,
 }
 
 impl DeployAcceptor {
     pub(crate) fn new() -> Self {
-        Self::default()
+        DeployAcceptor {
+            cached_deploy_configs: HashMap::new(),
+        }
     }
 
     /// Handles receiving a new `Deploy` from a peer or client.
@@ -58,16 +77,16 @@ impl DeployAcceptor {
     ) -> Effects<Event> {
         // TODO - where to get version from?
         let chainspec_version = Version::new(1, 0, 0);
-        let cached_chainspec = self.chainspecs.get(&chainspec_version).cloned();
-        match cached_chainspec {
-            Some(chainspec) => {
+        let cached_config = self.cached_deploy_configs.get(&chainspec_version).cloned();
+        match cached_config {
+            Some(genesis_config) => {
                 effect_builder
                     .immediately()
                     .event(move |_| Event::GetChainspecResult {
                         deploy,
                         source,
                         chainspec_version,
-                        maybe_chainspec: Box::new(Some(chainspec)),
+                        maybe_deploy_config: Box::new(Some(genesis_config)),
                     })
             }
             None => effect_builder
@@ -76,7 +95,7 @@ impl DeployAcceptor {
                     deploy,
                     source,
                     chainspec_version,
-                    maybe_chainspec: Box::new(maybe_chainspec),
+                    maybe_deploy_config: Box::new(maybe_chainspec.map(|c| c.into())),
                 }),
         }
     }
@@ -86,9 +105,9 @@ impl DeployAcceptor {
         effect_builder: EffectBuilder<REv>,
         deploy: Box<Deploy>,
         source: Source<NodeId>,
-        chainspec: Chainspec,
+        deploy_config: DeployAcceptorConfig,
     ) -> Effects<Event> {
-        if is_valid(&*deploy, chainspec) {
+        if is_valid(&*deploy, deploy_config) {
             let cloned_deploy = deploy.clone();
             effect_builder
                 .put_deploy_to_storage(cloned_deploy)
@@ -146,12 +165,13 @@ impl<REv: ReactorEventT, R: Rng + CryptoRng + ?Sized> Component<REv, R> for Depl
                 deploy,
                 source,
                 chainspec_version,
-                maybe_chainspec,
-            } => match *maybe_chainspec {
-                Some(chainspec) => {
+                maybe_deploy_config,
+            } => match *maybe_deploy_config {
+                Some(deploy_config) => {
                     // Update chainspec cache.
-                    self.chainspecs.insert(chainspec_version, chainspec.clone());
-                    self.validate(effect_builder, deploy, source, chainspec)
+                    self.cached_deploy_configs
+                        .insert(chainspec_version, deploy_config.clone());
+                    self.validate(effect_builder, deploy, source, deploy_config)
                 }
                 None => self.failed_to_get_chainspec(deploy, source, chainspec_version),
             },
@@ -164,34 +184,32 @@ impl<REv: ReactorEventT, R: Rng + CryptoRng + ?Sized> Component<REv, R> for Depl
     }
 }
 
-fn is_valid(deploy: &Deploy, chainspec: Chainspec) -> bool {
-    if deploy.header().chain_name() != chainspec.genesis.name {
+fn is_valid(deploy: &Deploy, config: DeployAcceptorConfig) -> bool {
+    if deploy.header().chain_name() != config.chain_name {
         warn!(
             deploy_hash = %deploy.id(),
             deploy_header = %deploy.header(),
-            chain_name = %chainspec.genesis.name,
+            chain_name = %config.chain_name,
             "invalid chain identifier"
         );
         return false;
     }
 
-    if deploy.header().dependencies().len()
-        > chainspec.genesis.deploy_config.max_dependencies as usize
-    {
+    if deploy.header().dependencies().len() > config.deploy_config.max_dependencies as usize {
         warn!(
             deploy_hash = %deploy.id(),
             deploy_header = %deploy.header(),
-            max_dependencies = %chainspec.genesis.deploy_config.max_dependencies,
+            max_dependencies = %config.deploy_config.max_dependencies,
             "deploy dependency ceiling exceeded"
         );
         return false;
     }
 
-    if deploy.header().ttl() > chainspec.genesis.deploy_config.max_ttl {
+    if deploy.header().ttl() > config.deploy_config.max_ttl {
         warn!(
             deploy_hash = %deploy.id(),
             deploy_header = %deploy.header(),
-            max_ttl = %chainspec.genesis.deploy_config.max_ttl,
+            max_ttl = %config.deploy_config.max_ttl,
             "deploy ttl excessive"
         );
         return false;

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -2,8 +2,8 @@ use std::fmt::{self, Display, Formatter};
 
 use semver::Version;
 
-use super::Source;
-use crate::{components::chainspec_loader::Chainspec, small_network::NodeId, types::Deploy};
+use super::{DeployAcceptorConfig, Source};
+use crate::{small_network::NodeId, types::Deploy};
 
 /// `DeployAcceptor` events.
 #[derive(Debug)]
@@ -18,7 +18,7 @@ pub enum Event {
         deploy: Box<Deploy>,
         source: Source<NodeId>,
         chainspec_version: Version,
-        maybe_chainspec: Box<Option<Chainspec>>,
+        maybe_deploy_config: Box<Option<DeployAcceptorConfig>>,
     },
     /// The result of the `DeployAcceptor` putting a `Deploy` to the storage component.
     PutToStorageResult {
@@ -36,10 +36,10 @@ impl Display for Event {
             }
             Event::GetChainspecResult {
                 chainspec_version,
-                maybe_chainspec,
+                maybe_deploy_config,
                 ..
             } => {
-                if maybe_chainspec.is_some() {
+                if maybe_deploy_config.is_some() {
                     write!(formatter, "got chainspec at {}", chainspec_version)
                 } else {
                     write!(


### PR DESCRIPTION
Instead of caching the whole chainspec, which also contains raw bytes of Wasm system contracts, cache only the data that is necessary for deploy validation.