### PR TITLE
NO-TICKET: add option to enable colored logging output, off by default

### DIFF
--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -1043,7 +1043,7 @@ mod test_harness {
 
     #[test]
     fn liveness_test_no_faults() {
-        let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true));
+        let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true, true));
 
         let mut rng = TestRng::new();
         let cv_count = 10;
@@ -1107,7 +1107,7 @@ mod test_harness {
 
     #[test]
     fn liveness_test_some_mute() {
-        let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true));
+        let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true, true));
 
         let mut rng = TestRng::new();
         let cv_count = 10;
@@ -1148,7 +1148,7 @@ mod test_harness {
 
     #[test]
     fn liveness_test_some_equivocate() {
-        let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true));
+        let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true, true));
 
         let mut rng = TestRng::new();
         let cv_count = 10;

--- a/node/src/logging.rs
+++ b/node/src/logging.rs
@@ -24,7 +24,14 @@ use tracing_subscriber::{
 pub struct LoggingConfig {
     /// Output format for log.
     format: LoggingFormat,
-    /// Abbreviate module names.
+
+    /// Colored output (has no effect if JSON format is enabled).
+    ///
+    /// If set, the logger will inject ANSI color codes into log messages.  This is useful if
+    /// writing out to stdout or stderr on an ANSI terminal, but not so if writing to a logfile.
+    color: bool,
+
+    /// Abbreviate module names (has no effect if JSON format is enabled).
     ///
     /// If set, human-readable formats will abbreviate module names, `foo::bar::baz::bizz` will
     /// turn into `f:b:b:bizz`.
@@ -33,9 +40,10 @@ pub struct LoggingConfig {
 
 impl LoggingConfig {
     /// Creates a new instance of LoggingConfig.
-    pub fn new(format: LoggingFormat, abbreviate_modules: bool) -> Self {
+    pub fn new(format: LoggingFormat, color: bool, abbreviate_modules: bool) -> Self {
         LoggingConfig {
             format,
+            color,
             abbreviate_modules,
         }
     }
@@ -62,13 +70,34 @@ impl Default for LoggingFormat {
 /// This is used to implement tracing's `FormatEvent` so that we can customize the way tracing
 /// events are formatted.
 struct FmtEvent {
-    // Whether module segments should be shortened to first letter only.
+    /// Whether to use ANSI color formatting or not.
+    ansi_color: bool,
+    /// Whether module segments should be shortened to first letter only.
     abbreviate_modules: bool,
 }
 
 impl FmtEvent {
-    fn new(abbreviate_modules: bool) -> Self {
-        FmtEvent { abbreviate_modules }
+    fn new(ansi_color: bool, abbreviate_modules: bool) -> Self {
+        FmtEvent {
+            ansi_color,
+            abbreviate_modules,
+        }
+    }
+
+    fn enable_dimmed_if_ansi(&self, writer: &mut dyn fmt::Write) -> fmt::Result {
+        if self.ansi_color {
+            write!(writer, "{}", Style::new().dimmed().prefix())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn disable_dimmed_if_ansi(&self, writer: &mut dyn fmt::Write) -> fmt::Result {
+        if self.ansi_color {
+            write!(writer, "{}", Style::new().dimmed().suffix())
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -83,29 +112,32 @@ where
         writer: &mut dyn fmt::Write,
         event: &Event<'_>,
     ) -> fmt::Result {
-        // print the date/time with dimmed style
-        let dimmed = Style::new().dimmed();
-        write!(writer, "{}", dimmed.prefix())?;
+        // print the date/time with dimmed style if `ansi_color` is true
+        self.enable_dimmed_if_ansi(writer)?;
         SystemTime.format_time(writer)?;
-        write!(writer, "{}", dimmed.suffix())?;
+        self.disable_dimmed_if_ansi(writer)?;
 
-        // print the log level in color
+        // print the log level
         let meta = event.metadata();
-        let color = match *meta.level() {
-            Level::TRACE => Color::Purple,
-            Level::DEBUG => Color::Blue,
-            Level::INFO => Color::Green,
-            Level::WARN => Color::Yellow,
-            Level::ERROR => Color::Red,
-        };
+        if self.ansi_color {
+            let color = match *meta.level() {
+                Level::TRACE => Color::Purple,
+                Level::DEBUG => Color::Blue,
+                Level::INFO => Color::Green,
+                Level::WARN => Color::Yellow,
+                Level::ERROR => Color::Red,
+            };
 
-        write!(
-            writer,
-            " {}{:<6}{}",
-            color.prefix(),
-            meta.level().to_string(),
-            color.suffix()
-        )?;
+            write!(
+                writer,
+                " {}{:<6}{}",
+                color.prefix(),
+                meta.level().to_string(),
+                color.suffix()
+            )?;
+        } else {
+            write!(writer, " {:<6}", meta.level().to_string())?;
+        }
 
         // print the span information as per
         // https://github.com/tokio-rs/tracing/blob/21f28f74/tracing-subscriber/src/fmt/format/mod.rs#L667-L695
@@ -129,7 +161,7 @@ where
             writer.write_char(' ')?;
         }
 
-        // print the module path, filename and line number with dimmed style
+        // print the module path, filename and line number with dimmed style if `ansi_color` is true
         let module = {
             let full_module_path = meta.module_path().unwrap_or_default();
             if self.abbreviate_modules {
@@ -163,15 +195,9 @@ where
 
         let line = meta.line().unwrap_or_default();
 
-        write!(
-            writer,
-            "{}[{} {}:{}]{} ",
-            dimmed.prefix(),
-            module,
-            file,
-            line,
-            dimmed.suffix()
-        )?;
+        self.enable_dimmed_if_ansi(writer)?;
+        write!(writer, "[{} {}:{}] ", module, file, line,)?;
+        self.disable_dimmed_if_ansi(writer)?;
 
         // print the log message and other fields
         ctx.format_fields(writer, event)?;
@@ -209,7 +235,7 @@ pub fn init_with_config(config: &LoggingConfig) -> anyhow::Result<()> {
                 .with_writer(io::stdout)
                 .with_env_filter(EnvFilter::from_default_env())
                 .fmt_fields(formatter)
-                .event_format(FmtEvent::new(config.abbreviate_modules))
+                .event_format(FmtEvent::new(config.color, config.abbreviate_modules))
                 .finish(),
         )?,
         // JSON logging writes to `stdout` as well but uses the JSON format.

--- a/resources/charlie/config-example.toml
+++ b/resources/charlie/config-example.toml
@@ -15,11 +15,14 @@ chainspec_config_path = '/etc/casper/chainspec.toml'
 # =================================
 [logging]
 
-# Abbreviate module names in text ouptut.
-abbreviate_modules = false
-
 # Output format.  Possible values are 'text' or 'json'.
 format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
 
 
 # ===================================

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -15,11 +15,14 @@ chainspec_config_path = 'chainspec.toml'
 # =================================
 [logging]
 
-# Abbreviate module names in text ouptut.
-abbreviate_modules = false
-
 # Output format.  Possible values are 'text' or 'json'.
 format = 'text'
+
+# Colored output.  Has no effect if format = 'json'.
+color = false
+
+# Abbreviate module names in text output.  Has no effect if format = 'json'.
+abbreviate_modules = false
 
 
 # ===================================


### PR DESCRIPTION
Currently, log files where we use `text` rather than `json` for the output get polluted with ANSI escape sequences.

This PR disables colored output by default, allowing users to explicitly enable it when logging to console.