### PR TITLE
EE-1042: check key against caller in Auction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/execution_engine/src/core/resolvers/v1_function_index.rs
+++ b/execution_engine/src/core/resolvers/v1_function_index.rs
@@ -49,6 +49,7 @@ pub enum FunctionIndex {
     RemoveContractUserGroupIndex,
     ExtendContractUserGroupURefsIndex,
     RemoveContractUserGroupURefsIndex,
+    Blake2b,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution_engine/src/core/resolvers/v1_resolver.rs
+++ b/execution_engine/src/core/resolvers/v1_resolver.rs
@@ -205,7 +205,7 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 FunctionIndex::RemoveContractUserGroupURefsIndex.into(),
             ),
             "blake2b" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 4][..], None),
+                Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::Blake2b.into(),
             ),
             #[cfg(feature = "test-support")]

--- a/execution_engine/src/core/resolvers/v1_resolver.rs
+++ b/execution_engine/src/core/resolvers/v1_resolver.rs
@@ -204,6 +204,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 6][..], Some(ValueType::I32)),
                 FunctionIndex::RemoveContractUserGroupURefsIndex.into(),
             ),
+            "blake2b" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 4][..], None),
+                FunctionIndex::Blake2b.into(),
+            ),
             #[cfg(feature = "test-support")]
             "print" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], None),

--- a/execution_engine/src/core/runtime/auction_internal.rs
+++ b/execution_engine/src/core/runtime/auction_internal.rs
@@ -1,9 +1,10 @@
 use casper_types::{
+    account,
     account::AccountHash,
     auction::{Auction, MintProvider, RuntimeProvider, StorageProvider, SystemProvider},
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::auction::Error,
-    ApiError, CLTyped, CLValue, Key, TransferredTo, URef, U512,
+    ApiError, CLTyped, CLValue, Key, TransferredTo, URef, BLAKE2B_DIGEST_LENGTH, U512,
 };
 
 use super::Runtime;
@@ -78,6 +79,10 @@ where
         self.context
             .put_key(name.to_string(), key)
             .expect("should put key")
+    }
+
+    fn blake2b<T: AsRef<[u8]>>(&self, data: T) -> [u8; BLAKE2B_DIGEST_LENGTH] {
+        account::blake2b(data)
     }
 }
 

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -676,10 +676,14 @@ where
                 scoped_instrumenter.add_property("out_size", out_size.to_string());
                 let input: Vec<u8> = self.bytes_from_mem(in_ptr, in_size as usize)?;
                 let digest = account::blake2b(&input);
+                if digest.len() != out_size as usize {
+                    let err_value = u32::from(api_error::ApiError::BufferTooSmall) as i32;
+                    return Ok(Some(RuntimeValue::I32(err_value)));
+                }
                 self.memory
                     .set(out_ptr, &digest)
                     .map_err(|error| Error::Interpreter(error.into()))?;
-                Ok(None)
+                Ok(Some(RuntimeValue::I32(0)))
             }
         }
     }

--- a/execution_engine/src/core/runtime/scoped_instrumenter.rs
+++ b/execution_engine/src/core/runtime/scoped_instrumenter.rs
@@ -139,6 +139,7 @@ impl Drop for ScopedInstrumenter {
             FunctionIndex::RemoveContractUserGroupURefsIndex => {
                 "host_remove_contract_user_group_urefs"
             }
+            FunctionIndex::Blake2b => "host_blake2b",
         };
 
         let mut properties = mem::take(&mut self.properties);

--- a/grpc/test_support/src/internal/mod.rs
+++ b/grpc/test_support/src/internal/mod.rs
@@ -45,15 +45,7 @@ lazy_static! {
     // NOTE: Those values could be contants but are kept az lazy statics to avoid changes of `*FOO` into `FOO` back and forth.
     pub static ref DEFAULT_GENESIS_CONFIG_HASH: Blake2bHash = [42; 32].into();
     pub static ref DEFAULT_ACCOUNT_PUBLIC_KEY: PublicKey = PublicKey::Ed25519([199; 32]);
-    pub static ref DEFAULT_ACCOUNT_ADDR: AccountHash = {
-        // Default addr initialized to seemingly unique address to avoid accidental collisions
-        // with custom addresses in tests.
-        let mut account_hash_bytes: [u8; 32] = Default::default();
-        for (position, byte) in account_hash_bytes.iter_mut().enumerate() {
-            *byte = 100u8 + position as u8;
-        }
-        AccountHash::new(account_hash_bytes)
-    };
+    pub static ref DEFAULT_ACCOUNT_ADDR: AccountHash = AccountHash::from(*DEFAULT_ACCOUNT_PUBLIC_KEY);
     pub static ref DEFAULT_ACCOUNT_KEY: AccountHash = *DEFAULT_ACCOUNT_ADDR;
     pub static ref DEFAULT_ACCOUNTS: Vec<GenesisAccount> = {
         let mut ret = Vec::new();

--- a/grpc/tests/src/test/contract_api/blake2b.rs
+++ b/grpc/tests/src/test/contract_api/blake2b.rs
@@ -1,0 +1,62 @@
+use rand::Rng;
+
+use casper_engine_test_support::{
+    internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
+    DEFAULT_ACCOUNT_ADDR,
+};
+use casper_types::{account, runtime_args, RuntimeArgs, BLAKE2B_DIGEST_LENGTH};
+
+const BLAKE2B_WASM: &str = "blake2b.wasm";
+const ARG_BYTES: &str = "bytes";
+const HASH_RESULT: &str = "hash_result";
+
+fn get_digest(builder: &InMemoryWasmTestBuilder) -> [u8; BLAKE2B_DIGEST_LENGTH] {
+    let account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+
+    let uref = account
+        .named_keys()
+        .get(HASH_RESULT)
+        .expect("should have value");
+
+    builder
+        .query(None, *uref, &[])
+        .expect("should query")
+        .as_cl_value()
+        .cloned()
+        .expect("should be CLValue")
+        .into_t()
+        .expect("should convert")
+}
+
+#[ignore]
+#[test]
+fn should_hash() {
+    const INPUT_LENGTH: usize = 32;
+    const RUNS: usize = 100;
+
+    let mut rng = rand::thread_rng();
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    for _ in 0..RUNS {
+        let input: [u8; INPUT_LENGTH] = rng.gen();
+
+        let exec_request = ExecuteRequestBuilder::standard(
+            *DEFAULT_ACCOUNT_ADDR,
+            BLAKE2B_WASM,
+            runtime_args! {
+                ARG_BYTES => input.to_vec()
+            },
+        )
+        .build();
+
+        builder.exec(exec_request).commit().expect_success();
+
+        let digest = get_digest(&builder);
+        let expected_digest = account::blake2b(&input);
+        assert_eq!(digest, expected_digest);
+    }
+}

--- a/grpc/tests/src/test/contract_api/mod.rs
+++ b/grpc/tests/src/test/contract_api/mod.rs
@@ -1,4 +1,5 @@
 mod account;
+mod blake2b;
 mod create_purse;
 mod get_arg;
 mod get_blocktime;

--- a/grpc/tests/src/test/regression/ee_597.rs
+++ b/grpc/tests/src/test/regression/ee_597.rs
@@ -1,25 +1,48 @@
-use casper_engine_test_support::{
-    internal::{
-        utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST,
-    },
-    DEFAULT_ACCOUNT_ADDR,
+use lazy_static::lazy_static;
+
+use casper_engine_test_support::internal::{
+    utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS,
 };
-use casper_types::{system_contract_errors::auction, ApiError, RuntimeArgs};
+use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
+use casper_types::{
+    account::AccountHash, system_contract_errors::auction, ApiError, PublicKey, RuntimeArgs, U512,
+};
 
 const CONTRACT_EE_597_REGRESSION: &str = "ee_597_regression.wasm";
+
+const VALID_PUBLIC_KEY: PublicKey = PublicKey::Ed25519([42; 32]);
+const VALID_BALANCE: u64 = 1_000_000_000;
+
+lazy_static! {
+    static ref VALID_ADDR: AccountHash = VALID_PUBLIC_KEY.into();
+}
 
 #[ignore]
 #[test]
 fn should_fail_when_bonding_amount_is_zero_ee_597_regression() {
+    let accounts = {
+        let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
+        let account = GenesisAccount::new(
+            VALID_PUBLIC_KEY,
+            *VALID_ADDR,
+            Motes::new(VALID_BALANCE.into()),
+            Motes::new(U512::zero()),
+        );
+        tmp.push(account);
+        tmp
+    };
+
+    let run_genesis_request = utils::create_run_genesis_request(accounts);
+
     let exec_request = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
+        *VALID_ADDR,
         CONTRACT_EE_597_REGRESSION,
         RuntimeArgs::default(),
     )
     .build();
 
     let result = InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .run_genesis(&run_genesis_request)
         .exec(exec_request)
         .commit()
         .finish();

--- a/grpc/tests/src/test/system_contracts/auction/bids.rs
+++ b/grpc/tests/src/test/system_contracts/auction/bids.rs
@@ -1,5 +1,7 @@
 use std::{collections::BTreeSet, iter::FromIterator};
 
+use lazy_static::lazy_static;
+
 use casper_engine_test_support::{
     internal::{
         utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS,
@@ -27,9 +29,6 @@ const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
 const CONTRACT_AUCTION_BIDS: &str = "auction_bids.wasm";
 const TRANSFER_AMOUNT: u64 = 250_000_000 + 1000;
 const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
-const NON_FOUNDER_VALIDATOR_1: PublicKey = PublicKey::Ed25519([3; 32]);
-const NON_FOUNDER_VALIDATOR_1_ADDR: AccountHash = AccountHash::new([4; 32]);
-const NON_FOUNDER_VALIDATOR_2_ADDR: AccountHash = AccountHash::new([6; 32]);
 
 const UNDELEGATE_PURSE: &str = "undelegate_purse";
 
@@ -51,33 +50,57 @@ const DELEGATE_AMOUNT_1: u64 = 125_000;
 const DELEGATE_AMOUNT_2: u64 = 15_000;
 const UNDELEGATE_AMOUNT_1: u64 = 35_000;
 
+const NON_FOUNDER_VALIDATOR_1_PK: PublicKey = PublicKey::Ed25519([3; 32]);
+const NON_FOUNDER_VALIDATOR_2_PK: PublicKey = PublicKey::Ed25519([4; 32]);
+
 const ACCOUNT_1_PK: PublicKey = PublicKey::Ed25519([200; 32]);
-const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([201; 32]);
-const ACCOUNT_1_BALANCE: u64 = 10_000_000;
+const ACCOUNT_1_BALANCE: u64 = 1_000_000_000;
 const ACCOUNT_1_BOND: u64 = 100_000;
 
 const ACCOUNT_2_PK: PublicKey = PublicKey::Ed25519([202; 32]);
-const ACCOUNT_2_ADDR: AccountHash = AccountHash::new([203; 32]);
-const ACCOUNT_2_BALANCE: u64 = 25_000_000;
+const ACCOUNT_2_BALANCE: u64 = 1_000_000_000;
 const ACCOUNT_2_BOND: u64 = 200_000;
 
 const BID_ACCOUNT_1_PK: PublicKey = PublicKey::Ed25519([204; 32]);
-const BID_ACCOUNT_1_ADDR: AccountHash = AccountHash::new([205; 32]);
+const BID_ACCOUNT_1_BALANCE: u64 = 1_000_000_000;
+const BID_ACCOUNT_1_BOND: u64 = 0;
 
 const BID_ACCOUNT_2_PK: PublicKey = PublicKey::Ed25519([206; 32]);
+const BID_ACCOUNT_2_BALANCE: u64 = 1_000_000_000;
+const BID_ACCOUNT_2_BOND: u64 = 0;
+
+lazy_static! {
+    static ref NON_FOUNDER_VALIDATOR_1_ADDR: AccountHash = NON_FOUNDER_VALIDATOR_1_PK.into();
+    static ref NON_FOUNDER_VALIDATOR_2_ADDR: AccountHash = NON_FOUNDER_VALIDATOR_2_PK.into();
+    static ref ACCOUNT_1_ADDR: AccountHash = ACCOUNT_1_PK.into();
+    static ref ACCOUNT_2_ADDR: AccountHash = ACCOUNT_2_PK.into();
+    static ref BID_ACCOUNT_1_ADDR: AccountHash = BID_ACCOUNT_1_PK.into();
+    static ref BID_ACCOUNT_2_ADDR: AccountHash = BID_ACCOUNT_2_PK.into();
+}
 
 #[ignore]
 #[test]
 fn should_run_add_bid() {
+    let accounts = {
+        let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
+        let account_1 = GenesisAccount::new(
+            BID_ACCOUNT_1_PK,
+            *BID_ACCOUNT_1_ADDR,
+            Motes::new(BID_ACCOUNT_1_BALANCE.into()),
+            Motes::new(BID_ACCOUNT_1_BOND.into()),
+        );
+        tmp.push(account_1);
+        tmp
+    };
+
+    let run_genesis_request = utils::create_run_genesis_request(accounts);
+
     let mut builder = InMemoryWasmTestBuilder::default();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+    builder.run_genesis(&run_genesis_request);
 
-    let auction_hash = builder.get_auction_contract_hash();
-
-    //
     let exec_request_1 = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_PUBLIC_KEY => BID_ACCOUNT_1_PK,
@@ -90,6 +113,7 @@ fn should_run_add_bid() {
 
     builder.exec(exec_request_1).commit().expect_success();
 
+    let auction_hash = builder.get_auction_contract_hash();
     let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
 
     assert_eq!(bids.len(), 1);
@@ -104,7 +128,7 @@ fn should_run_add_bid() {
 
     // 2nd bid top-up
     let exec_request_2 = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_PUBLIC_KEY => BID_ACCOUNT_1_PK,
@@ -130,7 +154,7 @@ fn should_run_add_bid() {
 
     // 3. withdraw some amount
     let exec_request_3 = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_WITHDRAW_BID,
@@ -173,7 +197,23 @@ fn should_run_add_bid() {
 #[ignore]
 #[test]
 fn should_run_delegate_and_undelegate() {
+    let accounts = {
+        let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
+        let account_1 = GenesisAccount::new(
+            BID_ACCOUNT_1_PK,
+            *BID_ACCOUNT_1_ADDR,
+            Motes::new(BID_ACCOUNT_1_BALANCE.into()),
+            Motes::new(BID_ACCOUNT_1_BOND.into()),
+        );
+        tmp.push(account_1);
+        tmp
+    };
+
+    let run_genesis_request = utils::create_run_genesis_request(accounts);
+
     let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&run_genesis_request);
 
     let transfer_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -189,7 +229,7 @@ fn should_run_delegate_and_undelegate() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => NON_FOUNDER_VALIDATOR_1_ADDR,
+            "target" => *NON_FOUNDER_VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -197,10 +237,10 @@ fn should_run_delegate_and_undelegate() {
 
     // non-founding validator request
     let add_bid_request_1 = ExecuteRequestBuilder::standard(
-        NON_FOUNDER_VALIDATOR_1_ADDR,
+        *NON_FOUNDER_VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
-            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1,
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1_PK,
             ARG_ENTRY_POINT => ARG_ADD_BID,
             ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_1),
             ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
@@ -208,7 +248,6 @@ fn should_run_delegate_and_undelegate() {
     )
     .build();
 
-    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
     builder.exec(transfer_request_1).commit().expect_success();
     builder.exec(transfer_request_2).commit().expect_success();
     builder.exec(add_bid_request_1).commit().expect_success();
@@ -217,7 +256,7 @@ fn should_run_delegate_and_undelegate() {
 
     let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
     assert_eq!(bids.len(), 1);
-    let active_bid = bids.get(&NON_FOUNDER_VALIDATOR_1).unwrap();
+    let active_bid = bids.get(&NON_FOUNDER_VALIDATOR_1_PK).unwrap();
     assert_eq!(
         builder.get_purse_balance(active_bid.bonding_purse),
         U512::from(ADD_BID_AMOUNT_1)
@@ -233,12 +272,12 @@ fn should_run_delegate_and_undelegate() {
 
     //
     let exec_request_1 = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_DELEGATE,
             ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
-            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK,
             ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
@@ -249,7 +288,7 @@ fn should_run_delegate_and_undelegate() {
     assert_eq!(delegators.len(), 1);
 
     let delegated_amount_1 = delegators
-        .get(&NON_FOUNDER_VALIDATOR_1.clone())
+        .get(&NON_FOUNDER_VALIDATOR_1_PK.clone())
         .and_then(|map| map.get(&BID_ACCOUNT_1_PK.clone()))
         .cloned()
         .unwrap_or_default();
@@ -262,12 +301,12 @@ fn should_run_delegate_and_undelegate() {
 
     // 2nd bid top-up
     let exec_request_2 = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_DELEGATE,
             ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_2),
-            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK,
             ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
@@ -279,7 +318,7 @@ fn should_run_delegate_and_undelegate() {
     assert_eq!(delegators.len(), 1);
 
     let delegated_amount_2 = delegators
-        .get(&NON_FOUNDER_VALIDATOR_1)
+        .get(&NON_FOUNDER_VALIDATOR_1_PK)
         .and_then(|map| map.get(&BID_ACCOUNT_1_PK.clone()))
         .cloned()
         .unwrap_or_default();
@@ -291,12 +330,12 @@ fn should_run_delegate_and_undelegate() {
     );
 
     let exec_request_3 = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_UNDELEGATE,
             ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_1),
-            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK,
             ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
@@ -311,7 +350,7 @@ fn should_run_delegate_and_undelegate() {
     assert_eq!(delegators.len(), 1);
 
     let delegated_amount_3 = delegators
-        .get(&NON_FOUNDER_VALIDATOR_1.clone())
+        .get(&NON_FOUNDER_VALIDATOR_1_PK.clone())
         .and_then(|map| map.get(&BID_ACCOUNT_1_PK.clone()))
         .cloned()
         .unwrap_or_default();
@@ -326,31 +365,40 @@ fn should_run_delegate_and_undelegate() {
 #[ignore]
 #[test]
 fn should_calculate_era_validators() {
-    assert_ne!(ACCOUNT_1_ADDR, ACCOUNT_2_ADDR,);
-    assert_ne!(ACCOUNT_2_ADDR, BID_ACCOUNT_1_ADDR,);
-    assert_ne!(ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR,);
+    assert_ne!(*ACCOUNT_1_ADDR, *ACCOUNT_2_ADDR,);
+    assert_ne!(*ACCOUNT_2_ADDR, *BID_ACCOUNT_1_ADDR,);
+    assert_ne!(*ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR,);
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account_1 = GenesisAccount::new(
             ACCOUNT_1_PK,
-            ACCOUNT_1_ADDR,
+            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
         let account_2 = GenesisAccount::new(
             ACCOUNT_2_PK,
-            ACCOUNT_2_ADDR,
+            *ACCOUNT_2_ADDR,
             Motes::new(ACCOUNT_2_BALANCE.into()),
             Motes::new(ACCOUNT_2_BOND.into()),
         );
+        let account_3 = GenesisAccount::new(
+            BID_ACCOUNT_1_PK,
+            *BID_ACCOUNT_1_ADDR,
+            Motes::new(BID_ACCOUNT_1_BALANCE.into()),
+            Motes::new(BID_ACCOUNT_1_BOND.into()),
+        );
         tmp.push(account_1);
         tmp.push(account_2);
+        tmp.push(account_3);
         tmp
     };
 
     let run_genesis_request = utils::create_run_genesis_request(accounts);
 
     let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&run_genesis_request);
 
     let transfer_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -365,13 +413,11 @@ fn should_calculate_era_validators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => NON_FOUNDER_VALIDATOR_1_ADDR,
+            "target" => *NON_FOUNDER_VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
-
-    builder.run_genesis(&run_genesis_request);
 
     let auction_hash = builder.get_auction_contract_hash();
     let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
@@ -394,7 +440,7 @@ fn should_calculate_era_validators() {
 
     // non-founding validator request
     let add_bid_request_1 = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_PUBLIC_KEY => BID_ACCOUNT_1_PK,
@@ -492,13 +538,13 @@ fn should_get_first_seigniorage_recipients() {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account_1 = GenesisAccount::new(
             ACCOUNT_1_PK,
-            ACCOUNT_1_ADDR,
+            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
         let account_2 = GenesisAccount::new(
             ACCOUNT_2_PK,
-            ACCOUNT_2_ADDR,
+            *ACCOUNT_2_ADDR,
             Motes::new(ACCOUNT_2_BALANCE.into()),
             Motes::new(ACCOUNT_2_BOND.into()),
         );
@@ -617,7 +663,7 @@ fn should_release_founder_stake() {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account_1 = GenesisAccount::new(
             ACCOUNT_1_PK,
-            ACCOUNT_1_ADDR,
+            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
@@ -677,7 +723,7 @@ fn should_fail_to_get_era_validators() {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account_1 = GenesisAccount::new(
             ACCOUNT_1_PK,
-            ACCOUNT_1_ADDR,
+            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
@@ -703,7 +749,7 @@ fn should_fail_to_get_era_validators() {
 fn should_use_era_validators_endpoint_for_first_era() {
     let extra_accounts = vec![GenesisAccount::new(
         ACCOUNT_1_PK,
-        ACCOUNT_1_ADDR,
+        *ACCOUNT_1_ADDR,
         Motes::new(ACCOUNT_1_BALANCE.into()),
         Motes::new(ACCOUNT_1_BOND.into()),
     )];
@@ -735,31 +781,46 @@ fn should_use_era_validators_endpoint_for_first_era() {
 #[ignore]
 #[test]
 fn should_calculate_era_validators_multiple_new_bids() {
-    assert_ne!(ACCOUNT_1_ADDR, ACCOUNT_2_ADDR,);
-    assert_ne!(ACCOUNT_2_ADDR, BID_ACCOUNT_1_ADDR,);
-    assert_ne!(ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR,);
+    assert_ne!(*ACCOUNT_1_ADDR, *ACCOUNT_2_ADDR,);
+    assert_ne!(*ACCOUNT_2_ADDR, *BID_ACCOUNT_1_ADDR,);
+    assert_ne!(*ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR,);
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account_1 = GenesisAccount::new(
             ACCOUNT_1_PK,
-            ACCOUNT_1_ADDR,
+            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
         let account_2 = GenesisAccount::new(
             ACCOUNT_2_PK,
-            ACCOUNT_2_ADDR,
+            *ACCOUNT_2_ADDR,
             Motes::new(ACCOUNT_2_BALANCE.into()),
             Motes::new(ACCOUNT_2_BOND.into()),
         );
+        let account_3 = GenesisAccount::new(
+            BID_ACCOUNT_1_PK,
+            *BID_ACCOUNT_1_ADDR,
+            Motes::new(BID_ACCOUNT_1_BALANCE.into()),
+            Motes::new(BID_ACCOUNT_1_BOND.into()),
+        );
+        let account_4 = GenesisAccount::new(
+            BID_ACCOUNT_2_PK,
+            *BID_ACCOUNT_2_ADDR,
+            Motes::new(BID_ACCOUNT_2_BALANCE.into()),
+            Motes::new(BID_ACCOUNT_2_BOND.into()),
+        );
         tmp.push(account_1);
         tmp.push(account_2);
+        tmp.push(account_3);
+        tmp.push(account_4);
         tmp
     };
 
     let run_genesis_request = utils::create_run_genesis_request(accounts);
 
     let mut builder = InMemoryWasmTestBuilder::default();
+
     builder.run_genesis(&run_genesis_request);
 
     let genesis_validator_weights = builder
@@ -785,8 +846,8 @@ fn should_calculate_era_validators_multiple_new_bids() {
     // Fund additional accounts
     for target in &[
         SYSTEM_ADDR,
-        NON_FOUNDER_VALIDATOR_1_ADDR,
-        NON_FOUNDER_VALIDATOR_2_ADDR,
+        *NON_FOUNDER_VALIDATOR_1_ADDR,
+        *NON_FOUNDER_VALIDATOR_2_ADDR,
     ] {
         let transfer_request_1 = ExecuteRequestBuilder::standard(
             *DEFAULT_ACCOUNT_ADDR,
@@ -802,7 +863,7 @@ fn should_calculate_era_validators_multiple_new_bids() {
 
     // non-founding validator request
     let add_bid_request_1 = ExecuteRequestBuilder::standard(
-        NON_FOUNDER_VALIDATOR_1_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_PUBLIC_KEY => BID_ACCOUNT_1_PK,
@@ -813,7 +874,7 @@ fn should_calculate_era_validators_multiple_new_bids() {
     )
     .build();
     let add_bid_request_2 = ExecuteRequestBuilder::standard(
-        NON_FOUNDER_VALIDATOR_2_ADDR,
+        *BID_ACCOUNT_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_PUBLIC_KEY => BID_ACCOUNT_2_PK,
@@ -892,7 +953,7 @@ fn undelegated_funds_should_be_released() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => NON_FOUNDER_VALIDATOR_1_ADDR,
+            "target" => *NON_FOUNDER_VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -902,17 +963,17 @@ fn undelegated_funds_should_be_released() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => BID_ACCOUNT_1_ADDR,
+            "target" => *BID_ACCOUNT_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        NON_FOUNDER_VALIDATOR_1_ADDR,
+        *NON_FOUNDER_VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
-            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1,
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1_PK,
             ARG_ENTRY_POINT => ARG_ADD_BID,
             ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_1),
             ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
@@ -921,12 +982,12 @@ fn undelegated_funds_should_be_released() {
     .build();
 
     let delegator_1_validator_1_delegate_request = ExecuteRequestBuilder::standard(
-        BID_ACCOUNT_1_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_DELEGATE,
             ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
-            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK,
             ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
@@ -953,12 +1014,12 @@ fn undelegated_funds_should_be_released() {
     }
 
     let delegator_1_undelegate_request = ExecuteRequestBuilder::standard(
-        BID_ACCOUNT_1_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_UNDELEGATE,
             ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_1),
-            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK,
             ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
@@ -970,7 +1031,7 @@ fn undelegated_funds_should_be_released() {
         .expect_success();
 
     let delegator_1_undelegate_purse = builder
-        .get_account(BID_ACCOUNT_1_ADDR)
+        .get_account(*BID_ACCOUNT_1_ADDR)
         .expect("should have account")
         .named_keys()
         .get(UNDELEGATE_PURSE)
@@ -1012,7 +1073,7 @@ fn fully_undelegated_funds_should_be_released() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => NON_FOUNDER_VALIDATOR_1_ADDR,
+            "target" => *NON_FOUNDER_VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1022,17 +1083,17 @@ fn fully_undelegated_funds_should_be_released() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => BID_ACCOUNT_1_ADDR,
+            "target" => *BID_ACCOUNT_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        NON_FOUNDER_VALIDATOR_1_ADDR,
+        *NON_FOUNDER_VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
-            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1,
+            ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1_PK,
             ARG_ENTRY_POINT => ARG_ADD_BID,
             ARG_AMOUNT => U512::from(ADD_BID_AMOUNT_1),
             ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
@@ -1041,12 +1102,12 @@ fn fully_undelegated_funds_should_be_released() {
     .build();
 
     let delegator_1_validator_1_delegate_request = ExecuteRequestBuilder::standard(
-        BID_ACCOUNT_1_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_DELEGATE,
             ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
-            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK,
             ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
@@ -1073,12 +1134,12 @@ fn fully_undelegated_funds_should_be_released() {
     }
 
     let delegator_1_undelegate_request = ExecuteRequestBuilder::standard(
-        BID_ACCOUNT_1_ADDR,
+        *BID_ACCOUNT_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => ARG_UNDELEGATE,
             ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
-            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1,
+            ARG_VALIDATOR => NON_FOUNDER_VALIDATOR_1_PK,
             ARG_DELEGATOR => BID_ACCOUNT_1_PK,
         },
     )
@@ -1090,7 +1151,7 @@ fn fully_undelegated_funds_should_be_released() {
         .expect_success();
 
     let delegator_1_undelegate_purse = builder
-        .get_account(BID_ACCOUNT_1_ADDR)
+        .get_account(*BID_ACCOUNT_1_ADDR)
         .expect("should have account")
         .named_keys()
         .get(UNDELEGATE_PURSE)

--- a/grpc/tests/src/test/system_contracts/auction/distribute.rs
+++ b/grpc/tests/src/test/system_contracts/auction/distribute.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use lazy_static::lazy_static;
 use num_rational::Ratio;
 
 use casper_engine_test_support::{
@@ -26,17 +27,20 @@ const TRANSFER_AMOUNT: u64 = 250_000_000;
 const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 
 const VALIDATOR_1: PublicKey = PublicKey::Ed25519([3; 32]);
-const VALIDATOR_1_ADDR: AccountHash = AccountHash::new([4; 32]);
 const VALIDATOR_2: PublicKey = PublicKey::Ed25519([5; 32]);
-const VALIDATOR_2_ADDR: AccountHash = AccountHash::new([6; 32]);
 const VALIDATOR_3: PublicKey = PublicKey::Ed25519([7; 32]);
-const VALIDATOR_3_ADDR: AccountHash = AccountHash::new([8; 32]);
 const DELEGATOR_1: PublicKey = PublicKey::Ed25519([204; 32]);
-const DELEGATOR_1_ADDR: AccountHash = AccountHash::new([205; 32]);
 const DELEGATOR_2: PublicKey = PublicKey::Ed25519([206; 32]);
-const DELEGATOR_2_ADDR: AccountHash = AccountHash::new([207; 32]);
 const DELEGATOR_3: PublicKey = PublicKey::Ed25519([208; 32]);
-const DELEGATOR_3_ADDR: AccountHash = AccountHash::new([209; 32]);
+
+lazy_static! {
+    static ref VALIDATOR_1_ADDR: AccountHash = VALIDATOR_1.into();
+    static ref VALIDATOR_2_ADDR: AccountHash = VALIDATOR_2.into();
+    static ref VALIDATOR_3_ADDR: AccountHash = VALIDATOR_3.into();
+    static ref DELEGATOR_1_ADDR: AccountHash = DELEGATOR_1.into();
+    static ref DELEGATOR_2_ADDR: AccountHash = DELEGATOR_2.into();
+    static ref DELEGATOR_3_ADDR: AccountHash = DELEGATOR_3.into();
+}
 
 fn withdraw_validator_reward(
     builder: &mut InMemoryWasmTestBuilder,
@@ -121,7 +125,7 @@ fn should_distribute_delegation_rate_zero() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" =>SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -131,7 +135,7 @@ fn should_distribute_delegation_rate_zero() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_1_ADDR,
+            "target" => *VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -141,7 +145,7 @@ fn should_distribute_delegation_rate_zero() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_1_ADDR,
+            "target" => *DELEGATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -151,14 +155,14 @@ fn should_distribute_delegation_rate_zero() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_2_ADDR,
+            "target" => *DELEGATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_1_ADDR,
+        *VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -170,7 +174,7 @@ fn should_distribute_delegation_rate_zero() {
     .build();
 
     let delegator_1_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_1_ADDR,
+        *DELEGATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -182,7 +186,7 @@ fn should_distribute_delegation_rate_zero() {
     .build();
 
     let delegator_2_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_2_ADDR,
+        *DELEGATOR_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -234,18 +238,18 @@ fn should_distribute_delegation_rate_zero() {
     builder.exec(distribute_request).commit().expect_success();
 
     let validator_1_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_1_ADDR, VALIDATOR_1);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_1_ADDR, VALIDATOR_1);
     let expected_validator_1_balance =
         (expected_total_reward * participant_portion + remainders).to_integer();
     assert_eq!(validator_1_balance, expected_validator_1_balance);
 
     let delegator_1_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
     let expected_delegator_1_balance = (expected_total_reward * participant_portion).to_integer();
     assert_eq!(delegator_1_balance, expected_delegator_1_balance);
 
     let delegator_2_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
     let expected_delegator_2_balance = (expected_total_reward * participant_portion).to_integer();
     assert_eq!(delegator_2_balance, expected_delegator_2_balance);
 
@@ -254,15 +258,15 @@ fn should_distribute_delegation_rate_zero() {
 
     // Subsequently, there should be no more rewards
     let validator_1_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_1_ADDR, VALIDATOR_1);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_1_ADDR, VALIDATOR_1);
     assert!(validator_1_balance.is_zero());
 
     let delegator_1_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
     assert!(delegator_1_balance.is_zero());
 
     let delegator_2_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
     assert!(delegator_2_balance.is_zero());
 }
 
@@ -289,7 +293,7 @@ fn should_distribute_delegation_rate_half() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" =>SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -299,7 +303,7 @@ fn should_distribute_delegation_rate_half() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_1_ADDR,
+            "target" => *VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -309,7 +313,7 @@ fn should_distribute_delegation_rate_half() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_1_ADDR,
+            "target" => *DELEGATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -319,14 +323,14 @@ fn should_distribute_delegation_rate_half() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_2_ADDR,
+            "target" => *DELEGATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_1_ADDR,
+        *VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -338,7 +342,7 @@ fn should_distribute_delegation_rate_half() {
     .build();
 
     let delegator_1_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_1_ADDR,
+        *DELEGATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -350,7 +354,7 @@ fn should_distribute_delegation_rate_half() {
     .build();
 
     let delegator_2_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_2_ADDR,
+        *DELEGATOR_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -402,18 +406,18 @@ fn should_distribute_delegation_rate_half() {
     builder.exec(distribute_request).commit().expect_success();
 
     let validator_1_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_1_ADDR, VALIDATOR_1);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_1_ADDR, VALIDATOR_1);
     let expected_validator_1_balance =
         (expected_total_reward * validator_share + remainders).to_integer();
     assert_eq!(validator_1_balance, expected_validator_1_balance);
 
     let delegator_1_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
     let expected_delegator_1_balance = (expected_total_reward * delegator_shares).to_integer();
     assert_eq!(delegator_1_balance, expected_delegator_1_balance);
 
     let delegator_2_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
     let expected_delegator_2_balance = (expected_total_reward * delegator_shares).to_integer();
     assert_eq!(delegator_2_balance, expected_delegator_2_balance);
 
@@ -437,7 +441,7 @@ fn should_distribute_delegation_rate_full() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" =>SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -447,7 +451,7 @@ fn should_distribute_delegation_rate_full() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_1_ADDR,
+            "target" => *VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -457,7 +461,7 @@ fn should_distribute_delegation_rate_full() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_1_ADDR,
+            "target" => *DELEGATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -467,14 +471,14 @@ fn should_distribute_delegation_rate_full() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_2_ADDR,
+            "target" => *DELEGATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_1_ADDR,
+        *VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -486,7 +490,7 @@ fn should_distribute_delegation_rate_full() {
     .build();
 
     let delegator_1_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_1_ADDR,
+        *DELEGATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -498,7 +502,7 @@ fn should_distribute_delegation_rate_full() {
     .build();
 
     let delegator_2_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_2_ADDR,
+        *DELEGATOR_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -550,18 +554,18 @@ fn should_distribute_delegation_rate_full() {
     builder.exec(distribute_request).commit().expect_success();
 
     let validator_1_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_1_ADDR, VALIDATOR_1);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_1_ADDR, VALIDATOR_1);
     let expected_validator_1_balance =
         (expected_total_reward * Ratio::from(U512::one())).to_integer();
     assert_eq!(validator_1_balance, expected_validator_1_balance);
 
     let delegator_1_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
     let expected_delegator_1_balance = U512::zero();
     assert_eq!(delegator_1_balance, expected_delegator_1_balance);
 
     let delegator_2_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
     let expected_delegator_2_balance = U512::zero();
     assert_eq!(delegator_2_balance, expected_delegator_2_balance);
 
@@ -591,7 +595,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" =>SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -601,7 +605,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_1_ADDR,
+            "target" =>*VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -611,7 +615,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_1_ADDR,
+            "target" =>*DELEGATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -621,14 +625,14 @@ fn should_distribute_uneven_delegation_rate_zero() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_2_ADDR,
+            "target" =>*DELEGATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_1_ADDR,
+        *VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -640,7 +644,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
     .build();
 
     let delegator_1_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_1_ADDR,
+        *DELEGATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -652,7 +656,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
     .build();
 
     let delegator_2_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_2_ADDR,
+        *DELEGATOR_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -704,18 +708,18 @@ fn should_distribute_uneven_delegation_rate_zero() {
     builder.exec(distribute_request).commit().expect_success();
 
     let validator_1_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_1_ADDR, VALIDATOR_1);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_1_ADDR, VALIDATOR_1);
     let expected_validator_1_balance =
         (expected_total_reward * validator_1_portion + remainder).to_integer();
     assert_eq!(validator_1_balance, expected_validator_1_balance);
 
     let delegator_1_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
     let expected_delegator_1_balance = (expected_total_reward * delegator_1_portion).to_integer();
     assert_eq!(delegator_1_balance, expected_delegator_1_balance);
 
     let delegator_2_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
     let expected_delegator_2_balance = (expected_total_reward * delegator_2_portion).to_integer();
     assert_eq!(delegator_2_balance, expected_delegator_2_balance);
 
@@ -745,7 +749,7 @@ fn should_distribute_by_factor() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" =>SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -755,7 +759,7 @@ fn should_distribute_by_factor() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_1_ADDR,
+            "target" =>*VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -765,7 +769,7 @@ fn should_distribute_by_factor() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_2_ADDR,
+            "target" =>*VALIDATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -775,14 +779,14 @@ fn should_distribute_by_factor() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_3_ADDR,
+            "target" =>*VALIDATOR_3_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_1_ADDR,
+        *VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -794,7 +798,7 @@ fn should_distribute_by_factor() {
     .build();
 
     let validator_2_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_2_ADDR,
+        *VALIDATOR_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -806,7 +810,7 @@ fn should_distribute_by_factor() {
     .build();
 
     let validator_3_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_3_ADDR,
+        *VALIDATOR_3_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -860,17 +864,17 @@ fn should_distribute_by_factor() {
     builder.exec(distribute_request).commit().expect_success();
 
     let validator_1_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_1_ADDR, VALIDATOR_1);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_1_ADDR, VALIDATOR_1);
     let expected_validator_1_balance = (expected_total_reward * one_third).to_integer();
     assert_eq!(validator_1_balance, expected_validator_1_balance);
 
     let validator_2_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_2_ADDR, VALIDATOR_2);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_2_ADDR, VALIDATOR_2);
     let expected_validator_2_balance = (expected_total_reward * one_third).to_integer();
     assert_eq!(validator_2_balance, expected_validator_2_balance);
 
     let validator_3_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_3_ADDR, VALIDATOR_3);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_3_ADDR, VALIDATOR_3);
     let expected_validator_3_balance = (expected_total_reward * one_third).to_integer();
     assert_eq!(validator_3_balance, expected_validator_3_balance);
 
@@ -901,7 +905,7 @@ fn should_distribute_by_factor_regardless_of_stake() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" =>SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -911,7 +915,7 @@ fn should_distribute_by_factor_regardless_of_stake() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_1_ADDR,
+            "target" =>*VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -921,7 +925,7 @@ fn should_distribute_by_factor_regardless_of_stake() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_2_ADDR,
+            "target" =>*VALIDATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -931,14 +935,14 @@ fn should_distribute_by_factor_regardless_of_stake() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_3_ADDR,
+            "target" =>*VALIDATOR_3_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_1_ADDR,
+        *VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -950,7 +954,7 @@ fn should_distribute_by_factor_regardless_of_stake() {
     .build();
 
     let validator_2_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_2_ADDR,
+        *VALIDATOR_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -962,7 +966,7 @@ fn should_distribute_by_factor_regardless_of_stake() {
     .build();
 
     let validator_3_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_3_ADDR,
+        *VALIDATOR_3_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -1016,17 +1020,17 @@ fn should_distribute_by_factor_regardless_of_stake() {
     builder.exec(distribute_request).commit().expect_success();
 
     let validator_1_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_1_ADDR, VALIDATOR_1);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_1_ADDR, VALIDATOR_1);
     let expected_validator_1_balance = (expected_total_reward * one_third).to_integer();
     assert_eq!(validator_1_balance, expected_validator_1_balance);
 
     let validator_2_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_2_ADDR, VALIDATOR_2);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_2_ADDR, VALIDATOR_2);
     let expected_validator_2_balance = (expected_total_reward * one_third).to_integer();
     assert_eq!(validator_2_balance, expected_validator_2_balance);
 
     let validator_3_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_3_ADDR, VALIDATOR_3);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_3_ADDR, VALIDATOR_3);
     let expected_validator_3_balance = (expected_total_reward * one_third).to_integer();
     assert_eq!(validator_3_balance, expected_validator_3_balance);
 
@@ -1059,7 +1063,7 @@ fn should_distribute_by_factor_uneven() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" =>SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1069,7 +1073,7 @@ fn should_distribute_by_factor_uneven() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_1_ADDR,
+            "target" =>*VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1079,7 +1083,7 @@ fn should_distribute_by_factor_uneven() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_2_ADDR,
+            "target" =>*VALIDATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1089,14 +1093,14 @@ fn should_distribute_by_factor_uneven() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_3_ADDR,
+            "target" =>*VALIDATOR_3_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_1_ADDR,
+        *VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -1108,7 +1112,7 @@ fn should_distribute_by_factor_uneven() {
     .build();
 
     let validator_2_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_2_ADDR,
+        *VALIDATOR_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -1120,7 +1124,7 @@ fn should_distribute_by_factor_uneven() {
     .build();
 
     let validator_3_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_3_ADDR,
+        *VALIDATOR_3_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -1174,17 +1178,17 @@ fn should_distribute_by_factor_uneven() {
     builder.exec(distribute_request).commit().expect_success();
 
     let validator_1_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_1_ADDR, VALIDATOR_1);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_1_ADDR, VALIDATOR_1);
     let expected_validator_1_balance = (expected_total_reward * one_half).to_integer();
     assert_eq!(validator_1_balance, expected_validator_1_balance);
 
     let validator_2_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_2_ADDR, VALIDATOR_2);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_2_ADDR, VALIDATOR_2);
     let expected_validator_2_balance = (expected_total_reward * three_tenths).to_integer();
     assert_eq!(validator_2_balance, expected_validator_2_balance);
 
     let validator_3_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_3_ADDR, VALIDATOR_3);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_3_ADDR, VALIDATOR_3);
     let expected_validator_3_balance = (expected_total_reward * one_fifth).to_integer();
     assert_eq!(validator_3_balance, expected_validator_3_balance);
 
@@ -1221,7 +1225,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" =>SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1231,7 +1235,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_1_ADDR,
+            "target" =>*VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1241,7 +1245,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_2_ADDR,
+            "target" =>*VALIDATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1251,7 +1255,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_3_ADDR,
+            "target" =>*VALIDATOR_3_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1261,7 +1265,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_1_ADDR,
+            "target" =>*DELEGATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1271,7 +1275,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_2_ADDR,
+            "target" =>*DELEGATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1281,14 +1285,14 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_3_ADDR,
+            "target" =>*DELEGATOR_3_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_1_ADDR,
+        *VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -1300,7 +1304,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     .build();
 
     let validator_2_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_2_ADDR,
+        *VALIDATOR_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -1312,7 +1316,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     .build();
 
     let validator_3_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_3_ADDR,
+        *VALIDATOR_3_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -1324,7 +1328,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     .build();
 
     let delegator_1_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_1_ADDR,
+        *DELEGATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -1336,7 +1340,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     .build();
 
     let delegator_2_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_2_ADDR,
+        *DELEGATOR_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -1348,7 +1352,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     .build();
 
     let delegator_3_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_3_ADDR,
+        *DELEGATOR_3_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -1408,22 +1412,22 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     builder.exec(distribute_request).commit().expect_success();
 
     let validator_1_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_1_ADDR, VALIDATOR_1);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_1_ADDR, VALIDATOR_1);
 
     let validator_2_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_2_ADDR, VALIDATOR_2);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_2_ADDR, VALIDATOR_2);
 
     let validator_3_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_3_ADDR, VALIDATOR_3);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_3_ADDR, VALIDATOR_3);
 
     let delegator_1_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
 
     let delegator_2_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_2);
 
     let delegator_3_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_3_ADDR, VALIDATOR_2, DELEGATOR_3);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_3_ADDR, VALIDATOR_2, DELEGATOR_3);
 
     let total_payout: U512 = [
         validator_1_balance,
@@ -1471,7 +1475,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" =>SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1481,7 +1485,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_1_ADDR,
+            "target" =>*VALIDATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1491,7 +1495,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_2_ADDR,
+            "target" =>*VALIDATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1501,7 +1505,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => VALIDATOR_3_ADDR,
+            "target" =>*VALIDATOR_3_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1511,7 +1515,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_1_ADDR,
+            "target" =>*DELEGATOR_1_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1521,7 +1525,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_2_ADDR,
+            "target" =>*DELEGATOR_2_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1531,14 +1535,14 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => DELEGATOR_3_ADDR,
+            "target" =>*DELEGATOR_3_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
     .build();
 
     let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_1_ADDR,
+        *VALIDATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -1550,7 +1554,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     .build();
 
     let validator_2_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_2_ADDR,
+        *VALIDATOR_2_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -1562,7 +1566,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     .build();
 
     let validator_3_add_bid_request = ExecuteRequestBuilder::standard(
-        VALIDATOR_3_ADDR,
+        *VALIDATOR_3_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_ADD_BID,
@@ -1574,7 +1578,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     .build();
 
     let delegator_1_validator_1_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_1_ADDR,
+        *DELEGATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -1586,7 +1590,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     .build();
 
     let delegator_1_validator_2_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_1_ADDR,
+        *DELEGATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -1598,7 +1602,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     .build();
 
     let delegator_1_validator_3_delegate_request = ExecuteRequestBuilder::standard(
-        DELEGATOR_1_ADDR,
+        *DELEGATOR_1_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DELEGATE,
@@ -1658,22 +1662,22 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     builder.exec(distribute_request).commit().expect_success();
 
     let validator_1_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_1_ADDR, VALIDATOR_1);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_1_ADDR, VALIDATOR_1);
     let expected_validator_1_balance = (expected_total_reward * validator_1_portion).to_integer();
     assert_eq!(validator_1_balance, expected_validator_1_balance);
 
     let validator_2_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_2_ADDR, VALIDATOR_2);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_2_ADDR, VALIDATOR_2);
     let expected_validator_2_balance = (expected_total_reward * validator_2_portion).to_integer();
     assert_eq!(validator_2_balance, expected_validator_2_balance);
 
     let validator_3_balance =
-        withdraw_validator_reward(&mut builder, VALIDATOR_3_ADDR, VALIDATOR_3);
+        withdraw_validator_reward(&mut builder, *VALIDATOR_3_ADDR, VALIDATOR_3);
     let expected_validator_3_balance = (expected_total_reward * validator_3_portion).to_integer();
     assert_eq!(validator_3_balance, expected_validator_3_balance);
 
     let delegator_1_validator_1_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_1_ADDR, VALIDATOR_1, DELEGATOR_1);
     let expected_delegator_1_validator_1_balance =
         (expected_total_reward * delegator_1_validator_1_portion).to_integer();
     assert_eq!(
@@ -1682,7 +1686,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     );
 
     let delegator_1_validator_2_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_1_ADDR, VALIDATOR_2, DELEGATOR_1);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_1_ADDR, VALIDATOR_2, DELEGATOR_1);
     let expected_delegator_1_validator_2_balance =
         (expected_total_reward * delegator_1_validator_2_portion).to_integer();
     assert_eq!(
@@ -1691,7 +1695,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     );
 
     let delegator_1_validator_3_balance =
-        withdraw_delegator_reward(&mut builder, DELEGATOR_1_ADDR, VALIDATOR_3, DELEGATOR_1);
+        withdraw_delegator_reward(&mut builder, *DELEGATOR_1_ADDR, VALIDATOR_3, DELEGATOR_1);
     let expected_delegator_1_validator_3_balance =
         (expected_total_reward * delegator_1_validator_3_portion).to_integer();
     assert_eq!(
@@ -1712,4 +1716,262 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     .sum();
 
     assert_eq!(total_payout, expected_total_reward_integer - remainder);
+}
+
+#[ignore]
+#[should_panic]
+#[test]
+fn should_prevent_theft_of_validator_reward() {
+    const VALIDATOR_1_STAKE: u64 = 1_000_000;
+    const DELEGATOR_1_STAKE: u64 = 1_000_000;
+    const DELEGATOR_2_STAKE: u64 = 1_000_000;
+
+    const VALIDATOR_1_DELEGATION_RATE: DelegationRate = 0;
+
+    let system_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" =>SYSTEM_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let validator_1_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => *VALIDATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let delegator_1_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => *DELEGATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let delegator_2_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => *DELEGATOR_2_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
+        *VALIDATOR_1_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_ADD_BID,
+            ARG_AMOUNT => U512::from(VALIDATOR_1_STAKE),
+            ARG_DELEGATION_RATE => VALIDATOR_1_DELEGATION_RATE,
+            ARG_PUBLIC_KEY => VALIDATOR_1,
+        },
+    )
+    .build();
+
+    let delegator_1_delegate_request = ExecuteRequestBuilder::standard(
+        *DELEGATOR_1_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_DELEGATE,
+            ARG_AMOUNT => U512::from(DELEGATOR_1_STAKE),
+            ARG_VALIDATOR => VALIDATOR_1,
+            ARG_DELEGATOR => DELEGATOR_1,
+        },
+    )
+    .build();
+
+    let delegator_2_delegate_request = ExecuteRequestBuilder::standard(
+        *DELEGATOR_2_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_DELEGATE,
+            ARG_AMOUNT => U512::from(DELEGATOR_2_STAKE),
+            ARG_VALIDATOR => VALIDATOR_1,
+            ARG_DELEGATOR => DELEGATOR_2,
+        },
+    )
+    .build();
+
+    let post_genesis_requests = vec![
+        system_fund_request,
+        validator_1_fund_request,
+        delegator_1_fund_request,
+        delegator_2_fund_request,
+        validator_1_add_bid_request,
+        delegator_1_delegate_request,
+        delegator_2_delegate_request,
+    ];
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    for request in post_genesis_requests {
+        builder.exec(request).commit().expect_success();
+    }
+
+    for _ in 0..5 {
+        super::run_auction(&mut builder);
+    }
+
+    let reward_factors: BTreeMap<PublicKey, u64> = {
+        let mut tmp = BTreeMap::new();
+        tmp.insert(VALIDATOR_1, BLOCK_REWARD);
+        tmp
+    };
+
+    let distribute_request = ExecuteRequestBuilder::standard(
+        SYSTEM_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
+            ARG_REWARD_FACTORS => reward_factors
+        },
+    )
+    .build();
+
+    builder.exec(distribute_request).commit().expect_success();
+
+    withdraw_validator_reward(&mut builder, *DELEGATOR_1_ADDR, VALIDATOR_1);
+}
+
+#[ignore]
+#[should_panic]
+#[test]
+fn should_prevent_theft_of_delegator_reward() {
+    const VALIDATOR_1_STAKE: u64 = 1_000_000;
+    const DELEGATOR_1_STAKE: u64 = 1_000_000;
+    const DELEGATOR_2_STAKE: u64 = 1_000_000;
+
+    const VALIDATOR_1_DELEGATION_RATE: DelegationRate = 0;
+
+    let system_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" =>SYSTEM_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let validator_1_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => *VALIDATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let delegator_1_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => *DELEGATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let delegator_2_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => *DELEGATOR_2_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let validator_1_add_bid_request = ExecuteRequestBuilder::standard(
+        *VALIDATOR_1_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_ADD_BID,
+            ARG_AMOUNT => U512::from(VALIDATOR_1_STAKE),
+            ARG_DELEGATION_RATE => VALIDATOR_1_DELEGATION_RATE,
+            ARG_PUBLIC_KEY => VALIDATOR_1,
+        },
+    )
+    .build();
+
+    let delegator_1_delegate_request = ExecuteRequestBuilder::standard(
+        *DELEGATOR_1_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_DELEGATE,
+            ARG_AMOUNT => U512::from(DELEGATOR_1_STAKE),
+            ARG_VALIDATOR => VALIDATOR_1,
+            ARG_DELEGATOR => DELEGATOR_1,
+        },
+    )
+    .build();
+
+    let delegator_2_delegate_request = ExecuteRequestBuilder::standard(
+        *DELEGATOR_2_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_DELEGATE,
+            ARG_AMOUNT => U512::from(DELEGATOR_2_STAKE),
+            ARG_VALIDATOR => VALIDATOR_1,
+            ARG_DELEGATOR => DELEGATOR_2,
+        },
+    )
+    .build();
+
+    let post_genesis_requests = vec![
+        system_fund_request,
+        validator_1_fund_request,
+        delegator_1_fund_request,
+        delegator_2_fund_request,
+        validator_1_add_bid_request,
+        delegator_1_delegate_request,
+        delegator_2_delegate_request,
+    ];
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    for request in post_genesis_requests {
+        builder.exec(request).commit().expect_success();
+    }
+
+    for _ in 0..5 {
+        super::run_auction(&mut builder);
+    }
+
+    let reward_factors: BTreeMap<PublicKey, u64> = {
+        let mut tmp = BTreeMap::new();
+        tmp.insert(VALIDATOR_1, BLOCK_REWARD);
+        tmp
+    };
+
+    let distribute_request = ExecuteRequestBuilder::standard(
+        SYSTEM_ADDR,
+        CONTRACT_AUCTION_BIDS,
+        runtime_args! {
+            ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
+            ARG_REWARD_FACTORS => reward_factors
+        },
+    )
+    .build();
+
+    builder.exec(distribute_request).commit().expect_success();
+
+    withdraw_delegator_reward(&mut builder, *DELEGATOR_2_ADDR, VALIDATOR_1, DELEGATOR_1);
 }

--- a/grpc/tests/src/test/system_contracts/auction_bidding.rs
+++ b/grpc/tests/src/test/system_contracts/auction_bidding.rs
@@ -185,7 +185,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
 #[test]
 fn should_fail_bonding_with_insufficient_funds() {
     let account_1_public_key: PublicKey = PublicKey::Ed25519([123; 32]);
-    let account_1_hash = AccountHash::new([124; 32]);
+    let account_1_hash = AccountHash::from(account_1_public_key);
 
     let exec_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -235,14 +235,15 @@ fn should_fail_bonding_with_insufficient_funds() {
 #[test]
 fn should_fail_unbonding_validator_with_locked_funds() {
     let account_1_public_key = PublicKey::Ed25519([42; 32]);
-    let account_1_hash = AccountHash::new([43; 32]);
+    let account_1_hash = AccountHash::from(account_1_public_key);
+    let account_1_balance = U512::from(1_000_000_000);
 
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account = GenesisAccount::new(
             account_1_public_key,
             account_1_hash,
-            Motes::new(GENESIS_VALIDATOR_STAKE.into()) * Motes::new(2.into()),
+            Motes::new(account_1_balance),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()),
         );
         tmp.push(account);
@@ -252,7 +253,7 @@ fn should_fail_unbonding_validator_with_locked_funds() {
     let run_genesis_request = utils::create_run_genesis_request(accounts);
 
     let exec_request = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
+        account_1_hash,
         CONTRACT_AUCTION_BIDDING,
         runtime_args! {
             ARG_ENTRY_POINT => TEST_WITHDRAW_BID,
@@ -289,15 +290,13 @@ fn should_fail_unbonding_validator_with_locked_funds() {
 #[ignore]
 #[test]
 fn should_fail_unbonding_validator_without_bonding_first() {
-    let account_1_public_key = PublicKey::Ed25519([42; 32]);
-
     let exec_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_AUCTION_BIDDING,
         runtime_args! {
             ARG_ENTRY_POINT => TEST_WITHDRAW_BID,
             ARG_AMOUNT => U512::from(42),
-            ARG_PUBLIC_KEY => account_1_public_key,
+            ARG_PUBLIC_KEY => *DEFAULT_ACCOUNT_PUBLIC_KEY,
         },
     )
     .build();

--- a/node/src/crypto/asymmetric_key.rs
+++ b/node/src/crypto/asymmetric_key.rs
@@ -1580,6 +1580,19 @@ MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
             assert!(verify(message, &signature, &wrong_type_public_key).is_err());
             assert!(verify(&message[1..], &signature, &public_key).is_err());
         }
+
+        #[test]
+        fn account_hash_generation_is_consistent() {
+            let mut rng = TestRng::new();
+            let secret_key = SecretKey::random_ed25519(&mut rng);
+
+            let public_key_node = PublicKey::from(&secret_key);
+            let public_key_types: casper_types::PublicKey = public_key_node.into();
+
+            let hash_node: AccountHash = public_key_node.to_account_hash();
+            let hash_types: AccountHash = public_key_types.into();
+            assert_eq!(hash_types, hash_node)
+        }
     }
 
     mod secp256k1 {
@@ -1760,6 +1773,19 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
             let signature_low = Signature::new_secp256k1([1; SIGNATURE_LENGTH]).unwrap();
             let signature_high = Signature::new_secp256k1([3; SIGNATURE_LENGTH]).unwrap();
             check_ord_and_hash(signature_low, signature_high)
+        }
+
+        #[test]
+        fn account_hash_generation_is_consistent() {
+            let mut rng = TestRng::new();
+            let secret_key = SecretKey::random_secp256k1(&mut rng);
+
+            let public_key_node = PublicKey::from(&secret_key);
+            let public_key_types: casper_types::PublicKey = public_key_node.into();
+
+            let hash_node: AccountHash = public_key_node.to_account_hash();
+            let hash_types: AccountHash = public_key_types.into();
+            assert_eq!(hash_types, hash_node)
         }
     }
 

--- a/smart_contracts/contract/src/contract_api/runtime.rs
+++ b/smart_contracts/contract/src/contract_api/runtime.rs
@@ -308,7 +308,7 @@ pub fn is_valid_uref(uref: URef) -> bool {
 /// Returns a 32-byte BLAKE2b digest
 pub fn blake2b<T: AsRef<[u8]>>(input: T) -> [u8; BLAKE2B_DIGEST_LENGTH] {
     let mut ret = [0; BLAKE2B_DIGEST_LENGTH];
-    unsafe {
+    let result = unsafe {
         ext_ffi::blake2b(
             input.as_ref().as_ptr(),
             input.as_ref().len(),
@@ -316,6 +316,7 @@ pub fn blake2b<T: AsRef<[u8]>>(input: T) -> [u8; BLAKE2B_DIGEST_LENGTH] {
             BLAKE2B_DIGEST_LENGTH,
         )
     };
+    api_error::result_from(result).unwrap_or_revert();
     ret
 }
 

--- a/smart_contracts/contract/src/contract_api/runtime.rs
+++ b/smart_contracts/contract/src/contract_api/runtime.rs
@@ -12,7 +12,7 @@ use casper_types::{
     bytesrepr::{self, FromBytes},
     contracts::{ContractVersion, NamedKeys},
     ApiError, BlockTime, CLTyped, CLValue, ContractHash, ContractPackageHash, Key, Phase,
-    RuntimeArgs, URef, BLOCKTIME_SERIALIZED_LENGTH, PHASE_SERIALIZED_LENGTH,
+    RuntimeArgs, URef, BLAKE2B_DIGEST_LENGTH, BLOCKTIME_SERIALIZED_LENGTH, PHASE_SERIALIZED_LENGTH,
 };
 
 use crate::{contract_api, ext_ffi, unwrap_or_revert::UnwrapOrRevert};
@@ -303,6 +303,20 @@ pub fn is_valid_uref(uref: URef) -> bool {
     let (uref_ptr, uref_size, _bytes) = contract_api::to_ptr(uref);
     let result = unsafe { ext_ffi::is_valid_uref(uref_ptr, uref_size) };
     result != 0
+}
+
+/// Returns a 32-byte BLAKE2b digest
+pub fn blake2b<T: AsRef<[u8]>>(input: T) -> [u8; BLAKE2B_DIGEST_LENGTH] {
+    let mut ret = [0; BLAKE2B_DIGEST_LENGTH];
+    unsafe {
+        ext_ffi::blake2b(
+            input.as_ref().as_ptr(),
+            input.as_ref().len(),
+            ret.as_mut_ptr(),
+            BLAKE2B_DIGEST_LENGTH,
+        )
+    };
+    ret
 }
 
 fn read_host_buffer_into(dest: &mut [u8]) -> Result<usize, ApiError> {

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -633,7 +633,7 @@ extern "C" {
     /// * `in_size` - length of bytes
     /// * `out_ptr` - pointer to the location where argument bytes will be copied from the host side
     /// * `out_size` - size of output pointer
-    pub fn blake2b(in_ptr: *const u8, in_size: usize, out_ptr: *mut u8, out_size: usize);
+    pub fn blake2b(in_ptr: *const u8, in_size: usize, out_ptr: *mut u8, out_size: usize) -> i32;
     /// Prints data directly to stanadard output on the host.
     ///
     /// # Arguments

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -626,7 +626,14 @@ extern "C" {
         urefs_ptr: *const u8,
         urefs_size: usize,
     ) -> i32;
-
+    /// Returns a 32-byte BLAKE2b hash digest from the given input bytes
+    ///
+    /// # Arguments
+    /// * `in_ptr` - pointer to bytes
+    /// * `in_size` - length of bytes
+    /// * `out_ptr` - pointer to the location where argument bytes will be copied from the host side
+    /// * `out_size` - size of output pointer
+    pub fn blake2b(in_ptr: *const u8, in_size: usize, out_ptr: *mut u8, out_size: usize);
     /// Prints data directly to stanadard output on the host.
     ///
     /// # Arguments

--- a/smart_contracts/contracts/system/auction/src/lib.rs
+++ b/smart_contracts/contracts/system/auction/src/lib.rs
@@ -27,7 +27,7 @@ use casper_types::{
     system_contract_errors,
     system_contract_errors::auction::Error,
     CLType, CLTyped, CLValue, EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Key,
-    Parameter, PublicKey, RuntimeArgs, TransferResult, URef, U512,
+    Parameter, PublicKey, RuntimeArgs, TransferResult, URef, BLAKE2B_DIGEST_LENGTH, U512,
 };
 
 struct AuctionContract;
@@ -73,6 +73,10 @@ impl RuntimeProvider for AuctionContract {
 
     fn put_key(&mut self, name: &str, key: Key) {
         runtime::put_key(name, key)
+    }
+
+    fn blake2b<T: AsRef<[u8]>>(&self, data: T) -> [u8; BLAKE2B_DIGEST_LENGTH] {
+        runtime::blake2b(data)
     }
 }
 

--- a/smart_contracts/contracts/test/blake2b/Cargo.toml
+++ b/smart_contracts/contracts/test/blake2b/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "blake2b"
+version = "0.1.0"
+authors = ["Henry Till <henrytill@gmail.com>"]
+edition = "2018"
+
+[[bin]]
+name = "blake2b"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[features]
+std = ["casper-contract/std", "casper-types/std"]
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/blake2b/src/main.rs
+++ b/smart_contracts/contracts/test/blake2b/src/main.rs
@@ -1,0 +1,20 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use casper_contract::contract_api::{runtime, storage};
+
+const HASH_RESULT: &str = "hash_result";
+
+const ARG_BYTES: &str = "bytes";
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let bytes: Vec<u8> = runtime::get_named_arg(ARG_BYTES);
+    let hash = runtime::blake2b(bytes);
+    let uref = storage::new_uref(hash);
+    runtime::put_key(HASH_RESULT, uref.into())
+}

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -14,6 +14,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 use num_rational::Ratio;
 
 use crate::{
+    account::AccountHash,
     system_contract_errors::auction::{Error, Result},
     Key, PublicKey, URef, U512,
 };
@@ -79,6 +80,11 @@ pub trait Auction:
         delegation_rate: DelegationRate,
         amount: U512,
     ) -> Result<(URef, U512)> {
+        let account_hash = AccountHash::from_public_key(public_key, |x| self.blake2b(x));
+        if self.get_caller() != account_hash {
+            return Err(Error::InvalidCaller);
+        }
+
         // Creates new purse with desired amount taken from `source_purse`
         // Bonds whole amount from the newly created purse
         let (bonding_purse, _total_amount) = detail::bond(self, public_key, source, amount)?;
@@ -120,6 +126,11 @@ pub trait Auction:
     /// The function returns a tuple of the (new) unbonding purse key and the new amount of motes
     /// remaining in the bid. If the target bid does not exist, the function call returns an error.
     fn withdraw_bid(&mut self, public_key: PublicKey, amount: U512) -> Result<(URef, U512)> {
+        let account_hash = AccountHash::from_public_key(public_key, |x| self.blake2b(x));
+        if self.get_caller() != account_hash {
+            return Err(Error::InvalidCaller);
+        }
+
         // Update bids or stakes
         let mut bids = internal::get_bids(self)?;
 
@@ -155,6 +166,11 @@ pub trait Auction:
         validator_public_key: PublicKey,
         amount: U512,
     ) -> Result<(URef, U512)> {
+        let account_hash = AccountHash::from_public_key(delegator_public_key, |x| self.blake2b(x));
+        if self.get_caller() != account_hash {
+            return Err(Error::InvalidCaller);
+        }
+
         let bids = internal::get_bids(self)?;
         if !bids.contains_key(&validator_public_key) {
             // Return early if target validator is not in `bids`
@@ -193,6 +209,11 @@ pub trait Auction:
         validator_public_key: PublicKey,
         amount: U512,
     ) -> Result<(URef, U512)> {
+        let account_hash = AccountHash::from_public_key(delegator_public_key, |x| self.blake2b(x));
+        if self.get_caller() != account_hash {
+            return Err(Error::InvalidCaller);
+        }
+
         let bids = internal::get_bids(self)?;
 
         // Return early if target validator is not in `bids`
@@ -560,6 +581,11 @@ pub trait Auction:
         delegator_public_key: PublicKey,
         target_purse: URef,
     ) -> Result<U512> {
+        let account_hash = AccountHash::from_public_key(delegator_public_key, |x| self.blake2b(x));
+        if self.get_caller() != account_hash {
+            return Err(Error::InvalidCaller);
+        }
+
         let mut outer: DelegatorRewardMap = internal::get_delegator_reward_map(self)?;
         let mut inner = outer
             .remove(&validator_public_key)
@@ -596,6 +622,11 @@ pub trait Auction:
         validator_public_key: PublicKey,
         target_purse: URef,
     ) -> Result<U512> {
+        let account_hash = AccountHash::from_public_key(validator_public_key, |x| self.blake2b(x));
+        if self.get_caller() != account_hash {
+            return Err(Error::InvalidCaller);
+        }
+
         let mut validator_reward_map = internal::get_validator_reward_map(self)?;
 
         let reward_amount: &mut U512 = validator_reward_map

--- a/types/src/auction/providers.rs
+++ b/types/src/auction/providers.rs
@@ -2,7 +2,7 @@ use crate::{
     account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::auction::Error,
-    CLTyped, Key, TransferResult, URef, U512,
+    CLTyped, Key, TransferResult, URef, BLAKE2B_DIGEST_LENGTH, U512,
 };
 
 /// Provider of runtime host functionality.
@@ -15,6 +15,9 @@ pub trait RuntimeProvider {
 
     /// Puts key under a `name`.
     fn put_key(&mut self, name: &str, key: Key);
+
+    /// Returns a 32-byte BLAKE2b digest
+    fn blake2b<T: AsRef<[u8]>>(&self, data: T) -> [u8; BLAKE2B_DIGEST_LENGTH];
 }
 
 /// Provides functionality of a contract storage.

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -70,7 +70,7 @@ pub use key::{
 };
 pub use phase::{Phase, PHASE_SERIALIZED_LENGTH};
 pub use protocol_version::{ProtocolVersion, VersionCheckResult};
-pub use public_key::PublicKey;
+pub use public_key::{PublicKey, Secp256k1Bytes};
 pub use runtime_args::{NamedArg, RuntimeArgs};
 pub use semver::{SemVer, SEM_VER_SERIALIZED_LENGTH};
 pub use system_contract_type::SystemContractType;

--- a/types/src/public_key.rs
+++ b/types/src/public_key.rs
@@ -23,10 +23,12 @@ mod big_array {
     big_array! { BigArray; super::SECP256K1_PUBLIC_KEY_LENGTH }
 }
 
+/// Represents the bytes of a secp256k1 public key.
 #[derive(Copy, Clone, DataSize, Serialize, Deserialize)]
 pub struct Secp256k1Bytes(#[serde(with = "big_array::BigArray")] [u8; SECP256K1_PUBLIC_KEY_LENGTH]);
 
 impl Secp256k1Bytes {
+    /// Returns the underlying bytes.
     pub fn value(self) -> [u8; SECP256K1_PUBLIC_KEY_LENGTH] {
         self.0
     }
@@ -103,6 +105,15 @@ impl PublicKey {
         match self {
             PublicKey::Ed25519(_) => ED25519_VARIANT_ID,
             PublicKey::Secp256k1(_) => SECP256K1_VARIANT_ID,
+        }
+    }
+}
+
+impl AsRef<[u8]> for PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            PublicKey::Ed25519(bytes) => bytes.as_ref(),
+            PublicKey::Secp256k1(bytes) => bytes.as_ref(),
         }
     }
 }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1041

**Notes:**
- In order to ensure efficient and cheap `AccountHash` construction for the `use-system-contracts` feature, this PR introduces a `runtime::blake2b` function in the contract API.  We aren't ready to officially support this yet - that would require AssemblyScript work and more testing - but this is a first foray in that direction.
- I chose to put the core hashing and construction code alongside `AccountHash` itself.  Providing the explicit `AccountHash::from_public_key` constructor allows us to pass the host-side hashing function while still giving us a better story for moving away from system contract support.  Specifically, the `From<PublicKey>` construction mechanism is much more convenient to use in tests and can eventually subsume the aforementioned constructor when system contract support is removed.
- I added some additional tests in `node` to ensure that the two implementations remain in sync.  