### PR TITLE
NO-TICKET: Reset peers on downloaded block

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -228,6 +228,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         I: Send + Copy + 'static,
         REv: ReactorEventT<I>,
     {
+        self.reset_peers(rng);
         self.state.block_downloaded(block_header);
         self.add_block(block_header.clone());
         match &self.state {


### PR DESCRIPTION
This fixes the bug where the linear chain synchronizer incorrectly runs out of peers to download deploys from.