### PR TITLE
Add `get_version` utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,7 @@ dependencies = [
  "uint",
  "untrusted",
  "uuid",
+ "vergen",
  "wabt",
  "warp",
  "warp-json-rpc",
@@ -3279,7 +3280,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d9500ea1488a61aa96da139039b78a92eef64a0f3c82d38173729f0ad73cf8"
 dependencies = [
- "log 0.3.9",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -5153,6 +5154,16 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vergen"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce50d8996df1f85af15f2cd8d33daae6e479575123ef4314a51a70a230739cb"
+dependencies = [
+ "bitflags 1.2.1",
+ "chrono",
+]
 
 [[package]]
 name = "version-sync"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -110,6 +110,9 @@ bench = false
 doctest = false
 test = false
 
+[build-dependencies]
+vergen = "3.1.0"
+
 [package.metadata.deb]
 features = ["vendored-openssl"]
 revision = "3"  # Increment with releases for updates to charlie data files when not version bumping casper-node.

--- a/node/build.rs
+++ b/node/build.rs
@@ -1,0 +1,9 @@
+use vergen::ConstantsFlags;
+
+fn main() {
+    let mut flags = ConstantsFlags::empty();
+    flags.toggle(ConstantsFlags::SEMVER_LIGHTWEIGHT);
+    flags.toggle(ConstantsFlags::SHA_SHORT);
+    flags.toggle(ConstantsFlags::REBUILD_ON_HEAD_CHANGE);
+    vergen::generate_cargo_keys(flags).expect("should generate the cargo keys");
+}

--- a/node/src/app/cli.rs
+++ b/node/src/app/cli.rs
@@ -7,7 +7,6 @@ pub mod arglang;
 use std::{env, fs, path::PathBuf, str::FromStr};
 
 use anyhow::{self, bail, Context};
-use lazy_static::lazy_static;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use regex::Regex;
@@ -23,17 +22,9 @@ use casper_node::{
 };
 use prometheus::Registry;
 
-lazy_static! {
-    static ref VERSION_STRING: String = format!(
-        "{}-{}",
-        env!("VERGEN_SEMVER_LIGHTWEIGHT"),
-        env!("VERGEN_SHA_SHORT")
-    );
-}
-
 // Note: The docstring on `Cli` is the help shown when calling the binary with `--help`.
 #[derive(Debug, StructOpt)]
-#[structopt(version = VERSION_STRING.as_str())]
+#[structopt(version = casper_node::VERSION_STRING.as_str())]
 /// Casper blockchain node.
 pub enum Cli {
     /// Run the validator node.

--- a/node/src/app/cli.rs
+++ b/node/src/app/cli.rs
@@ -7,6 +7,7 @@ pub mod arglang;
 use std::{env, fs, path::PathBuf, str::FromStr};
 
 use anyhow::{self, bail, Context};
+use lazy_static::lazy_static;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use regex::Regex;
@@ -22,19 +23,17 @@ use casper_node::{
 };
 use prometheus::Registry;
 
-/// Outputs a suitable version string.
-fn get_version() -> &'static str {
-    let s = Box::new(format!(
+lazy_static! {
+    static ref VERSION_STRING: String = format!(
         "{}-{}",
         env!("VERGEN_SEMVER_LIGHTWEIGHT"),
         env!("VERGEN_SHA_SHORT")
-    ));
-    Box::leak(s).as_str()
+    );
 }
 
 // Note: The docstring on `Cli` is the help shown when calling the binary with `--help`.
 #[derive(Debug, StructOpt)]
-#[structopt(version = get_version())]
+#[structopt(version = VERSION_STRING.as_str())]
 /// Casper blockchain node.
 pub enum Cli {
     /// Run the validator node.

--- a/node/src/app/cli.rs
+++ b/node/src/app/cli.rs
@@ -22,8 +22,19 @@ use casper_node::{
 };
 use prometheus::Registry;
 
+/// Outputs a suitable version string.
+fn get_version() -> &'static str {
+    let s = Box::new(format!(
+        "{}-{}",
+        env!("VERGEN_SEMVER_LIGHTWEIGHT"),
+        env!("VERGEN_SHA_SHORT")
+    ));
+    Box::leak(s).as_str()
+}
+
 // Note: The docstring on `Cli` is the help shown when calling the binary with `--help`.
 #[derive(Debug, StructOpt)]
+#[structopt(version = get_version())]
 /// Casper blockchain node.
 pub enum Cli {
     /// Run the validator node.

--- a/node/src/components/api_server/rpcs/info.rs
+++ b/node/src/components/api_server/rpcs/info.rs
@@ -185,7 +185,7 @@ pub struct GetStatusResult {
     /// The minimal info of the last block from the linear chain.
     pub last_finalized_block_info: Option<MinimalBlockInfo>,
     /// The compiled node version.
-    pub version: String,
+    pub build_version: String,
 }
 
 impl From<StatusFeed<NodeId>> for GetStatusResult {
@@ -194,7 +194,7 @@ impl From<StatusFeed<NodeId>> for GetStatusResult {
             api_version: CLIENT_API_VERSION.clone(),
             peers: peers_hashmap_to_btreemap(status_feed.peers),
             last_finalized_block_info: status_feed.last_finalized_block.map(Into::into),
-            version: crate::VERSION_STRING.clone(),
+            build_version: crate::VERSION_STRING.clone(),
         }
     }
 }

--- a/node/src/components/api_server/rpcs/info.rs
+++ b/node/src/components/api_server/rpcs/info.rs
@@ -184,6 +184,8 @@ pub struct GetStatusResult {
     pub peers: BTreeMap<String, SocketAddr>,
     /// The minimal info of the last block from the linear chain.
     pub last_finalized_block_info: Option<MinimalBlockInfo>,
+    /// The compiled node version.
+    pub version: String,
 }
 
 impl From<StatusFeed<NodeId>> for GetStatusResult {
@@ -192,6 +194,7 @@ impl From<StatusFeed<NodeId>> for GetStatusResult {
             api_version: CLIENT_API_VERSION.clone(),
             peers: peers_hashmap_to_btreemap(status_feed.peers),
             last_finalized_block_info: status_feed.last_finalized_block.map(Into::into),
+            version: crate::VERSION_STRING.clone(),
         }
     }
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -33,6 +33,8 @@ pub mod tls;
 pub mod types;
 pub mod utils;
 
+use lazy_static::lazy_static;
+
 pub(crate) use components::small_network;
 pub use components::{
     api_server::{rpcs, Config as ApiServerConfig},
@@ -44,3 +46,12 @@ pub use components::{
     storage::{Config as StorageConfig, Error as StorageError},
 };
 pub use utils::OS_PAGE_SIZE;
+
+lazy_static! {
+    /// Version string for the compiled node. Filled in at build time, output allocated at runtime.
+    pub static ref VERSION_STRING: String = format!(
+        "{}-{}",
+        env!("VERGEN_SEMVER_LIGHTWEIGHT"),
+        env!("VERGEN_SHA_SHORT")
+    );
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -49,9 +49,13 @@ pub use utils::OS_PAGE_SIZE;
 
 lazy_static! {
     /// Version string for the compiled node. Filled in at build time, output allocated at runtime.
-    pub static ref VERSION_STRING: String = format!(
-        "{}-{}",
-        env!("VERGEN_SEMVER_LIGHTWEIGHT"),
-        env!("VERGEN_SHA_SHORT")
-    );
+    pub static ref VERSION_STRING: String = if env!("VERGEN_SEMVER_LIGHTWEIGHT") == "UNKNOWN" {
+        env!("CARGO_PKG_VERSION").to_string()
+    } else {
+        format!(
+            "{}-{}",
+            env!("VERGEN_SEMVER_LIGHTWEIGHT"),
+            env!("VERGEN_SHA_SHORT")
+        )
+    };
 }

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -14,6 +14,8 @@ pub struct StatusFeed<I> {
     pub peers: HashMap<I, SocketAddr>,
     /// The chainspec info for this node.
     pub chainspec_info: ChainspecInfo,
+    /// The compiled node version.
+    pub version: &'static str,
 }
 
 impl<I> StatusFeed<I> {
@@ -26,6 +28,7 @@ impl<I> StatusFeed<I> {
             last_finalized_block,
             peers,
             chainspec_info,
+            version: crate::VERSION_STRING.as_str(),
         }
     }
 }


### PR DESCRIPTION
As a stopgap measure, make the `--version` command output useful stuff and report the version in RPC status and `/status`.