### PR TITLE
Gossiper metrics

### DIFF
--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -3,6 +3,7 @@ mod error;
 mod event;
 mod gossip_table;
 mod message;
+mod metrics;
 mod tests;
 
 use datasize::DataSize;
@@ -31,6 +32,8 @@ pub use error::Error;
 pub use event::Event;
 use gossip_table::{GossipAction, GossipTable};
 pub use message::Message;
+use metrics::GossiperMetrics;
+use prometheus::Registry;
 
 /// A helper trait whose bounds represent the requirements for a reactor event that `Gossiper` can
 /// work with.
@@ -102,6 +105,10 @@ where
     #[data_size(skip)] // Not well supported by datasize.
     get_from_holder:
         Box<dyn Fn(EffectBuilder<REv>, T::Id, NodeId) -> Effects<Event<T>> + Send + 'static>,
+
+    // Metrics collected for this gossiper instance.
+    #[data_size(skip)]
+    metrics: GossiperMetrics,
 }
 
 impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
@@ -119,34 +126,40 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
         get_from_holder: impl Fn(EffectBuilder<REv>, T::Id, NodeId) -> Effects<Event<T>>
             + Send
             + 'static,
-    ) -> Self {
+        registry: &Registry,
+    ) -> Result<Self, prometheus::Error> {
         assert!(
             !T::ID_IS_COMPLETE_ITEM,
             "this should only be called for types where T::ID_IS_COMPLETE_ITEM is false"
         );
-        Gossiper {
+        Ok(Gossiper {
             table: GossipTable::new(config),
             gossip_timeout: Duration::from_secs(config.gossip_request_timeout_secs()),
             get_from_peer_timeout: Duration::from_secs(config.get_remainder_timeout_secs()),
             get_from_holder: Box::new(get_from_holder),
-        }
+            metrics: GossiperMetrics::new("TODO", registry)?,
+        })
     }
 
     /// Constructs a new gossiper component for use where `T::ID_IS_COMPLETE_ITEM == true`, i.e.
     /// where the gossip messages themselves contain the actual data being gossiped.
-    pub(crate) fn new_for_complete_items(config: Config) -> Self {
+    pub(crate) fn new_for_complete_items(
+        config: Config,
+        registry: &Registry,
+    ) -> Result<Self, prometheus::Error> {
         assert!(
             T::ID_IS_COMPLETE_ITEM,
             "this should only be called for types where T::ID_IS_COMPLETE_ITEM is true"
         );
-        Gossiper {
+        Ok(Gossiper {
             table: GossipTable::new(config),
             gossip_timeout: Duration::from_secs(config.gossip_request_timeout_secs()),
             get_from_peer_timeout: Duration::from_secs(config.get_remainder_timeout_secs()),
             get_from_holder: Box::new(|_, item, _| {
                 panic!("gossiper should never try to get {}", item)
             }),
-        }
+            metrics: GossiperMetrics::new("TODO", registry)?,
+        })
     }
 
     /// Handles a new item received from a peer or client.

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -121,7 +121,11 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
     ///
     /// For an example of how `get_from_holder` should be implemented, see
     /// `gossiper::get_deploy_from_store()` which is used by `Gossiper<Deploy>`.
+    ///
+    /// Must be supplied with a name, which should be a snake-case identifier to disambiguate the
+    /// specific gossiper from other potentially present gossipers.
     pub(crate) fn new_for_partial_items(
+        name: &str,
         config: Config,
         get_from_holder: impl Fn(EffectBuilder<REv>, T::Id, NodeId) -> Effects<Event<T>>
             + Send
@@ -137,13 +141,17 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
             gossip_timeout: Duration::from_secs(config.gossip_request_timeout_secs()),
             get_from_peer_timeout: Duration::from_secs(config.get_remainder_timeout_secs()),
             get_from_holder: Box::new(get_from_holder),
-            metrics: GossiperMetrics::new("TODO", registry)?,
+            metrics: GossiperMetrics::new(name, registry)?,
         })
     }
 
     /// Constructs a new gossiper component for use where `T::ID_IS_COMPLETE_ITEM == true`, i.e.
     /// where the gossip messages themselves contain the actual data being gossiped.
+    ///
+    /// Must be supplied with a name, which should be a snake-case identifier to disambiguate the
+    /// specific gossiper from other potentially present gossipers.
     pub(crate) fn new_for_complete_items(
+        name: &str,
         config: Config,
         registry: &Registry,
     ) -> Result<Self, prometheus::Error> {
@@ -158,7 +166,7 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
             get_from_holder: Box::new(|_, item, _| {
                 panic!("gossiper should never try to get {}", item)
             }),
-            metrics: GossiperMetrics::new("TODO", registry)?,
+            metrics: GossiperMetrics::new(name, registry)?,
         })
     }
 

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -169,6 +169,8 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
         item_id: T::Id,
         source: Source<NodeId>,
     ) -> Effects<Event<T>> {
+        self.metrics.items_received.inc();
+
         if let Some(should_gossip) = self.table.new_complete_data(&item_id, source.node_id()) {
             self.gossip(
                 effect_builder,

--- a/node/src/components/gossiper/gossip_table.rs
+++ b/node/src/components/gossiper/gossip_table.rs
@@ -120,6 +120,23 @@ pub(crate) struct GossipTable<T> {
     finished_entry_duration: Duration,
 }
 
+impl<T> GossipTable<T> {
+    /// Number of items currently being gossiped.
+    pub fn items_current(&self) -> usize {
+        self.current.len()
+    }
+
+    /// Number of items that are kept but are finished gossiping.
+    pub fn items_finished(&self) -> usize {
+        self.finished.len()
+    }
+
+    /// Number of items for which gossipping is currently paused.
+    pub fn items_paused(&self) -> usize {
+        self.paused.len()
+    }
+}
+
 impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
     /// Returns a new `GossipTable` using the provided configuration.
     pub(crate) fn new(config: Config) -> Self {

--- a/node/src/components/gossiper/metrics.rs
+++ b/node/src/components/gossiper/metrics.rs
@@ -1,10 +1,20 @@
-use prometheus::{IntCounter, Registry};
+use prometheus::{IntCounter, IntGauge, Registry};
 
 /// Metrics for the gossiper component.
 #[derive(Debug)]
 pub struct GossiperMetrics {
     /// Total number of items received by the gossiper.
     pub(super) items_received: IntCounter,
+    /// Total number of items gossipped onwards after receiving.
+    pub(super) items_regossipped: IntCounter,
+    /// Number of times the process had to pause due to running out of peers.
+    pub(super) times_ran_out_of_peers: IntCounter,
+    /// Number of items in the gossip table that are paused.
+    pub(super) tbl_items_paused: IntGauge,
+    /// Number of items in the gossip table that are currently being gossiped.
+    pub(super) tbl_items_current: IntGauge,
+    /// Number of items in the gossip table that are currently being finished.
+    pub(super) tbl_items_finished: IntGauge,
 
     /// Reference to the registry for unregistering.
     registry: Registry,
@@ -20,11 +30,51 @@ impl GossiperMetrics {
                 name
             ),
         )?;
+        let items_regossipped = IntCounter::new(
+            format!("{}_items_regossipped", name),
+            format!(
+                "number of items received by the {} that were received and gossiped onwards",
+                name
+            ),
+        )?;
+        let times_ran_out_of_peers = IntCounter::new(
+            format!("{}_times_ran_out_of_peers", name),
+            format!(
+                "number of times the {} gossiper ran out of peers and had to pause",
+                name
+            ),
+        )?;
+        let tbl_items_paused = IntGauge::new(
+            format!("{}_tbl_items_paused", name),
+            format!(
+                "number of items in the gossip table of {} in state paused",
+                name
+            ),
+        )?;
+        let tbl_items_current = IntGauge::new(
+            format!("{}_tbl_items_current", name),
+            format!(
+                "number of items in the gossip table of {} in state current",
+                name
+            ),
+        )?;
+        let tbl_items_finished = IntGauge::new(
+            format!("{}_tbl_items_finished", name),
+            format!(
+                "number of items in the gossip table of {} in state finished",
+                name
+            ),
+        )?;
 
         registry.register(Box::new(items_received.clone()))?;
 
         Ok(GossiperMetrics {
             items_received,
+            items_regossipped,
+            times_ran_out_of_peers,
+            tbl_items_paused,
+            tbl_items_current,
+            tbl_items_finished,
             registry: registry.clone(),
         })
     }
@@ -35,5 +85,20 @@ impl Drop for GossiperMetrics {
         self.registry
             .unregister(Box::new(self.items_received.clone()))
             .expect("did not expect deregistering items_received to fail");
+        self.registry
+            .unregister(Box::new(self.items_regossipped.clone()))
+            .expect("did not expect deregistering items_regossipped to fail");
+        self.registry
+            .unregister(Box::new(self.times_ran_out_of_peers.clone()))
+            .expect("did not expect deregistering times_ran_out_of_peers to fail");
+        self.registry
+            .unregister(Box::new(self.tbl_items_paused.clone()))
+            .expect("did not expect deregistering tbl_items_paused to fail");
+        self.registry
+            .unregister(Box::new(self.tbl_items_current.clone()))
+            .expect("did not expect deregistering tbl_items_current to fail");
+        self.registry
+            .unregister(Box::new(self.tbl_items_finished.clone()))
+            .expect("did not expect deregistering tbl_items_finished to fail");
     }
 }

--- a/node/src/components/gossiper/metrics.rs
+++ b/node/src/components/gossiper/metrics.rs
@@ -4,7 +4,7 @@ use prometheus::{IntCounter, Registry};
 #[derive(Debug)]
 pub struct GossiperMetrics {
     /// Total number of items received by the gossiper.
-    items_received: IntCounter,
+    pub(super) items_received: IntCounter,
 
     /// Reference to the registry for unregistering.
     registry: Registry,

--- a/node/src/components/gossiper/metrics.rs
+++ b/node/src/components/gossiper/metrics.rs
@@ -67,6 +67,11 @@ impl GossiperMetrics {
         )?;
 
         registry.register(Box::new(items_received.clone()))?;
+        registry.register(Box::new(items_regossipped.clone()))?;
+        registry.register(Box::new(times_ran_out_of_peers.clone()))?;
+        registry.register(Box::new(tbl_items_paused.clone()))?;
+        registry.register(Box::new(tbl_items_current.clone()))?;
+        registry.register(Box::new(tbl_items_finished.clone()))?;
 
         Ok(GossiperMetrics {
             items_received,

--- a/node/src/components/gossiper/metrics.rs
+++ b/node/src/components/gossiper/metrics.rs
@@ -1,0 +1,39 @@
+use prometheus::{IntCounter, Registry};
+
+/// Metrics for the gossiper component.
+#[derive(Debug)]
+pub struct GossiperMetrics {
+    /// Total number of items received by the gossiper.
+    items_received: IntCounter,
+
+    /// Reference to the registry for unregistering.
+    registry: Registry,
+}
+
+impl GossiperMetrics {
+    /// Creates a new instance of gossiper metrics, using the given prefix.
+    pub fn new(name: &str, registry: &Registry) -> Result<Self, prometheus::Error> {
+        let items_received = IntCounter::new(
+            format!("{}_items_received", name),
+            format!(
+                "number of items received by the {} gossiper component",
+                name
+            ),
+        )?;
+
+        registry.register(Box::new(items_received.clone()))?;
+
+        Ok(GossiperMetrics {
+            items_received,
+            registry: registry.clone(),
+        })
+    }
+}
+
+impl Drop for GossiperMetrics {
+    fn drop(&mut self) {
+        self.registry
+            .unregister(Box::new(self.items_received.clone()))
+            .expect("did not expect deregistering items_received to fail");
+    }
+}

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -119,7 +119,7 @@ impl reactor::Reactor for Reactor {
 
     fn new(
         config: Self::Config,
-        _registry: &Registry,
+        registry: &Registry,
         event_queue: EventQueueHandle<Self::Event>,
         rng: &mut dyn CryptoRngCore,
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
@@ -129,7 +129,8 @@ impl reactor::Reactor for Reactor {
         let storage = Storage::new(WithDir::new(storage_tempdir.path(), storage_config)).unwrap();
 
         let deploy_acceptor = DeployAcceptor::new();
-        let deploy_gossiper = Gossiper::new_for_partial_items(config, get_deploy_from_storage);
+        let deploy_gossiper =
+            Gossiper::new_for_partial_items(config, get_deploy_from_storage, registry)?;
 
         let reactor = Reactor {
             network,

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -129,8 +129,12 @@ impl reactor::Reactor for Reactor {
         let storage = Storage::new(WithDir::new(storage_tempdir.path(), storage_config)).unwrap();
 
         let deploy_acceptor = DeployAcceptor::new();
-        let deploy_gossiper =
-            Gossiper::new_for_partial_items(config, get_deploy_from_storage, registry)?;
+        let deploy_gossiper = Gossiper::new_for_partial_items(
+            "deploy_gossiper",
+            config,
+            get_deploy_from_storage,
+            registry,
+        )?;
 
         let reactor = Reactor {
             network,

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -105,13 +105,13 @@ impl Reactor for TestReactor {
 
     fn new(
         cfg: Self::Config,
-        _registry: &Registry,
+        registry: &Registry,
         event_queue: EventQueueHandle<Self::Event>,
         _rng: &mut dyn CryptoRngCore,
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
         let (net, effects) = SmallNetwork::new(event_queue, cfg, false)?;
         let gossiper_config = gossiper::Config::default();
-        let address_gossiper = Gossiper::new_for_complete_items(gossiper_config);
+        let address_gossiper = Gossiper::new_for_complete_items(gossiper_config, registry)?;
 
         Ok((
             TestReactor {

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -111,7 +111,8 @@ impl Reactor for TestReactor {
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
         let (net, effects) = SmallNetwork::new(event_queue, cfg, false)?;
         let gossiper_config = gossiper::Config::default();
-        let address_gossiper = Gossiper::new_for_complete_items(gossiper_config, registry)?;
+        let address_gossiper =
+            Gossiper::new_for_complete_items("address_gossiper", gossiper_config, registry)?;
 
         Ok((
             TestReactor {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -310,7 +310,8 @@ impl reactor::Reactor for Reactor {
         let linear_chain_fetcher = Fetcher::new(config.gossip);
         let effects = reactor::wrap_effects(Event::Network, net_effects);
 
-        let address_gossiper = Gossiper::new_for_complete_items(config.gossip, registry)?;
+        let address_gossiper =
+            Gossiper::new_for_complete_items("address_gossiper", config.gossip, registry)?;
 
         let effect_builder = EffectBuilder::new(event_queue);
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -310,7 +310,7 @@ impl reactor::Reactor for Reactor {
         let linear_chain_fetcher = Fetcher::new(config.gossip);
         let effects = reactor::wrap_effects(Event::Network, net_effects);
 
-        let address_gossiper = Gossiper::new_for_complete_items(config.gossip);
+        let address_gossiper = Gossiper::new_for_complete_items(config.gossip, registry)?;
 
         let effect_builder = EffectBuilder::new(event_queue);
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -334,12 +334,14 @@ impl reactor::Reactor for Reactor {
         let effect_builder = EffectBuilder::new(event_queue);
         let (net, net_effects) = SmallNetwork::new(event_queue, config.network, true)?;
 
-        let address_gossiper = Gossiper::new_for_complete_items(config.gossip, registry)?;
+        let address_gossiper =
+            Gossiper::new_for_complete_items("address_gossiper", config.gossip, registry)?;
 
         let api_server = ApiServer::new(config.http_server, effect_builder);
         let deploy_acceptor = DeployAcceptor::new();
         let deploy_fetcher = Fetcher::new(config.gossip);
         let deploy_gossiper = Gossiper::new_for_partial_items(
+            "deploy_gossiper",
             config.gossip,
             gossiper::get_deploy_from_storage::<Deploy, Event>,
             registry,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -334,7 +334,7 @@ impl reactor::Reactor for Reactor {
         let effect_builder = EffectBuilder::new(event_queue);
         let (net, net_effects) = SmallNetwork::new(event_queue, config.network, true)?;
 
-        let address_gossiper = Gossiper::new_for_complete_items(config.gossip);
+        let address_gossiper = Gossiper::new_for_complete_items(config.gossip, registry)?;
 
         let api_server = ApiServer::new(config.http_server, effect_builder);
         let deploy_acceptor = DeployAcceptor::new();
@@ -342,7 +342,8 @@ impl reactor::Reactor for Reactor {
         let deploy_gossiper = Gossiper::new_for_partial_items(
             config.gossip,
             gossiper::get_deploy_from_storage::<Deploy, Event>,
-        );
+            registry,
+        )?;
         let (deploy_buffer, deploy_buffer_effects) = DeployBuffer::new(effect_builder);
         let mut effects = reactor::wrap_effects(Event::DeployBuffer, deploy_buffer_effects);
         // Post state hash is expected to be present.


### PR DESCRIPTION
This add metrics to the gossiper component and prepare most other reactors for "proper" metrics.

The metrics may note be complete, but they are a good start. This is also a jumping off point for @darthsiroftardis and further metrics implementation.

Whoever is reviewing this, please double check there are no typos in the wiring, because those make metrics silently report invalid data.