### PR TITLE
NDRS-455: fix contract runtime initialization issue

### DIFF
--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -33,6 +33,7 @@ use crate::{
     crypto::hash,
     effect::{requests::ContractRuntimeRequest, EffectBuilder, EffectExt, Effects},
     types::CryptoRngCore,
+    utils::WithDir,
     Chainspec, StorageConfig,
 };
 
@@ -342,11 +343,11 @@ pub enum ConfigError {
 
 impl ContractRuntime {
     pub(crate) fn new(
-        storage_config: &StorageConfig,
+        storage_config: WithDir<StorageConfig>,
         contract_runtime_config: Config,
         registry: &Registry,
     ) -> Result<Self, ConfigError> {
-        let path = storage_config.path();
+        let path = storage_config.with_dir(storage_config.value().path());
         let environment = Arc::new(LmdbEnvironment::new(
             path.as_path(),
             contract_runtime_config.max_global_state_size(),

--- a/node/src/components/small_network/config.rs
+++ b/node/src/components/small_network/config.rs
@@ -5,9 +5,6 @@ use std::time::Duration;
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
-#[cfg(test)]
-use crate::utils::format_address;
-
 /// Default binding address.
 ///
 /// Uses a fixed port per node, but binds on any interface.
@@ -84,9 +81,11 @@ impl Config {
     /// Constructs a `Config` suitable for use by a node joining a testnet on a single machine.
     pub(crate) fn default_local_net(known_peer_port: u16) -> Self {
         Config {
-            bind_address: format_address(TEST_BIND_INTERFACE, 0),
-            public_address: format_address(TEST_BIND_INTERFACE, 0),
-            known_addresses: vec![format_address(TEST_BIND_INTERFACE, known_peer_port)],
+            bind_address: SocketAddr::from((TEST_BIND_INTERFACE, 0)).to_string(),
+            public_address: SocketAddr::from((TEST_BIND_INTERFACE, 0)).to_string(),
+            known_addresses: vec![
+                SocketAddr::from((TEST_BIND_INTERFACE, known_peer_port)).to_string()
+            ],
             gossip_interval: DEFAULT_TEST_GOSSIP_INTERVAL,
             systemd_support: false,
         }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -507,25 +507,23 @@ impl<B: Value + 'static, D: Value + Item + 'static> StorageType for LmdbStorage<
     type Deploy = D;
 
     fn new(config: WithDir<Config>) -> Result<Self> {
-        let (root, config) = config.into_parts();
-        let path = if config.path().is_relative() {
-            root.join(config.path())
-        } else {
-            config.path()
-        };
-        fs::create_dir_all(&path).map_err(|error| Error::CreateDir {
-            dir: path.display().to_string(),
+        let root = config.with_dir(config.value().path());
+        fs::create_dir_all(&root).map_err(|error| Error::CreateDir {
+            dir: root.display().to_string(),
             source: error,
         })?;
 
-        let block_store_path = path.join(BLOCK_STORE_FILENAME);
-        let deploy_store_path = path.join(DEPLOY_STORE_FILENAME);
-        let chainspec_store_path = path.join(CHAINSPEC_STORE_FILENAME);
+        let block_store_path = root.join(BLOCK_STORE_FILENAME);
+        let deploy_store_path = root.join(DEPLOY_STORE_FILENAME);
+        let chainspec_store_path = root.join(CHAINSPEC_STORE_FILENAME);
 
-        let block_store = LmdbStore::new(block_store_path, config.max_block_store_size())?;
-        let deploy_store = LmdbStore::new(deploy_store_path, config.max_deploy_store_size())?;
-        let chainspec_store =
-            LmdbChainspecStore::new(chainspec_store_path, config.max_chainspec_store_size())?;
+        let block_store = LmdbStore::new(block_store_path, config.value().max_block_store_size())?;
+        let deploy_store =
+            LmdbStore::new(deploy_store_path, config.value().max_deploy_store_size())?;
+        let chainspec_store = LmdbChainspecStore::new(
+            chainspec_store_path,
+            config.value().max_chainspec_store_size(),
+        )?;
 
         Ok(LmdbStorage {
             block_store: Arc::new(block_store),

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -132,9 +132,10 @@ impl reactor::Reactor for Reactor {
 
         let effect_builder = EffectBuilder::new(event_queue);
 
-        let storage = Storage::new(WithDir::new(&root, config.storage.clone()))?;
+        let storage_config = WithDir::new(&root, config.storage.clone());
+        let storage = Storage::new(storage_config.clone())?;
         let contract_runtime =
-            ContractRuntime::new(&config.storage, config.contract_runtime, registry)?;
+            ContractRuntime::new(storage_config, config.contract_runtime, registry)?;
         let (chainspec_loader, chainspec_effects) =
             ChainspecLoader::new(chainspec, effect_builder)?;
 


### PR DESCRIPTION
When we changed to use `WithDir` for the storage component (to enable setting the correct path for LMDB), we overlooked doing that for the contract runtime, which piggybacks on the storage config for this path.

This PR fixes that, and also cleans up some unused functions from `utils` (they weren't being flagged by the compiler as they were unnecessarily `pub` rather than `pub(crate)`).