### PR TITLE
NO-TICKET: update casper-updater crate to match new repo structure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,6 +69,11 @@ steps:
   - cargo generate-lockfile
   - cargo audit
 
+- name: updater-dry-run
+  <<: *buildenv
+  commands:
+  - cargo run --package=casper-updater -- --root-dir=. --dry-run
+
 - name: cargo-test
   <<: *buildenv
   commands:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "casper-updater"
+version = "0.2.0"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "regex",
+ "semver 0.11.0",
+]
+
+[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,28 +1,30 @@
 [workspace]
 
 members = [
+    "ci/casper-updater",
+    "client",
     "execution_engine",
-    "smart_contracts/contract",
-    "smart_contracts/contracts/[!.]*/*",
+    "grpc/cargo-casper",
     "grpc/server",
     "grpc/test_support",
     "grpc/tests",
-    "grpc/cargo-casper",
-    "types",
     "node",
-    "client",
+    "smart_contracts/contract",
+    "smart_contracts/contracts/[!.]*/*",
+    "types",
 ]
 
 default-members = [
+    "ci/casper-updater",
+    "client",
     "execution_engine",
-    "smart_contracts/contract",
+    "grpc/cargo-casper",
     "grpc/server",
     "grpc/test_support",
     "grpc/tests",
-    "grpc/cargo-casper",
-    "types",
     "node",
-    "client",
+    "smart_contracts/contract",
+    "types",
 ]
 
 # Include debug symbols in the release build of `casper-engine-tests` so that `simple-transfer` will yield useful

--- a/ci/casper-updater/Cargo.toml
+++ b/ci/casper-updater/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
+description = "A tool to update versions of all published CasperLabs packages."
+edition = "2018"
+license-file = "../../LICENSE"
+name = "casper-updater"
+readme = "README.md"
+version = "0.2.0"
+
+[dependencies]
+clap = "2"
+lazy_static = "1"
+regex = "1"
+semver = "0.11"

--- a/ci/casper-updater/README.md
+++ b/ci/casper-updater/README.md
@@ -1,0 +1,11 @@
+# casper-updater
+
+A tool to update versions of all published CasperLabs packages.
+
+# Usage
+
+The tool iterates through each published CasperLabs package, asking for a new version for each or automatically bumping the major, minor or patch version if `--bump=[major|minor|patch]` was specified.  Once a valid version is specified, all files dependent on that version are updated.
+
+If you run the tool from its own directory it will expect to find the casper-node root directory at '../..'.  Alternatively, you can give the path to the casper-node root directory via `--root-dir`.    
+
+To see a list of files which will be affected, or to check that the tool's regex matches are up to date, run the tool with `--dry-run`.

--- a/ci/casper-updater/src/dependent_file.rs
+++ b/ci/casper-updater/src/dependent_file.rs
@@ -1,0 +1,59 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use regex::Regex;
+
+/// A file which is dependent on the version of a certain CasperLabs crate.
+pub struct DependentFile {
+    /// Full path to the file.
+    path: PathBuf,
+    /// Current contents of the file.
+    contents: String,
+    /// Regex applicable to the portion to be updated.
+    regex: Regex,
+    /// Function which generates the replacement string once the updated version is known.
+    replacement: fn(&str) -> String,
+}
+
+impl DependentFile {
+    pub fn new<P: AsRef<Path>>(
+        relative_path: P,
+        regex: Regex,
+        replacement: fn(&str) -> String,
+    ) -> Self {
+        let path = crate::root_dir().join(relative_path);
+        let contents = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("should read {}: {:?}", path.display(), error));
+        assert!(
+            regex.find(&contents).is_some(),
+            "regex '{}' failed to get a match in {}",
+            regex,
+            path.display()
+        );
+
+        DependentFile {
+            path,
+            contents,
+            regex,
+            replacement,
+        }
+    }
+
+    pub fn update(&self, updated_version: &str) {
+        let updated_contents = self
+            .regex
+            .replace(&self.contents, (self.replacement)(updated_version).as_str());
+        fs::write(&self.path, updated_contents.as_ref())
+            .unwrap_or_else(|error| panic!("should write {}: {:?}", self.path.display(), error));
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn contents(&self) -> &str {
+        &self.contents
+    }
+}

--- a/ci/casper-updater/src/main.rs
+++ b/ci/casper-updater/src/main.rs
@@ -1,0 +1,205 @@
+//! A tool to update versions of all published CasperLabs packages.
+
+#![warn(unused, missing_copy_implementations, missing_docs)]
+#![deny(
+    deprecated_in_future,
+    future_incompatible,
+    macro_use_extern_crate,
+    rust_2018_idioms,
+    nonstandard_style,
+    single_use_lifetimes,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unstable_features,
+    unused_import_braces,
+    unused_lifetimes,
+    unused_qualifications,
+    unused_results,
+    warnings,
+    clippy::all
+)]
+#![forbid(
+    const_err,
+    arithmetic_overflow,
+    invalid_type_param_default,
+    macro_expanded_macro_exports_accessed_by_absolute_paths,
+    missing_fragment_specifier,
+    mutable_transmutes,
+    no_mangle_const_items,
+    order_dependent_trait_objects,
+    overflowing_literals,
+    pub_use_of_private_extern_crate,
+    unknown_crate_types
+)]
+
+mod dependent_file;
+mod package;
+mod regex_data;
+
+use std::{
+    env,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use clap::{crate_version, App, Arg};
+use lazy_static::lazy_static;
+
+use package::Package;
+
+const APP_NAME: &str = "Casper Updater";
+
+const ROOT_DIR_ARG_NAME: &str = "root-dir";
+const ROOT_DIR_ARG_SHORT: &str = "r";
+const ROOT_DIR_ARG_VALUE_NAME: &str = "PATH";
+const ROOT_DIR_ARG_HELP: &str =
+    "Path to casper-node root directory.  If not supplied, assumes it is at ../..";
+
+const BUMP_ARG_NAME: &str = "bump";
+const BUMP_ARG_SHORT: &str = "b";
+const BUMP_ARG_VALUE_NAME: &str = "VERSION-COMPONENT";
+const BUMP_ARG_HELP: &str =
+    "Increase all crates' versions automatically without asking for user input.  For a crate at \
+    version x.y.z, the version will be bumped to (x+1).0.0, x.(y+1).0, or x.y.(z+1) depending on \
+    which version component is specified";
+const MAJOR: &str = "major";
+const MINOR: &str = "minor";
+const PATCH: &str = "patch";
+
+const DRY_RUN_ARG_NAME: &str = "dry-run";
+const DRY_RUN_ARG_SHORT: &str = "d";
+const DRY_RUN_ARG_HELP: &str = "Check all regexes get matches in current casper-node repo";
+
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub(crate) enum BumpVersion {
+    Major,
+    Minor,
+    Patch,
+}
+
+struct Args {
+    root_dir: PathBuf,
+    bump_version: Option<BumpVersion>,
+    dry_run: bool,
+}
+
+/// The full path to the casper-node root directory.
+pub(crate) fn root_dir() -> &'static Path {
+    &ARGS.root_dir
+}
+
+/// The version component to bump, if any.
+pub(crate) fn bump_version() -> Option<BumpVersion> {
+    ARGS.bump_version
+}
+
+/// Whether we're doing a dry run or not.
+pub(crate) fn is_dry_run() -> bool {
+    ARGS.dry_run
+}
+
+lazy_static! {
+    static ref ARGS: Args = get_args();
+}
+
+fn get_args() -> Args {
+    let arg_matches = App::new(APP_NAME)
+        .version(crate_version!())
+        .arg(
+            Arg::with_name(ROOT_DIR_ARG_NAME)
+                .long(ROOT_DIR_ARG_NAME)
+                .short(ROOT_DIR_ARG_SHORT)
+                .value_name(ROOT_DIR_ARG_VALUE_NAME)
+                .help(ROOT_DIR_ARG_HELP)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(BUMP_ARG_NAME)
+                .long(BUMP_ARG_NAME)
+                .short(BUMP_ARG_SHORT)
+                .value_name(BUMP_ARG_VALUE_NAME)
+                .help(BUMP_ARG_HELP)
+                .takes_value(true)
+                .possible_values(&[MAJOR, MINOR, PATCH]),
+        )
+        .arg(
+            Arg::with_name(DRY_RUN_ARG_NAME)
+                .long(DRY_RUN_ARG_NAME)
+                .short(DRY_RUN_ARG_SHORT)
+                .help(DRY_RUN_ARG_HELP),
+        )
+        .get_matches();
+
+    let root_dir = match arg_matches.value_of(ROOT_DIR_ARG_NAME) {
+        Some(path) => PathBuf::from_str(path).expect("should be a valid unicode path"),
+        None => env::current_dir()
+            .expect("should be able to access current working dir")
+            .parent()
+            .expect("current working dir should have parent")
+            .parent()
+            .expect("current working dir should have two parents")
+            .to_path_buf(),
+    };
+
+    let bump_version = arg_matches
+        .value_of(BUMP_ARG_NAME)
+        .map(|value| match value {
+            MAJOR => BumpVersion::Major,
+            MINOR => BumpVersion::Minor,
+            PATCH => BumpVersion::Patch,
+            _ => unreachable!(),
+        });
+
+    let dry_run = arg_matches.is_present(DRY_RUN_ARG_NAME);
+
+    Args {
+        root_dir,
+        bump_version,
+        dry_run,
+    }
+}
+
+fn main() {
+    let types = Package::cargo("types", &*regex_data::types::DEPENDENT_FILES);
+    types.update();
+
+    let execution_engine = Package::cargo(
+        "execution_engine",
+        &*regex_data::execution_engine::DEPENDENT_FILES,
+    );
+    execution_engine.update();
+
+    let node = Package::cargo("node", &*regex_data::node::DEPENDENT_FILES);
+    node.update();
+
+    let grpc_server = Package::cargo("grpc/server", &*regex_data::grpc_server::DEPENDENT_FILES);
+    grpc_server.update();
+
+    let client = Package::cargo("client", &*regex_data::client::DEPENDENT_FILES);
+    client.update();
+
+    let smart_contracts_contract = Package::cargo(
+        "smart_contracts/contract",
+        &*regex_data::smart_contracts_contract::DEPENDENT_FILES,
+    );
+    smart_contracts_contract.update();
+
+    let smart_contracts_contract_as = Package::assembly_script(
+        "smart_contracts/contract_as",
+        &*regex_data::smart_contracts_contract_as::DEPENDENT_FILES,
+    );
+    smart_contracts_contract_as.update();
+
+    let grpc_test_support = Package::cargo(
+        "grpc/test_support",
+        &*regex_data::grpc_test_support::DEPENDENT_FILES,
+    );
+    grpc_test_support.update();
+
+    let grpc_cargo_casper = Package::cargo(
+        "grpc/cargo-casper",
+        &*regex_data::grpc_cargo_casper::DEPENDENT_FILES,
+    );
+    grpc_cargo_casper.update();
+}

--- a/ci/casper-updater/src/package.rs
+++ b/ci/casper-updater/src/package.rs
@@ -1,0 +1,228 @@
+use std::{
+    io::{self, Write},
+    path::Path,
+};
+
+use regex::Regex;
+use semver::Version;
+
+use crate::{
+    dependent_file::DependentFile,
+    regex_data::{
+        MANIFEST_NAME_REGEX, MANIFEST_VERSION_REGEX, PACKAGE_JSON_NAME_REGEX,
+        PACKAGE_JSON_VERSION_REGEX,
+    },
+    BumpVersion,
+};
+
+const CAPTURE_INDEX: usize = 2;
+
+/// Represents a published CasperLabs crate or AssemblyScript package which may need its version
+/// updated.
+pub struct Package {
+    /// This package's name as specified in its manifest.
+    name: String,
+    /// This package's current version as specified in its manifest.
+    current_version: Version,
+    /// Files which must be updated if this package's version is changed, including this package's
+    /// own manifest file.  The other files will often be from a different package.
+    dependent_files: &'static Vec<DependentFile>,
+}
+
+trait PackageConsts {
+    const MANIFEST: &'static str;
+    fn name_regex() -> &'static Regex;
+    fn version_regex() -> &'static Regex;
+}
+
+struct CargoPackage;
+
+impl PackageConsts for CargoPackage {
+    const MANIFEST: &'static str = "Cargo.toml";
+
+    fn name_regex() -> &'static Regex {
+        &*MANIFEST_NAME_REGEX
+    }
+
+    fn version_regex() -> &'static Regex {
+        &*MANIFEST_VERSION_REGEX
+    }
+}
+
+struct AssemblyScriptPackage;
+
+impl PackageConsts for AssemblyScriptPackage {
+    const MANIFEST: &'static str = "package.json";
+
+    fn name_regex() -> &'static Regex {
+        &*PACKAGE_JSON_NAME_REGEX
+    }
+
+    fn version_regex() -> &'static Regex {
+        &*PACKAGE_JSON_VERSION_REGEX
+    }
+}
+
+#[allow(clippy::ptr_arg)]
+impl Package {
+    pub fn cargo<P: AsRef<Path>>(
+        relative_path: P,
+        dependent_files: &'static Vec<DependentFile>,
+    ) -> Self {
+        Self::new::<_, CargoPackage>(relative_path, dependent_files)
+    }
+
+    pub fn assembly_script<P: AsRef<Path>>(
+        relative_path: P,
+        dependent_files: &'static Vec<DependentFile>,
+    ) -> Self {
+        Self::new::<_, AssemblyScriptPackage>(relative_path, dependent_files)
+    }
+
+    fn new<P: AsRef<Path>, T: PackageConsts>(
+        relative_path: P,
+        dependent_files: &'static Vec<DependentFile>,
+    ) -> Self {
+        let manifest_path = crate::root_dir().join(&relative_path).join(T::MANIFEST);
+
+        let manifest = dependent_files
+            .iter()
+            .find(|&file| file.path() == manifest_path)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{} should be a dependent file of {}",
+                    manifest_path.display(),
+                    relative_path.as_ref().display()
+                )
+            });
+
+        let find_value = |regex: &Regex| {
+            regex
+                .captures(manifest.contents())
+                .unwrap_or_else(|| {
+                    panic!(
+                        "should find package name and version in {}",
+                        manifest_path.display()
+                    )
+                })
+                .get(CAPTURE_INDEX)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "package name and version should be regex capture at index {} in {}",
+                        CAPTURE_INDEX,
+                        manifest_path.display()
+                    )
+                })
+                .as_str()
+                .to_string()
+        };
+
+        let name = find_value(T::name_regex());
+        let version = find_value(T::version_regex());
+        let current_version = Version::parse(&version).expect("should parse current version");
+
+        Package {
+            name,
+            current_version,
+            dependent_files,
+        }
+    }
+
+    pub fn update(&self) {
+        if crate::is_dry_run() {
+            println!(
+                "Current version of {} is {}",
+                self.name, self.current_version
+            );
+            if let Some(bump_version) = crate::bump_version() {
+                let updated_version = self.get_updated_version_from_bump(bump_version);
+                println!("Will be updated to {}", updated_version);
+            }
+            println!("Files affected by this package's version:");
+            for dependent_file in self.dependent_files {
+                let relative_path = dependent_file
+                    .path()
+                    .strip_prefix(crate::root_dir())
+                    .expect("should strip prefix");
+                println!("\t* {}", relative_path.display());
+            }
+            println!();
+            return;
+        }
+
+        let updated_version = match crate::bump_version() {
+            None => match self.get_updated_version_from_user() {
+                Some(version) => version,
+                None => return,
+            },
+            Some(bump_version) => self.get_updated_version_from_bump(bump_version),
+        };
+
+        for dependent_file in self.dependent_files {
+            dependent_file.update(&updated_version.to_string());
+        }
+
+        println!(
+            "Updated {} from {} to {}.",
+            self.name, self.current_version, updated_version
+        );
+    }
+
+    fn get_updated_version_from_bump(&self, bump_version: BumpVersion) -> Version {
+        match bump_version {
+            BumpVersion::Major => Version::new(self.current_version.major + 1, 0, 0),
+            BumpVersion::Minor => Version::new(
+                self.current_version.major,
+                self.current_version.minor + 1,
+                0,
+            ),
+            BumpVersion::Patch => Version::new(
+                self.current_version.major,
+                self.current_version.minor,
+                self.current_version.patch + 1,
+            ),
+        }
+    }
+
+    fn get_updated_version_from_user(&self) -> Option<Version> {
+        loop {
+            print!(
+                "Current version of {} is {}.  Enter new version (leave blank for unchanged): ",
+                self.name, self.current_version
+            );
+            io::stdout().flush().expect("should flush stdout");
+            let mut input = String::new();
+            match io::stdin().read_line(&mut input) {
+                Ok(_) => {
+                    input = input.trim_end().to_string();
+                    if input.is_empty() {
+                        return None;
+                    }
+
+                    let new_version = match Version::parse(&input) {
+                        Ok(version) => version,
+                        Err(error) => {
+                            println!("\n{} is not a valid version: {}.", input, error);
+                            continue;
+                        }
+                    };
+
+                    if new_version < self.current_version {
+                        println!(
+                            "Updated version ({}) is lower than current version ({})",
+                            new_version, self.current_version
+                        );
+                        continue;
+                    }
+
+                    return if new_version == self.current_version {
+                        None
+                    } else {
+                        Some(new_version)
+                    };
+                }
+                Err(error) => println!("\nFailed to read from stdin: {}.", error),
+            }
+        }
+    }
+}

--- a/ci/casper-updater/src/regex_data.rs
+++ b/ci/casper-updater/src/regex_data.rs
@@ -1,0 +1,291 @@
+#![allow(clippy::wildcard_imports)]
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+use crate::dependent_file::DependentFile;
+
+lazy_static! {
+    pub static ref MANIFEST_NAME_REGEX: Regex = Regex::new(r#"(?m)(^name = )"([^"]+)"#).unwrap();
+    pub static ref MANIFEST_VERSION_REGEX: Regex =
+        Regex::new(r#"(?m)(^version = )"([^"]+)"#).unwrap();
+    pub static ref PACKAGE_JSON_NAME_REGEX: Regex =
+        Regex::new(r#"(?m)(^  "name": )"([^"]+)"#).unwrap();
+    pub static ref PACKAGE_JSON_VERSION_REGEX: Regex =
+        Regex::new(r#"(?m)(^  "version": )"([^"]+)"#).unwrap();
+}
+
+fn replacement(updated_version: &str) -> String {
+    format!(r#"$1"{}"#, updated_version)
+}
+
+fn replacement_with_slash(updated_version: &str) -> String {
+    format!(r#"$1/{}"#, updated_version)
+}
+
+pub mod types {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
+            vec![
+                DependentFile::new(
+                    "client/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-types = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "execution_engine/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-types = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "grpc/cargo-casper/src/common.rs",
+                    Regex::new(r#"(?m)("casper-types",\s*)"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "grpc/server/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-types = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "grpc/test_support/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-types = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "node/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-types = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "smart_contracts/contract/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-types = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "types/Cargo.toml",
+                    MANIFEST_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "types/src/lib.rs",
+                    Regex::new(
+                        r#"(?m)(#!\[doc\(html_root_url = "https://docs.rs/casper-types)/(?:[^"]+)"#,
+                    )
+                    .unwrap(),
+                    replacement_with_slash,
+                ),
+            ]
+        };
+    }
+}
+
+pub mod execution_engine {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
+            vec![
+                DependentFile::new(
+                    "client/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-execution-engine = \{[^\}]*version = )"(?:[^"]+)"#)
+                        .unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "grpc/server/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-execution-engine = \{[^\}]*version = )"(?:[^"]+)"#)
+                        .unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "grpc/test_support/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-execution-engine = \{[^\}]*version = )"(?:[^"]+)"#)
+                        .unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "node/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-execution-engine = \{[^\}]*version = )"(?:[^"]+)"#)
+                        .unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "execution_engine/Cargo.toml",
+                    MANIFEST_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "execution_engine/src/lib.rs",
+                    Regex::new(r#"(?m)(#!\[doc\(html_root_url = "https://docs.rs/casper-execution-engine)/(?:[^"]+)"#).unwrap(),
+                    replacement_with_slash,
+                ),
+            ]
+        };
+    }
+}
+
+pub mod node {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
+            vec![
+                DependentFile::new(
+                    "client/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-node = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "node/Cargo.toml",
+                    MANIFEST_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "node/src/lib.rs",
+                    Regex::new(
+                        r#"(?m)(#!\[doc\(html_root_url = "https://docs.rs/casper-node)/(?:[^"]+)"#,
+                    )
+                    .unwrap(),
+                    replacement_with_slash,
+                ),
+            ]
+        };
+    }
+}
+
+pub mod grpc_server {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
+            vec![
+                DependentFile::new(
+                    "grpc/server/Cargo.toml",
+                    MANIFEST_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "grpc/test_support/Cargo.toml",
+                    Regex::new(
+                        r#"(?m)(^casper-engine-grpc-server = \{[^\}]*version = )"(?:[^"]+)"#,
+                    )
+                    .unwrap(),
+                    replacement,
+                ),
+            ]
+        };
+    }
+}
+
+pub mod client {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
+            vec![DependentFile::new(
+                "client/Cargo.toml",
+                MANIFEST_VERSION_REGEX.clone(),
+                replacement,
+            )]
+        };
+    }
+}
+
+pub mod smart_contracts_contract {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
+            vec![
+                DependentFile::new(
+                    "grpc/cargo-casper/src/common.rs",
+                    Regex::new(r#"(?m)("casper-contract",\s*)"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "grpc/test_support/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-contract = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "smart_contracts/contract/Cargo.toml",
+                    MANIFEST_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "smart_contracts/contract/src/lib.rs",
+                    Regex::new(r#"(?m)(#!\[doc\(html_root_url = "https://docs.rs/casper-contract)/(?:[^"]+)"#).unwrap(),
+                    replacement_with_slash,
+                ),
+            ]
+        };
+    }
+}
+
+pub mod smart_contracts_contract_as {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
+            vec![
+                DependentFile::new(
+                    "smart_contracts/contract_as/package.json",
+                    PACKAGE_JSON_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "smart_contracts/contract_as/package-lock.json",
+                    PACKAGE_JSON_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+            ]
+        };
+    }
+}
+
+pub mod grpc_test_support {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
+            vec![
+                DependentFile::new(
+                    "grpc/cargo-casper/src/tests_package.rs",
+                    Regex::new(r#"(?m)("casper-engine-test-support",\s*)"(?:[^"]+)"#).unwrap(),
+                    cargo_casper_src_test_package_rs_replacement,
+                ),
+                DependentFile::new(
+                    "grpc/test_support/Cargo.toml",
+                    MANIFEST_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "grpc/test_support/src/lib.rs",
+                    Regex::new(r#"(?m)(#!\[doc\(html_root_url = "https://docs.rs/casper-engine-test-support)/(?:[^"]+)"#).unwrap(),
+                    replacement_with_slash,
+                ),
+            ]
+        };
+    }
+
+    fn cargo_casper_src_test_package_rs_replacement(updated_version: &str) -> String {
+        format!(r#"$1"{}"#, updated_version)
+    }
+}
+
+pub mod grpc_cargo_casper {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
+            vec![DependentFile::new(
+                "grpc/cargo-casper/Cargo.toml",
+                MANIFEST_VERSION_REGEX.clone(),
+                replacement,
+            )]
+        };
+    }
+}

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -7,9 +7,9 @@ description = "A client for interacting with the Casper network"
 
 [dependencies]
 base64 = "0.12.3"
-casper-execution-engine = { path = "../execution_engine" }
-casper-node = { path = "../node" }
-casper-types = { path = "../types", features = ["std"] }
+casper-execution-engine = { version = "0.7.0", path = "../execution_engine" }
+casper-node = { version = "0.1.0", path = "../node" }
+casper-types = { version = "0.6.0", path = "../types", features = ["std"] }
 clap = "2.33.1"
 futures = "0.3.5"
 hex = { version = "0.4.2", features = ["serde"] }

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "0.7.0"
+version = "0.7.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."
@@ -14,7 +14,7 @@ license-file = "../LICENSE"
 anyhow = "1.0.28"
 base16 = "0.2.1"
 blake2 = "0.8.1"
-casper-types = { version = "0.6.0", path = "../types", package = "casper-types", features = ["std", "gens"] }
+casper-types = { version = "0.6.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 datasize = "0.2.0"
 csv = "1.1.3"

--- a/execution_engine/src/config.rs
+++ b/execution_engine/src/config.rs
@@ -1,3 +1,5 @@
+//! Configuration options for the execution engine.
+
 use serde::{Deserialize, Serialize};
 
 use crate::shared::utils;
@@ -10,22 +12,22 @@ const DEFAULT_USE_SYSTEM_CONTRACTS: bool = false;
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 pub struct Config {
-    /// Whether to use system contracts or not.  Defaults to false.
     use_system_contracts: Option<bool>,
-    /// The maximum size of the database to use for the global state store.
-    ///
-    /// Defaults to 805,306,368,000 == 750 GiB.
-    ///
-    /// The size should be a multiple of the OS page size.
     max_global_state_size: Option<usize>,
 }
 
 impl Config {
+    /// Whether to use system contracts or not.  Defaults to false.
     pub fn use_system_contracts(&self) -> bool {
         self.use_system_contracts
             .unwrap_or(DEFAULT_USE_SYSTEM_CONTRACTS)
     }
 
+    /// The maximum size of the database to use for the global state store.
+    ///
+    /// Defaults to 805,306,368,000 == 750 GiB.
+    ///
+    /// The size should be a multiple of the OS page size.
     pub fn max_global_state_size(&self) -> usize {
         let value = self
             .max_global_state_size

--- a/execution_engine/src/core/runtime/auction_internal.rs
+++ b/execution_engine/src/core/runtime/auction_internal.rs
@@ -67,7 +67,7 @@ where
     R: StateReader<Key, StoredValue>,
     R::Error: Into<execution::Error>,
 {
-    fn get_caller(&self) -> casper_types::account::AccountHash {
+    fn get_caller(&self) -> AccountHash {
         self.context.get_caller()
     }
 

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -1076,7 +1076,7 @@ fn extract_urefs(cl_value: &CLValue) -> Result<Vec<URef>, Error> {
                 Ok(map.values().cloned().collect())
             }
             (CLType::PublicKey, CLType::URef) => {
-                let map: BTreeMap<casper_types::PublicKey, URef> = cl_value.to_owned().into_t()?;
+                let map: BTreeMap<PublicKey, URef> = cl_value.to_owned().into_t()?;
                 Ok(map.values().cloned().collect())
             }
             (CLType::Bool, CLType::Key) => {
@@ -1124,7 +1124,7 @@ fn extract_urefs(cl_value: &CLValue) -> Result<Vec<URef>, Error> {
                 Ok(map.values().cloned().filter_map(Key::into_uref).collect())
             }
             (CLType::PublicKey, CLType::Key) => {
-                let map: BTreeMap<casper_types::PublicKey, Key> = cl_value.to_owned().into_t()?;
+                let map: BTreeMap<PublicKey, Key> = cl_value.to_owned().into_t()?;
                 Ok(map.values().cloned().filter_map(Key::into_uref).collect())
             }
             (_, _) => Ok(vec![]),

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,3 +1,18 @@
+//! The engine which executes smart contracts on the Casper network.
+
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/0.7.0")]
+#![doc(
+    html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
+    html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",
+    test(attr(forbid(warnings)))
+)]
+#![warn(
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications
+)]
+
 pub mod config;
 pub mod core;
 pub mod shared;

--- a/grpc/server/Cargo.toml
+++ b/grpc/server/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [dependencies]
-casper-execution-engine = { path = "../../execution_engine", features = ["gens"] }
+casper-execution-engine = { version = "0.7.0", path = "../../execution_engine", features = ["gens"] }
 casper-types = { version = "0.6.0", path = "../../types", features = ["std", "gens"] }
 clap = "2"
 ctrlc = "3"

--- a/grpc/test_support/Cargo.toml
+++ b/grpc/test_support/Cargo.toml
@@ -13,7 +13,7 @@ license-file = "../../LICENSE"
 [dependencies]
 casper-contract = { version = "0.6.0", path = "../../smart_contracts/contract" }
 casper-engine-grpc-server = { version = "0.20.0", path = "../server" }
-casper-execution-engine = { path = "../../execution_engine" }
+casper-execution-engine = { version = "0.7.0", path = "../../execution_engine" }
 casper-types = { version = "0.6.0", path = "../../types", features = ["std"] }
 grpc = "0.6.1"
 lazy_static = "1"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/CasperLabs/casper-node"
 license-file = "../LICENSE"
-publish = false  # Prevent accidental `cargo publish` for now.
 default-run = "casper-node"
 
 [dependencies]
@@ -19,7 +18,7 @@ backtrace = "0.3.50"
 base16 = "0.2.1"
 base64 = "0.12.3"
 blake2 = { version = "0.8.1", default-features = false }
-casper-execution-engine = { path = "../execution_engine" }
+casper-execution-engine = { version = "0.7.0", path = "../execution_engine" }
 casper-types = { version = "0.6.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 csv = "1.1.3"

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -6,9 +6,9 @@
 //! ## Application structure
 //!
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
-//! its core event loop is found inside the [reactor](reactor/index.html). To get a tour of the
-//! sourcecode, be sure to run `cargo doc --open`.
+//! its core event loop is found inside the [reactor](reactor/index.html).
 
+#![doc(html_root_url = "https://docs.rs/casper-node/0.1.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contracts/system/auction-install/Cargo.toml
+++ b/smart_contracts/contracts/system/auction-install/Cargo.toml
@@ -16,6 +16,6 @@ std = ["casper-contract/std", "casper-types/std"]
 no-unstable-features = ["casper-contract/no-unstable-features", "casper-types/no-unstable-features"]
 
 [dependencies]
+auction = { path = "../auction" }
 casper-contract = { path = "../../../contract" }
-auction = { version = "0.1.0", path = "../auction" }
-casper-types = { version = "0.6.0", path = "../../../../types" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/system/standard-payment-install/Cargo.toml
+++ b/smart_contracts/contracts/system/standard-payment-install/Cargo.toml
@@ -17,5 +17,5 @@ no-unstable-features = ["casper-contract/no-unstable-features", "casper-types/no
 
 [dependencies]
 casper-contract = { path = "../../../contract" }
-standard-payment = { version = "0.1.0", path = "../standard-payment" }
-casper-types = { version = "0.6.0", path = "../../../../types" }
+casper-types = { path = "../../../../types" }
+standard-payment = { path = "../standard-payment" }


### PR DESCRIPTION
This PR copies over the `casperlabs-updater` from the old repo.  The bulk of the new files only have small changes relating to references to the old EE path.  The main source of changes is in `regex_data.rs`.

I also added execution of this binary with the `--dry-run` flag to the drone file.