### PR TITLE
NO-TICKET: Use the args supplied in stop-dev.sh

### DIFF
--- a/stop-dev.sh
+++ b/stop-dev.sh
@@ -4,17 +4,17 @@
 
 set -eu
 
-BASEDIR=$(readlink -f $(dirname $0))
-CHAINSPEC=$(mktemp -t chainspec_XXXXXXXX --suffix .toml)
-
 ARGS="$@"
 # If no nodes defined, stop all.
 NODES="${ARGS:-1 2 3 4 5}"
 
+# print the warning if node 1 is one of the selected nodes to be stopped
+case "$NODES" in
+    *"1"*) echo "NOTE: Stopping node 1 will also stop other nodes started with run-dev.sh"
+esac
+
 for i in $NODES; do
-    case "$NODES" in
-        *"$i"*) systemctl --user stop node-$i
-    esac
+    systemctl --user stop node-$i
 done;
 
 rm /tmp/chainspec_*

--- a/stop-dev.sh
+++ b/stop-dev.sh
@@ -11,7 +11,7 @@ ARGS="$@"
 # If no nodes defined, stop all.
 NODES="${ARGS:-1 2 3 4 5}"
 
-for i in 1 2 3 4 5; do
+for i in $NODES; do
     case "$NODES" in
         *"$i"*) systemctl --user stop node-$i
     esac


### PR DESCRIPTION
This makes the `stop-dev.sh` script use the arguments supplied if there were any, instead of always using "1 2 3 4 5".