### PR TITLE
NDRS-514: Fix a panic on get_validators

### DIFF
--- a/run-dev.sh
+++ b/run-dev.sh
@@ -9,10 +9,13 @@ CHAINSPEC=$(mktemp -t chainspec_XXXXXXXX --suffix .toml)
 TRUSTED_HASH="${TRUSTED_HASH:-}"
 
 # Generate a genesis timestamp 30 seconds into the future, unless explicity given a different one.
-TIMESTAMP=$(python3 -c 'from datetime import datetime, timedelta; print((datetime.utcnow() + timedelta(seconds=20)).isoformat("T") + "Z")') 
+TIMESTAMP=$(python3 -c 'from datetime import datetime, timedelta; print((datetime.utcnow() + timedelta(seconds=20)).isoformat("T") + "Z")')
 TIMESTAMP=${GENESIS_TIMESTAMP:-$TIMESTAMP}
 
 echo "GENESIS_TIMESTAMP=${TIMESTAMP}"
+
+# Build the contracts
+make build-contracts-rs
 
 # Build the node first, so that `sleep` in the loop has an effect.
 cargo build -p casper-node


### PR DESCRIPTION
The failure was caused by outdated contract binaries. This fix adds a contract building step to `run-dev.sh` in order to make sure that the contracts are always up to date.