### PR TITLE
NDRS-516: system contract hash capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-contract-hashes"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/grpc/tests/src/test/deploy/context_association.rs
+++ b/grpc/tests/src/test/deploy/context_association.rs
@@ -1,0 +1,72 @@
+use casper_engine_test_support::{
+    internal::{
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_KEY,
+        DEFAULT_RUN_GENESIS_REQUEST,
+    },
+    DEFAULT_ACCOUNT_ADDR,
+};
+
+use casper_types::{
+    runtime_args,
+    system_contract_type::{AUCTION, MINT, PROOF_OF_STAKE},
+    RuntimeArgs, U512,
+};
+
+const SYSTEM_CONTRACT_HASHES_WASM: &str = "system_contract_hashes.wasm";
+const ARG_AMOUNT: &str = "amount";
+
+#[ignore]
+#[test]
+fn should_put_system_contract_hashes_to_account_context() {
+    let payment_purse_amount = U512::from(10_000_000);
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    let request = {
+        let deploy = DeployItemBuilder::new()
+            .with_address(*DEFAULT_ACCOUNT_ADDR)
+            .with_session_code(SYSTEM_CONTRACT_HASHES_WASM, runtime_args! {})
+            .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => payment_purse_amount})
+            .with_authorization_keys(&[*DEFAULT_ACCOUNT_KEY])
+            .with_deploy_hash([1; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder
+        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .exec(request)
+        .expect_success()
+        .commit();
+
+    let account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("account should exist");
+
+    let named_keys = account.named_keys();
+
+    assert!(named_keys.contains_key(MINT), "should contain mint");
+    assert!(
+        named_keys.contains_key(PROOF_OF_STAKE),
+        "should contain proof of stake"
+    );
+    assert!(named_keys.contains_key(AUCTION), "should contain auction");
+
+    assert_eq!(
+        named_keys[MINT].into_hash().expect("should be a hash"),
+        builder.get_mint_contract_hash(),
+        "mint_contract_hash should match"
+    );
+    assert_eq!(
+        named_keys[PROOF_OF_STAKE]
+            .into_hash()
+            .expect("should be a hash"),
+        builder.get_pos_contract_hash(),
+        "pos_contract_hash should match"
+    );
+    assert_eq!(
+        named_keys[AUCTION].into_hash().expect("should be a hash"),
+        builder.get_auction_contract_hash(),
+        "auction_contract_hash should match"
+    );
+}

--- a/grpc/tests/src/test/deploy/mod.rs
+++ b/grpc/tests/src/test/deploy/mod.rs
@@ -1,3 +1,4 @@
+mod context_association;
 mod non_standard_payment;
 mod preconditions;
 mod stored_contracts;

--- a/smart_contracts/contracts/test/system-contract-hashes/Cargo.toml
+++ b/smart_contracts/contracts/test/system-contract-hashes/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "system-contract-hashes"
+version = "0.1.0"
+authors = ["Ed Hastings <ehastings@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "system_contract_hashes"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/system-contract-hashes/src/main.rs
+++ b/smart_contracts/contracts/test/system-contract-hashes/src/main.rs
@@ -1,0 +1,12 @@
+#![no_std]
+#![no_main]
+
+use casper_contract::contract_api::{runtime, system};
+use casper_types::system_contract_type::{AUCTION, MINT, PROOF_OF_STAKE};
+
+#[no_mangle]
+pub extern "C" fn call() {
+    runtime::put_key(MINT, system::get_mint().into());
+    runtime::put_key(PROOF_OF_STAKE, system::get_proof_of_stake().into());
+    runtime::put_key(AUCTION, system::get_auction().into());
+}

--- a/types/src/system_contract_type.rs
+++ b/types/src/system_contract_type.rs
@@ -24,13 +24,13 @@ pub enum SystemContractType {
 }
 
 /// Name of mint system contract
-const MINT: &str = "mint";
+pub const MINT: &str = "mint";
 /// Name of proof of stake system contract
 pub const PROOF_OF_STAKE: &str = "proof of stake";
 /// Name of standard payment system contract
 const STANDARD_PAYMENT: &str = "standard payment";
 /// Name of auction system contract
-const AUCTION: &str = "auction";
+pub const AUCTION: &str = "auction";
 
 impl From<SystemContractType> for u32 {
     fn from(system_contract_type: SystemContractType) -> u32 {


### PR DESCRIPTION
This PR offers a temporary workaround to allow the contract hashes for mint, pos, and auction to be discoverable on charlie testnet, allowing specific interactions with query in the client such as inspecting bid state.

https://casperlabs.atlassian.net/browse/NDRS-516