### PR TITLE
EE-1066: move hardcoded validator slots to chainspec

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -1,7 +1,6 @@
 use std::{fmt, iter};
 
 use datasize::DataSize;
-use hex_fmt::HexFmt;
 use num_traits::Zero;
 use rand::{
     distributions::{Distribution, Standard},
@@ -216,7 +215,7 @@ impl Distribution<GenesisConfig> for Standard {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExecConfig {
     mint_installer_bytes: Vec<u8>,
     proof_of_stake_installer_bytes: Vec<u8>,
@@ -284,22 +283,6 @@ impl ExecConfig {
 
     pub fn validator_slots(&self) -> u32 {
         self.validator_slots
-    }
-}
-
-impl fmt::Debug for ExecConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(
-            f,
-            "validator_slots: {}, mint_installer_bytes: {:10}, proof_of_stake_installer_bytes: {:10}, standard_payment_installer_bytes: {:10}, auction_installer_bytes: {:10}, wasm_costs: {:?}, accounts: {:?}",
-            &self.validator_slots,
-            HexFmt(&self.mint_installer_bytes),
-            HexFmt(&self.proof_of_stake_installer_bytes),
-            HexFmt(&self.standard_payment_installer_bytes),
-            HexFmt(&self.auction_installer_bytes),
-            &self.wasm_costs,
-            &self.accounts,
-        )
     }
 }
 

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -1,6 +1,7 @@
 use std::{fmt, iter};
 
 use datasize::DataSize;
+use hex_fmt::HexFmt;
 use num_traits::Zero;
 use rand::{
     distributions::{Distribution, Standard},
@@ -215,7 +216,7 @@ impl Distribution<GenesisConfig> for Standard {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ExecConfig {
     mint_installer_bytes: Vec<u8>,
     proof_of_stake_installer_bytes: Vec<u8>,
@@ -223,6 +224,7 @@ pub struct ExecConfig {
     auction_installer_bytes: Vec<u8>,
     accounts: Vec<GenesisAccount>,
     wasm_costs: WasmCosts,
+    validator_slots: u32,
 }
 
 impl ExecConfig {
@@ -233,6 +235,7 @@ impl ExecConfig {
         auction_installer_bytes: Vec<u8>,
         accounts: Vec<GenesisAccount>,
         wasm_costs: WasmCosts,
+        validator_slots: u32,
     ) -> ExecConfig {
         ExecConfig {
             mint_installer_bytes,
@@ -241,6 +244,7 @@ impl ExecConfig {
             auction_installer_bytes,
             accounts,
             wasm_costs,
+            validator_slots,
         }
     }
 
@@ -277,6 +281,26 @@ impl ExecConfig {
     pub fn push_account(&mut self, account: GenesisAccount) {
         self.accounts.push(account)
     }
+
+    pub fn validator_slots(&self) -> u32 {
+        self.validator_slots
+    }
+}
+
+impl fmt::Debug for ExecConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "validator_slots: {}, mint_installer_bytes: {:10}, proof_of_stake_installer_bytes: {:10}, standard_payment_installer_bytes: {:10}, auction_installer_bytes: {:10}, wasm_costs: {:?}, accounts: {:?}",
+            &self.validator_slots,
+            HexFmt(&self.mint_installer_bytes),
+            HexFmt(&self.proof_of_stake_installer_bytes),
+            HexFmt(&self.standard_payment_installer_bytes),
+            HexFmt(&self.auction_installer_bytes),
+            &self.wasm_costs,
+            &self.accounts,
+        )
+    }
 }
 
 impl Distribution<ExecConfig> for Standard {
@@ -299,6 +323,8 @@ impl Distribution<ExecConfig> for Standard {
 
         let wasm_costs = rng.gen();
 
+        let validator_slots = rng.gen();
+
         ExecConfig {
             mint_installer_bytes,
             proof_of_stake_installer_bytes,
@@ -306,6 +332,7 @@ impl Distribution<ExecConfig> for Standard {
             auction_installer_bytes,
             accounts,
             wasm_costs,
+            validator_slots,
         }
     }
 }

--- a/execution_engine/src/core/engine_state/upgrade.rs
+++ b/execution_engine/src/core/engine_state/upgrade.rs
@@ -63,9 +63,11 @@ pub struct UpgradeConfig {
     upgrade_installer_bytes: Option<Vec<u8>>,
     wasm_costs: Option<WasmCosts>,
     activation_point: Option<ActivationPoint>,
+    new_validator_slots: Option<u32>,
 }
 
 impl UpgradeConfig {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pre_state_hash: Blake2bHash,
         current_protocol_version: ProtocolVersion,
@@ -74,6 +76,7 @@ impl UpgradeConfig {
         upgrade_installer_bytes: Option<Vec<u8>>,
         wasm_costs: Option<WasmCosts>,
         activation_point: Option<ActivationPoint>,
+        new_validator_slots: Option<u32>,
     ) -> Self {
         UpgradeConfig {
             pre_state_hash,
@@ -83,6 +86,7 @@ impl UpgradeConfig {
             upgrade_installer_bytes,
             wasm_costs,
             activation_point,
+            new_validator_slots,
         }
     }
 
@@ -114,5 +118,9 @@ impl UpgradeConfig {
 
     pub fn activation_point(&self) -> Option<u64> {
         self.activation_point
+    }
+
+    pub fn new_validator_slots(&self) -> Option<u32> {
+        self.new_validator_slots
     }
 }

--- a/grpc/server/protobuf/casper/ipc.proto
+++ b/grpc/server/protobuf/casper/ipc.proto
@@ -284,6 +284,8 @@ message ChainSpec {
             repeated GenesisAccount accounts = 4;
             // costs at genesis
             CostTable costs = 5;
+            // The total number of validator slots available to auction.
+            uint32 validator_slots = 7;
 
             message GenesisAccount {
                 bytes public_key_bytes = 1;
@@ -357,7 +359,14 @@ message ChainSpec {
         DeployCode upgrade_installer = 3;
         // Note: this is optional; only needed when costs are changing
         CostTable new_costs = 4;
+        // DeployConfig changes
         DeployConfig new_deploy_config = 5;
+        // Change the total number of validator slots to this number (optional)
+        NewValidatorSlots new_validator_slots = 6;
+    }
+
+    message NewValidatorSlots {
+        uint32 new_validator_slots = 1;
     }
 
     message ActivationPoint {

--- a/grpc/server/src/engine_server/mappings/ipc/exec_config.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/exec_config.rs
@@ -20,6 +20,7 @@ impl TryFrom<ipc::ChainSpec_GenesisConfig_ExecConfig> for ExecConfig {
         let proof_of_stake_initializer_bytes = pb_exec_config.take_pos_installer();
         let standard_payment_installer_bytes = pb_exec_config.take_standard_payment_installer();
         let auction_installer_bytes = pb_exec_config.take_auction_installer();
+        let validator_slots = pb_exec_config.get_validator_slots();
         Ok(ExecConfig::new(
             mint_initializer_bytes,
             proof_of_stake_initializer_bytes,
@@ -27,6 +28,7 @@ impl TryFrom<ipc::ChainSpec_GenesisConfig_ExecConfig> for ExecConfig {
             auction_installer_bytes,
             accounts,
             wasm_costs,
+            validator_slots,
         ))
     }
 }
@@ -52,6 +54,7 @@ impl From<ExecConfig> for ipc::ChainSpec_GenesisConfig_ExecConfig {
         pb_exec_config
             .mut_costs()
             .set_wasm(exec_config.wasm_costs().into());
+        pb_exec_config.set_validator_slots(exec_config.validator_slots());
         pb_exec_config
     }
 }

--- a/grpc/server/src/engine_server/mappings/ipc/upgrade_request.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/upgrade_request.rs
@@ -41,6 +41,16 @@ impl TryFrom<UpgradeRequest> for UpgradeConfig {
             Some(upgrade_point.get_activation_point().rank)
         };
 
+        let new_validator_slots: Option<u32> = if !upgrade_point.has_new_validator_slots() {
+            None
+        } else {
+            Some(
+                upgrade_point
+                    .take_new_validator_slots()
+                    .get_new_validator_slots(),
+            )
+        };
+
         Ok(UpgradeConfig::new(
             pre_state_hash,
             current_protocol_version,
@@ -49,6 +59,7 @@ impl TryFrom<UpgradeRequest> for UpgradeConfig {
             upgrade_installer_bytes,
             wasm_costs,
             activation_point,
+            new_validator_slots,
         ))
     }
 }

--- a/grpc/test_support/src/internal/mod.rs
+++ b/grpc/test_support/src/internal/mod.rs
@@ -33,6 +33,7 @@ pub const MINT_INSTALL_CONTRACT: &str = "mint_install.wasm";
 pub const POS_INSTALL_CONTRACT: &str = "pos_install.wasm";
 pub const STANDARD_PAYMENT_INSTALL_CONTRACT: &str = "standard_payment_install.wasm";
 pub const AUCTION_INSTALL_CONTRACT: &str = "auction_install.wasm";
+pub const DEFAULT_VALIDATOR_SLOTS: u32 = 5;
 
 pub const DEFAULT_CHAIN_NAME: &str = "gerald";
 pub const DEFAULT_GENESIS_TIMESTAMP: u64 = 0;
@@ -79,6 +80,7 @@ lazy_static! {
             auction_installer_bytes,
             DEFAULT_ACCOUNTS.clone(),
             *DEFAULT_WASM_COSTS,
+            DEFAULT_VALIDATOR_SLOTS,
         )
     };
     pub static ref DEFAULT_GENESIS_CONFIG: GenesisConfig = {

--- a/grpc/test_support/src/internal/upgrade_request_builder.rs
+++ b/grpc/test_support/src/internal/upgrade_request_builder.rs
@@ -1,7 +1,7 @@
 use casper_engine_grpc_server::engine_server::{
     ipc::{
         ChainSpec_ActivationPoint, ChainSpec_CostTable, ChainSpec_CostTable_WasmCosts,
-        ChainSpec_UpgradePoint, DeployCode, UpgradeRequest,
+        ChainSpec_NewValidatorSlots, ChainSpec_UpgradePoint, DeployCode, UpgradeRequest,
     },
     state,
 };
@@ -15,6 +15,7 @@ pub struct UpgradeRequestBuilder {
     upgrade_installer: DeployCode,
     new_costs: Option<ChainSpec_CostTable_WasmCosts>,
     activation_point: ChainSpec_ActivationPoint,
+    new_validator_slots: Option<u32>,
 }
 
 impl UpgradeRequestBuilder {
@@ -34,6 +35,11 @@ impl UpgradeRequestBuilder {
 
     pub fn with_new_protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
         self.new_protocol_version = protocol_version.into();
+        self
+    }
+
+    pub fn with_new_validator_slots(mut self, new_validator_slots: u32) -> Self {
+        self.new_validator_slots = Some(new_validator_slots);
         self
     }
 
@@ -78,6 +84,14 @@ impl UpgradeRequestBuilder {
                 upgrade_point.set_new_costs(cost_table);
             }
         }
+        match self.new_validator_slots {
+            None => {}
+            Some(new_validator_slots) => {
+                let mut chainspec_new_validator_slots = ChainSpec_NewValidatorSlots::new();
+                chainspec_new_validator_slots.set_new_validator_slots(new_validator_slots);
+                upgrade_point.set_new_validator_slots(chainspec_new_validator_slots);
+            }
+        }
         upgrade_point.set_protocol_version(self.new_protocol_version);
         upgrade_point.set_upgrade_installer(self.upgrade_installer);
 
@@ -97,6 +111,7 @@ impl Default for UpgradeRequestBuilder {
             upgrade_installer: Default::default(),
             new_costs: None,
             activation_point: Default::default(),
+            new_validator_slots: Default::default(),
         }
     }
 }

--- a/grpc/test_support/src/internal/utils.rs
+++ b/grpc/test_support/src/internal/utils.rs
@@ -22,8 +22,9 @@ use casper_types::Key;
 
 use crate::internal::{
     AUCTION_INSTALL_CONTRACT, DEFAULT_CHAIN_NAME, DEFAULT_GENESIS_CONFIG_HASH,
-    DEFAULT_GENESIS_TIMESTAMP, DEFAULT_PROTOCOL_VERSION, DEFAULT_WASM_COSTS, MINT_INSTALL_CONTRACT,
-    POS_INSTALL_CONTRACT, STANDARD_PAYMENT_INSTALL_CONTRACT,
+    DEFAULT_GENESIS_TIMESTAMP, DEFAULT_PROTOCOL_VERSION, DEFAULT_VALIDATOR_SLOTS,
+    DEFAULT_WASM_COSTS, MINT_INSTALL_CONTRACT, POS_INSTALL_CONTRACT,
+    STANDARD_PAYMENT_INSTALL_CONTRACT,
 };
 
 lazy_static! {
@@ -128,6 +129,7 @@ pub fn create_exec_config(accounts: Vec<GenesisAccount>) -> ExecConfig {
     let standard_payment_installer_bytes = read_wasm_file_bytes(STANDARD_PAYMENT_INSTALL_CONTRACT);
     let auction_installer_bytes = read_wasm_file_bytes(AUCTION_INSTALL_CONTRACT);
     let wasm_costs = *DEFAULT_WASM_COSTS;
+    let validator_slots = DEFAULT_VALIDATOR_SLOTS;
     ExecConfig::new(
         mint_installer_bytes,
         proof_of_stake_installer_bytes,
@@ -135,6 +137,7 @@ pub fn create_exec_config(accounts: Vec<GenesisAccount>) -> ExecConfig {
         auction_installer_bytes,
         accounts,
         wasm_costs,
+        validator_slots,
     )
 }
 

--- a/grpc/tests/src/profiling/state_initializer.rs
+++ b/grpc/tests/src/profiling/state_initializer.rs
@@ -9,8 +9,8 @@ use clap::{crate_version, App};
 use casper_engine_test_support::internal::{
     utils, DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, ARG_AMOUNT,
     AUCTION_INSTALL_CONTRACT, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG_HASH,
-    DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, DEFAULT_WASM_COSTS, MINT_INSTALL_CONTRACT,
-    POS_INSTALL_CONTRACT, STANDARD_PAYMENT_INSTALL_CONTRACT,
+    DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, DEFAULT_VALIDATOR_SLOTS, DEFAULT_WASM_COSTS,
+    MINT_INSTALL_CONTRACT, POS_INSTALL_CONTRACT, STANDARD_PAYMENT_INSTALL_CONTRACT,
 };
 use casper_execution_engine::core::engine_state::{
     engine_config::EngineConfig, genesis::ExecConfig, run_genesis_request::RunGenesisRequest,
@@ -79,6 +79,7 @@ fn main() {
         auction_installer_bytes,
         DEFAULT_ACCOUNTS.clone(),
         *DEFAULT_WASM_COSTS,
+        DEFAULT_VALIDATOR_SLOTS,
     );
     let run_genesis_request = RunGenesisRequest::new(
         *DEFAULT_GENESIS_CONFIG_HASH,

--- a/grpc/tests/src/test/system_contracts/auction_install.rs
+++ b/grpc/tests/src/test/system_contracts/auction_install.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use casper_engine_test_support::{
     internal::{
         exec_with_return, ExecuteRequestBuilder, WasmTestBuilder, DEFAULT_BLOCK_TIME,
-        DEFAULT_RUN_GENESIS_REQUEST,
+        DEFAULT_RUN_GENESIS_REQUEST, DEFAULT_VALIDATOR_SLOTS,
     },
     DEFAULT_ACCOUNT_ADDR,
 };
@@ -11,8 +11,9 @@ use casper_execution_engine::core::engine_state::EngineConfig;
 use casper_types::{
     account::AccountHash,
     auction::{
-        BIDS_KEY, BID_PURSES_KEY, DELEGATORS_KEY, DELEGATOR_REWARD_MAP, DELEGATOR_REWARD_PURSE,
-        ERA_ID_KEY, ERA_VALIDATORS_KEY, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_PURSES_KEY,
+        ARG_GENESIS_VALIDATORS, ARG_MINT_CONTRACT_PACKAGE_HASH, ARG_VALIDATOR_SLOTS, BIDS_KEY,
+        BID_PURSES_KEY, DELEGATORS_KEY, DELEGATOR_REWARD_MAP, DELEGATOR_REWARD_PURSE, ERA_ID_KEY,
+        ERA_VALIDATORS_KEY, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_PURSES_KEY,
         VALIDATOR_REWARD_MAP, VALIDATOR_REWARD_PURSE,
     },
     runtime_args, ContractHash, RuntimeArgs, U512,
@@ -23,8 +24,8 @@ const TRANSFER_AMOUNT: u64 = 250_000_000 + 1000;
 const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 const DEPLOY_HASH_2: [u8; 32] = [2u8; 32];
 
-// one named_key for each validator and three for the purses
-const EXPECTED_KNOWN_KEYS_LEN: usize = 11;
+// one named_key for each validator and three for the purses and one for validator slots
+const EXPECTED_KNOWN_KEYS_LEN: usize = 12;
 
 #[ignore]
 #[test]
@@ -75,8 +76,9 @@ fn should_run_auction_install_contract() {
         DEPLOY_HASH_2,
         "install",
         runtime_args! {
-            "mint_contract_package_hash" => mint.contract_package_hash(),
-            "genesis_validators" => genesis_validators,
+            ARG_MINT_CONTRACT_PACKAGE_HASH => mint.contract_package_hash(),
+            ARG_GENESIS_VALIDATORS => genesis_validators,
+            ARG_VALIDATOR_SLOTS => DEFAULT_VALIDATOR_SLOTS
         },
         vec![],
     );

--- a/grpc/tests/src/test/system_contracts/genesis.rs
+++ b/grpc/tests/src/test/system_contracts/genesis.rs
@@ -2,8 +2,9 @@ use lazy_static::lazy_static;
 
 use casper_engine_test_support::{
     internal::{
-        utils, InMemoryWasmTestBuilder, AUCTION_INSTALL_CONTRACT, DEFAULT_WASM_COSTS,
-        MINT_INSTALL_CONTRACT, POS_INSTALL_CONTRACT, STANDARD_PAYMENT_INSTALL_CONTRACT,
+        utils, InMemoryWasmTestBuilder, AUCTION_INSTALL_CONTRACT, DEFAULT_VALIDATOR_SLOTS,
+        DEFAULT_WASM_COSTS, MINT_INSTALL_CONTRACT, POS_INSTALL_CONTRACT,
+        STANDARD_PAYMENT_INSTALL_CONTRACT,
     },
     AccountHash,
 };
@@ -66,6 +67,7 @@ fn should_run_genesis() {
     let auction_installer_bytes = utils::read_wasm_file_bytes(AUCTION_INSTALL_CONTRACT);
     let protocol_version = ProtocolVersion::V1_0_0;
     let wasm_costs = *DEFAULT_WASM_COSTS;
+    let validator_slots = DEFAULT_VALIDATOR_SLOTS;
 
     let exec_config = ExecConfig::new(
         mint_installer_bytes,
@@ -74,6 +76,7 @@ fn should_run_genesis() {
         auction_installer_bytes,
         GENESIS_CUSTOM_ACCOUNTS.clone(),
         wasm_costs,
+        validator_slots,
     );
     let run_genesis_request =
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, exec_config);
@@ -130,6 +133,7 @@ fn should_track_total_token_supply_in_mint() {
     let accounts = GENESIS_CUSTOM_ACCOUNTS.clone();
     let wasm_costs = *DEFAULT_WASM_COSTS;
     let protocol_version = ProtocolVersion::V1_0_0;
+    let validator_slots = DEFAULT_VALIDATOR_SLOTS;
 
     let ee_config = ExecConfig::new(
         mint_installer_bytes,
@@ -138,6 +142,7 @@ fn should_track_total_token_supply_in_mint() {
         auction_installer_bytes,
         accounts.clone(),
         wasm_costs,
+        validator_slots,
     );
     let run_genesis_request =
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, ee_config);
@@ -182,6 +187,7 @@ fn should_fail_if_bad_mint_install_contract_is_provided() {
         let auction_installer_bytes = utils::read_wasm_file_bytes(AUCTION_INSTALL_CONTRACT);
         let protocol_version = ProtocolVersion::V1_0_0;
         let wasm_costs = *DEFAULT_WASM_COSTS;
+        let validator_slots = DEFAULT_VALIDATOR_SLOTS;
 
         let exec_config = ExecConfig::new(
             mint_installer_bytes,
@@ -190,6 +196,7 @@ fn should_fail_if_bad_mint_install_contract_is_provided() {
             auction_installer_bytes,
             GENESIS_CUSTOM_ACCOUNTS.clone(),
             wasm_costs,
+            validator_slots,
         );
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, exec_config)
     };
@@ -212,6 +219,7 @@ fn should_fail_if_bad_pos_install_contract_is_provided() {
         let auction_installer_bytes = utils::read_wasm_file_bytes(AUCTION_INSTALL_CONTRACT);
         let protocol_version = ProtocolVersion::V1_0_0;
         let wasm_costs = *DEFAULT_WASM_COSTS;
+        let validator_slots = DEFAULT_VALIDATOR_SLOTS;
         let exec_config = ExecConfig::new(
             mint_installer_bytes,
             pos_installer_bytes,
@@ -219,6 +227,7 @@ fn should_fail_if_bad_pos_install_contract_is_provided() {
             auction_installer_bytes,
             GENESIS_CUSTOM_ACCOUNTS.clone(),
             wasm_costs,
+            validator_slots,
         );
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, exec_config)
     };

--- a/grpc/tests/src/test/system_contracts/upgrade.rs
+++ b/grpc/tests/src/test/system_contracts/upgrade.rs
@@ -11,7 +11,7 @@ use casper_execution_engine::{
     core::engine_state::{upgrade::ActivationPoint, Error},
     shared::wasm_costs::WasmCosts,
 };
-use casper_types::ProtocolVersion;
+use casper_types::{auction::VALIDATOR_SLOTS_KEY, ProtocolVersion};
 #[cfg(feature = "use-system-contracts")]
 use casper_types::{runtime_args, CLValue, Key, RuntimeArgs, U512};
 
@@ -643,4 +643,63 @@ fn should_fail_major_upgrade_without_installer() {
         failed_deploy.message,
         Error::InvalidUpgradeConfig.to_string()
     );
+}
+
+#[ignore]
+#[test]
+fn should_upgrade_only_validator_slots() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    let sem_ver = PROTOCOL_VERSION.value();
+    let new_protocol_version =
+        ProtocolVersion::from_parts(sem_ver.major, sem_ver.minor, sem_ver.patch + 1);
+
+    let valdiator_slot_key = builder
+        .get_contract(builder.get_auction_contract_hash())
+        .expect("auction should exist")
+        .named_keys()[VALIDATOR_SLOTS_KEY];
+
+    let before_validator_slots: u32 = builder
+        .query(None, valdiator_slot_key, &[])
+        .expect("should have validator slots")
+        .as_cl_value()
+        .expect("should be CLValue")
+        .clone()
+        .into_t()
+        .expect("should be u32");
+
+    let new_validator_slots = before_validator_slots + 1;
+
+    let mut upgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(PROTOCOL_VERSION)
+            .with_new_protocol_version(new_protocol_version)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .with_new_validator_slots(new_validator_slots)
+            .build()
+    };
+
+    builder.upgrade_with_upgrade_request(&mut upgrade_request);
+
+    let upgrade_response = builder
+        .get_upgrade_response(0)
+        .expect("should have response");
+
+    assert!(upgrade_response.has_success(), "expected success");
+
+    let after_validator_slots: u32 = builder
+        .query(None, valdiator_slot_key, &[])
+        .expect("should have validator slots")
+        .as_cl_value()
+        .expect("should be CLValue")
+        .clone()
+        .into_t()
+        .expect("should be u32");
+
+    assert_eq!(
+        new_validator_slots, after_validator_slots,
+        "should have upgraded validator slots to expected value"
+    )
 }

--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -164,6 +164,7 @@ impl Loadable for Vec<GenesisAccount> {
 pub struct GenesisConfig {
     pub(crate) name: String,
     pub(crate) timestamp: Timestamp,
+    pub(crate) validator_slots: u32,
     // We don't have an implementation for the semver version type, we skip it for now
     #[data_size(skip)]
     pub(crate) protocol_version: Version,
@@ -238,6 +239,7 @@ impl GenesisConfig {
     pub fn random(rng: &mut TestRng) -> Self {
         let name = rng.gen::<char>().to_string();
         let timestamp = Timestamp::random(rng);
+        let validator_slots = rng.gen::<u32>();
         let protocol_version = Version::new(
             rng.gen_range(0, 10),
             rng.gen::<u8>() as u64,
@@ -255,6 +257,7 @@ impl GenesisConfig {
         GenesisConfig {
             name,
             timestamp,
+            validator_slots,
             protocol_version,
             mint_installer_bytes,
             pos_installer_bytes,
@@ -282,6 +285,7 @@ pub(crate) struct UpgradePoint {
     pub(crate) upgrade_installer_args: Option<Vec<u8>>,
     pub(crate) new_costs: Option<WasmCosts>,
     pub(crate) new_deploy_config: Option<DeployConfig>,
+    pub(crate) new_validator_slots: Option<u32>,
 }
 
 #[cfg(test)]
@@ -312,6 +316,7 @@ impl UpgradePoint {
         } else {
             None
         };
+        let new_validator_slots = rng.gen::<Option<u32>>();
 
         UpgradePoint {
             activation_point,
@@ -320,6 +325,7 @@ impl UpgradePoint {
             upgrade_installer_args,
             new_costs,
             new_deploy_config,
+            new_validator_slots,
         }
     }
 }
@@ -359,6 +365,7 @@ impl Into<ExecConfig> for Chainspec {
             self.genesis.auction_installer_bytes,
             self.genesis.accounts,
             self.genesis.costs,
+            self.genesis.validator_slots,
         )
     }
 }

--- a/node/src/components/chainspec_loader/config.rs
+++ b/node/src/components/chainspec_loader/config.rs
@@ -22,11 +22,13 @@ const DEFAULT_STANDARD_PAYMENT_INSTALLER_PATH: &str = "standard_payment_install.
 const DEFAULT_AUCTION_INSTALLER_PATH: &str = "auction_install.wasm";
 const DEFAULT_ACCOUNTS_CSV_PATH: &str = "accounts.csv";
 const DEFAULT_UPGRADE_INSTALLER_PATH: &str = "upgrade_install.wasm";
+const DEFAULT_VALIDATOR_SLOTS: u32 = 5;
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
 struct Genesis {
     name: String,
     timestamp: Timestamp,
+    validator_slots: u32,
     protocol_version: Version,
     mint_installer_path: External<Vec<u8>>,
     pos_installer_path: External<Vec<u8>>,
@@ -40,6 +42,7 @@ impl Default for Genesis {
         Genesis {
             name: String::from(DEFAULT_CHAIN_NAME),
             timestamp: Timestamp::zero(),
+            validator_slots: DEFAULT_VALIDATOR_SLOTS,
             protocol_version: Version::from((1, 0, 0)),
             mint_installer_path: External::path(DEFAULT_MINT_INSTALLER_PATH),
             pos_installer_path: External::path(DEFAULT_POS_INSTALLER_PATH),
@@ -60,6 +63,7 @@ struct UpgradePoint {
     activation_point: chainspec::ActivationPoint,
     new_costs: Option<WasmCosts>,
     new_deploy_config: Option<chainspec::DeployConfig>,
+    new_validator_slots: Option<u32>,
 }
 
 impl From<&chainspec::UpgradePoint> for UpgradePoint {
@@ -70,6 +74,7 @@ impl From<&chainspec::UpgradePoint> for UpgradePoint {
             activation_point: upgrade_point.activation_point,
             new_costs: upgrade_point.new_costs,
             new_deploy_config: upgrade_point.new_deploy_config,
+            new_validator_slots: upgrade_point.new_validator_slots,
         }
     }
 }
@@ -94,6 +99,7 @@ impl UpgradePoint {
             upgrade_installer_args,
             new_costs: self.new_costs,
             new_deploy_config: self.new_deploy_config,
+            new_validator_slots: self.new_validator_slots,
         })
     }
 }
@@ -114,6 +120,7 @@ impl From<&chainspec::Chainspec> for ChainspecConfig {
         let genesis = Genesis {
             name: chainspec.genesis.name.clone(),
             timestamp: chainspec.genesis.timestamp,
+            validator_slots: chainspec.genesis.validator_slots,
             protocol_version: chainspec.genesis.protocol_version.clone(),
             mint_installer_path: External::path(DEFAULT_MINT_INSTALLER_PATH),
             pos_installer_path: External::path(DEFAULT_POS_INSTALLER_PATH),
@@ -191,6 +198,7 @@ pub(super) fn parse_toml<P: AsRef<Path>>(chainspec_path: P) -> Result<chainspec:
     let genesis = chainspec::GenesisConfig {
         name: chainspec.genesis.name,
         timestamp: chainspec.genesis.timestamp,
+        validator_slots: chainspec.genesis.validator_slots,
         protocol_version: chainspec.genesis.protocol_version,
         mint_installer_bytes,
         pos_installer_bytes,

--- a/resources/charlie/chainspec.toml
+++ b/resources/charlie/chainspec.toml
@@ -22,6 +22,8 @@ standard_payment_installer_path = '/etc/casper/wasm/standard_payment_install.was
 auction_installer_path = '/etc/casper/wasm/auction_install.wasm'
 # Path (absolute, or relative to this chainspec.toml) to the CSV file containing initial account balances and bonds.
 accounts_path = '/etc/casper/accounts.csv'
+# Number of slots available in validator auction.
+validator_slots = 15
 
 [highway]
 # Tick unit is milliseconds.

--- a/resources/local/chainspec.toml
+++ b/resources/local/chainspec.toml
@@ -22,6 +22,8 @@ standard_payment_installer_path = '../../target/wasm32-unknown-unknown/release/s
 auction_installer_path = '../../target/wasm32-unknown-unknown/release/auction_install.wasm'
 # Path (absolute, or relative to this chainspec.toml) to the CSV file containing initial account balances and bonds.
 accounts_path = 'accounts.csv'
+# Number of slots available in validator auction.
+validator_slots = 5
 
 [highway]
 # Tick unit is milliseconds.

--- a/resources/test/valid/chainspec.toml
+++ b/resources/test/valid/chainspec.toml
@@ -7,6 +7,7 @@ pos_installer_path = 'pos.wasm'
 standard_payment_installer_path = 'standard_payment.wasm'
 auction_installer_path = 'auction_install.wasm'
 accounts_path = 'accounts.csv'
+validator_slots = 5
 
 [highway]
 genesis_era_start_timestamp = '2020-09-18T18:45:00Z'

--- a/smart_contracts/contracts/system/auction-install/src/main.rs
+++ b/smart_contracts/contracts/system/auction-install/src/main.rs
@@ -12,10 +12,11 @@ use casper_types::{
     auction::{
         Bid, BidPurses, Bids, DelegatorRewardMap, Delegators, EraValidators, SeigniorageRecipient,
         SeigniorageRecipients, SeigniorageRecipientsSnapshot, UnbondingPurses, ValidatorRewardMap,
-        ValidatorWeights, AUCTION_DELAY, BIDS_KEY, BID_PURSES_KEY, DEFAULT_LOCKED_FUNDS_PERIOD,
+        ValidatorWeights, ARG_GENESIS_VALIDATORS, ARG_MINT_CONTRACT_PACKAGE_HASH,
+        ARG_VALIDATOR_SLOTS, AUCTION_DELAY, BIDS_KEY, BID_PURSES_KEY, DEFAULT_LOCKED_FUNDS_PERIOD,
         DELEGATORS_KEY, DELEGATOR_REWARD_MAP, DELEGATOR_REWARD_PURSE, ERA_ID_KEY,
         ERA_VALIDATORS_KEY, INITIAL_ERA_ID, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
-        UNBONDING_PURSES_KEY, VALIDATOR_REWARD_MAP, VALIDATOR_REWARD_PURSE,
+        UNBONDING_PURSES_KEY, VALIDATOR_REWARD_MAP, VALIDATOR_REWARD_PURSE, VALIDATOR_SLOTS_KEY,
     },
     contracts::{NamedKeys, CONTRACT_INITIAL_VERSION},
     runtime_args,
@@ -27,12 +28,13 @@ const HASH_KEY_NAME: &str = "auction_hash";
 const ACCESS_KEY_NAME: &str = "auction_access";
 const ENTRY_POINT_MINT: &str = "mint";
 const ARG_AMOUNT: &str = "amount";
-const ARG_GENESIS_VALIDATORS: &str = "genesis_validators";
 
 #[no_mangle]
 pub extern "C" fn install() {
     let mint_package_hash: ContractPackageHash =
-        runtime::get_named_arg("mint_contract_package_hash");
+        runtime::get_named_arg(ARG_MINT_CONTRACT_PACKAGE_HASH);
+
+    let validator_slots: u32 = runtime::get_named_arg(ARG_VALIDATOR_SLOTS);
 
     let entry_points = auction::get_entry_points();
     let (contract_package_hash, access_uref) = storage::create_contract_package_at_hash();
@@ -111,6 +113,10 @@ pub extern "C" fn install() {
         named_keys.insert(
             VALIDATOR_REWARD_MAP.into(),
             storage::new_uref(ValidatorRewardMap::new()).into(),
+        );
+        named_keys.insert(
+            VALIDATOR_SLOTS_KEY.into(),
+            storage::new_uref(validator_slots).into(),
         );
 
         named_keys

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -344,6 +344,9 @@ pub trait Auction:
 
         detail::process_unbond_requests(self)?;
 
+        // get allowed validator slots total
+        let validator_slots = internal::get_validator_slots(self)?;
+
         let mut era_id = internal::get_era_id(self)?;
 
         let mut bids = internal::get_bids(self)?;
@@ -405,7 +408,7 @@ pub trait Auction:
         scores.sort_by(|(_, lhs), (_, rhs)| rhs.cmp(lhs));
 
         // Fill in remaining validators
-        let remaining_auction_slots = AUCTION_SLOTS.saturating_sub(bid_weights.len());
+        let remaining_auction_slots = validator_slots.saturating_sub(bid_weights.len());
         bid_weights.extend(scores.into_iter().take(remaining_auction_slots));
 
         let mut era_validators = internal::get_era_validators(self)?;

--- a/types/src/auction/constants.rs
+++ b/types/src/auction/constants.rs
@@ -4,9 +4,6 @@ use crate::account::AccountHash;
 /// System account hash.
 pub const SYSTEM_ACCOUNT: AccountHash = AccountHash::new([0; 32]);
 
-/// Maximum number of era validator slots.
-pub const AUCTION_SLOTS: usize = 5;
-
 /// Number of eras before an auction actually defines the set of validators.
 pub const AUCTION_DELAY: u64 = 3;
 
@@ -26,6 +23,9 @@ pub const DELEGATION_RATE_DENOMINATOR: u64 = 1_000_000_000_000;
 /// We use one trillion as a block reward unit because it's large enough to allow precise
 /// fractions, and small enough for many block rewards to fit into a u64.
 pub const BLOCK_REWARD: u64 = 1_000_000_000_000;
+
+/// Total validator slots allowed.
+pub const VALIDATOR_SLOTS_KEY: &str = "validator_slots";
 
 /// Named constant for `amount`.
 pub const ARG_AMOUNT: &str = "amount";
@@ -57,6 +57,12 @@ pub const ARG_DELEGATOR_PUBLIC_KEY: &str = "delegator_public_key";
 pub const ARG_TARGET_PURSE: &str = "target_purse";
 /// Named constant for `unbond_purse`.
 pub const ARG_UNBOND_PURSE: &str = "unbond_purse";
+/// Named constant for `validator_slots` argument.
+pub const ARG_VALIDATOR_SLOTS: &str = VALIDATOR_SLOTS_KEY;
+/// Named constant for `mint_contract_package_hash`
+pub const ARG_MINT_CONTRACT_PACKAGE_HASH: &str = "mint_contract_package_hash";
+/// Named constant for `genesis_validators`
+pub const ARG_GENESIS_VALIDATORS: &str = "genesis_validators";
 
 /// Named constant for method `get_era_validators`.
 pub const METHOD_GET_ERA_VALIDATORS: &str = "get_era_validators";

--- a/types/src/auction/internal.rs
+++ b/types/src/auction/internal.rs
@@ -1,4 +1,4 @@
-use uint::core_::convert::TryInto;
+use core::convert::TryInto;
 
 use crate::{
     auction::{

--- a/types/src/auction/internal.rs
+++ b/types/src/auction/internal.rs
@@ -1,9 +1,11 @@
+use uint::core_::convert::TryInto;
+
 use crate::{
     auction::{
         providers::StorageProvider, Bids, DelegatorRewardMap, Delegators, EraId, EraValidators,
         RuntimeProvider, SeigniorageRecipientsSnapshot, ValidatorRewardMap, BIDS_KEY,
         DELEGATORS_KEY, DELEGATOR_REWARD_MAP, ERA_ID_KEY, ERA_VALIDATORS_KEY,
-        SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, VALIDATOR_REWARD_MAP,
+        SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, VALIDATOR_REWARD_MAP, VALIDATOR_SLOTS_KEY,
     },
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::auction::{Error, Result},
@@ -139,4 +141,15 @@ where
     P: StorageProvider + RuntimeProvider + ?Sized,
 {
     write_to(provider, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, snapshot)
+}
+
+pub fn get_validator_slots<P>(provider: &mut P) -> Result<usize>
+where
+    P: StorageProvider + RuntimeProvider + ?Sized,
+{
+    let validator_slots: u32 = read_from(provider, VALIDATOR_SLOTS_KEY)?;
+    let validator_slots = validator_slots
+        .try_into()
+        .map_err(|_| Error::InvalidValidatorSlotsValue)?;
+    Ok(validator_slots)
 }

--- a/types/src/system_contract_errors/auction.rs
+++ b/types/src/system_contract_errors/auction.rs
@@ -88,9 +88,12 @@ pub enum Error {
     /// current era validators when distributing rewards.
     #[fail(display = "Mismatched era validator sets to distribute rewards")]
     MismatchedEraValidators = 22,
-    /// Failed to mint reward tokens
+    /// Failed to mint reward tokens.
     #[fail(display = "Failed to mint rewards")]
-    MintReward,
+    MintReward = 23,
+    /// Invalid number of validator slots.
+    #[fail(display = "Invalid number of validator slots")]
+    InvalidValidatorSlotsValue = 24,
 }
 
 impl CLTyped for Error {


### PR DESCRIPTION
This PR makes validator slots a configurable chainspec variable rather than a hardcoded value.

https://casperlabs.atlassian.net/browse/EE-1066