### PR TITLE
Add cargo profile to version string

### DIFF
--- a/node/build.rs
+++ b/node/build.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use vergen::ConstantsFlags;
 
 fn main() {
@@ -6,4 +8,10 @@ fn main() {
     flags.toggle(ConstantsFlags::SHA_SHORT);
     flags.toggle(ConstantsFlags::REBUILD_ON_HEAD_CHANGE);
     vergen::generate_cargo_keys(flags).expect("should generate the cargo keys");
+
+    // Make the build profile available to rustc at compile time.
+    println!(
+        "cargo:rustc-env=NODE_BUILD_PROFILE={}",
+        env::var("PROFILE").unwrap()
+    );
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -61,7 +61,7 @@ lazy_static! {
             )
         };
 
-        // Add an `@DEBUG` (or similar) tag in read on non-release versions.
+        // Add a `@DEBUG` (or similar) tag to release string on non-release builds.
         if env!("NODE_BUILD_PROFILE") != "release" {
             version += "@";
             version.push_str(&Red.paint(&env!("NODE_BUILD_PROFILE").to_uppercase()).to_string());

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -33,6 +33,7 @@ pub mod tls;
 pub mod types;
 pub mod utils;
 
+use ansi_term::Color::Red;
 use lazy_static::lazy_static;
 
 pub(crate) use components::small_network;
@@ -49,17 +50,23 @@ pub use utils::OS_PAGE_SIZE;
 
 lazy_static! {
     /// Version string for the compiled node. Filled in at build time, output allocated at runtime.
-    pub static ref VERSION_STRING: String = if env!("VERGEN_SEMVER_LIGHTWEIGHT") == "UNKNOWN" {
-        format!("{}@{}",
-            env!("CARGO_PKG_VERSION"),
-            env!("NODE_BUILD_PROFILE"),
-        )
-    } else {
-        format!(
-            "{}-{}@{}",
-            env!("VERGEN_SEMVER_LIGHTWEIGHT"),
-            env!("VERGEN_SHA_SHORT"),
-            env!("NODE_BUILD_PROFILE"),
-        )
+    pub static ref VERSION_STRING: String = {
+        let mut version = if env!("VERGEN_SEMVER_LIGHTWEIGHT") == "UNKNOWN" {
+            env!("CARGO_PKG_VERSION").to_string()
+        } else {
+            format!(
+                "{}-{}",
+                env!("VERGEN_SEMVER_LIGHTWEIGHT"),
+                env!("VERGEN_SHA_SHORT"),
+            )
+        };
+
+        // Add an `@DEBUG` (or similar) tag in read on non-release versions.
+        if env!("NODE_BUILD_PROFILE") != "release" {
+            version += "@";
+            version.push_str(&Red.paint(&env!("NODE_BUILD_PROFILE").to_uppercase()).to_string());
+        }
+
+        version
     };
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -50,12 +50,16 @@ pub use utils::OS_PAGE_SIZE;
 lazy_static! {
     /// Version string for the compiled node. Filled in at build time, output allocated at runtime.
     pub static ref VERSION_STRING: String = if env!("VERGEN_SEMVER_LIGHTWEIGHT") == "UNKNOWN" {
-        env!("CARGO_PKG_VERSION").to_string()
+        format!("{}@{}",
+            env!("CARGO_PKG_VERSION"),
+            env!("NODE_BUILD_PROFILE"),
+        )
     } else {
         format!(
-            "{}-{}",
+            "{}-{}@{}",
             env!("VERGEN_SEMVER_LIGHTWEIGHT"),
-            env!("VERGEN_SHA_SHORT")
+            env!("VERGEN_SHA_SHORT"),
+            env!("NODE_BUILD_PROFILE"),
         )
     };
 }


### PR DESCRIPTION
Allows others to tell whether a particular version was compiled with or without the `--release` flag.