### PR TITLE
EE-1045: Fix slashing for validators

### DIFF
--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -2009,17 +2009,6 @@ where
                 CLValue::from_t(result).map_err(Self::reverter)?
             }
 
-            auction::METHOD_QUASH_BID => {
-                let validator_public_keys: Vec<casper_types::PublicKey> =
-                    Self::get_named_argument(&runtime_args, auction::ARG_VALIDATOR_KEYS)?;
-
-                runtime
-                    .quash_bid(validator_public_keys)
-                    .map_err(Self::reverter)?;
-
-                CLValue::from_t(()).map_err(Self::reverter)?
-            }
-
             auction::METHOD_RUN_AUCTION => {
                 runtime.run_auction().map_err(Self::reverter)?;
                 CLValue::from_t(()).map_err(Self::reverter)?

--- a/grpc/test_support/src/internal/wasm_test_builder.rs
+++ b/grpc/test_support/src/internal/wasm_test_builder.rs
@@ -687,18 +687,14 @@ where
             .expect("should get era validators")
     }
 
-    pub fn get_value<T: FromBytes + CLTyped>(
-        &mut self,
-        contract_hash: ContractHash,
-        name: &str,
-    ) -> T {
+    pub fn get_value<T>(&mut self, contract_hash: ContractHash, name: &str) -> T
+    where
+        T: FromBytes + CLTyped,
+    {
         let contract = self
             .get_contract(contract_hash)
             .expect("should have contract");
-        let key = contract
-            .named_keys()
-            .get(name)
-            .expect("should have named key");
+        let key = contract.named_keys().get(name).expect("should have purse");
         let stored_value = self.query(None, *key, &[]).expect("should query");
         let cl_value = stored_value
             .as_cl_value()

--- a/grpc/tests/src/test/regression/ee_1045.rs
+++ b/grpc/tests/src/test/regression/ee_1045.rs
@@ -1,0 +1,211 @@
+use std::{collections::BTreeSet, iter::FromIterator};
+
+use casper_engine_test_support::{
+    internal::{utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS},
+    DEFAULT_ACCOUNT_ADDR,
+};
+use casper_execution_engine::{core::engine_state::genesis::GenesisAccount, shared::motes::Motes};
+use casper_types::{
+    account::AccountHash,
+    auction::{
+        ARG_VALIDATOR_PUBLIC_KEYS, AUCTION_DELAY, INITIAL_ERA_ID, METHOD_RUN_AUCTION, METHOD_SLASH,
+    },
+    runtime_args, PublicKey, RuntimeArgs, U512,
+};
+
+const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
+const CONTRACT_AUCTION_BIDS: &str = "auction_bids.wasm";
+
+const ARG_AMOUNT: &str = "amount";
+const ARG_ENTRY_POINT: &str = "entry_point";
+
+const TRANSFER_AMOUNT: u64 = 250_000_000 + 1000;
+
+const ACCOUNT_1_PK: PublicKey = PublicKey::Ed25519([200; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([201; 32]);
+const ACCOUNT_1_BALANCE: u64 = 10_000_000;
+const ACCOUNT_1_BOND: u64 = 100_000;
+
+const ACCOUNT_2_PK: PublicKey = PublicKey::Ed25519([202; 32]);
+const ACCOUNT_2_ADDR: AccountHash = AccountHash::new([203; 32]);
+const ACCOUNT_2_BALANCE: u64 = 25_000_000;
+const ACCOUNT_2_BOND: u64 = 200_000;
+
+const ACCOUNT_3_PK: PublicKey = PublicKey::Ed25519([150; 32]);
+const ACCOUNT_3_ADDR: AccountHash = AccountHash::new([151; 32]);
+const ACCOUNT_3_BALANCE: u64 = 25_000_000;
+const ACCOUNT_3_BOND: u64 = 200_000;
+
+const ACCOUNT_4_PK: PublicKey = PublicKey::Ed25519([170; 32]);
+const ACCOUNT_4_ADDR: AccountHash = AccountHash::new([171; 32]);
+const ACCOUNT_4_BALANCE: u64 = 25_000_000;
+const ACCOUNT_4_BOND: u64 = 200_000;
+
+const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
+
+#[ignore]
+#[test]
+fn should_run_ee_1045_squash_validators() {
+    let account_1 = GenesisAccount::new(
+        ACCOUNT_1_PK,
+        ACCOUNT_1_ADDR,
+        Motes::new(ACCOUNT_1_BALANCE.into()),
+        Motes::new(ACCOUNT_1_BOND.into()),
+    );
+    let account_2 = GenesisAccount::new(
+        ACCOUNT_2_PK,
+        ACCOUNT_2_ADDR,
+        Motes::new(ACCOUNT_2_BALANCE.into()),
+        Motes::new(ACCOUNT_2_BOND.into()),
+    );
+    let account_3 = GenesisAccount::new(
+        ACCOUNT_3_PK,
+        ACCOUNT_3_ADDR,
+        Motes::new(ACCOUNT_3_BALANCE.into()),
+        Motes::new(ACCOUNT_3_BOND.into()),
+    );
+    let account_4 = GenesisAccount::new(
+        ACCOUNT_4_PK,
+        ACCOUNT_4_ADDR,
+        Motes::new(ACCOUNT_4_BALANCE.into()),
+        Motes::new(ACCOUNT_4_BOND.into()),
+    );
+
+    let round_1_validator_squash = vec![ACCOUNT_2_PK, ACCOUNT_4_PK];
+    let round_2_validator_squash = vec![ACCOUNT_1_PK, ACCOUNT_3_PK];
+
+    let extra_accounts = vec![account_1, account_2, account_3, account_4];
+
+    let accounts = {
+        let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
+        tmp.extend(extra_accounts.clone());
+        tmp
+    };
+
+    let run_genesis_request = utils::create_run_genesis_request(accounts);
+
+    let transfer_request_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => SYSTEM_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&run_genesis_request);
+
+    let genesis_validator_weights = builder
+        .get_era_validators(INITIAL_ERA_ID)
+        .expect("should have genesis validator weights");
+
+    let mut new_era_id = INITIAL_ERA_ID + AUCTION_DELAY + 1;
+    assert!(builder.get_era_validators(new_era_id).is_none());
+    assert!(builder.get_era_validators(new_era_id - 1).is_some());
+
+    builder.exec(transfer_request_1).expect_success().commit();
+
+    let auction_contract = builder.get_auction_contract_hash();
+
+    let squash_request_1 = {
+        let args = runtime_args! {
+            ARG_VALIDATOR_PUBLIC_KEYS => round_1_validator_squash.clone(),
+        };
+        ExecuteRequestBuilder::contract_call_by_hash(
+            SYSTEM_ADDR,
+            auction_contract,
+            METHOD_SLASH,
+            args,
+        )
+        .build()
+    };
+
+    let squash_request_2 = {
+        let args = runtime_args! {
+            ARG_VALIDATOR_PUBLIC_KEYS => round_2_validator_squash.clone(),
+        };
+        ExecuteRequestBuilder::contract_call_by_hash(
+            SYSTEM_ADDR,
+            auction_contract,
+            METHOD_SLASH,
+            args,
+        )
+        .build()
+    };
+
+    let run_auction_request_1 = ExecuteRequestBuilder::standard(
+        SYSTEM_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_RUN_AUCTION
+        },
+    )
+    .build();
+
+    let run_auction_request_2 = ExecuteRequestBuilder::standard(
+        SYSTEM_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_RUN_AUCTION
+        },
+    )
+    .build();
+
+    //
+    // ROUND 1
+    //
+    builder.exec(squash_request_1).expect_success().commit();
+
+    // new_era_id += 1;
+    assert!(builder.get_era_validators(new_era_id).is_none());
+    assert!(builder.get_era_validators(new_era_id - 1).is_some());
+
+    builder
+        .exec(run_auction_request_1)
+        .commit()
+        .expect_success();
+
+    let post_round_1_auction_weights = builder
+        .get_era_validators(new_era_id)
+        .expect("should have new era validator weights computed");
+
+    assert_ne!(genesis_validator_weights, post_round_1_auction_weights);
+
+    let lhs = BTreeSet::from_iter(genesis_validator_weights.keys().copied());
+    let rhs = BTreeSet::from_iter(post_round_1_auction_weights.keys().copied());
+    assert_eq!(
+        lhs.difference(&rhs).copied().collect::<BTreeSet<_>>(),
+        BTreeSet::from_iter(round_1_validator_squash.clone())
+    );
+
+    //
+    // ROUND 2
+    //
+    builder.exec(squash_request_2).expect_success().commit();
+    new_era_id += 1;
+    assert!(builder.get_era_validators(new_era_id).is_none());
+    assert!(builder.get_era_validators(new_era_id - 1).is_some());
+
+    builder
+        .exec(run_auction_request_2)
+        .commit()
+        .expect_success();
+
+    let post_round_2_auction_weights = builder
+        .get_era_validators(new_era_id)
+        .expect("should have new era validator weights computed");
+
+    assert_ne!(genesis_validator_weights, post_round_2_auction_weights);
+
+    let lhs = BTreeSet::from_iter(post_round_1_auction_weights.keys().copied());
+    let rhs = BTreeSet::from_iter(post_round_2_auction_weights.keys().copied());
+    assert_eq!(
+        lhs.difference(&rhs).copied().collect::<BTreeSet<_>>(),
+        BTreeSet::from_iter(round_2_validator_squash)
+    );
+
+    assert!(post_round_2_auction_weights.is_empty()); // all validators are squashed
+}

--- a/grpc/tests/src/test/regression/ee_1045.rs
+++ b/grpc/tests/src/test/regression/ee_1045.rs
@@ -78,7 +78,7 @@ fn should_run_ee_1045_squash_validators() {
 
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        tmp.extend(extra_accounts.clone());
+        tmp.extend(extra_accounts);
         tmp
     };
 
@@ -178,7 +178,7 @@ fn should_run_ee_1045_squash_validators() {
     let rhs = BTreeSet::from_iter(post_round_1_auction_weights.keys().copied());
     assert_eq!(
         lhs.difference(&rhs).copied().collect::<BTreeSet<_>>(),
-        BTreeSet::from_iter(round_1_validator_squash.clone())
+        BTreeSet::from_iter(round_1_validator_squash)
     );
 
     //

--- a/grpc/tests/src/test/regression/mod.rs
+++ b/grpc/tests/src/test/regression/mod.rs
@@ -1,3 +1,4 @@
+mod ee_1045;
 mod ee_221;
 mod ee_401;
 mod ee_441;

--- a/grpc/tests/src/test/step.rs
+++ b/grpc/tests/src/test/step.rs
@@ -89,15 +89,27 @@ fn should_step() {
         builder.get_value(auction_hash, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY);
 
     let bids_before_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
-    assert!(bids_before_slashing.contains_key(&ACCOUNT_1_PK));
+    assert!(
+        bids_before_slashing.contains_key(&ACCOUNT_1_PK),
+        "should have entry in the genesis bids table {:?}",
+        bids_before_slashing
+    );
 
     let bid_purses_before_slashing: BidPurses = builder.get_value(auction_hash, BID_PURSES_KEY);
-    assert!(bid_purses_before_slashing.contains_key(&ACCOUNT_1_PK));
+    assert!(
+        bid_purses_before_slashing.contains_key(&ACCOUNT_1_PK),
+        "should have bid purse in the bids purses table {:?}",
+        bid_purses_before_slashing
+    );
 
     builder.step(step_request);
 
     let bids_after_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
-    assert!(!bids_after_slashing.contains_key(&ACCOUNT_1_PK));
+    assert!(
+        !bids_after_slashing.contains_key(&ACCOUNT_1_PK),
+        "should not have entry in bids table after slashing {:?}",
+        bids_after_slashing
+    );
 
     // bid purses should not have slashed validator after slashing
     let bid_purses_after_slashing: BidPurses = builder.get_value(auction_hash, BID_PURSES_KEY);
@@ -114,7 +126,10 @@ fn should_step() {
     );
 
     let bids_after_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
-    assert_ne!(bids_before_slashing, bids_after_slashing);
+    assert_ne!(
+        bids_before_slashing, bids_after_slashing,
+        "bids table should be different before and after slashing"
+    );
 
     // seigniorage snapshot should have changed after auction
     let after_auction_seigniorage: SeigniorageRecipientsSnapshot =

--- a/grpc/tests/src/test/step.rs
+++ b/grpc/tests/src/test/step.rs
@@ -9,11 +9,10 @@ use casper_execution_engine::{
 use casper_types::{
     account::AccountHash,
     auction::{
-        BidPurses, SeigniorageRecipientsSnapshot, BID_PURSES_KEY,
+        BidPurses, Bids, SeigniorageRecipientsSnapshot, BIDS_KEY, BID_PURSES_KEY,
         SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, VALIDATOR_REWARD_PURSE,
     },
-    bytesrepr::FromBytes,
-    CLTyped, ContractHash, Key, ProtocolVersion, PublicKey,
+    ContractHash, Key, ProtocolVersion, PublicKey,
 };
 
 const ACCOUNT_1_PK: PublicKey = PublicKey::Ed25519([200; 32]);
@@ -37,16 +36,6 @@ fn get_named_key(
         .named_keys()
         .get(name)
         .expect("should have bid purses")
-}
-
-fn get_value<T: FromBytes + CLTyped>(builder: &mut InMemoryWasmTestBuilder, key: Key) -> T {
-    let stored_value = builder.query(None, key, &[]).expect("should query");
-    let cl_value = stored_value
-        .as_cl_value()
-        .cloned()
-        .expect("should be cl value");
-    let result: T = cl_value.into_t().expect("should convert");
-    result
 }
 
 fn initialize_builder() -> WasmTestBuilder<InMemoryGlobalState> {
@@ -85,41 +74,33 @@ fn should_step() {
         .with_parent_state_hash(builder.get_post_state_hash())
         .with_protocol_version(ProtocolVersion::V1_0_0)
         .with_slash_item(SlashItem::new(ACCOUNT_1_PK))
-        // TODO: currently, it is necessary to add a reward item for account_1 due to the genesis
-        // validator slashing immunity bug; when that bug is fixed, the below line adding
-        // reward item for ACCOUNT_1_PK and this comment should be removed.
         .with_reward_item(RewardItem::new(ACCOUNT_1_PK, 100000))
         .with_reward_item(RewardItem::new(ACCOUNT_2_PK, 100000))
         .build();
 
     let auction_hash = builder.get_auction_contract_hash();
 
-    let bid_purse_key = get_named_key(&mut builder, auction_hash, BID_PURSES_KEY);
     let reward_purse_key = get_named_key(&mut builder, auction_hash, VALIDATOR_REWARD_PURSE)
         .into_uref()
         .expect("should be uref");
-    let auction_seigniorage_key = get_named_key(
-        &mut builder,
-        auction_hash,
-        SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
-    );
 
     let before_balance = builder.get_purse_balance(reward_purse_key);
     let before_auction_seigniorage: SeigniorageRecipientsSnapshot =
-        get_value(&mut builder, auction_seigniorage_key);
+        builder.get_value(auction_hash, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY);
 
-    // TODO: this is currently not possible due to a bug in the slashing logic
-    //       the genesis validators are not slashable due to an oversight in initialization.
-    // let _bid_purses_before_slashing: BidPurses = get_value(&mut builder, bid_purse_key);
-    // assert!(
-    //     bid_purses_before_slashing.contains_key(&ACCOUNT_1_PK),
-    //     "should contain slashed validator)"
-    // );
+    let bids_before_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    assert!(bids_before_slashing.contains_key(&ACCOUNT_1_PK));
+
+    let bid_purses_before_slashing: BidPurses = builder.get_value(auction_hash, BID_PURSES_KEY);
+    assert!(bid_purses_before_slashing.contains_key(&ACCOUNT_1_PK));
 
     builder.step(step_request);
 
+    let bids_after_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    assert!(!bids_after_slashing.contains_key(&ACCOUNT_1_PK));
+
     // bid purses should not have slashed validator after slashing
-    let bid_purses_after_slashing: BidPurses = get_value(&mut builder, bid_purse_key);
+    let bid_purses_after_slashing: BidPurses = builder.get_value(auction_hash, BID_PURSES_KEY);
     assert!(
         !bid_purses_after_slashing.contains_key(&ACCOUNT_1_PK),
         "should not contain slashed validator)"
@@ -132,9 +113,12 @@ fn should_step() {
         "reward balance should change"
     );
 
+    let bids_after_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    assert_ne!(bids_before_slashing, bids_after_slashing);
+
     // seigniorage snapshot should have changed after auction
     let after_auction_seigniorage: SeigniorageRecipientsSnapshot =
-        get_value(&mut builder, auction_seigniorage_key);
+        builder.get_value(auction_hash, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY);
     assert!(
         !before_auction_seigniorage
             .keys()

--- a/smart_contracts/contracts/system/auction-install/src/main.rs
+++ b/smart_contracts/contracts/system/auction-install/src/main.rs
@@ -49,13 +49,16 @@ pub extern "C" fn install() {
 
         // List of validators for initial era.
         let mut initial_validator_weights = ValidatorWeights::new();
+        // Initial bid purses calculated based on founder validator stakes
+        let mut bid_purses = BidPurses::new();
 
-        for (validator_account_hash, amount) in genesis_validators {
+        for (validator_public_key, amount) in genesis_validators {
             let bonding_purse = create_purse(mint_package_hash, amount);
             let founding_validator =
                 Bid::new_locked(bonding_purse, amount, DEFAULT_LOCKED_FUNDS_PERIOD);
-            validators.insert(validator_account_hash, founding_validator);
-            initial_validator_weights.insert(validator_account_hash, amount);
+            validators.insert(validator_public_key, founding_validator);
+            initial_validator_weights.insert(validator_public_key, amount);
+            bid_purses.insert(validator_public_key, bonding_purse);
         }
 
         let initial_snapshot_range = INITIAL_ERA_ID..=INITIAL_ERA_ID + AUCTION_DELAY;
@@ -87,10 +90,7 @@ pub extern "C" fn install() {
             ERA_VALIDATORS_KEY.into(),
             storage::new_uref(era_validators).into(),
         );
-        named_keys.insert(
-            BID_PURSES_KEY.into(),
-            storage::new_uref(BidPurses::new()).into(),
-        );
+        named_keys.insert(BID_PURSES_KEY.into(), storage::new_uref(bid_purses).into());
         named_keys.insert(
             UNBONDING_PURSES_KEY.into(),
             storage::new_uref(UnbondingPurses::new()).into(),

--- a/smart_contracts/contracts/system/auction/src/lib.rs
+++ b/smart_contracts/contracts/system/auction/src/lib.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate alloc;
 
-use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
+use alloc::{boxed::Box, collections::BTreeMap};
 use core::result::Result as StdResult;
 
 use casper_contract::{
@@ -16,11 +16,11 @@ use casper_types::{
         Auction, DelegationRate, MintProvider, RuntimeProvider, SeigniorageRecipients,
         StorageProvider, SystemProvider, ValidatorWeights, ARG_AMOUNT, ARG_DELEGATION_RATE,
         ARG_DELEGATOR, ARG_DELEGATOR_PUBLIC_KEY, ARG_ERA_ID, ARG_PUBLIC_KEY, ARG_REWARD_FACTORS,
-        ARG_SOURCE_PURSE, ARG_TARGET_PURSE, ARG_VALIDATOR, ARG_VALIDATOR_KEYS,
-        ARG_VALIDATOR_PUBLIC_KEY, ARG_VALIDATOR_PUBLIC_KEYS, METHOD_ADD_BID, METHOD_DELEGATE,
-        METHOD_DISTRIBUTE, METHOD_GET_ERA_VALIDATORS, METHOD_QUASH_BID, METHOD_READ_ERA_ID,
-        METHOD_READ_SEIGNIORAGE_RECIPIENTS, METHOD_RUN_AUCTION, METHOD_SLASH, METHOD_UNDELEGATE,
-        METHOD_WITHDRAW_BID, METHOD_WITHDRAW_DELEGATOR_REWARD, METHOD_WITHDRAW_VALIDATOR_REWARD,
+        ARG_SOURCE_PURSE, ARG_TARGET_PURSE, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY,
+        ARG_VALIDATOR_PUBLIC_KEYS, METHOD_ADD_BID, METHOD_DELEGATE, METHOD_DISTRIBUTE,
+        METHOD_GET_ERA_VALIDATORS, METHOD_READ_ERA_ID, METHOD_READ_SEIGNIORAGE_RECIPIENTS,
+        METHOD_RUN_AUCTION, METHOD_SLASH, METHOD_UNDELEGATE, METHOD_WITHDRAW_BID,
+        METHOD_WITHDRAW_DELEGATOR_REWARD, METHOD_WITHDRAW_VALIDATOR_REWARD,
     },
     bytesrepr::{FromBytes, ToBytes},
     mint::{METHOD_MINT, METHOD_READ_BASE_ROUND_REWARD},
@@ -202,13 +202,6 @@ pub extern "C" fn undelegate() {
 }
 
 #[no_mangle]
-pub extern "C" fn quash_bid() {
-    let validator_keys: Vec<PublicKey> = runtime::get_named_arg("validator_keys");
-
-    AuctionContract.quash_bid(validator_keys).unwrap_or_revert();
-}
-
-#[no_mangle]
 pub extern "C" fn run_auction() {
     AuctionContract.run_auction().unwrap_or_revert();
 }
@@ -336,18 +329,6 @@ pub fn get_entry_points() -> EntryPoints {
             Parameter::new(ARG_AMOUNT, U512::cl_type()),
         ],
         U512::cl_type(),
-        EntryPointAccess::Public,
-        EntryPointType::Contract,
-    );
-    entry_points.add_entry_point(entry_point);
-
-    let entry_point = EntryPoint::new(
-        METHOD_QUASH_BID,
-        vec![Parameter::new(
-            ARG_VALIDATOR_KEYS,
-            Vec::<AccountHash>::cl_type(),
-        )],
-        CLType::Unit,
         EntryPointAccess::Public,
         EntryPointType::Contract,
     );

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -245,30 +245,6 @@ pub trait Auction:
         Ok(new_amount)
     }
 
-    /// Removes validator entries from either founders or validators, wherever they
-    /// might be found.
-    ///
-    /// This function is intended to be called together with the slash function in the Mint
-    /// contract.
-    fn quash_bid(&mut self, validator_public_keys: Vec<PublicKey>) -> Result<()> {
-        // Clean up inside `bids`
-        let mut validators = internal::get_bids(self)?;
-
-        let mut modified_validators = 0usize;
-
-        for validator_public_key in &validator_public_keys {
-            if validators.remove(validator_public_key).is_some() {
-                modified_validators += 1;
-            }
-        }
-
-        if modified_validators > 0 {
-            internal::set_bids(self, validators)?;
-        }
-
-        Ok(())
-    }
-
     /// Slashes each validator.
     ///
     /// This can be only invoked through a system call.
@@ -276,6 +252,8 @@ pub trait Auction:
         if self.get_caller() != SYSTEM_ACCOUNT {
             return Err(Error::InvalidCaller);
         }
+
+        detail::quash_bid(self, &validator_public_keys)?;
 
         let bid_purses_uref = self
             .get_key(BID_PURSES_KEY)

--- a/types/src/auction/constants.rs
+++ b/types/src/auction/constants.rs
@@ -68,8 +68,6 @@ pub const METHOD_WITHDRAW_BID: &str = "withdraw_bid";
 pub const METHOD_DELEGATE: &str = "delegate";
 /// Named constant for method `undelegate`.
 pub const METHOD_UNDELEGATE: &str = "undelegate";
-/// Named constant for method `quash_bid`.
-pub const METHOD_QUASH_BID: &str = "quash_bid";
 /// Named constant for method `run_auction`.
 pub const METHOD_RUN_AUCTION: &str = "run_auction";
 /// Named constant for method `slash`.

--- a/types/src/auction/detail.rs
+++ b/types/src/auction/detail.rs
@@ -227,3 +227,30 @@ where
     internal::set_validator_reward_map(provider, validator_reward_map)?;
     Ok(())
 }
+
+/// Removes validator entries from either founders or validators, wherever they
+/// might be found.
+///
+/// This function is intended to be called together with the slash function in the Mint
+/// contract.
+pub(crate) fn quash_bid<P: StorageProvider + RuntimeProvider + ?Sized>(
+    provider: &mut P,
+    validator_public_keys: &[PublicKey],
+) -> Result<()> {
+    // Clean up inside `bids`
+    let mut validators = internal::get_bids(provider)?;
+
+    let mut modified_validators = 0usize;
+
+    for validator_public_key in validator_public_keys {
+        if validators.remove(validator_public_key).is_some() {
+            modified_validators += 1;
+        }
+    }
+
+    if modified_validators > 0 {
+        internal::set_bids(provider, validators)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1045

Removes `quash_bid` and makes it an impl detail, and then `slash` uses it to slash validator bids.