### PR TITLE
[charlie] Improve logging in the era supervisor.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -478,12 +478,10 @@ where
         consensus_result: ConsensusProtocolResult<I, ProtoBlock, PublicKey>,
     ) -> Effects<Event<I>> {
         match consensus_result {
-            ConsensusProtocolResult::InvalidIncomingMessage(msg, sender, error) => {
+            ConsensusProtocolResult::InvalidIncomingMessage(_, sender, error) => {
                 // TODO: we will probably want to disconnect from the sender here
-                // TODO: Print a more readable representation of the message.
                 error!(
-                    ?msg,
-                    ?sender,
+                    %sender,
                     ?error,
                     "invalid incoming message to consensus instance"
                 );

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -6,8 +6,8 @@ use std::{
 use rand::{CryptoRng, Rng};
 use serde::{de::DeserializeOwned, Serialize};
 
-pub(crate) trait NodeIdT: Clone + Debug + Send + Eq + Hash + 'static {}
-impl<I> NodeIdT for I where I: Clone + Debug + Send + Eq + Hash + 'static {}
+pub(crate) trait NodeIdT: Clone + Display + Debug + Send + Eq + Hash + 'static {}
+impl<I> NodeIdT for I where I: Clone + Display + Debug + Send + Eq + Hash + 'static {}
 
 /// A validator identifier.
 pub(crate) trait ValidatorIdT: Eq + Ord + Clone + Debug + Hash {}

--- a/node/src/tls.rs
+++ b/node/src/tls.rs
@@ -722,7 +722,7 @@ impl Display for CertFingerprint {
 
 impl Display for KeyFingerprint {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.0, f)
+        write!(f, "{}", HexFmt(self.0.bytes()))
     }
 }
 


### PR DESCRIPTION
1. Removes `msg` field. It was a vector of bytes that don't tell us anything but was spamming the logs.
2. Displays sender's full key fingerprint instead of capping it.


cherry-picked from another PR to `master`.