### PR TITLE
[OP-1540] release to bintray and github

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -221,7 +221,7 @@ steps:
 - name: publish-prod-bintray
   <<: *buildenv
   commands:
-  - "./upload.sh --repo-name casper-debian-tests --package-name casper-node"
+  - "./upload.sh --repo-name debian --package-name casper-node"
   environment:
     CL_VAULT_TOKEN:
       from_secret: vault_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,11 +47,18 @@ steps:
   settings:
     restore: true
 
+- name: build-deb-update-revision
+  <<: *buildenv
+  commands:
+    - "./update-rev.sh" 
+
 - name: cargo-fmt
   <<: *buildenv
   commands:
   - rustup component add rustfmt
   - cargo fmt --all -- --check
+  depends_on:
+  - build-deb-update-revision
 
 - name: cargo-clippy
   <<: *buildenv
@@ -61,6 +68,8 @@ steps:
   - make setup-rs
   - rustup component add clippy
   - cargo clippy --all-targets --all-features --workspace
+  depends_on:
+  - build-deb-update-revision
 
 - name: cargo-audit
   <<: *buildenv
@@ -68,11 +77,15 @@ steps:
   - cargo install cargo-audit
   - cargo generate-lockfile
   - cargo audit
+  depends_on:
+  - build-deb-update-revision
 
 - name: updater-dry-run
   <<: *buildenv
   commands:
   - cargo run --package=casper-updater -- --root-dir=. --dry-run
+  depends_on:
+  - build-deb-update-revision
 
 - name: cargo-test
   <<: *buildenv
@@ -80,6 +93,8 @@ steps:
   - make setup
   - make test
   - make test-contracts
+  depends_on:
+  - build-deb-update-revision
 
 - name: rebuild-cache
   <<: *cache
@@ -91,6 +106,33 @@ steps:
     event:
     - push
 
+- name: build-deb
+  <<: *buildenv
+  commands:
+    - "make deb"
+  depends_on:
+  - cargo-test
+
+# we want to publish to the test repo, only when code is pushed to master or release-* branch. 
+# bors should make sure, that it has passed on staging or trying branches
+- name: publish-test-bintray
+  <<: *buildenv
+  commands:
+  - "./upload.sh --repo-name casper-debian-tests --package-name casper-node"
+  environment:
+    CL_VAULT_TOKEN:
+      from_secret: vault_token
+    CL_VAULT_HOST:
+      from_secret: vault_host
+  when:
+    branch:
+    - master
+    - "release-*"
+    event:
+    - push  
+  depends_on:
+  - build-deb
+
 volumes:
   - name: cache
     host:
@@ -101,6 +143,7 @@ trigger:
   - master
   - trying
   - staging
+  - "release-*"
 
 ---
 # Anchor for default buildenv
@@ -108,9 +151,9 @@ __buildenv: &buildenv
   image: "casperlabs/buildenv:latest"
   environment:
     CARGO_HOME: ".cargo"
-
+# act on release - when the tag is created
 kind: pipeline
-name: on-tag
+name: release-by-tag
 
 steps:
 - name: restore-cache-tag
@@ -127,22 +170,67 @@ steps:
       - ./.cargo/.crates.toml
     restore: true
 
-- name: build-release-tag
+- name: update-revision
   <<: *buildenv
   commands:
-  - "cargo build --release"
-  depends_on:
-  - restore-cache-tag
+    - "./update-rev.sh"
 
-- name: build-deb-tag
+- name: cargo-fmt
   <<: *buildenv
   commands:
-    - "cd grpc/server && cargo deb -p casper-engine-grpc-server --no-build"
-    - "cd node && cargo deb -p casper-node --no-build"
+  - rustup component add rustfmt
+  - cargo fmt --all -- --check
   depends_on:
-  - build-release-tag
+    - update-revision
 
-- name: publish-github-tag
+- name: cargo-clippy
+  <<: *buildenv
+  environment:
+    RUSTFLAGS: '-D warnings'
+  commands:
+  - make setup-rs
+  - rustup component add clippy
+  - cargo clippy --all-targets --all-features --workspace
+  depends_on:
+    - update-revision
+
+- name: cargo-audit
+  <<: *buildenv
+  commands:
+  - cargo install cargo-audit
+  - cargo generate-lockfile
+  - cargo audit
+  depends_on:
+  - cargo-clippy
+
+- name: build-deb
+  <<: *buildenv
+  commands:
+    - "make setup-rs"
+    - "make deb"
+  depends_on:
+  - cargo-audit
+
+- name: publish-crate-tag-TODO
+  <<: *buildenv
+  commands:
+  - "echo TODO"
+  depends_on:
+  - cargo-audit
+
+- name: publish-prod-bintray
+  <<: *buildenv
+  commands:
+  - "./upload.sh --repo-name casper-debian-tests --package-name casper-node"
+  environment:
+    CL_VAULT_TOKEN:
+      from_secret: vault_token
+    CL_VAULT_HOST:
+      from_secret: vault_host
+  depends_on:
+  - build-deb
+
+- name: publish-github-pre-release
   image: plugins/github-release
   settings:
     api_key:
@@ -155,31 +243,19 @@ steps:
     prerelease:
     - true
   depends_on:
-  - build-deb-tag
-
-- name: publish-crate-tag
-  <<: *buildenv
-  commands:
-  - "echo TODO"
-  depends_on:
-  - build-release-tag
-
-- name: publish-bintray-tag
-  <<: *buildenv
-  commands:
-  - "echo TODO"
-  depends_on:
-  - build-deb-tag
+  - build-deb
+  when:
+    ref:
+    - refs/tags/v*
 
 volumes:
   - name: cache
     host:
       path: /tmp/cache
-
+# push to test repo every time we are going to merge to master (via staging), trying or pushing to release (hot fix)
 trigger:
   ref:
   - refs/tags/v*
-
 ---
 kind: pipeline
 name: failed-build-alert
@@ -206,6 +282,7 @@ trigger:
   - master
   - trying
   - staging
+  - "release-*"
 
 depends_on:
 - cargo

--- a/update-rev.sh
+++ b/update-rev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ue 
+
+DEST_FILE='node/Cargo.toml'
+
+if [ -f $DEST_FILE ]; then 
+  echo "[INFO] Going to update $DEST_FILE with revision set to $DRONE_BUILD_NUMBER"
+  sed -i s'/^revision =.*/revision = "'"${DRONE_BUILD_NUMBER}"'"/' $DEST_FILE
+  cat $DEST_FILE
+else
+  echo "[ERRPR] Unable to find: $DEST_FILE"
+  exit 1
+fi

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+
+get_help() {
+  echo -e "Usage: $0 --repo-name <NAME> --package-name <PACKAGE_NAME> [--package-version <VERSION>]\n"
+  echo -e "Example: $0 --repo-name debian --package-name casper-node\n"
+  echo "Note: If --package-version is not set DRONE_TAG will be used."
+}
+
+parse_args() {
+  if [ $# -eq 0 ]; then
+    get_help
+    exit 1
+  fi
+  optspec=":h-:"
+  while getopts "$optspec" optchar; do
+    case "${optchar}" in
+      -)
+        case "${OPTARG}" in
+          repo-name)
+            val="${!OPTIND}"; OPTIND=$(( $OPTIND + 1 ))
+            #echo "Parsing option: '--${OPTARG}', value: '${val}'" >&2
+            BINTRAY_REPO_NAME=${val}
+            ;;
+          package-name)
+            val="${!OPTIND}"; OPTIND=$(( $OPTIND + 1 ))
+            #echo "Parsing option: '--${OPTARG}', value: '${val}'" >&2
+            BINTRAY_PACKAGE_NAME=${val}
+            ;;
+          package-version)
+            val="${!OPTIND}"; OPTIND=$(( $OPTIND + 1 ))
+            #echo "Parsing option: '--${OPTARG}', value: '${val}'" >&2
+            PACKAGE_VERSION=${val}
+            ;;
+          help)
+            get_help
+            exit 1
+            ;;
+          *)
+            echo "${optspec:0:1} ${OPTARG}" 
+            #if [ "$OPTERR" = 1 ] && [ "${optspec:0:1}" != ":" ]; then
+            if [ "$OPTERR" = 1 ]; then
+              echo -e "Unknown option --${OPTARG}\n" >&2
+              get_help
+              exit 1
+            fi
+            ;;
+        esac;;
+      h)
+        get_help
+        exit 1
+        ;;
+      *)
+        if [ "$OPTERR" = 1 ] || [ "${optspec:0:1}" = ":" ]; then
+          echo "Non-option argument: '-${OPTARG}'" >&2
+          exit 1
+        fi
+        ;;
+    esac
+  done
+  # obligatory paramas goes here  
+  if [ -z ${BINTRAY_REPO_NAME+x} ]; then
+    echo "[ERROR] Missing repository name."
+    get_help
+    exit 1
+  fi
+
+  if [ -z ${BINTRAY_PACKAGE_NAME+x} ]; then
+    echo "[ERROR] Missing package name."
+    get_help
+    exit 1
+  fi
+
+  # if not set take it from node/Cargo.toml
+  if [ -z ${PACKAGE_VERSION+x} ]; then
+    NODE_CONFIG_FILE="$RUN_DIR/node/Cargo.toml"
+    PACKAGE_VERSION="$(grep -oP "^version\s=\s\"\K(.*)\"" $NODE_CONFIG_FILE | sed -e s'/"//g')"
+  fi
+
+  echo "[INFO] PACKAGE_VERSION set to $PACKAGE_VERSION"
+}
+
+abspath() {
+  # generate absolute path from relative path
+  # $1     : relative filename
+  # return : absolute path
+  if [ -d "$1" ]; then
+    # dir
+    (cd "$1"; pwd)
+  elif [ -f "$1" ]; then
+    # file
+    if [[ $1 == */* ]]; then
+      echo "$(cd "${1%/*}"; pwd)/${1##*/}"
+    else
+      echo "$(pwd)/$1"
+    fi
+  fi
+}
+
+export RUN_DIR=$(dirname $(abspath $0))
+parse_args "$@"
+
+export CREDENTIAL_FILE="$RUN_DIR/credentials.json"
+export CREDENTIAL_FILE_TMP="$RUN_DIR/vault_output.json"
+export API_URL="https://api.bintray.com"
+export UPLOAD_DIR="$(pwd)/target/debian"
+export BINTRAY_USER='casperlabs-service'
+export BINTRAY_ORG_NAME='casperlabs'
+export BINTRAY_REPO_URL="$BINTRAY_ORG_NAME/$BINTRAY_REPO_NAME/$BINTRAY_PACKAGE_NAME"
+export CL_VAULT_URL="${CL_VAULT_HOST}/v1/sre/cicd/bintray"
+
+echo "Run dir set to: $RUN_DIR"
+echo "Repo URL: $BINTRAY_REPO_URL"
+echo "Package version set to: $PACKAGE_VERSION"
+
+# get bintray private key and passphrase
+echo "-H \"X-Vault-Token: $CL_VAULT_TOKEN\"" > ~/.curlrc
+curl -s -q -X GET $CL_VAULT_URL/credentials --output $CREDENTIAL_FILE_TMP
+if [ ! -f $CREDENTIAL_FILE_TMP ]; then
+  echo "[ERROR] Unable to fetch credentails for bintray from vault: $CL_VAULT_URL"
+  exit 1
+else
+  echo "Found bintray credentials file - $CREDENTIAL_FILE_TMP"
+  # get just the body required by bintray, strip off vault payload
+  /bin/cat $CREDENTIAL_FILE_TMP | jq -r .data > $CREDENTIAL_FILE
+fi
+
+# get bintray api key
+curl -s -q -X GET $CL_VAULT_URL/bintray_api_key --output $CREDENTIAL_FILE_TMP
+if [ ! -f $CREDENTIAL_FILE_TMP ]; then
+  echo "[ERROR] Unable to fetch api_key for bintray from vault: $CL_VAULT_URL"
+  exit 1
+else
+  echo "Found bintray credentials file - $CREDENTIAL_FILE_TMP"
+  # get just the body required by bintray, strip off vault payload
+  export BINTRAY_API_KEY=$(/bin/cat $CREDENTIAL_FILE_TMP | jq -r .data.bintray_api_key)
+fi
+
+
+if [ -d "$UPLOAD_DIR" ]; then
+  cd $UPLOAD_DIR
+else
+  echo "[ERROR] Not such dir: $UPLOAD_DIR"
+  exit 1
+fi
+
+# allow overwrite version for test repo
+if [ "$BINTRAY_REPO_NAME" == "casper-debian-tests" ]; then
+  echo "[INFO] Setting override=1 for the test repo: $BINTRAY_REPO_NAME"
+  export BINTRAY_UPLOAD_URL="$API_URL/content/$BINTRAY_REPO_URL/${PACKAGE_VERSION}/{}?override=1"
+else
+  export BINTRAY_UPLOAD_URL="$API_URL/content/$BINTRAY_REPO_URL/${PACKAGE_VERSION}/{}"
+fi
+
+echo "Uploading file to bintray:${PACKAGE_VERSION} ..."
+echo -e "\nDEBIAN" && find . -maxdepth 1 -type f -iregex ".*casper-node.*\\.deb" -printf "%f\n" | xargs -I {} sh -c "echo Attempting to upload [{}] && curl -T {} -u$BINTRAY_USER:$BINTRAY_API_KEY $BINTRAY_UPLOAD_URL && echo"
+
+sleep 5 && echo -e "\nPublishing CL Packages on bintray..."
+curl -s -X POST -u$BINTRAY_USER:$BINTRAY_API_KEY $API_URL/content/$BINTRAY_REPO_URL/${PACKAGE_VERSION}/publish
+
+sleep 5 && echo -e "\nGPG Signing CL Packages on bintray..."
+curl -s -X POST -u$BINTRAY_USER:$BINTRAY_API_KEY -H "Content-Type: application/json" --data "@$CREDENTIAL_FILE" $API_URL/gpg/$BINTRAY_REPO_URL/versions/${PACKAGE_VERSION}
+
+sleep 5 && echo -e "\nPublishing GPG Signatures on bintray..."
+curl -s -X POST -u$BINTRAY_USER:$BINTRAY_API_KEY $API_URL/content/$BINTRAY_REPO_URL/${PACKAGE_VERSION}/publish
+
+sleep 5 && echo -e "\nCalculating repo metadata on bintray..."
+curl -s -X POST -u$BINTRAY_USER:$BINTRAY_API_KEY -H "Content-Type: application/json" --data "@$CREDENTIAL_FILE" $API_URL/calc_metadata/$BINTRAY_REPO_URL/versions/${PACKAGE_VERSION}
+
+echo -e "\n Fetch meta data for uploaded files"
+TEMP_DEB_FILE=uploaded_contents_debian_${PACKAGE_VERSION}.json
+curl -s -X GET -u$BINTRAY_USER:$BINTRAY_API_KEY -H "Content-Type: application/json" $API_URL/packages/$BINTRAY_REPO_URL/files?include_unpublished=1 > $TEMP_DEB_FILE
+
+# checking
+DEB_FILE_NAME=$(cat $TEMP_DEB_FILE | jq -r 'nth(1; .[] | select (.version == "'${PACKAGE_VERSION}'") ) | .path' )
+
+DEB_ASC_FILE_NAME=$(cat $TEMP_DEB_FILE |  jq -r 'nth(0; .[] | select (.version == "'${PACKAGE_VERSION}'") ) | .path' )
+
+if [[ "$DEB_FILE_NAME" =~ casper-node.*.deb$ ]]; then
+  echo "Found $DEB_FILE_NAME on bintray";
+else
+  echo "[ERRROR] Unable to find uploaded packages on bintray - missing $DEB_FILE_NAME"
+  exit 1
+fi
+
+if [[ "$DEB_ASC_FILE_NAME" =~ casper-node.*.deb.asc$ ]]; then
+  echo "Found $DEB_ASC_FILE_NAME on bintray";
+else
+  echo "[ERRROR] Unable to find uploaded packages on bintray - missing $DEB_ASC_FILE_NAME"
+  exit 1
+fi


### PR DESCRIPTION
- build deb package for PR and pushes to master, staging, trying, release-*
- push deb package to test repo for above triggers 
- push deb package to prod repo for tag event 
- create draft release on github for tag event 
- support for vault - getting bintray credentials from internal vault 
- support for dynamic revision based on DRONE_BUILD_NR
- CICD tests has been done here : https://drone-auto.casperlabs.io/CasperLabs/test-casper-node-cicd