### PR TITLE
NO-TICKET: include chainspec info in rpc status endpoint

### DIFF
--- a/node/src/components/api_server/rpcs/info.rs
+++ b/node/src/components/api_server/rpcs/info.rs
@@ -180,6 +180,10 @@ impl From<Block> for MinimalBlockInfo {
 pub struct GetStatusResult {
     /// The RPC API version.
     pub api_version: Version,
+    /// The chainspec name.
+    pub chainspec_name: String,
+    /// The genesis root hash.
+    pub genesis_root_hash: String,
     /// The node ID and network address of each connected peer.
     pub peers: BTreeMap<String, SocketAddr>,
     /// The minimal info of the last block from the linear chain.
@@ -188,8 +192,16 @@ pub struct GetStatusResult {
 
 impl From<StatusFeed<NodeId>> for GetStatusResult {
     fn from(status_feed: StatusFeed<NodeId>) -> Self {
+        let chainspec_name = status_feed.chainspec_info.name();
+        let genesis_root_hash = status_feed
+            .chainspec_info
+            .root_hash()
+            .unwrap_or_default()
+            .to_string();
         GetStatusResult {
             api_version: CLIENT_API_VERSION.clone(),
+            chainspec_name,
+            genesis_root_hash,
             peers: peers_hashmap_to_btreemap(status_feed.peers),
             last_finalized_block_info: status_feed.last_finalized_block.map(Into::into),
         }

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -75,6 +75,14 @@ impl ChainspecInfo {
     pub(crate) fn new(name: String, root_hash: Option<Digest>) -> ChainspecInfo {
         ChainspecInfo { name, root_hash }
     }
+
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn root_hash(&self) -> Option<Digest> {
+        self.root_hash
+    }
 }
 
 impl From<ChainspecLoader> for ChainspecInfo {


### PR DESCRIPTION
The chainspec info was not being included in the rpc output for some reason; this PR includes it.

```
curl -i -X POST -H 'Content-Type: application/json' -d '{"id":1,"jsonrpc":"2.0","method":"info_get_status"}' 'http://localhost:7777/rpc'
```
```
HTTP/1.1 200 OK
content-type: application/json
content-length: 193
date: Tue, 06 Oct 2020 16:51:30 GMT
{"jsonrpc":"2.0","id":1,"result":{"api_version":"1.0.0","chainspec_name":"casper-example","genesis_root_hash":"a59d..42df","peers":{"7561..547f":"127.0.0.1:41742"},"last_finalized_block":null}}>
```

