### PR TITLE
NO-TICKET: update BlockHeightStore

### DIFF
--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -135,8 +135,8 @@ pub mod block_hash {
     const ARG_SHORT: &str = "b";
     const ARG_VALUE_NAME: &str = super::ARG_HEX_STRING;
     const ARG_HELP: &str =
-        "Hex-encoded block hash.  If not given, the latest finalized block as known at the given \
-        node will be used";
+        "Hex-encoded block hash.  If not given, the last block added to the chain as known at the \
+        given node will be used";
 
     pub(crate) fn arg(order: usize) -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)

--- a/node/src/components/api_server.rs
+++ b/node/src/components/api_server.rs
@@ -188,7 +188,7 @@ where
                 maybe_hash: None,
                 responder,
             }) => effect_builder
-                .get_last_finalized_block()
+                .get_highest_block()
                 .event(move |result| Event::GetBlockResult {
                     maybe_hash: None,
                     result: Box::new(result),
@@ -219,12 +219,12 @@ where
                     main_responder: responder,
                 }),
             Event::ApiRequest(ApiRequest::GetStatus { responder }) => async move {
-                let (last_finalized_block, peers, chainspec_info) = join!(
-                    effect_builder.get_last_finalized_block(),
+                let (last_added_block, peers, chainspec_info) = join!(
+                    effect_builder.get_highest_block(),
                     effect_builder.network_peers(),
                     effect_builder.get_chainspec_info()
                 );
-                let status_feed = StatusFeed::new(last_finalized_block, peers, chainspec_info);
+                let status_feed = StatusFeed::new(last_added_block, peers, chainspec_info);
                 info!("GetStatus --status_feed: {:?}", status_feed);
                 responder.respond(status_feed).await;
             }

--- a/node/src/components/api_server/rpcs/info.rs
+++ b/node/src/components/api_server/rpcs/info.rs
@@ -187,7 +187,7 @@ pub struct GetStatusResult {
     /// The node ID and network address of each connected peer.
     pub peers: BTreeMap<String, SocketAddr>,
     /// The minimal info of the last block from the linear chain.
-    pub last_finalized_block_info: Option<MinimalBlockInfo>,
+    pub last_added_block_info: Option<MinimalBlockInfo>,
     /// The compiled node version.
     pub build_version: String,
 }
@@ -205,7 +205,7 @@ impl From<StatusFeed<NodeId>> for GetStatusResult {
             chainspec_name,
             genesis_root_hash,
             peers: peers_hashmap_to_btreemap(status_feed.peers),
-            last_finalized_block_info: status_feed.last_finalized_block.map(Into::into),
+            last_added_block_info: status_feed.last_added_block.map(Into::into),
             build_version: crate::VERSION_STRING.clone(),
         }
     }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -211,7 +211,9 @@ pub trait StorageType {
                 let block_result = block_store
                     .put(*block)
                     .unwrap_or_else(|error| panic!("failed to put {}: {}", block_hash, error));
-                if height_result != block_result {
+                // TODO: once blocks' signatures are handled as metadata, this condition can be
+                //       changed to just `height_result != block_result`.
+                if height_result != block_result && !block_result {
                     panic!(
                         "mismatch in put results. height_result: {}. block_result: {}",
                         height_result, block_result

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -1,9 +1,12 @@
+mod block_height_store;
 mod chainspec_store;
 mod config;
 mod error;
 mod event;
+mod in_mem_block_height_store;
 mod in_mem_chainspec_store;
 mod in_mem_store;
+mod lmdb_block_height_store;
 mod lmdb_chainspec_store;
 mod lmdb_store;
 mod store;
@@ -32,21 +35,24 @@ use crate::{
         EffectBuilder, EffectExt, Effects, Responder,
     },
     protocol::Message,
-    types::{json_compatibility::ExecutionResult, Block, BlockHash, CryptoRngCore, Deploy, Item},
+    types::{json_compatibility::ExecutionResult, Block, CryptoRngCore, Deploy, Item},
     utils::WithDir,
 };
+use block_height_store::BlockHeightStore;
 use chainspec_store::ChainspecStore;
 pub use config::Config;
 pub use error::Error;
 pub(crate) use error::Result;
 pub use event::Event;
+use in_mem_block_height_store::InMemBlockHeightStore;
 use in_mem_chainspec_store::InMemChainspecStore;
 use in_mem_store::InMemStore;
+use lmdb_block_height_store::LmdbBlockHeightStore;
 use lmdb_chainspec_store::LmdbChainspecStore;
 use lmdb_store::LmdbStore;
 use store::{DeployStore, Multiple, Store};
 
-pub(crate) type Storage = LmdbStorage<Block, BlockHeightHash<BlockHash>, Deploy>;
+pub(crate) type Storage = LmdbStorage<Block, Deploy>;
 
 pub(crate) type DeployResults<S> = Multiple<Option<<S as StorageType>::Deploy>>;
 pub(crate) type DeployHashes<S> = Multiple<<<S as StorageType>::Deploy as Value>::Id>;
@@ -96,56 +102,15 @@ pub trait Value: ValueT {
     fn take_header(self) -> Self::Header;
 }
 
+pub trait WithBlockHeight: Value {
+    fn height(&self) -> u64;
+}
+
 /// Metadata associated with a block.
 #[derive(Default, Clone, Serialize, Deserialize, Debug)]
 pub struct BlockMetadata {
     /// The finalization signatures of a block.
     pub proofs: Vec<Signature>,
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
-pub struct BlockHeightHash<H> {
-    pub height: u64,
-    pub block_hash: H,
-}
-
-#[derive(Debug, Default)]
-pub struct BlockHeightHashMetadata;
-
-impl<H: Display> Display for BlockHeightHash<H> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "BlockHeightMetadata(height={}, hash={})",
-            self.height, self.block_hash
-        )
-    }
-}
-
-impl<H: ValueT + Hash + Ord> Value for BlockHeightHash<H> {
-    type Id = u64;
-
-    type Header = H;
-
-    fn id(&self) -> &Self::Id {
-        &self.height
-    }
-
-    fn header(&self) -> &Self::Header {
-        &self.block_hash
-    }
-
-    fn take_header(self) -> Self::Header {
-        self.block_hash
-    }
-}
-
-impl From<&Block> for BlockHeightHash<BlockHash> {
-    fn from(b: &Block) -> Self {
-        let height = b.height();
-        let block_hash = *(*b).hash();
-        BlockHeightHash { height, block_hash }
-    }
 }
 
 /// Metadata associated with a deploy.
@@ -177,13 +142,12 @@ impl<B: Value> Default for DeployMetadata<B> {
 /// If this trait is ultimately only used for testing scenarios, we shouldn't need to expose it to
 /// the reactor - it can simply use a concrete type which implements this trait.
 pub trait StorageType {
-    type Block: Value;
+    type Block: Value + WithBlockHeight;
     type Deploy: Value + Item;
-    type BlockHeight: Value + for<'de> From<&'de Self::Block>;
 
     fn block_store(&self) -> Arc<dyn Store<Value = Self::Block>>;
 
-    fn block_height_store(&self) -> Arc<dyn Store<Value = Self::BlockHeight>>;
+    fn block_height_store(&self) -> Arc<dyn BlockHeightStore<<Self::Block as Value>::Id>>;
 
     fn deploy_store(
         &self,
@@ -234,20 +198,29 @@ pub trait StorageType {
     {
         let block_store = self.block_store();
         let block_height_store = self.block_height_store();
-        let block_hash = *block.id();
         async move {
             let result = task::spawn_blocking(move || {
-                let block_deref = *block;
-                let block_height_metadata = (&block_deref).into();
-                let result = block_store.put(block_deref);
-                let _ = block_height_store
-                    .put(block_height_metadata)
-                    .expect("should run");
-                result
+                let height = block.height();
+                let block_hash = *block.id();
+                let height_result =
+                    block_height_store
+                        .put(height, block_hash)
+                        .unwrap_or_else(|error| {
+                            panic!("failed to put height for {}: {}", block_hash, error)
+                        });
+                let block_result = block_store
+                    .put(*block)
+                    .unwrap_or_else(|error| panic!("failed to put {}: {}", block_hash, error));
+                if height_result != block_result {
+                    panic!(
+                        "mismatch in put results. height_result: {}. block_result: {}",
+                        height_result, block_result
+                    );
+                }
+                height_result
             })
             .await
-            .expect("should run")
-            .unwrap_or_else(|error| panic!("failed to put {}: {}", block_hash, error));
+            .expect("should run");
             responder.respond(result).await
         }
         .ignore()
@@ -275,36 +248,59 @@ pub trait StorageType {
         .ignore()
     }
 
-    fn get_block_by_height(
+    fn get_block_at_height(
         &self,
-        block_height: <Self::BlockHeight as Value>::Id,
+        block_height: u64,
         responder: Responder<Option<Self::Block>>,
     ) -> Effects<Event<Self>>
     where
         Self: Sized,
-        <Self::Block as Value>::Id: From<<Self::BlockHeight as Value>::Header>, /* Evidence that
-                                                                                 * IDs
-                                                                                 * are interchangable.
-                                                                                 */
     {
         let block_height_store = self.block_height_store();
         let block_store = self.block_store();
         async move {
             let result = task::spawn_blocking(move || {
                 block_height_store
-                    .get(smallvec![block_height])
-                    .pop()
-                    .expect("can contain only one element")
+                    .get(block_height)
                     .unwrap_or_else(|error| {
                         panic!(
-                            "failed to get block height metadata {}: {}",
+                            "failed to get entry for block height {}: {}",
                             block_height, error
                         )
                     })
-                    .and_then(|metadata| {
-                        let block_hash = metadata.take_header();
+                    .and_then(|block_hash| {
                         block_store
-                            .get(smallvec![block_hash.clone().into()])
+                            .get(smallvec![block_hash])
+                            .pop()
+                            .expect("can only contain one result")
+                            .unwrap_or_else(|error| {
+                                panic!("failed to get block {}: {}", block_hash, error)
+                            })
+                    })
+            })
+            .await
+            .expect("should run");
+            responder.respond(result).await
+        }
+        .ignore()
+    }
+
+    fn get_highest_block(&self, responder: Responder<Option<Self::Block>>) -> Effects<Event<Self>>
+    where
+        Self: Sized,
+    {
+        let block_height_store = self.block_height_store();
+        let block_store = self.block_store();
+        async move {
+            let result = task::spawn_blocking(move || {
+                block_height_store
+                    .highest()
+                    .unwrap_or_else(|error| {
+                        panic!("failed to get entry for latest block: {}", error)
+                    })
+                    .and_then(|block_hash| {
+                        block_store
+                            .get(smallvec![block_hash])
                             .pop()
                             .expect("can only contain one result")
                             .unwrap_or_else(|error| {
@@ -508,8 +504,6 @@ where
     REv: From<NetworkRequest<NodeId, Message>> + Send,
     S: StorageType,
     Self: Sized + 'static,
-    <<S as StorageType>::Block as Value>::Id:
-        From<<<S as StorageType>::BlockHeight as Value>::Header>,
 {
     type Event = Event<S>;
 
@@ -530,13 +524,16 @@ where
                 block_hash,
                 responder,
             }) => self.get_block(block_hash, responder),
+            Event::Request(StorageRequest::GetBlockAtHeight { height, responder }) => {
+                self.get_block_at_height(height, responder)
+            }
+            Event::Request(StorageRequest::GetHighestBlock { responder }) => {
+                self.get_highest_block(responder)
+            }
             Event::Request(StorageRequest::GetBlockHeader {
                 block_hash,
                 responder,
             }) => self.get_block_header(block_hash, responder),
-            Event::Request(StorageRequest::GetBlockAtHeight { height, responder }) => {
-                self.get_block_by_height(height, responder)
-            }
             Event::Request(StorageRequest::PutDeploy { deploy, responder }) => {
                 self.put_deploy(deploy, responder)
             }
@@ -570,30 +567,28 @@ where
 
 // Concrete type of `Storage` backed by in-memory stores.
 #[derive(Debug)]
-pub(crate) struct InMemStorage<B: Value, BH: Value, D: Value> {
+pub(crate) struct InMemStorage<B: Value, D: Value> {
     block_store: Arc<InMemStore<B, BlockMetadata>>,
-    block_height_store: Arc<InMemStore<BH, BlockHeightHashMetadata>>,
+    block_height_store: Arc<InMemBlockHeightStore<B::Id>>,
     deploy_store: Arc<InMemStore<D, DeployMetadata<B>>>,
     chainspec_store: Arc<InMemChainspecStore>,
 }
 
 #[allow(trivial_casts)]
-impl<
-        B: Value + 'static,
-        BH: Value + for<'de> From<&'de B> + 'static,
-        D: Value + Item + 'static,
-    > StorageType for InMemStorage<B, BH, D>
+impl<B, D> StorageType for InMemStorage<B, D>
+where
+    B: Value + WithBlockHeight + 'static,
+    D: Value + Item + 'static,
 {
     type Block = B;
     type Deploy = D;
-    type BlockHeight = BH;
 
     fn block_store(&self) -> Arc<dyn Store<Value = B>> {
         Arc::clone(&self.block_store) as Arc<dyn Store<Value = B>>
     }
 
-    fn block_height_store(&self) -> Arc<dyn Store<Value = BH>> {
-        Arc::clone(&self.block_height_store) as Arc<dyn Store<Value = BH>>
+    fn block_height_store(&self) -> Arc<dyn BlockHeightStore<B::Id>> {
+        Arc::clone(&self.block_height_store) as Arc<dyn BlockHeightStore<B::Id>>
     }
 
     fn deploy_store(&self) -> Arc<dyn DeployStore<Block = B, Deploy = D, Value = D>> {
@@ -607,7 +602,7 @@ impl<
     fn new(_config: WithDir<Config>) -> Result<Self> {
         Ok(InMemStorage {
             block_store: Arc::new(InMemStore::new()),
-            block_height_store: Arc::new(InMemStore::new()),
+            block_height_store: Arc::new(InMemBlockHeightStore::new()),
             deploy_store: Arc::new(InMemStore::new()),
             chainspec_store: Arc::new(InMemChainspecStore::new()),
         })
@@ -616,28 +611,25 @@ impl<
 
 // Concrete type of `Storage` backed by LMDB stores.
 #[derive(DataSize, Debug)]
-pub struct LmdbStorage<B, BH, D>
+pub struct LmdbStorage<B, D>
 where
     B: Value,
     D: Value,
-    BH: Value,
 {
     block_store: Arc<LmdbStore<B, BlockMetadata>>,
-    block_height_store: Arc<LmdbStore<BH, BlockHeightHashMetadata>>,
+    block_height_store: Arc<LmdbBlockHeightStore>,
     deploy_store: Arc<LmdbStore<D, DeployMetadata<B>>>,
     chainspec_store: Arc<LmdbChainspecStore>,
 }
 
 #[allow(trivial_casts)]
-impl<
-        B: Value + 'static,
-        BH: Value + for<'de> From<&'de B> + 'static,
-        D: Value + Item + 'static,
-    > StorageType for LmdbStorage<B, BH, D>
+impl<B, D> StorageType for LmdbStorage<B, D>
+where
+    B: Value + WithBlockHeight + 'static,
+    D: Value + Item + 'static,
 {
     type Block = B;
     type Deploy = D;
-    type BlockHeight = BH;
 
     fn new(config: WithDir<Config>) -> Result<Self> {
         let root = config.with_dir(config.value().path());
@@ -652,9 +644,9 @@ impl<
         let chainspec_store_path = root.join(CHAINSPEC_STORE_FILENAME);
 
         let block_store = LmdbStore::new(block_store_path, config.value().max_block_store_size())?;
-        let block_height_store = LmdbStore::new(
+        let block_height_store = LmdbBlockHeightStore::new(
             block_height_store_path,
-            config.value().max_block_store_size(),
+            config.value().max_block_height_store_size(),
         )?;
         let deploy_store =
             LmdbStore::new(deploy_store_path, config.value().max_deploy_store_size())?;
@@ -675,15 +667,15 @@ impl<
         Arc::clone(&self.block_store) as Arc<dyn Store<Value = B>>
     }
 
+    fn block_height_store(&self) -> Arc<dyn BlockHeightStore<B::Id>> {
+        Arc::clone(&self.block_height_store) as Arc<dyn BlockHeightStore<B::Id>>
+    }
+
     fn deploy_store(&self) -> Arc<dyn DeployStore<Block = B, Deploy = D, Value = D>> {
         Arc::clone(&self.deploy_store) as Arc<dyn DeployStore<Block = B, Deploy = D, Value = D>>
     }
 
     fn chainspec_store(&self) -> Arc<dyn ChainspecStore> {
         Arc::clone(&self.chainspec_store) as Arc<dyn ChainspecStore>
-    }
-
-    fn block_height_store(&self) -> Arc<dyn Store<Value = BH>> {
-        Arc::clone(&self.block_height_store) as Arc<dyn Store<Value = BH>>
     }
 }

--- a/node/src/components/storage/block_height_store.rs
+++ b/node/src/components/storage/block_height_store.rs
@@ -1,0 +1,157 @@
+// use serde::{Deserialize, Serialize};
+
+use super::Result;
+
+/// Trait defining the API for a block height store managed by the storage component.
+pub trait BlockHeightStore<H>: Send + Sync {
+    /// Returns true if no entry previously existed at the given height.
+    fn put(&self, height: u64, block_hash: H) -> Result<bool>;
+    fn get(&self, height: u64) -> Result<Option<H>>;
+    fn highest(&self) -> Result<Option<H>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp;
+
+    use rand::Rng;
+
+    use super::{
+        super::{Config, InMemBlockHeightStore, LmdbBlockHeightStore},
+        *,
+    };
+    use crate::testing::TestRng;
+
+    fn should_put_then_get<T: BlockHeightStore<String>>(block_height_store: &mut T) {
+        let mut rng = TestRng::new();
+
+        let height = rng.gen();
+
+        block_height_store.put(height, height.to_string()).unwrap();
+        let maybe_hash = block_height_store.get(height).unwrap();
+        let recovered_hash = maybe_hash.unwrap();
+
+        assert_eq!(height.to_string(), recovered_hash);
+    }
+
+    #[test]
+    fn lmdb_block_height_store_should_put_then_get() {
+        let (config, _tempdir) = Config::default_for_tests();
+        let mut lmdb_block_height_store =
+            LmdbBlockHeightStore::new(config.path(), config.max_block_height_store_size()).unwrap();
+        should_put_then_get(&mut lmdb_block_height_store);
+    }
+
+    #[test]
+    fn in_mem_block_height_store_should_put_then_get() {
+        let mut in_mem_block_height_store = InMemBlockHeightStore::new();
+        should_put_then_get(&mut in_mem_block_height_store);
+    }
+
+    fn should_fail_get<T: BlockHeightStore<String>>(block_height_store: &mut T) {
+        let mut rng = TestRng::new();
+
+        let height = rng.gen();
+
+        block_height_store.put(height, height.to_string()).unwrap();
+        assert!(block_height_store
+            .get(height.wrapping_add(1))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn lmdb_block_height_store_should_fail_to_get_unknown_version() {
+        let (config, _tempdir) = Config::default_for_tests();
+        let mut lmdb_block_height_store =
+            LmdbBlockHeightStore::new(config.path(), config.max_block_height_store_size()).unwrap();
+        should_fail_get(&mut lmdb_block_height_store);
+    }
+
+    #[test]
+    fn in_mem_block_height_store_should_fail_to_get_unknown_version() {
+        let mut in_mem_block_height_store = InMemBlockHeightStore::new();
+        should_fail_get(&mut in_mem_block_height_store);
+    }
+
+    fn should_get_highest<T: BlockHeightStore<String>>(block_height_store: &mut T) {
+        const BLOCK_COUNT: usize = 1000;
+        let mut rng = TestRng::new();
+
+        assert!(block_height_store.highest().unwrap().is_none());
+
+        let mut max = 0;
+        for _ in 0..BLOCK_COUNT {
+            let height = rng.gen();
+            max = cmp::max(max, height);
+
+            block_height_store.put(height, height.to_string()).unwrap();
+            let maybe_hash = block_height_store.highest().unwrap();
+            let highest_hash = maybe_hash.unwrap();
+
+            assert_eq!(max.to_string(), highest_hash);
+        }
+    }
+
+    #[test]
+    fn lmdb_block_height_store_should_get_highest() {
+        let (config, _tempdir) = Config::default_for_tests();
+        let mut lmdb_block_height_store =
+            LmdbBlockHeightStore::new(config.path(), config.max_block_height_store_size()).unwrap();
+        should_get_highest(&mut lmdb_block_height_store);
+    }
+
+    #[test]
+    fn in_mem_block_height_store_should_get_highest() {
+        let mut in_mem_block_height_store = InMemBlockHeightStore::new();
+        should_get_highest(&mut in_mem_block_height_store);
+    }
+
+    #[test]
+    fn lmdb_block_height_store_initialize_highest() {
+        const BLOCK_COUNT: usize = 100;
+
+        let (config, _tempdir) = Config::default_for_tests();
+        let mut rng = TestRng::new();
+
+        // Populate the DB then drop it.
+        let max_height = {
+            let lmdb_block_height_store =
+                LmdbBlockHeightStore::new(config.path(), config.max_block_height_store_size())
+                    .unwrap();
+
+            let mut max = 0;
+            for _ in 0..BLOCK_COUNT {
+                let height = rng.gen();
+                max = cmp::max(max, height);
+
+                lmdb_block_height_store
+                    .put(height, height.to_string())
+                    .unwrap();
+            }
+
+            let maybe_hash: Option<String> = lmdb_block_height_store.highest().unwrap();
+            let highest_hash = maybe_hash.unwrap();
+            assert_eq!(max.to_string(), highest_hash);
+            max
+        };
+
+        // Check a new DB correctly retrieves the max height.
+        let lmdb_block_height_store =
+            LmdbBlockHeightStore::new(config.path(), config.max_block_height_store_size()).unwrap();
+
+        let maybe_hash: Option<String> = lmdb_block_height_store.highest().unwrap();
+        let highest_hash = maybe_hash.unwrap();
+        assert_eq!(max_height.to_string(), highest_hash);
+
+        // Check adding a new higher value correctly updates the highest.
+        let new_high = max_height + 1;
+        lmdb_block_height_store
+            .put(new_high, new_high.to_string())
+            .unwrap();
+
+        let maybe_hash: Option<String> = lmdb_block_height_store.highest().unwrap();
+        let highest_hash = maybe_hash.unwrap();
+        assert_eq!(new_high.to_string(), highest_hash);
+    }
+}

--- a/node/src/components/storage/config.rs
+++ b/node/src/components/storage/config.rs
@@ -15,6 +15,7 @@ const APPLICATION: &str = "casper-node";
 
 const DEFAULT_MAX_BLOCK_STORE_SIZE: usize = 483_183_820_800; // 450 GiB
 const DEFAULT_MAX_DEPLOY_STORE_SIZE: usize = 322_122_547_200; // 300 GiB
+const DEFAULT_MAX_BLOCK_HEIGHT_STORE_SIZE: usize = 10_485_100; // 10 MiB
 const DEFAULT_MAX_CHAINSPEC_STORE_SIZE: usize = 1_073_741_824; // 1 GiB
 
 #[cfg(test)]
@@ -43,6 +44,12 @@ pub struct Config {
     ///
     /// The size should be a multiple of the OS page size.
     max_deploy_store_size: Option<usize>,
+    /// The maximum size of the database to use for the block-height store.
+    ///
+    /// Defaults to 10,485,100 == 10 MiB.
+    ///
+    /// The size should be a multiple of the OS page size.
+    max_block_height_store_size: Option<usize>,
     /// The maximum size of the database to use for the chainspec store.
     ///
     /// Defaults to 1,073,741,824 == 1 GiB.
@@ -63,6 +70,7 @@ impl Config {
             path,
             max_block_store_size: Some(DEFAULT_TEST_MAX_DB_SIZE),
             max_deploy_store_size: Some(DEFAULT_TEST_MAX_DB_SIZE),
+            max_block_height_store_size: Some(DEFAULT_TEST_MAX_DB_SIZE),
             max_chainspec_store_size: Some(DEFAULT_TEST_MAX_DB_SIZE),
         };
         (config, tempdir)
@@ -84,6 +92,14 @@ impl Config {
         let value = self
             .max_deploy_store_size
             .unwrap_or(DEFAULT_MAX_DEPLOY_STORE_SIZE);
+        utils::check_multiple_of_page_size(value);
+        value
+    }
+
+    pub(crate) fn max_block_height_store_size(&self) -> usize {
+        let value = self
+            .max_block_height_store_size
+            .unwrap_or(DEFAULT_MAX_BLOCK_HEIGHT_STORE_SIZE);
         utils::check_multiple_of_page_size(value);
         value
     }
@@ -114,6 +130,7 @@ impl Default for Config {
             path,
             max_block_store_size: Some(DEFAULT_MAX_BLOCK_STORE_SIZE),
             max_deploy_store_size: Some(DEFAULT_MAX_DEPLOY_STORE_SIZE),
+            max_block_height_store_size: Some(DEFAULT_MAX_BLOCK_HEIGHT_STORE_SIZE),
             max_chainspec_store_size: Some(DEFAULT_MAX_CHAINSPEC_STORE_SIZE),
         }
     }

--- a/node/src/components/storage/in_mem_block_height_store.rs
+++ b/node/src/components/storage/in_mem_block_height_store.rs
@@ -1,0 +1,51 @@
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    fmt::Debug,
+    sync::RwLock,
+};
+
+use super::{BlockHeightStore, Result};
+
+/// In-memory version of a store.
+#[derive(Debug)]
+pub(super) struct InMemBlockHeightStore<H> {
+    inner: RwLock<BTreeMap<u64, H>>,
+}
+
+impl<H> InMemBlockHeightStore<H> {
+    pub(crate) fn new() -> Self {
+        InMemBlockHeightStore {
+            inner: RwLock::new(BTreeMap::new()),
+        }
+    }
+}
+
+impl<H: Send + Sync + Clone> BlockHeightStore<H> for InMemBlockHeightStore<H> {
+    fn put(&self, height: u64, block_hash: H) -> Result<bool> {
+        if let Entry::Vacant(entry) = self.inner.write().expect("should lock").entry(height) {
+            entry.insert(block_hash);
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn get(&self, height: u64) -> Result<Option<H>> {
+        Ok(self
+            .inner
+            .read()
+            .expect("should lock")
+            .get(&height)
+            .cloned())
+    }
+
+    fn highest(&self) -> Result<Option<H>> {
+        Ok(self
+            .inner
+            .read()
+            .expect("should lock")
+            .values()
+            .rev()
+            .next()
+            .cloned())
+    }
+}

--- a/node/src/components/storage/lmdb_block_height_store.rs
+++ b/node/src/components/storage/lmdb_block_height_store.rs
@@ -1,0 +1,85 @@
+use std::{
+    fmt::Debug,
+    path::Path,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use lmdb::{
+    self, Cursor, Database, DatabaseFlags, Environment, EnvironmentFlags, Transaction, WriteFlags,
+};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use super::{BlockHeightStore, Result};
+
+/// LMDB version of a store.
+#[derive(Debug)]
+pub(super) struct LmdbBlockHeightStore {
+    env: Environment,
+    db: Database,
+    highest: AtomicU64,
+}
+
+impl LmdbBlockHeightStore {
+    pub(crate) fn new<P: AsRef<Path>>(db_path: P, max_size: usize) -> Result<Self> {
+        let env = Environment::new()
+            .set_flags(EnvironmentFlags::NO_SUB_DIR)
+            .set_map_size(max_size)
+            .open(db_path.as_ref())?;
+        let db = env.create_db(None, DatabaseFlags::INTEGER_KEY)?;
+
+        // Get the last key, which will represent the largest block height, since the LMDB is sorted
+        // by integer key increasing.
+        let mut max_height_bytes = [0; 8];
+        let txn = env.begin_ro_txn().expect("should create ro txn");
+        {
+            let mut cursor = txn.open_ro_cursor(db).expect("should create ro cursor");
+            for (height_bytes, _value) in cursor.iter() {
+                max_height_bytes.copy_from_slice(height_bytes);
+            }
+        }
+        txn.commit().expect("should commit txn");
+        let highest = AtomicU64::new(u64::from_ne_bytes(max_height_bytes));
+
+        info!("opened DB at {}", db_path.as_ref().display());
+
+        Ok(LmdbBlockHeightStore { env, db, highest })
+    }
+}
+
+impl<H: Serialize + for<'de> Deserialize<'de>> BlockHeightStore<H> for LmdbBlockHeightStore {
+    fn put(&self, height: u64, block_hash: H) -> Result<bool> {
+        let serialized_value = rmp_serde::to_vec(&block_hash)?;
+        let mut txn = self.env.begin_rw_txn().expect("should create rw txn");
+        let result = match txn.put(
+            self.db,
+            &height.to_ne_bytes(),
+            &serialized_value,
+            WriteFlags::NO_OVERWRITE,
+        ) {
+            Ok(()) => true,
+            Err(lmdb::Error::KeyExist) => false,
+            Err(error) => panic!("should put height: {:?}", error),
+        };
+        let _ = self.highest.fetch_max(height, Ordering::SeqCst);
+        txn.commit().expect("should commit txn");
+        Ok(result)
+    }
+
+    fn get(&self, height: u64) -> Result<Option<H>> {
+        let txn = self.env.begin_ro_txn().expect("should create ro txn");
+        let serialized_value = match txn.get(self.db, &height.to_ne_bytes()) {
+            Ok(value) => value,
+            Err(lmdb::Error::NotFound) => return Ok(None),
+            Err(error) => panic!("should get: {:?}", error),
+        };
+        let block_hash = rmp_serde::from_read_ref(serialized_value)?;
+        txn.commit().expect("should commit txn");
+        Ok(Some(block_hash))
+    }
+
+    fn highest(&self) -> Result<Option<H>> {
+        let highest = self.highest.load(Ordering::Relaxed);
+        self.get(highest)
+    }
+}

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -202,10 +202,15 @@ pub enum StorageRequest<S: StorageType + 'static> {
         /// storage.
         responder: Responder<Option<S::Block>>,
     },
-    /// Retrieve linear chain block with given height.
+    /// Retrieve block with given height.
     GetBlockAtHeight {
         /// Height of the block.
-        height: <S::BlockHeight as Value>::Id,
+        height: u64,
+        /// Responder.
+        responder: Responder<Option<S::Block>>,
+    },
+    /// Retrieve highest block.
+    GetHighestBlock {
         /// Responder.
         responder: Responder<Option<S::Block>>,
     },
@@ -277,6 +282,10 @@ impl<S: StorageType> Display for StorageRequest<S> {
         match self {
             StorageRequest::PutBlock { block, .. } => write!(formatter, "put {}", block),
             StorageRequest::GetBlock { block_hash, .. } => write!(formatter, "get {}", block_hash),
+            StorageRequest::GetBlockAtHeight { height, .. } => {
+                write!(formatter, "get block at height {}", height)
+            }
+            StorageRequest::GetHighestBlock { .. } => write!(formatter, "get highest block"),
             StorageRequest::GetBlockHeader { block_hash, .. } => {
                 write!(formatter, "get {}", block_hash)
             }
@@ -302,9 +311,6 @@ impl<S: StorageType> Display for StorageRequest<S> {
             ),
             StorageRequest::GetChainspec { version, .. } => {
                 write!(formatter, "get chainspec {}", version)
-            }
-            StorageRequest::GetBlockAtHeight { height, .. } => {
-                write!(formatter, "get block at height {}", height)
             }
         }
     }
@@ -629,8 +635,6 @@ type BlockHeight = u64;
 pub enum LinearChainRequest<I> {
     /// Request whole block from the linear chain, by hash.
     BlockRequest(BlockHash, I),
-    /// Get last finalized block.
-    LastFinalizedBlock(Responder<Option<LinearBlock>>),
     /// Request for a linear chain block at height.
     BlockAtHeight(BlockHeight, I),
 }
@@ -641,7 +645,6 @@ impl<I: Display> Display for LinearChainRequest<I> {
             LinearChainRequest::BlockRequest(bh, peer) => {
                 write!(f, "block request for hash {} from {}", bh, peer)
             }
-            LinearChainRequest::LastFinalizedBlock(_) => write!(f, "last finalized block request"),
             LinearChainRequest::BlockAtHeight(height, sender) => {
                 write!(f, "block request for {} from {}", height, sender)
             }

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -22,7 +22,7 @@ use super::{Item, Tag, Timestamp};
 use crate::{
     components::{
         consensus::{self, EraId},
-        storage::Value,
+        storage::{Value, WithBlockHeight},
     },
     crypto::{
         asymmetric_key::{PublicKey, Signature},
@@ -642,6 +642,12 @@ impl Value for Block {
 
     fn take_header(self) -> Self::Header {
         self.header
+    }
+}
+
+impl WithBlockHeight for Block {
+    fn height(&self) -> u64 {
+        self.height()
     }
 }
 

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -8,8 +8,8 @@ use crate::{components::chainspec_loader::ChainspecInfo, types::Block};
 #[derive(Debug, Serialize)]
 #[serde(bound = "I: Eq + Hash + Serialize")]
 pub struct StatusFeed<I> {
-    /// The last finalized block.
-    pub last_finalized_block: Option<Block>,
+    /// The last block added to the chain.
+    pub last_added_block: Option<Block>,
     /// The peer nodes which are connected to this node.
     pub peers: HashMap<I, SocketAddr>,
     /// The chainspec info for this node.
@@ -20,12 +20,12 @@ pub struct StatusFeed<I> {
 
 impl<I> StatusFeed<I> {
     pub(crate) fn new(
-        last_finalized_block: Option<Block>,
+        last_added_block: Option<Block>,
         peers: HashMap<I, SocketAddr>,
         chainspec_info: ChainspecInfo,
     ) -> Self {
         StatusFeed {
-            last_finalized_block,
+            last_added_block,
             peers,
             chainspec_info,
             version: crate::VERSION_STRING.as_str(),

--- a/resources/charlie/config-example.toml
+++ b/resources/charlie/config-example.toml
@@ -107,6 +107,13 @@ path = '/root/.local/share/casper-node'
 # The size should be a multiple of the OS page size.
 #max_deploy_store_size = 322122547200
 
+# Optional maximum size of the database to use for the block height store.
+#
+# If unset, defaults to 10,485,100 == 10 MiB.
+#
+# The size should be a multiple of the OS page size.
+#max_block_height_store_size = 1073741824
+
 # Optional maximum size of the database to use for the chainspec store.
 #
 # If unset, defaults to 1,073,741,824 == 1 GiB.

--- a/resources/charlie/config-example.toml
+++ b/resources/charlie/config-example.toml
@@ -112,7 +112,7 @@ path = '/root/.local/share/casper-node'
 # If unset, defaults to 10,485,100 == 10 MiB.
 #
 # The size should be a multiple of the OS page size.
-#max_block_height_store_size = 1073741824
+#max_block_height_store_size = 10485100
 
 # Optional maximum size of the database to use for the chainspec store.
 #

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -120,7 +120,7 @@ path = '../node-storage'
 # If unset, defaults to 10,485,100 == 10 MiB.
 #
 # The size should be a multiple of the OS page size.
-#max_block_height_store_size = 1073741824
+#max_block_height_store_size = 10485100
 
 # Optional maximum size of the database to use for the chainspec store.
 #

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -115,6 +115,13 @@ path = '../node-storage'
 # The size should be a multiple of the OS page size.
 #max_deploy_store_size = 322122547200
 
+# Optional maximum size of the database to use for the block height store.
+#
+# If unset, defaults to 10,485,100 == 10 MiB.
+#
+# The size should be a multiple of the OS page size.
+#max_block_height_store_size = 1073741824
+
 # Optional maximum size of the database to use for the chainspec store.
 #
 # If unset, defaults to 1,073,741,824 == 1 GiB.


### PR DESCRIPTION
This PR updates the `BlockHeightStore` to be a specialized store rather than piggybacking on the existing `Store` trait, which was only designed to be suitable for storing blocks and deploys.  This has allowed for the removal of the `BlockHeightHash` type and the useless `BlockHeightHashMetadata` type.

It simplifies getting a value from the store (the `Store` trait only allows getting a collection of values) and allows us to easily provide a way to get the highest stored value, meaning we have a way to retrieve the highest block from the storage component.  This in turn allows us to remove the cached `last_block` from the linear chain component.

The DB is also able to specify the `DatabaseFlags::INTEGER_KEY` which should provide better performance than the default string sorted by lexicographical order.

One change which should be included in `master` regardless of whether this PR is approved or not is the addition of a new config value specifying the max size of the block height DB.  Currently it uses the value for the block store DB which is defaulted to 450 GiB.