### PR TITLE
NDRS-491: fix deploy validation

### DIFF
--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -216,5 +216,5 @@ fn is_valid(deploy: &Deploy, config: DeployAcceptorConfig) -> bool {
 
     // TODO - check if there is more that can be validated here.
 
-    true
+    deploy.is_valid()
 }

--- a/node/src/crypto/asymmetric_key.rs
+++ b/node/src/crypto/asymmetric_key.rs
@@ -25,7 +25,10 @@ use serde::{
     Deserialize, Serialize, Serializer,
 };
 use signature::{RandomizedSigner, Signature as Sig, Verifier};
+use tracing::info;
 use untrusted::Input;
+
+use casper_types::bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH};
 
 use super::{Error, Result};
 #[cfg(test)]
@@ -36,6 +39,8 @@ use crate::{
     utils::{read_file, write_file},
 };
 use casper_types::account::AccountHash;
+
+const TAG_LENGTH: usize = U8_SERIALIZED_LENGTH;
 
 const ED25519_TAG: u8 = 1;
 const ED25519: &str = "Ed25519";
@@ -476,7 +481,7 @@ impl PublicKey {
         };
         // Hash the preimage data using blake2b256 and return it.
         let digest = hash(&preimage);
-        AccountHash::new(digest.to_bytes())
+        AccountHash::new(digest.to_array())
     }
 
     /// Attempts to write the public key PEM-encoded to the configured file path.
@@ -725,6 +730,62 @@ impl Serialize for PublicKey {
 impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         deserialize(deserializer)
+    }
+}
+
+impl ToBytes for PublicKey {
+    fn to_bytes(&self) -> StdResult<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        match self {
+            PublicKey::Ed25519(public_key) => {
+                buffer.insert(0, ED25519_TAG);
+                buffer.extend(public_key.as_ref().to_vec().into_bytes()?);
+            }
+            PublicKey::Secp256k1(public_key) => {
+                buffer.insert(0, SECP256K1_TAG);
+                buffer.extend(public_key.as_ref().to_vec().into_bytes()?);
+            }
+        }
+        Ok(buffer)
+    }
+
+    // TODO: implement ToBytes for `&[u8]` to avoid allocating via `to_vec()` here.
+    fn serialized_length(&self) -> usize {
+        TAG_LENGTH
+            + match self {
+                PublicKey::Ed25519(public_key) => public_key.as_ref().to_vec().serialized_length(),
+                PublicKey::Secp256k1(public_key) => {
+                    public_key.as_ref().to_vec().serialized_length()
+                }
+            }
+    }
+}
+
+impl FromBytes for PublicKey {
+    fn from_bytes(bytes: &[u8]) -> StdResult<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            ED25519_TAG => {
+                let (raw_bytes, remainder) = Vec::<u8>::from_bytes(remainder)?;
+                let public_key = Self::ed25519_from_bytes(&raw_bytes).map_err(|error| {
+                    info!("failed deserializing to public key: {}", error);
+                    bytesrepr::Error::Formatting
+                })?;
+                Ok((public_key, remainder))
+            }
+            SECP256K1_TAG => {
+                let (raw_bytes, remainder) = Vec::<u8>::from_bytes(remainder)?;
+                let public_key = Self::secp256k1_from_bytes(&raw_bytes).map_err(|error| {
+                    info!("failed deserializing to public key: {}", error);
+                    bytesrepr::Error::Formatting
+                })?;
+                Ok((public_key, remainder))
+            }
+            _ => {
+                info!("failed deserializing to public key: invalid tag {}", tag);
+                Err(bytesrepr::Error::Formatting)
+            }
+        }
     }
 }
 
@@ -1254,6 +1315,9 @@ mod tests {
         let deserialized = serde_json::from_slice(&serialized).unwrap();
         assert_eq!(public_key, deserialized);
         assert_eq!(public_key.tag(), deserialized.tag());
+
+        // Using bytesrepr.
+        bytesrepr::test_serialization_roundtrip(&public_key);
     }
 
     fn public_key_der_roundtrip(public_key: PublicKey) {

--- a/node/src/crypto/hash.rs
+++ b/node/src/crypto/hash.rs
@@ -35,7 +35,7 @@ impl Digest {
     pub const LENGTH: usize = 32;
 
     /// Returns a copy of the wrapped `u8` array.
-    pub fn to_bytes(&self) -> [u8; Digest::LENGTH] {
+    pub fn to_array(&self) -> [u8; Digest::LENGTH] {
         self.0
     }
 
@@ -121,7 +121,8 @@ impl ToBytes for Digest {
 
 impl FromBytes for Digest {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        <[u8; Digest::LENGTH]>::from_bytes(bytes).map(|(inner, rem)| (Digest(inner), rem))
+        <[u8; Digest::LENGTH]>::from_bytes(bytes)
+            .map(|(inner, remainder)| (Digest(inner), remainder))
     }
 }
 
@@ -139,7 +140,7 @@ pub fn hash<T: AsRef<[u8]>>(data: T) -> Digest {
 
 impl From<Digest> for Blake2bHash {
     fn from(digest: Digest) -> Self {
-        let digest_bytes = digest.to_bytes();
+        let digest_bytes = digest.to_array();
         Blake2bHash::from(digest_bytes)
     }
 }
@@ -241,5 +242,12 @@ mod test {
             hash_hex_alt,
             "0x0000000000000000000000000000000000000000000000000000000000000000"
         )
+    }
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let mut rng = TestRng::new();
+        let hash = Digest::random(&mut rng);
+        bytesrepr::test_serialization_roundtrip(&hash);
     }
 }

--- a/types/src/public_key.rs
+++ b/types/src/public_key.rs
@@ -119,7 +119,7 @@ impl AsRef<[u8]> for PublicKey {
 }
 
 impl ToBytes for PublicKey {
-    fn to_bytes(&self) -> Result<Vec<u8>, crate::bytesrepr::Error> {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         buffer.extend(self.variant_id().to_bytes()?);
         match self {
@@ -128,6 +128,7 @@ impl ToBytes for PublicKey {
         }
         Ok(buffer)
     }
+
     fn serialized_length(&self) -> usize {
         PUBLIC_KEY_VARIANT_LENGTH
             + match self {


### PR DESCRIPTION
This PR moves the basic validation of a `Deploy` from the `serde::Deserialize` implementation to a standalone method.  It is called only from within the `DeployAcceptor`, through which all new deploys should pass.  It is not called from the `DeployBuffer` as the check is somewhat expensive and shouldn't be needed there (please confirm whether my assumption is correct or not @goral09?).

This PR also includes an initial tranche of `ToBytes` and `FromBytes` implementations which are used when creating a new `Deploy`.