### PR TITLE
[charlie] logging enhancements & timestamp workaround

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -270,6 +270,19 @@ where
             highway.activate_validator(our_id, secret, timestamp.max(start_time))
         } else {
             info!("not voting in era {}", era_id.0);
+            if start_time >= self.node_start_time {
+                info!(
+                    "node was started at time {}, which is not earlier than the era start {}",
+                    self.node_start_time, start_time
+                );
+            } else if min_end_time < timestamp {
+                info!(
+                    "era started too long ago ({}; earliest end {}), current timestamp {}",
+                    start_time, min_end_time, timestamp
+                );
+            } else {
+                info!("not a validator; our ID: {}", our_id);
+            }
             Vec::new()
         };
 

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -224,12 +224,7 @@ impl<C: Context> ActiveValidator<C> {
             return false;
         }
         // If it's not a proposal, the sender is faulty, or we are, don't send a confirmation.
-        if vote.creator == self.vidx
-            || self.is_faulty(state)
-            || state.has_evidence(vote.creator)
-            || state.leader(vote.timestamp) != vote.creator
-            || vote.timestamp != state::round_id(vote.timestamp, vote.round_exp)
-        {
+        if vote.creator == self.vidx || self.is_faulty(state) || !state.is_correct_proposal(vote) {
             return false;
         }
         if let Some(vote) = self.latest_vote(state) {

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -223,17 +223,30 @@ impl<C: Context> ActiveValidator<C> {
             warn!(%vote.timestamp, %timestamp, "added a vote with a future timestamp");
             return false;
         }
-        let r_exp = self.round_exp(state, timestamp);
-        timestamp >> r_exp == vote.timestamp >> r_exp // Current round.
-            && state.leader(vote.timestamp) == vote.creator // The creator is the round's leader.
-            && vote.timestamp == state::round_id(vote.timestamp, vote.round_exp) // It's a proposal.
-            && vote.creator != self.vidx // We didn't send it ourselves.
-            && !state.has_evidence(vote.creator) // The creator is not faulty.
-            && !self.is_faulty(state) // We are not faulty.
-            && self.latest_vote(state)
-                .map_or(true, |vote| {
-                    !vote.panorama.sees_correct(state, vhash)
-                }) // We haven't confirmed it already.
+        // If it's not a proposal, the sender is faulty, or we are, don't send a confirmation.
+        if vote.creator == self.vidx
+            || self.is_faulty(state)
+            || state.has_evidence(vote.creator)
+            || state.leader(vote.timestamp) != vote.creator
+            || vote.timestamp != state::round_id(vote.timestamp, vote.round_exp)
+        {
+            return false;
+        }
+        if let Some(vote) = self.latest_vote(state) {
+            if vote.panorama.sees_correct(state, vhash) {
+                error!(%vhash, "called on_new_vote with already confirmed proposal");
+                return false; // We already sent a confirmation.
+            }
+        }
+        let r_id = state::round_id(timestamp, self.round_exp(state, timestamp));
+        if vote.timestamp != r_id {
+            warn!(
+                %vote.timestamp, %r_id,
+                "received proposal from unexpected round",
+            );
+            return false;
+        }
+        true
     }
 
     /// Returns the panorama of the confirmation for the leader vote `vhash`.

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -125,16 +125,17 @@ impl<C: Context> ActiveValidator<C> {
     pub(crate) fn on_new_vote<R: Rng + CryptoRng + ?Sized>(
         &mut self,
         vhash: &C::Hash,
-        timestamp: Timestamp,
+        mut timestamp: Timestamp,
         state: &State<C>,
         rng: &mut R,
     ) -> Vec<Effect<C>> {
         if let Some(evidence) = state.opt_evidence(self.vidx) {
             return vec![Effect::WeEquivocated(evidence.clone())];
         }
-        if self.earliest_vote_time(state) > timestamp {
-            warn!(%timestamp, "skipping outdated confirmation");
-        } else if self.should_send_confirmation(vhash, timestamp, state) {
+        // TODO: `timestamp` should be the _current_ timestamp and we need to delay incoming votes
+        // with a future timestamp.
+        timestamp = self.earliest_vote_time(state).max(timestamp);
+        if self.should_send_confirmation(vhash, timestamp, state) {
             let panorama = self.confirmation_panorama(vhash, state);
             if panorama.has_correct() {
                 let confirmation_vote = self.new_vote(panorama, timestamp, None, state, rng);
@@ -310,11 +311,16 @@ impl<C: Context> ActiveValidator<C> {
         vec![Effect::ScheduleTimer(self.next_timer)]
     }
 
-    /// Returns the earliest timestamp where we can cast our next vote without equivocating, i.e.
-    /// the timestamp of our previous vote, or 0 if there is none.
+    /// Returns the earliest timestamp where we can cast our next vote: It can't be earlier than
+    /// our previous vote, and it can't be the third vote in a single round.
     fn earliest_vote_time(&self, state: &State<C>) -> Timestamp {
         self.latest_vote(state)
-            .map_or_else(Timestamp::zero, |vh| vh.timestamp)
+            .map_or_else(Timestamp::zero, |vote| {
+                vote.previous().map_or(vote.timestamp, |vh2| {
+                    let vote2 = state.vote(vh2);
+                    vote.timestamp.max(vote2.round_id() + vote2.round_len())
+                })
+            })
     }
 
     /// Returns the most recent vote by this validator.

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -457,6 +457,13 @@ impl<C: Context> State<C> {
         vote.timestamp + vote.round_len() * self.params.reward_delay()
     }
 
+    /// Returns `true` if this is a proposal and the creator is not faulty.
+    pub(super) fn is_correct_proposal(&self, vote: &Vote<C>) -> bool {
+        !self.has_evidence(vote.creator)
+            && self.leader(vote.timestamp) == vote.creator
+            && vote.timestamp == round_id(vote.timestamp, vote.round_exp)
+    }
+
     /// Returns the hash of the message with the given sequence number from the creator of `hash`,
     /// or `None` if the sequence number is higher than that of the vote with `hash`.
     fn find_in_swimlane<'a>(&'a self, hash: &'a C::Hash, seq_number: u64) -> Option<&'a C::Hash> {


### PR DESCRIPTION
This backports the changes from #283, #297, #291 as suggested by @afck.

Tests run fine, are we sure this has no unforseen impact?