### PR TITLE
[NDRS-433] - Consensus using Timestamp::now() for timestamps

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -126,7 +126,7 @@ impl<C: Context> ActiveValidator<C> {
     pub(crate) fn on_new_vote(
         &mut self,
         vhash: &C::Hash,
-        timestamp: Timestamp,
+        now: Timestamp,
         state: &State<C>,
         instance_id: C::InstanceId,
         rng: &mut dyn CryptoRngCore,
@@ -134,11 +134,10 @@ impl<C: Context> ActiveValidator<C> {
         if let Some(evidence) = state.opt_evidence(self.vidx) {
             return vec![Effect::WeEquivocated(evidence.clone())];
         }
-        if self.should_send_confirmation(vhash, timestamp, state) {
+        if self.should_send_confirmation(vhash, now, state) {
             let panorama = self.confirmation_panorama(vhash, state);
             if panorama.has_correct() {
-                let confirmation_vote =
-                    self.new_vote(panorama, timestamp, None, state, instance_id, rng);
+                let confirmation_vote = self.new_vote(panorama, now, None, state, instance_id, rng);
                 let vv = ValidVertex(Vertex::Vote(confirmation_vote));
                 return vec![Effect::NewVertex(vv)];
             }

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -223,7 +223,7 @@ impl<C: Context> ActiveValidator<C> {
     ) -> bool {
         let earliest_vote_time = self.earliest_vote_time(state);
         if timestamp < earliest_vote_time {
-            error!(%earliest_vote_time, %timestamp, "earliest_vote_time is greater than current time stamp");
+            warn!(%earliest_vote_time, %timestamp, "earliest_vote_time is greater than current time stamp");
             return false;
         };
         let vote = state.vote(vhash);

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -228,7 +228,7 @@ impl<C: Context> ActiveValidator<C> {
         };
         let vote = state.vote(vhash);
         if vote.timestamp > timestamp {
-            error!(%vote.timestamp, %timestamp, "added a vote with a future timestamp, should never happen");
+            warn!(%vote.timestamp, %timestamp, "added a vote with a future timestamp");
             return false;
         }
         // If it's not a proposal, the sender is faulty, or we are, don't send a confirmation.

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -537,15 +537,8 @@ where
                     {
                         Err((pvv, error)) => return Ok(Err((pvv.into_vertex(), error))),
                         Ok(valid_vertex) => self.call_validator(rng, &recipient, |v, rng| {
-                            // TODO: Find a better way of making deterministic timestamps for
-                            // testing than this kluge
-                            let now = match &valid_vertex {
-                                ValidVertex(Vertex::Vote(signed_wire_vote)) => {
-                                    signed_wire_vote.wire_vote.timestamp
-                                }
-                                ValidVertex(Vertex::Evidence(_)) => 0.into(),
-                            };
-                            v.highway_mut().add_valid_vertex(valid_vertex, rng, now)
+                            v.highway_mut()
+                                .add_valid_vertex(valid_vertex, rng, delivery_time)
                         })?,
                     }
                 };

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -535,7 +535,15 @@ where
                     {
                         Err((pvv, error)) => return Ok(Err((pvv.into_vertex(), error))),
                         Ok(valid_vertex) => self.call_validator(rng, &recipient, |v, rng| {
-                            v.highway_mut().add_valid_vertex(valid_vertex, rng)
+                            // TODO: Find a better way of making deterministic timestamps for
+                            // testing than this kluge
+                            let now = match &valid_vertex {
+                                ValidVertex(Vertex::Vote(signed_wire_vote)) => {
+                                    signed_wire_vote.wire_vote.timestamp
+                                }
+                                ValidVertex(Vertex::Evidence(_)) => 0.into(),
+                            };
+                            v.highway_mut().add_valid_vertex(valid_vertex, rng, now)
                         })?,
                     }
                 };

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -340,7 +340,7 @@ where
             message.payload(),
         );
 
-        let messages = self.process_message(rng, recipient, message)?;
+        let messages = self.process_message(rng, recipient, message, delivery_time)?;
 
         let targeted_messages = messages
             .into_iter()
@@ -410,6 +410,7 @@ where
         rng: &mut dyn CryptoRngCore,
         validator_id: ValidatorId,
         message: Message<HighwayMessage>,
+        delivery_time: Timestamp,
     ) -> TestResult<Vec<HighwayMessage>> {
         self.node_mut(&validator_id)?
             .push_messages_received(vec![message.clone()]);
@@ -426,7 +427,7 @@ where
                     })?
                 }
                 HighwayMessage::NewVertex(v) => {
-                    match self.add_vertex(rng, validator_id, sender_id, v.clone())? {
+                    match self.add_vertex(rng, validator_id, sender_id, v.clone(), delivery_time)? {
                         Ok(msgs) => {
                             trace!("{:?} successfuly added to the state.", v);
                             msgs
@@ -504,6 +505,7 @@ where
         recipient: ValidatorId,
         sender: ValidatorId,
         vertex: Vertex<TestContext>,
+        delivery_time: Timestamp,
     ) -> TestRunResult<Vec<HighwayMessage>> {
         // 1. pre_validate_vertex
         // 2. missing_dependency
@@ -519,7 +521,7 @@ where
                 .pre_validate_vertex(vertex)
             {
                 Err((v, error)) => Ok(Err((v, error))),
-                Ok(pvv) => self.synchronize_validator(rng, recipient, sender, pvv),
+                Ok(pvv) => self.synchronize_validator(rng, recipient, sender, pvv, delivery_time),
             }
         }?;
 
@@ -564,6 +566,7 @@ where
         recipient: ValidatorId,
         sender: ValidatorId,
         pvv: PreValidatedVertex<TestContext>,
+        delivery_time: Timestamp,
     ) -> TestRunResult<(PreValidatedVertex<TestContext>, Vec<HighwayMessage>)> {
         // There may be more than one dependency missing and we want to sync all of them.
         loop {
@@ -577,17 +580,19 @@ where
 
             match validator.highway().missing_dependency(&pvv) {
                 None => return Ok(Ok((pvv, messages))),
-                Some(d) => match self.synchronize_dependency(rng, d, recipient, sender)? {
-                    Ok(sync_messages) => {
-                        // `hwm` represent messages produced while synchronizing `d`.
-                        messages.extend(sync_messages)
+                Some(d) => {
+                    match self.synchronize_dependency(rng, d, recipient, sender, delivery_time)? {
+                        Ok(sync_messages) => {
+                            // `hwm` represent messages produced while synchronizing `d`.
+                            messages.extend(sync_messages)
+                        }
+                        Err(vertex_error) => {
+                            // An error occurred when trying to synchronize a missing dependency.
+                            // We must stop the synchronization process and return it to the caller.
+                            return Ok(Err(vertex_error));
+                        }
                     }
-                    Err(vertex_error) => {
-                        // An error occurred when trying to synchronize a missing dependency.
-                        // We must stop the synchronization process and return it to the caller.
-                        return Ok(Err(vertex_error));
-                    }
-                },
+                }
             }
         }
     }
@@ -604,6 +609,7 @@ where
         missing_dependency: Dependency<TestContext>,
         recipient: ValidatorId,
         sender: ValidatorId,
+        delivery_time: Timestamp,
     ) -> TestRunResult<Vec<HighwayMessage>> {
         let vertex = self
             .node_mut(&sender)?
@@ -613,7 +619,7 @@ where
             .map(|vv| vv.0)
             .ok_or_else(|| TestRunError::SenderMissingDependency(sender, missing_dependency))?;
 
-        self.add_vertex(rng, recipient, sender, vertex)
+        self.add_vertex(rng, recipient, sender, vertex, delivery_time)
     }
 
     /// Returns a `MutableHandle` on the `HighwayTestHarness` object


### PR DESCRIPTION
Highway now uses a timestamp set to `Timestamp::now()` where appropriate.

Exceptions to this are:

  1. Activity scheduled by the reactor (use the scheduled timestamp instead)
  2. Block proposals (use the block timestamp here)

This code assumes that messages with timestamps in the future have been rescheduled and all messages being processed by highway are in the past.

I have made a follow-up ticket to tackle rescheduling future messages here: https://casperlabs.atlassian.net/browse/NDRS-499