### PR TITLE
NO-TICK: add client contracts target in Makefile (and to deb)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ build-contracts-rs: \
 .PHONY: build-system-contracts
 build-system-contracts: $(SYSTEM_CONTRACTS)
 
+.PHONY: build-client-contracts
+build-client-contracts: $(CLIENT_CONTRACTS)
+
 build-contract-as/%:
 	cd $* && $(NPM) run asbuild
 
@@ -185,7 +188,7 @@ clean:
 	$(CARGO) clean
 
 .PHONY: build-for-packaging
-build-for-packaging: build-system-contracts
+build-for-packaging: build-system-contracts build-client-contracts
 	$(CARGO) build --release
 
 .PHONY: deb


### PR DESCRIPTION
- client contracts build is a missing target in Makefile atm
- Also, since we're shipping casper-client in `.deb` atm, might as well add that to `make deb`

Or you could just `make build-client-contracts -j`