### PR TITLE
NDRS-482: Falls back to Linear chain storage if block not present in `BlockExecutor::parent_map`.

### DIFF
--- a/node/src/components/api_server/rpcs/chain.rs
+++ b/node/src/components/api_server/rpcs/chain.rs
@@ -113,7 +113,7 @@ impl RpcWithOptionalParamsExt for GetGlobalStateHash {
             // Return the result.
             let result = Self::ResponseResult {
                 api_version: CLIENT_API_VERSION.clone(),
-                global_state_hash: maybe_block.map(|block| *block.global_state_hash()),
+                global_state_hash: maybe_block.map(|block| *block.post_state_hash()),
             };
             Ok(response_builder.success(result)?)
         }

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -90,8 +90,13 @@ impl BlockExecutor {
         }
     }
 
-    pub(crate) fn with_parent_map(mut self, linear_chain: Vec<Block>) -> Self {
-        let parent_map = linear_chain
+    /// Adds the "parent map" to the instance of `BlockExecutor`.
+    ///
+    /// When transitioning from `joiner` to `validator` states we need
+    /// to carry over the last finalized block so that the next blocks in the linear chain
+    /// have the state to build on.
+    pub(crate) fn with_parent_map(mut self, lfb: Option<Block>) -> Self {
+        let parent_map = lfb
             .into_iter()
             .map(|block| {
                 (
@@ -227,9 +232,8 @@ impl BlockExecutor {
             self.execute_next_deploy_or_create_block(effect_builder, state)
         } else {
             let height = finalized_block.height();
-            println!("No pre-state hash for height {}", height);
+            debug!("No pre-state hash for height {}", height);
             // The parent block has not been executed yet; delay handling.
-            let height = finalized_block.height();
             self.exec_queue.insert(height, (finalized_block, deploys));
             Effects::new()
         }

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -103,7 +103,7 @@ impl BlockExecutor {
                     block.height(),
                     ExecutedBlockSummary {
                         hash: *block.hash(),
-                        post_state_hash: *block.global_state_hash(),
+                        post_state_hash: *block.post_state_hash(),
                         accumulated_seed: block.header().accumulated_seed(),
                     },
                 )

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -265,7 +265,7 @@ impl BlockExecutor {
         match parent {
             None => {
                 let height = finalized_block.height();
-                debug!("No pre-state hash for height {}", height);
+                debug!("no pre-state hash for height {}", height);
                 // The parent block has not been executed yet; delay handling.
                 self.exec_queue.insert(height, (finalized_block, deploys));
                 Effects::new()

--- a/node/src/components/block_executor/event.rs
+++ b/node/src/components/block_executor/event.rs
@@ -1,7 +1,7 @@
 use crate::{
     crypto::hash::Digest,
     effect::requests::BlockExecutorRequest,
-    types::{json_compatibility::ExecutionResult, Deploy, DeployHash, FinalizedBlock},
+    types::{json_compatibility::ExecutionResult, BlockHash, Deploy, DeployHash, FinalizedBlock},
 };
 use casper_execution_engine::{
     core::{
@@ -28,6 +28,15 @@ pub enum Event {
         finalized_block: FinalizedBlock,
         /// Contents of deploys. All deploys are expected to be present in the storage component.
         deploys: VecDeque<Deploy>,
+    },
+    GetParentResult {
+        /// The block that needs the deploys for execution.
+        finalized_block: FinalizedBlock,
+        /// Contents of deploys. All deploys are expected to be present in the storage component.
+        deploys: VecDeque<Deploy>,
+        /// Parent of the newly finalized block.
+        /// If it's the first block after Genesis then `parent` is `None`.
+        parent: Option<(BlockHash, Digest, Digest)>,
     },
     /// The result of executing a single deploy.
     DeployExecutionResult {
@@ -66,6 +75,16 @@ impl Display for Event {
                 "fetch deploys for finalized block with height {} has {} deploys",
                 finalized_block.height(),
                 deploys.len()
+            ),
+            Event::GetParentResult {
+                finalized_block,
+                parent,
+                ..
+            } => write!(
+                f,
+                "found_parent={} for finalized block with height {}",
+                parent.is_some(),
+                finalized_block.height()
             ),
             Event::DeployExecutionResult {
                 state,

--- a/node/src/components/block_executor/event.rs
+++ b/node/src/components/block_executor/event.rs
@@ -150,7 +150,7 @@ pub struct State {
     pub finalized_block: FinalizedBlock,
     /// Deploys which have still to be executed.
     pub remaining_deploys: VecDeque<Deploy>,
-    /// A collection of result of executing the deploys.
+    /// A collection of results of executing the deploys.
     pub execution_results: HashMap<DeployHash, ExecutionResult>,
     /// Current pre-state hash of global storage.  Is initialized with the parent block's
     /// post-state hash, and is updated after each commit.

--- a/node/src/components/block_executor/event.rs
+++ b/node/src/components/block_executor/event.rs
@@ -1,0 +1,139 @@
+use crate::{
+    crypto::hash::Digest,
+    effect::requests::BlockExecutorRequest,
+    types::{json_compatibility::ExecutionResult, Deploy, DeployHash, FinalizedBlock},
+};
+use casper_execution_engine::{
+    core::{
+        engine_state,
+        engine_state::{step::StepResult, ExecutionResults, RootNotFound},
+    },
+    storage::global_state::CommitResult,
+};
+use derive_more::From;
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::Display,
+};
+
+/// Block executor component event.
+#[derive(Debug, From)]
+pub enum Event {
+    /// A request made of the Block executor component.
+    #[from]
+    Request(BlockExecutorRequest),
+    /// Received all requested deploys.
+    GetDeploysResult {
+        /// The block that needs the deploys for execution.
+        finalized_block: FinalizedBlock,
+        /// Contents of deploys. All deploys are expected to be present in the storage component.
+        deploys: VecDeque<Deploy>,
+    },
+    /// The result of executing a single deploy.
+    DeployExecutionResult {
+        /// State of this request.
+        state: Box<State>,
+        /// The ID of the deploy currently being executed.
+        deploy_hash: DeployHash,
+        /// Result of deploy execution.
+        result: Result<ExecutionResults, RootNotFound>,
+    },
+    /// The result of committing a single set of transforms after executing a single deploy.
+    CommitExecutionEffects {
+        /// State of this request.
+        state: Box<State>,
+        /// Commit result for execution request.
+        commit_result: Result<CommitResult, engine_state::Error>,
+    },
+    /// The result of running the step on a switch block.
+    RunStepResult {
+        /// State of this request.
+        state: Box<State>,
+        /// The result.
+        result: Result<StepResult, engine_state::Error>,
+    },
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Event::Request(req) => write!(f, "{}", req),
+            Event::GetDeploysResult {
+                finalized_block,
+                deploys,
+            } => write!(
+                f,
+                "fetch deploys for finalized block with height {} has {} deploys",
+                finalized_block.height(),
+                deploys.len()
+            ),
+            Event::DeployExecutionResult {
+                state,
+                deploy_hash,
+                result: Ok(_),
+            } => write!(
+                f,
+                "execution result for {} of finalized block with height {} with \
+                pre-state hash {}: success",
+                deploy_hash,
+                state.finalized_block.height(),
+                state.pre_state_hash
+            ),
+            Event::DeployExecutionResult {
+                state,
+                deploy_hash,
+                result: Err(_),
+            } => write!(
+                f,
+                "execution result for {} of finalized block with height {} with \
+                pre-state hash {}: root not found",
+                deploy_hash,
+                state.finalized_block.height(),
+                state.pre_state_hash
+            ),
+            Event::CommitExecutionEffects {
+                state,
+                commit_result: Ok(CommitResult::Success { state_root, .. }),
+            } => write!(
+                f,
+                "commit execution effects of finalized block with height {} with \
+                pre-state hash {}: success with post-state hash {}",
+                state.finalized_block.height(),
+                state.pre_state_hash,
+                state_root,
+            ),
+            Event::CommitExecutionEffects {
+                state,
+                commit_result,
+            } => write!(
+                f,
+                "commit execution effects of finalized block with height {} with \
+                pre-state hash {}: failed {:?}",
+                state.finalized_block.height(),
+                state.pre_state_hash,
+                commit_result,
+            ),
+            Event::RunStepResult { state, result } => write!(
+                f,
+                "result of running the step after finalized block with height {} \
+                    with pre-state hash {}: {:?}",
+                state.finalized_block.height(),
+                state.pre_state_hash,
+                result
+            ),
+        }
+    }
+}
+
+/// Holds the state of an ongoing execute-commit cycle spawned from a given `Event::Request`.
+#[derive(Debug)]
+pub struct State {
+    pub finalized_block: FinalizedBlock,
+    /// Deploys which have still to be executed.
+    pub remaining_deploys: VecDeque<Deploy>,
+    /// A collection of result of executing the deploys.
+    pub execution_results: HashMap<DeployHash, ExecutionResult>,
+    /// Current pre-state hash of global storage.  Is initialized with the parent block's
+    /// post-state hash, and is updated after each commit.
+    pub pre_state_hash: Digest,
+}

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -101,6 +101,7 @@ use crate::{
         storage::{DeployHashes, DeployMetadata, DeployResults, StorageType, Value},
     },
     crypto::{asymmetric_key::Signature, hash::Digest},
+    effect::requests::LinearChainRequest,
     reactor::{EventQueueHandle, QueueKind},
     types::{
         json_compatibility::ExecutionResult, Block, BlockByHeight, BlockHash, BlockHeader,
@@ -380,6 +381,18 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| MetricsRequest::RenderNodeMetricsText { responder },
             QueueKind::Api,
+        )
+        .await
+    }
+
+    /// Retrieves block at `height` from the Linear Chain component.
+    pub(crate) async fn get_block_at_height_local<I>(self, height: u64) -> Option<Block>
+    where
+        REv: From<LinearChainRequest<I>>,
+    {
+        self.make_request(
+            |responder| LinearChainRequest::BlockAtHeightLocal(height, responder),
+            QueueKind::Regular,
         )
         .await
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -40,8 +40,8 @@ use crate::{
     },
     crypto::{asymmetric_key::Signature, hash::Digest},
     types::{
-        json_compatibility::ExecutionResult, Block as LinearBlock, BlockHash, BlockHeader, Deploy,
-        DeployHash, FinalizedBlock, Item, ProtoBlockHash, StatusFeed, Timestamp,
+        json_compatibility::ExecutionResult, Block as LinearBlock, Block, BlockHash, BlockHeader,
+        Deploy, DeployHash, FinalizedBlock, Item, ProtoBlockHash, StatusFeed, Timestamp,
     },
     utils::DisplayIter,
     Chainspec,
@@ -637,6 +637,9 @@ pub enum LinearChainRequest<I> {
     BlockRequest(BlockHash, I),
     /// Request for a linear chain block at height.
     BlockAtHeight(BlockHeight, I),
+    /// Local request for a linear chain block at height.
+    /// TODO: Unify `BlockAtHeight` and `BlockAtHeightLocal`.
+    BlockAtHeightLocal(BlockHeight, Responder<Option<Block>>),
 }
 
 impl<I: Display> Display for LinearChainRequest<I> {
@@ -647,6 +650,9 @@ impl<I: Display> Display for LinearChainRequest<I> {
             }
             LinearChainRequest::BlockAtHeight(height, sender) => {
                 write!(f, "block request for {} from {}", height, sender)
+            }
+            LinearChainRequest::BlockAtHeightLocal(height, _) => {
+                write!(f, "local request for block at height {}", height)
             }
         }
     }

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -352,8 +352,8 @@ impl reactor::Reactor for Reactor {
         let genesis_post_state_hash = chainspec_loader
             .genesis_post_state_hash()
             .expect("should have post state hash");
-        let block_executor =
-            BlockExecutor::new(genesis_post_state_hash).with_parent_map(linear_chain);
+        let block_executor = BlockExecutor::new(genesis_post_state_hash)
+            .with_parent_map(linear_chain.last().cloned());
         let proto_block_validator = BlockValidator::new();
         let linear_chain = LinearChain::new();
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -570,7 +570,7 @@ impl Block {
         &self.hash
     }
 
-    pub(crate) fn global_state_hash(&self) -> &Digest {
+    pub(crate) fn post_state_hash(&self) -> &Digest {
         self.header.global_state_hash()
     }
 


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-482

Instead of removing `parent_map` from the `BlockExecutor` entirely, treat it as a cache. If entry is not present in the cache, make a request to the storage. If the key not present in the storage, enqueue the execution for later when the block's parent gets finalized.

Instead of initializing `BlockExecutor::parent_map` with the whole linear chain, built during the joining phase, initialize it only with the last finalized block. 

`parent_map` cannot grow indefinitely and cause memory issues b/c its entries are removed in the `create_block` method.