### PR TITLE
EE-{1042,1052}: update Auction::undelegate to return purse, fix full undelegation

### DIFF
--- a/grpc/tests/src/test/system_contracts/auction/bids.rs
+++ b/grpc/tests/src/test/system_contracts/auction/bids.rs
@@ -876,7 +876,6 @@ fn should_calculate_era_validators_multiple_new_bids() {
 #[ignore]
 #[test]
 fn undelegated_funds_should_be_released() {
-    // TODO: investigate why this is needed for use-system-contracts but not the host-side version
     const SYSTEM_TRANSFER_AMOUNT: u64 = 1_000_000_000;
 
     let system_fund_request = ExecuteRequestBuilder::standard(
@@ -997,7 +996,6 @@ fn undelegated_funds_should_be_released() {
 #[ignore]
 #[test]
 fn fully_undelegated_funds_should_be_released() {
-    // TODO: investigate why this is needed for use-system-contracts but not the host-side version
     const SYSTEM_TRANSFER_AMOUNT: u64 = 1_000_000_000;
 
     let system_fund_request = ExecuteRequestBuilder::standard(

--- a/grpc/tests/src/test/system_contracts/auction/bids.rs
+++ b/grpc/tests/src/test/system_contracts/auction/bids.rs
@@ -903,7 +903,7 @@ fn undelegated_funds_should_be_released() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => BID_ACCOUNT_ADDR,
+            "target" => BID_ACCOUNT_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -922,13 +922,13 @@ fn undelegated_funds_should_be_released() {
     .build();
 
     let delegator_1_validator_1_delegate_request = ExecuteRequestBuilder::standard(
-        BID_ACCOUNT_ADDR,
+        BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_DELEGATE,
             ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
             ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
-            ARG_DELEGATOR => BID_ACCOUNT_PK,
+            ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
     .build();
@@ -954,13 +954,13 @@ fn undelegated_funds_should_be_released() {
     }
 
     let delegator_1_undelegate_request = ExecuteRequestBuilder::standard(
-        BID_ACCOUNT_ADDR,
+        BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_UNDELEGATE,
             ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_1),
             ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
-            ARG_DELEGATOR => BID_ACCOUNT_PK,
+            ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
     .build();
@@ -971,7 +971,7 @@ fn undelegated_funds_should_be_released() {
         .expect_success();
 
     let delegator_1_undelegate_purse = builder
-        .get_account(BID_ACCOUNT_ADDR)
+        .get_account(BID_ACCOUNT_1_ADDR)
         .expect("should have account")
         .named_keys()
         .get(UNDELEGATE_PURSE)
@@ -1024,7 +1024,7 @@ fn fully_undelegated_funds_should_be_released() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => BID_ACCOUNT_ADDR,
+            "target" => BID_ACCOUNT_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1043,13 +1043,13 @@ fn fully_undelegated_funds_should_be_released() {
     .build();
 
     let delegator_1_validator_1_delegate_request = ExecuteRequestBuilder::standard(
-        BID_ACCOUNT_ADDR,
+        BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_DELEGATE,
             ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
             ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
-            ARG_DELEGATOR => BID_ACCOUNT_PK,
+            ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
     .build();
@@ -1075,13 +1075,13 @@ fn fully_undelegated_funds_should_be_released() {
     }
 
     let delegator_1_undelegate_request = ExecuteRequestBuilder::standard(
-        BID_ACCOUNT_ADDR,
+        BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_UNDELEGATE,
             ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
             ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
-            ARG_DELEGATOR => BID_ACCOUNT_PK,
+            ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
     .build();
@@ -1092,7 +1092,7 @@ fn fully_undelegated_funds_should_be_released() {
         .expect_success();
 
     let delegator_1_undelegate_purse = builder
-        .get_account(BID_ACCOUNT_ADDR)
+        .get_account(BID_ACCOUNT_1_ADDR)
         .expect("should have account")
         .named_keys()
         .get(UNDELEGATE_PURSE)

--- a/grpc/tests/src/test/system_contracts/auction/bids.rs
+++ b/grpc/tests/src/test/system_contracts/auction/bids.rs
@@ -31,6 +31,8 @@ const NON_FOUNDER_VALIDATOR_1: PublicKey = PublicKey::Ed25519([3; 32]);
 const NON_FOUNDER_VALIDATOR_1_ADDR: AccountHash = AccountHash::new([4; 32]);
 const NON_FOUNDER_VALIDATOR_2_ADDR: AccountHash = AccountHash::new([6; 32]);
 
+const UNDELEGATE_PURSE: &str = "undelegate_purse";
+
 const ADD_BID_AMOUNT_1: u64 = 95_000;
 const ADD_BID_AMOUNT_2: u64 = 47_500;
 const ADD_BID_DELEGATION_RATE_1: DelegationRate = 125;
@@ -869,4 +871,240 @@ fn should_calculate_era_validators_multiple_new_bids() {
         new_validators,
         BTreeSet::from_iter(vec![BID_ACCOUNT_1_PK, BID_ACCOUNT_2_PK,])
     );
+}
+
+#[ignore]
+#[test]
+fn undelegated_funds_should_be_released() {
+    let system_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => SYSTEM_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let validator_1_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => NON_FOUNDER_VALIDATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let delegator_1_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => BID_ACCOUNT_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
+        NON_FOUNDER_VALIDATOR_1_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1,
+            ARG_ENTRY_POINT => ARG_ADD_BID,
+            ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_1),
+            ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
+        },
+    )
+    .build();
+
+    let delegator_1_validator_1_delegate_request = ExecuteRequestBuilder::standard(
+        BID_ACCOUNT_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => ARG_DELEGATE,
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_DELEGATOR => BID_ACCOUNT_PK,
+        },
+    )
+    .build();
+
+    let post_genesis_requests = vec![
+        system_fund_request,
+        delegator_1_fund_request,
+        validator_1_fund_request,
+        validator_1_add_bid_request,
+        delegator_1_validator_1_delegate_request,
+    ];
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    for request in post_genesis_requests {
+        builder.exec(request).commit().expect_success();
+    }
+
+    for _ in 0..5 {
+        super::run_auction(&mut builder);
+    }
+
+    let delegator_1_undelegate_request = ExecuteRequestBuilder::standard(
+        BID_ACCOUNT_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => ARG_UNDELEGATE,
+            ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_DELEGATOR => BID_ACCOUNT_PK,
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegator_1_undelegate_request)
+        .commit()
+        .expect_success();
+
+    let delegator_1_undelegate_purse = builder
+        .get_account(BID_ACCOUNT_ADDR)
+        .expect("should have account")
+        .named_keys()
+        .get(UNDELEGATE_PURSE)
+        .expect("should have key")
+        .into_uref()
+        .expect("should be uref");
+
+    for _ in 0..=DEFAULT_UNBONDING_DELAY {
+        let delegator_1_undelegate_purse_balance =
+            builder.get_purse_balance(delegator_1_undelegate_purse);
+        assert_eq!(delegator_1_undelegate_purse_balance, U512::zero());
+        super::run_auction(&mut builder);
+    }
+
+    let delegator_1_undelegate_purse_balance =
+        builder.get_purse_balance(delegator_1_undelegate_purse);
+    assert_eq!(
+        delegator_1_undelegate_purse_balance,
+        U512::from(UNDELEGATE_AMOUNT_1)
+    )
+}
+
+#[ignore]
+#[test]
+fn fully_undelegated_funds_should_be_released() {
+    let system_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => SYSTEM_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let validator_1_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => NON_FOUNDER_VALIDATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let delegator_1_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => BID_ACCOUNT_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
+        NON_FOUNDER_VALIDATOR_1_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1,
+            ARG_ENTRY_POINT => ARG_ADD_BID,
+            ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_1),
+            ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
+        },
+    )
+    .build();
+
+    let delegator_1_validator_1_delegate_request = ExecuteRequestBuilder::standard(
+        BID_ACCOUNT_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => ARG_DELEGATE,
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_DELEGATOR => BID_ACCOUNT_PK,
+        },
+    )
+    .build();
+
+    let post_genesis_requests = vec![
+        system_fund_request,
+        delegator_1_fund_request,
+        validator_1_fund_request,
+        validator_1_add_bid_request,
+        delegator_1_validator_1_delegate_request,
+    ];
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    for request in post_genesis_requests {
+        builder.exec(request).commit().expect_success();
+    }
+
+    for _ in 0..5 {
+        super::run_auction(&mut builder);
+    }
+
+    let delegator_1_undelegate_request = ExecuteRequestBuilder::standard(
+        BID_ACCOUNT_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => ARG_UNDELEGATE,
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_DELEGATOR => BID_ACCOUNT_PK,
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegator_1_undelegate_request)
+        .commit()
+        .expect_success();
+
+    let delegator_1_undelegate_purse = builder
+        .get_account(BID_ACCOUNT_ADDR)
+        .expect("should have account")
+        .named_keys()
+        .get(UNDELEGATE_PURSE)
+        .expect("should have key")
+        .into_uref()
+        .expect("should be uref");
+
+    for _ in 0..=DEFAULT_UNBONDING_DELAY {
+        let delegator_1_undelegate_purse_balance =
+            builder.get_purse_balance(delegator_1_undelegate_purse);
+        assert_eq!(delegator_1_undelegate_purse_balance, U512::zero());
+        super::run_auction(&mut builder);
+    }
+
+    let delegator_1_undelegate_purse_balance =
+        builder.get_purse_balance(delegator_1_undelegate_purse);
+    assert_eq!(
+        delegator_1_undelegate_purse_balance,
+        U512::from(DELEGATE_AMOUNT_1)
+    )
 }

--- a/grpc/tests/src/test/system_contracts/auction/bids.rs
+++ b/grpc/tests/src/test/system_contracts/auction/bids.rs
@@ -876,12 +876,15 @@ fn should_calculate_era_validators_multiple_new_bids() {
 #[ignore]
 #[test]
 fn undelegated_funds_should_be_released() {
+    // TODO: investigate why this is needed for use-system-contracts but not the host-side version
+    const SYSTEM_TRANSFER_AMOUNT: u64 = 1_000_000_000;
+
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
             "target" => SYSTEM_ADDR,
-            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+            ARG_AMOUNT => U512::from(SYSTEM_TRANSFER_AMOUNT)
         },
     )
     .build();
@@ -994,12 +997,15 @@ fn undelegated_funds_should_be_released() {
 #[ignore]
 #[test]
 fn fully_undelegated_funds_should_be_released() {
+    // TODO: investigate why this is needed for use-system-contracts but not the host-side version
+    const SYSTEM_TRANSFER_AMOUNT: u64 = 1_000_000_000;
+
     let system_fund_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
             "target" => SYSTEM_ADDR,
-            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+            ARG_AMOUNT => U512::from(SYSTEM_TRANSFER_AMOUNT)
         },
     )
     .build();

--- a/grpc/tests/src/test/system_contracts/auction/distribute.rs
+++ b/grpc/tests/src/test/system_contracts/auction/distribute.rs
@@ -13,7 +13,7 @@ use casper_types::{
         DelegationRate, ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_DELEGATOR_PUBLIC_KEY,
         ARG_PUBLIC_KEY, ARG_REWARD_FACTORS, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY, BLOCK_REWARD,
         DELEGATION_RATE_DENOMINATOR, METHOD_ADD_BID, METHOD_DELEGATE, METHOD_DISTRIBUTE,
-        METHOD_RUN_AUCTION, METHOD_WITHDRAW_DELEGATOR_REWARD, METHOD_WITHDRAW_VALIDATOR_REWARD,
+        METHOD_WITHDRAW_DELEGATOR_REWARD, METHOD_WITHDRAW_VALIDATOR_REWARD,
     },
     mint, runtime_args, PublicKey, RuntimeArgs, U512,
 };
@@ -37,18 +37,6 @@ const DELEGATOR_2: PublicKey = PublicKey::Ed25519([206; 32]);
 const DELEGATOR_2_ADDR: AccountHash = AccountHash::new([207; 32]);
 const DELEGATOR_3: PublicKey = PublicKey::Ed25519([208; 32]);
 const DELEGATOR_3_ADDR: AccountHash = AccountHash::new([209; 32]);
-
-fn run_auction(builder: &mut InMemoryWasmTestBuilder) {
-    let run_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => METHOD_RUN_AUCTION
-        },
-    )
-    .build();
-    builder.exec(run_request).commit().expect_success();
-}
 
 fn withdraw_validator_reward(
     builder: &mut InMemoryWasmTestBuilder,
@@ -224,7 +212,7 @@ fn should_distribute_delegation_rate_zero() {
     }
 
     for _ in 0..5 {
-        run_auction(&mut builder);
+        super::run_auction(&mut builder);
     }
 
     let reward_factors: BTreeMap<PublicKey, u64> = {
@@ -392,7 +380,7 @@ fn should_distribute_delegation_rate_half() {
     }
 
     for _ in 0..5 {
-        run_auction(&mut builder);
+        super::run_auction(&mut builder);
     }
 
     let reward_factors: BTreeMap<PublicKey, u64> = {
@@ -540,7 +528,7 @@ fn should_distribute_delegation_rate_full() {
     }
 
     for _ in 0..5 {
-        run_auction(&mut builder);
+        super::run_auction(&mut builder);
     }
 
     let reward_factors: BTreeMap<PublicKey, u64> = {
@@ -694,7 +682,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
     }
 
     for _ in 0..5 {
-        run_auction(&mut builder);
+        super::run_auction(&mut builder);
     }
 
     let reward_factors: BTreeMap<PublicKey, u64> = {
@@ -848,7 +836,7 @@ fn should_distribute_by_factor() {
     }
 
     for _ in 0..5 {
-        run_auction(&mut builder);
+        super::run_auction(&mut builder);
     }
 
     let reward_factors: BTreeMap<PublicKey, u64> = {
@@ -1004,7 +992,7 @@ fn should_distribute_by_factor_regardless_of_stake() {
     }
 
     for _ in 0..5 {
-        run_auction(&mut builder);
+        super::run_auction(&mut builder);
     }
 
     let reward_factors: BTreeMap<PublicKey, u64> = {
@@ -1162,7 +1150,7 @@ fn should_distribute_by_factor_uneven() {
     }
 
     for _ in 0..5 {
-        run_auction(&mut builder);
+        super::run_auction(&mut builder);
     }
 
     let reward_factors: BTreeMap<PublicKey, u64> = {
@@ -1396,7 +1384,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     }
 
     for _ in 0..5 {
-        run_auction(&mut builder);
+        super::run_auction(&mut builder);
     }
 
     let reward_factors: BTreeMap<PublicKey, u64> = {
@@ -1646,7 +1634,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     }
 
     for _ in 0..5 {
-        run_auction(&mut builder);
+        super::run_auction(&mut builder);
     }
 
     let reward_factors: BTreeMap<PublicKey, u64> = {

--- a/grpc/tests/src/test/system_contracts/auction/mod.rs
+++ b/grpc/tests/src/test/system_contracts/auction/mod.rs
@@ -1,2 +1,23 @@
 mod bids;
 mod distribute;
+
+use casper_engine_test_support::internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
+use casper_types::{
+    self, account::AccountHash, auction::METHOD_RUN_AUCTION, runtime_args, RuntimeArgs,
+};
+
+const ARG_ENTRY_POINT: &str = "entry_point";
+const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
+const CONTRACT_AUCTION_BIDS: &str = "auction_bids.wasm";
+
+fn run_auction(builder: &mut InMemoryWasmTestBuilder) {
+    let run_request = ExecuteRequestBuilder::standard(
+        SYSTEM_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_RUN_AUCTION
+        },
+    )
+    .build();
+    builder.exec(run_request).commit().expect_success();
+}

--- a/smart_contracts/contracts/system/auction/src/lib.rs
+++ b/smart_contracts/contracts/system/auction/src/lib.rs
@@ -335,7 +335,7 @@ pub fn get_entry_points() -> EntryPoints {
             Parameter::new(ARG_VALIDATOR, AccountHash::cl_type()),
             Parameter::new(ARG_AMOUNT, U512::cl_type()),
         ],
-        U512::cl_type(),
+        <(URef, U512)>::cl_type(),
         EntryPointAccess::Public,
         EntryPointType::Contract,
     );

--- a/smart_contracts/contracts/test/auction-bids/src/main.rs
+++ b/smart_contracts/contracts/test/auction-bids/src/main.rs
@@ -29,6 +29,8 @@ const ARG_RUN_AUCTION: &str = "run_auction";
 const ARG_READ_SEIGNIORAGE_RECIPIENTS: &str = "read_seigniorage_recipients";
 
 const REWARD_PURSE: &str = "reward_purse";
+const DELEGATE_PURSE: &str = "delegate_purse";
+const UNDELEGATE_PURSE: &str = "undelegate_purse";
 
 #[repr(u16)]
 enum Error {
@@ -95,7 +97,9 @@ fn delegate() {
         ARG_AMOUNT => amount,
     };
 
-    let (_purse, _amount): (URef, U512) = runtime::call_contract(auction, METHOD_DELEGATE, args);
+    let (purse, _amount): (URef, U512) = runtime::call_contract(auction, METHOD_DELEGATE, args);
+
+    runtime::put_key(DELEGATE_PURSE, purse.into())
 }
 
 fn undelegate() {
@@ -110,7 +114,10 @@ fn undelegate() {
         ARG_DELEGATOR => delegator,
     };
 
-    let _total_amount: U512 = runtime::call_contract(auction, METHOD_UNDELEGATE, args);
+    let (purse, _remaining_bid): (URef, U512) =
+        runtime::call_contract(auction, METHOD_UNDELEGATE, args);
+
+    runtime::put_key(UNDELEGATE_PURSE, purse.into());
 }
 
 fn run_auction() {

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -224,10 +224,9 @@ pub trait Auction:
         debug_assert!(_unbonding_purse_balance > new_amount);
 
         if new_amount.is_zero() {
-            // Inner map's mapped value should be zero as we subtracted mutable value.
             let _value = delegators_map
-                .remove(&validator_public_key)
-                .ok_or(Error::ValidatorNotFound)?;
+                .remove(&delegator_public_key)
+                .ok_or(Error::DelegatorNotFound)?;
             debug_assert!(_value.is_zero());
 
             let mut outer = internal::get_delegator_reward_map(self)?;


### PR DESCRIPTION
Refs:
https://casperlabs.atlassian.net/browse/EE-1042
https://casperlabs.atlassian.net/browse/EE-1052

Notice `TODO`s in tests.  Something fishy there.  I would expect Wasm-based system contract executions to cost more, I'm suspicious of the fact that none of our other tests have revealed this.
