### PR TITLE
NDRS-435: Add event queue counters. 

### DIFF
--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -90,8 +90,9 @@ impl<REv> EventQueueHandle<REv> {
         self.0.push(event.into(), queue_kind).await
     }
 
-    pub(crate) fn event_counts(&self) -> HashMap<QueueKind, usize> {
-        self.0.event_queue_counters()
+    /// Returns number of events in each of the scheduler's queues.
+    pub(crate) fn event_queues_counts(&self) -> HashMap<QueueKind, usize> {
+        self.0.event_queues_counts()
     }
 }
 

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -24,10 +24,10 @@
 //! in a step-wise manner using [`crank`](struct.Runner.html#method.crank) or indefinitely using
 //! [`run`](struct.Runner.html#method.crank).
 
+mod event_queue_metrics;
 pub mod initializer;
 pub mod joiner;
 mod queue_kind;
-mod event_queue_metrics;
 pub mod validator;
 
 use std::{

--- a/node/src/reactor/event_queue_metrics.rs
+++ b/node/src/reactor/event_queue_metrics.rs
@@ -48,6 +48,7 @@ impl EventQueueMetrics {
 
         let event_counts: String = event_queue_count
             .iter()
+            .sorted_by_key(|k| k.0)
             .map(|(queue, event_count)| {
                 let _ = self
                     .event_queue_gauges

--- a/node/src/reactor/event_queue_metrics.rs
+++ b/node/src/reactor/event_queue_metrics.rs
@@ -24,7 +24,7 @@ impl EventQueueMetrics {
     ) -> Result<Self, prometheus::Error> {
         let mut event_queue_gauges: HashMap<QueueKind, IntGauge> = HashMap::new();
         for queue_kind in event_queue_handle.event_queues_counts().keys() {
-            let key = format!("scheduler_queue_{}_count", queue_kind);
+            let key = format!("scheduler_queue_{}_count", queue_kind.metrics_name());
             let queue_event_counter = IntGauge::new(key, "Event in the queue.".to_string())?;
             registry.register(Box::new(queue_event_counter.clone()))?;
             let result = event_queue_gauges.insert(*queue_kind, queue_event_counter);
@@ -45,6 +45,8 @@ impl EventQueueMetrics {
     }
 
     /// Updates the event queues size metrics.
+    /// NOTE: Count may be off by one b/c of the way locking works when elements are popped.
+    /// It's fine for its purposes.
     pub(super) fn record_event_queue_counts<REv: 'static>(
         &self,
         event_queue_handle: &EventQueueHandle<REv>,

--- a/node/src/reactor/event_queue_metrics.rs
+++ b/node/src/reactor/event_queue_metrics.rs
@@ -5,10 +5,14 @@ use itertools::Itertools;
 use std::collections::HashMap;
 use tracing::debug;
 
+/// Metrics for event queue sizes.
 #[derive(Debug)]
 pub(super) struct EventQueueMetrics {
+    /// Per queue kind gauges that measure number of event in the queue.
     event_queue_gauges: HashMap<QueueKind, IntGauge>,
+    /// Total events count.
     event_total: IntGauge,
+    /// Instance of registry to unregister from when being dropped.
     registry: Registry,
 }
 

--- a/node/src/reactor/event_queue_metrics.rs
+++ b/node/src/reactor/event_queue_metrics.rs
@@ -1,0 +1,80 @@
+use prometheus::{self, IntGauge, Registry};
+
+use crate::reactor::{EventQueueHandle, QueueKind};
+use itertools::Itertools;
+use std::collections::HashMap;
+use tracing::debug;
+
+#[derive(Debug)]
+pub(super) struct EventQueueMetrics {
+    event_queue_gauges: HashMap<QueueKind, IntGauge>,
+    event_total: IntGauge,
+    registry: Registry,
+}
+
+impl EventQueueMetrics {
+    /// Initializes event queue sizes metrics.
+    pub(super) fn new<REv: 'static>(
+        registry: Registry,
+        event_queue_handle: EventQueueHandle<REv>,
+    ) -> Result<Self, prometheus::Error> {
+        let mut event_queue_gauges: HashMap<QueueKind, IntGauge> = HashMap::new();
+        for queue_kind in event_queue_handle.event_counts().keys() {
+            let key = format!("scheduler_queue_{:?}_count", queue_kind);
+            let queue_event_counter = IntGauge::new(key, "Event in the queue.".to_string())?;
+            registry.register(Box::new(queue_event_counter.clone()))?;
+            let result = event_queue_gauges.insert(*queue_kind, queue_event_counter);
+            assert!(result.is_none(), "Map keys should not be overwritten.");
+        }
+
+        let event_total = IntGauge::new(
+            "scheduler_queue_total_count",
+            "total count of events in queues.",
+        )?;
+        registry.register(Box::new(event_total.clone()))?;
+
+        Ok(EventQueueMetrics {
+            event_queue_gauges,
+            event_total,
+            registry,
+        })
+    }
+
+    pub(super) fn estimate<REv: 'static>(&self, event_queue_handle: &EventQueueHandle<REv>) {
+        let event_queue_count = event_queue_handle.event_counts();
+
+        let total = event_queue_count.values().sum::<usize>() as i64;
+        self.event_total.set(total);
+
+        let event_counts: String = event_queue_count
+            .iter()
+            .map(|(queue, event_count)| {
+                let _ = self
+                    .event_queue_gauges
+                    .get(queue)
+                    .map(|gauge| gauge.set(*event_count as i64))
+                    .expect("queue exists.");
+                format!("{:?}={}", queue, event_count)
+            })
+            .join(",");
+
+        debug!(%total, %event_counts, "Collected new set of event queue sizes metrics.")
+    }
+}
+
+impl Drop for EventQueueMetrics {
+    fn drop(&mut self) {
+        self.registry
+            .unregister(Box::new(self.event_total.clone()))
+            .expect("did not expect de-registering of scheduler_queue_total_count to fail.");
+        self.event_queue_gauges
+            .iter()
+            .for_each(|(key, queue_gauge)| {
+                self.registry
+                    .unregister(Box::new(queue_gauge.clone()))
+                    .unwrap_or_else(|_| {
+                        panic!("did not expect de-registering of {:?} to fail.", key)
+                    })
+            });
+    }
+}

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -42,8 +42,9 @@ use crate::{
     },
     protocol::Message,
     reactor::{
-        self, initializer,
+        self,
         event_queue_metrics::EventQueueMetrics,
+        initializer,
         validator::{self, Error, ValidatorInitConfig},
         EventQueueHandle, Finalize,
     },

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -636,7 +636,8 @@ impl reactor::Reactor for Reactor {
     }
 
     fn update_metrics(&mut self, event_queue_handle: EventQueueHandle<Self::Event>) {
-        self.event_queue_metrics.estimate(&event_queue_handle)
+        self.event_queue_metrics
+            .record_event_queue_counts(&event_queue_handle)
     }
 }
 

--- a/node/src/reactor/queue_kind.rs
+++ b/node/src/reactor/queue_kind.rs
@@ -11,7 +11,7 @@ use enum_iterator::IntoEnumIterator;
 /// Scheduling priority.
 ///
 /// Priorities are ordered from lowest to highest.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, IntoEnumIterator)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, IntoEnumIterator, Ord, PartialOrd)]
 pub enum QueueKind {
     /// Network events that were initiated outside of this node.
     ///

--- a/node/src/reactor/queue_kind.rs
+++ b/node/src/reactor/queue_kind.rs
@@ -38,7 +38,7 @@ impl Display for QueueKind {
             QueueKind::Regular => "Regular",
             QueueKind::Api => "Api",
         };
-        write!(f, "{}", str_value.to_string())
+        write!(f, "{}", str_value)
     }
 }
 
@@ -68,5 +68,14 @@ impl QueueKind {
         QueueKind::into_enum_iter()
             .map(|q| (q, q.weight()))
             .collect()
+    }
+
+    pub(crate) fn metrics_name(&self) -> &str {
+        match self {
+            QueueKind::NetworkIncoming => "network_incoming",
+            QueueKind::Network => "network",
+            QueueKind::Regular => "regular",
+            QueueKind::Api => "api",
+        }
     }
 }

--- a/node/src/reactor/queue_kind.rs
+++ b/node/src/reactor/queue_kind.rs
@@ -4,7 +4,7 @@
 //! round-robin manner. This way, events are only competing for time within one queue, non-congested
 //! queues can always assume to be speedily processed.
 
-use std::num::NonZeroUsize;
+use std::{fmt::Display, num::NonZeroUsize};
 
 use enum_iterator::IntoEnumIterator;
 
@@ -28,6 +28,18 @@ pub enum QueueKind {
     /// Metric events take precedence over most other events since missing a request for metrics
     /// might cause the requester to assume that the node is down and forcefully restart it.
     Api,
+}
+
+impl Display for QueueKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str_value = match self {
+            QueueKind::NetworkIncoming => "NetworkIncoming",
+            QueueKind::Network => "Network",
+            QueueKind::Regular => "Regular",
+            QueueKind::Api => "Api",
+        };
+        write!(f, "{}", str_value.to_string())
+    }
 }
 
 impl Default for QueueKind {

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -710,7 +710,8 @@ impl reactor::Reactor for Reactor {
 
     fn update_metrics(&mut self, event_queue_handle: EventQueueHandle<Self::Event>) {
         self.memory_metrics.estimate(&self);
-        self.event_queue_metrics.estimate(&event_queue_handle)
+        self.event_queue_metrics
+            .record_event_queue_counts(&event_queue_handle)
     }
 }
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -50,7 +50,7 @@ use crate::{
         EffectBuilder, Effects,
     },
     protocol::Message,
-    reactor::{self, EventQueueHandle},
+    reactor::{self, event_queue_metrics::EventQueueMetrics, EventQueueHandle},
     types::{Block, CryptoRngCore, Deploy, ProtoBlock, Tag},
     utils::Source,
 };
@@ -286,6 +286,9 @@ pub struct Reactor {
     // Non-components.
     #[data_size(skip)] // Never allocates heap data.
     memory_metrics: MemoryMetrics,
+
+    #[data_size(skip)]
+    event_queue_metrics: EventQueueMetrics,
 }
 
 #[cfg(test)]
@@ -323,6 +326,8 @@ impl reactor::Reactor for Reactor {
         } = config;
 
         let memory_metrics = MemoryMetrics::new(registry.clone())?;
+
+        let event_queue_metrics = EventQueueMetrics::new(registry.clone(), event_queue)?;
 
         let metrics = Metrics::new(registry.clone());
 
@@ -373,6 +378,7 @@ impl reactor::Reactor for Reactor {
                 proto_block_validator,
                 linear_chain,
                 memory_metrics,
+                event_queue_metrics,
             },
             effects,
         ))
@@ -702,8 +708,9 @@ impl reactor::Reactor for Reactor {
         }
     }
 
-    fn update_metrics(&mut self) {
-        self.memory_metrics.estimate(&self)
+    fn update_metrics(&mut self, event_queue_handle: EventQueueHandle<Self::Event>) {
+        self.memory_metrics.estimate(&self);
+        self.event_queue_metrics.estimate(&event_queue_handle)
     }
 }
 

--- a/node/src/utils/round_robin.rs
+++ b/node/src/utils/round_robin.rs
@@ -6,8 +6,10 @@
 
 use std::{
     collections::{HashMap, VecDeque},
+    fmt::Debug,
     hash::Hash,
     num::NonZeroUsize,
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use tokio::sync::{Mutex, Semaphore};
@@ -31,10 +33,39 @@ pub struct WeightedRoundRobin<I, K> {
     slots: Vec<Slot<K>>,
 
     /// Actual queues.
-    queues: HashMap<K, Mutex<VecDeque<I>>>,
+    queues: HashMap<K, QueueState<I>>,
 
     /// Number of items in all queues combined.
     total: Semaphore,
+}
+
+/// State that wraps queue and its event count.
+#[derive(Debug)]
+struct QueueState<I> {
+    event_count: AtomicUsize,
+    queue: Mutex<VecDeque<I>>,
+}
+
+impl<I> QueueState<I> {
+    fn new() -> Self {
+        QueueState {
+            event_count: AtomicUsize::new(0),
+            queue: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    async fn push_back(&self, element: I) {
+        self.queue.lock().await.push_back(element);
+        self.event_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn dec_count(&self) {
+        self.event_count.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    fn event_count(&self) -> usize {
+        self.event_count.load(Ordering::SeqCst)
+    }
 }
 
 /// The inner state of the queue iteration.
@@ -75,7 +106,7 @@ where
 
         let queues = weights
             .iter()
-            .map(|(idx, _)| (*idx, Mutex::new(VecDeque::new())))
+            .map(|(idx, _)| (*idx, QueueState::new()))
             .collect();
         let slots: Vec<Slot<K>> = weights
             .into_iter()
@@ -106,9 +137,8 @@ where
         self.queues
             .get(&queue)
             .expect("tried to push to non-existent queue")
-            .lock()
-            .await
-            .push_back(item);
+            .push_back(item)
+            .await;
 
         // We increase the item count after we've put the item into the queue.
         self.total.add_permits(1);
@@ -124,13 +154,13 @@ where
 
         // We know we have at least one item in a queue.
         loop {
-            let mut current_queue = self
+            let queue_state = self
                 .queues
                 // The queue disappearing should never happen.
                 .get(&inner.active_slot.key)
-                .expect("the queue disappeared. this should not happen")
-                .lock()
-                .await;
+                .expect("the queue disappeared. this should not happen");
+
+            let mut current_queue = queue_state.queue.lock().await;
 
             if inner.active_slot.tickets == 0 || current_queue.is_empty() {
                 // Go to next queue slot if we've exhausted the current queue.
@@ -142,19 +172,26 @@ where
             // We have hit a queue that is not empty. Decrease tickets and pop.
             inner.active_slot.tickets -= 1;
 
-            break (
-                current_queue
-                    .pop_front()
-                    // We hold the queue's lock and checked `is_empty` earlier.
-                    .expect("item disappeared. this should not happen"),
-                inner.active_slot.key,
-            );
+            let item = current_queue
+                .pop_front()
+                // We hold the queue's lock and checked `is_empty` earlier.
+                .expect("item disappeared. this should not happen");
+            queue_state.dec_count();
+            break (item, inner.active_slot.key);
         }
     }
 
     /// Returns the number of events currently in the queue.
     pub(crate) fn item_count(&self) -> usize {
         self.total.available_permits()
+    }
+
+    /// Returns the number of events in each of the queues.
+    pub(crate) fn event_queue_counters(&self) -> HashMap<K, usize> {
+        self.queues
+            .iter()
+            .map(|(key, queue)| (*key, queue.event_count()))
+            .collect()
     }
 }
 

--- a/node/src/utils/round_robin.rs
+++ b/node/src/utils/round_robin.rs
@@ -54,15 +54,18 @@ impl<I> QueueState<I> {
         }
     }
 
+    #[inline]
     async fn push_back(&self, element: I) {
         self.queue.lock().await.push_back(element);
         self.event_count.fetch_add(1, Ordering::SeqCst);
     }
 
+    #[inline]
     fn dec_count(&self) {
         self.event_count.fetch_sub(1, Ordering::SeqCst);
     }
 
+    #[inline]
     fn event_count(&self) -> usize {
         self.event_count.load(Ordering::SeqCst)
     }
@@ -187,7 +190,7 @@ where
     }
 
     /// Returns the number of events in each of the queues.
-    pub(crate) fn event_queue_counters(&self) -> HashMap<K, usize> {
+    pub(crate) fn event_queues_counts(&self) -> HashMap<K, usize> {
         self.queues
             .iter()
             .map(|(key, queue)| (*key, queue.event_count()))


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-435

Starts recording sizes of the reactor's event queues. 

For "active node" metrics will be available under `/metrics` endpoint and be dumped in the logs.
For "joining node" measurements will be available only in the logs (since there's no `/metrics` endpoint there at all).