### PR TITLE
NDRS-496 performance improvements

### DIFF
--- a/node/src/components/gossiper/gossip_table.rs
+++ b/node/src/components/gossiper/gossip_table.rs
@@ -103,17 +103,53 @@ impl State {
     }
 }
 
+#[derive(Debug)]
+struct Timeouts<T> {
+    values: Vec<(Instant, T)>,
+}
+
+impl<T> Timeouts<T> {
+    fn new() -> Self {
+        Timeouts { values: Vec::new() }
+    }
+
+    fn push(&mut self, timeout: Instant, data_id: T) {
+        self.values.push((timeout, data_id));
+    }
+
+    fn purge(&mut self, now: &Instant) -> impl Iterator<Item = T> + '_ {
+        // The values are sorted by timeout.  Locate the index of the first non-expired one.
+        let split_index = match self
+            .values
+            .binary_search_by(|(timeout, _data_id)| timeout.cmp(now))
+        {
+            Ok(index) => index,
+            Err(index) => index,
+        };
+
+        // Drain and return the expired IDs.
+        self.values
+            .drain(..split_index)
+            .map(|(_timeout, data_id)| data_id)
+    }
+}
+
 #[derive(DataSize, Debug)]
 pub(crate) struct GossipTable<T> {
     /// Data IDs for which gossiping is still ongoing.
     current: HashMap<T, State>,
-    /// Data IDs for which gossiping is complete.  The map's values are the times after which the
-    /// relevant entries can be removed.
-    finished: HashMap<T, Instant>,
+    /// Data IDs for which gossiping is complete.
+    finished: HashSet<T>,
+    /// Timeouts for removal of items from the `finished` cache.
+    #[data_size(skip)]
+    finished_timeouts: Timeouts<T>,
     /// Data IDs for which gossiping has been paused (likely due to detecting that the data was not
     /// correct as per our current knowledge).  Such data could later be decided as still requiring
     /// to be gossiped, so we retain the `State` part here in order to resume gossiping.
-    paused: HashMap<T, (State, Instant)>,
+    paused: HashMap<T, State>,
+    /// Timeouts for removal of items from the `paused` cache.
+    #[data_size(skip)]
+    paused_timeouts: Timeouts<T>,
     /// See `Config::infection_target`.
     infection_target: usize,
     /// Derived from `Config::saturation_limit_percent` - we gossip data while the number of
@@ -147,8 +183,10 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
             / (100 - usize::from(config.saturation_limit_percent()));
         GossipTable {
             current: HashMap::new(),
-            finished: HashMap::new(),
+            finished: HashSet::new(),
+            finished_timeouts: Timeouts::new(),
             paused: HashMap::new(),
+            paused_timeouts: Timeouts::new(),
             infection_target: usize::from(config.infection_target()),
             holders_limit,
             finished_entry_duration: Duration::from_secs(config.finished_entry_duration_secs()),
@@ -166,11 +204,11 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
     pub(crate) fn new_partial_data(&mut self, data_id: &T, holder: NodeId) -> GossipAction {
         self.purge_finished();
 
-        if self.finished.contains_key(data_id) {
+        if self.finished.contains(data_id) {
             return GossipAction::Noop;
         }
 
-        if let Some((state, _timeout)) = self.paused.get_mut(data_id) {
+        if let Some(state) = self.paused.get_mut(data_id) {
             let _ = state.holders.insert(holder);
             return GossipAction::Noop;
         }
@@ -206,7 +244,7 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
     ) -> Option<ShouldGossip> {
         self.purge_finished();
 
-        if self.finished.contains_key(data_id) {
+        if self.finished.contains(data_id) {
             return None;
         }
 
@@ -215,7 +253,7 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
             state.held_by_us = true;
         };
 
-        if let Some((state, _timeout)) = self.paused.get_mut(data_id) {
+        if let Some(state) = self.paused.get_mut(data_id) {
             update(state);
             return None;
         }
@@ -302,11 +340,12 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
         if is_finished {
             let _ = self.current.remove(data_id);
             let timeout = Instant::now() + self.finished_entry_duration;
-            let _ = self.finished.insert(*data_id, timeout);
+            let _ = self.finished.insert(*data_id);
+            let _ = self.finished_timeouts.push(timeout, *data_id);
             return GossipAction::Noop;
         }
 
-        let is_finished = if let Some((state, _timeout)) = self.paused.get_mut(data_id) {
+        let is_finished = if let Some(state) = self.paused.get_mut(data_id) {
             match update(state) {
                 Some(is_finished) => is_finished,
                 None => return GossipAction::Noop,
@@ -318,7 +357,8 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
         if is_finished {
             let _ = self.paused.remove(data_id);
             let timeout = Instant::now() + self.finished_entry_duration;
-            let _ = self.finished.insert(*data_id, timeout);
+            let _ = self.finished.insert(*data_id);
+            let _ = self.finished_timeouts.push(timeout, *data_id);
         }
 
         GossipAction::Noop
@@ -371,7 +411,7 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
             return action;
         }
 
-        if let Some((state, _timeout)) = self.paused.get_mut(data_id) {
+        if let Some(state) = self.paused.get_mut(data_id) {
             if !state.held_by_us {
                 let _ = state.holders.remove(&peer);
             }
@@ -386,7 +426,8 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
         if let Some(mut state) = self.current.remove(data_id) {
             state.in_flight_count = 0;
             let timeout = Instant::now() + self.finished_entry_duration;
-            let _ = self.paused.insert(*data_id, (state, timeout));
+            let _ = self.paused.insert(*data_id, state);
+            let _ = self.paused_timeouts.push(timeout, *data_id);
         }
     }
 
@@ -396,7 +437,7 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
     // TODO - remove lint relaxation once the method is used.
     #[cfg(test)]
     pub(crate) fn resume(&mut self, data_id: &T) -> Result<GossipAction, Error> {
-        let (mut state, _timeout) = self.paused.remove(data_id).ok_or(Error::NotPaused)?;
+        let mut state = self.paused.remove(data_id).ok_or(Error::NotPaused)?;
         let is_new = !state.held_by_us;
         let action = state.action(self.infection_target, self.holders_limit, is_new);
         let _ = self.current.insert(*data_id, state);
@@ -406,16 +447,14 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
     /// Retains only those finished entries which still haven't timed out.
     fn purge_finished(&mut self) {
         let now = Instant::now();
-        self.finished = self
-            .finished
-            .drain()
-            .filter(|(_, timeout)| *timeout > now)
-            .collect();
-        self.paused = self
-            .paused
-            .drain()
-            .filter(|(_, (_, timeout))| *timeout > now)
-            .collect();
+
+        for expired_finished in self.finished_timeouts.purge(&now) {
+            let _ = self.finished.remove(&expired_finished);
+        }
+
+        for expired_paused in self.paused_timeouts.purge(&now) {
+            let _ = self.paused.remove(&expired_paused);
+        }
     }
 }
 
@@ -424,9 +463,10 @@ mod tests {
     use std::{collections::BTreeSet, iter};
 
     use rand::Rng;
+    use test::Bencher;
 
     use super::{super::config::DEFAULT_FINISHED_ENTRY_DURATION_SECS, *};
-    use crate::{testing::TestRng, utils::DisplayIter};
+    use crate::{crypto::hash::Digest, testing::TestRng, types::DeployHash, utils::DisplayIter};
 
     const EXPECTED_DEFAULT_INFECTION_TARGET: usize = 3;
     const EXPECTED_DEFAULT_HOLDERS_LIMIT: usize = 15;
@@ -442,12 +482,7 @@ mod tests {
         let actual: BTreeSet<_> = gossip_table
             .current
             .get(data_id)
-            .or_else(|| {
-                gossip_table
-                    .paused
-                    .get(data_id)
-                    .map(|(state, _timeout)| state)
-            })
+            .or_else(|| gossip_table.paused.get(data_id))
             .map_or_else(BTreeSet::new, |state| state.holders.iter().collect());
         assert!(
             expected == actual,
@@ -516,7 +551,7 @@ mod tests {
 
         // Time the finished data out, then check same partial data causes `GetRemainder` to be
         // returned as per a completely new entry.
-        Instant::advance_time(DEFAULT_FINISHED_ENTRY_DURATION_SECS * 1_000);
+        Instant::advance_time(DEFAULT_FINISHED_ENTRY_DURATION_SECS * 1_000 + 1);
         let action = gossip_table.new_partial_data(&data_id, node_ids[0]);
         let expected = GossipAction::GetRemainder {
             holder: node_ids[0],
@@ -610,7 +645,7 @@ mod tests {
 
         // Time the finished data out, then check same complete data causes `ShouldGossip` to be
         // returned as per a completely new entry.
-        Instant::advance_time(DEFAULT_FINISHED_ENTRY_DURATION_SECS * 1_000);
+        Instant::advance_time(DEFAULT_FINISHED_ENTRY_DURATION_SECS * 1_000 + 1);
         let action = gossip_table.new_complete_data(&data_id, Some(node_ids[0]));
         let expected = Some(ShouldGossip {
             count: EXPECTED_DEFAULT_INFECTION_TARGET,
@@ -636,7 +671,7 @@ mod tests {
         for node_id in node_ids.iter().take(limit) {
             let action = gossip_table.we_infected(&data_id, *node_id);
             assert_eq!(GossipAction::Noop, action);
-            assert!(!gossip_table.finished.contains_key(&data_id));
+            assert!(!gossip_table.finished.contains(&data_id));
         }
 
         // Check recording an infection from an already-recorded infectee doesn't cause us to stop
@@ -648,12 +683,12 @@ mod tests {
             is_already_held: true,
         });
         assert_eq!(expected, action);
-        assert!(!gossip_table.finished.contains_key(&data_id));
+        assert!(!gossip_table.finished.contains(&data_id));
 
         // Check third new infection does cause us to stop gossiping.
         let action = gossip_table.we_infected(&data_id, node_ids[limit]);
         assert_eq!(GossipAction::Noop, action);
-        assert!(gossip_table.finished.contains_key(&data_id));
+        assert!(gossip_table.finished.contains(&data_id));
     }
 
     #[test]
@@ -877,12 +912,12 @@ mod tests {
         for node_id in &node_ids[0..EXPECTED_DEFAULT_INFECTION_TARGET] {
             let _ = gossip_table.we_infected(&data_id, *node_id);
         }
-        assert!(gossip_table.finished.contains_key(&data_id));
+        assert!(gossip_table.finished.contains(&data_id));
 
         // Time the finished data out and check it has been purged.
-        Instant::advance_time(DEFAULT_FINISHED_ENTRY_DURATION_SECS * 1_000);
+        Instant::advance_time(DEFAULT_FINISHED_ENTRY_DURATION_SECS * 1_000 + 1);
         gossip_table.purge_finished();
-        assert!(!gossip_table.finished.contains_key(&data_id));
+        assert!(!gossip_table.finished.contains(&data_id));
 
         // Add new complete data and pause.
         let _ = gossip_table.new_complete_data(&data_id, None);
@@ -890,8 +925,31 @@ mod tests {
         assert!(gossip_table.paused.contains_key(&data_id));
 
         // Time the paused data out and check it has been purged.
-        Instant::advance_time(DEFAULT_FINISHED_ENTRY_DURATION_SECS * 1_000);
+        Instant::advance_time(DEFAULT_FINISHED_ENTRY_DURATION_SECS * 1_000 + 1);
         gossip_table.purge_finished();
         assert!(!gossip_table.paused.contains_key(&data_id));
+    }
+
+    #[bench]
+    fn benchmark_purging(bencher: &mut Bencher) {
+        const ENTRY_COUNT: usize = 10_000;
+        let mut rng = TestRng::new();
+        let node_ids = random_node_ids(&mut rng);
+        let deploy_ids = iter::repeat_with(|| DeployHash::new(Digest::random(&mut rng)))
+            .take(ENTRY_COUNT)
+            .collect::<Vec<_>>();
+
+        let mut gossip_table = GossipTable::new(Config::default());
+
+        // Add new complete data and finish via infection limit.
+        for deploy_id in &deploy_ids {
+            let _ = gossip_table.new_complete_data(deploy_id, None);
+            for node_id in &node_ids[0..EXPECTED_DEFAULT_INFECTION_TARGET] {
+                let _ = gossip_table.we_infected(deploy_id, *node_id);
+            }
+            assert!(gossip_table.finished.contains(&deploy_id));
+        }
+
+        bencher.iter(|| gossip_table.purge_finished());
     }
 }

--- a/node/src/components/storage/lmdb_block_height_store.rs
+++ b/node/src/components/storage/lmdb_block_height_store.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use super::{BlockHeightStore, Error, Result};
+use crate::MAX_THREAD_COUNT;
 
 /// LMDB version of a store.
 #[derive(Debug)]
@@ -25,6 +26,8 @@ impl LmdbBlockHeightStore {
         let env = Environment::new()
             .set_flags(EnvironmentFlags::NO_SUB_DIR)
             .set_map_size(max_size)
+            // to avoid panic on excessive read-only transactions
+            .set_max_readers(MAX_THREAD_COUNT as u32)
             .open(db_path.as_ref())?;
         let db = env.create_db(None, DatabaseFlags::INTEGER_KEY)?;
 

--- a/node/src/components/storage/lmdb_chainspec_store.rs
+++ b/node/src/components/storage/lmdb_chainspec_store.rs
@@ -5,7 +5,7 @@ use semver::Version;
 use tracing::info;
 
 use super::{ChainspecStore, Error, Result};
-use crate::Chainspec;
+use crate::{Chainspec, MAX_THREAD_COUNT};
 
 /// LMDB version of a store.
 #[derive(Debug)]
@@ -19,6 +19,8 @@ impl LmdbChainspecStore {
         let env = Environment::new()
             .set_flags(EnvironmentFlags::NO_SUB_DIR)
             .set_map_size(max_size)
+            // to avoid panic on excessive read-only transactions
+            .set_max_readers(MAX_THREAD_COUNT as u32)
             .open(db_path.as_ref())?;
         let db = env.create_db(None, DatabaseFlags::empty())?;
         info!("opened DB at {}", db_path.as_ref().display());

--- a/node/src/components/storage/lmdb_store.rs
+++ b/node/src/components/storage/lmdb_store.rs
@@ -8,7 +8,7 @@ use smallvec::smallvec;
 use tracing::info;
 
 use super::{DeployMetadata, DeployStore, Error, Multiple, Result, Store, Value};
-use crate::types::json_compatibility::ExecutionResult;
+use crate::{types::json_compatibility::ExecutionResult, MAX_THREAD_COUNT};
 
 /// Used to namespace metadata associated with stored values.
 #[repr(u8)]
@@ -34,6 +34,8 @@ impl<V: Value, M: Default + Send + Sync> LmdbStore<V, M> {
         let env = Environment::new()
             .set_flags(EnvironmentFlags::NO_SUB_DIR)
             .set_map_size(max_size)
+            // to avoid panic on excessive read-only transactions
+            .set_max_readers(MAX_THREAD_COUNT as u32)
             .open(db_path.as_ref())?;
         let db = env.create_db(None, DatabaseFlags::empty())?;
         info!("opened DB at {}", db_path.as_ref().display());

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -51,6 +51,9 @@ pub use components::{
 };
 pub use utils::OS_PAGE_SIZE;
 
+/// The maximum thread count which should be spawned by the tokio runtime.
+pub const MAX_THREAD_COUNT: usize = 512;
+
 lazy_static! {
     /// Version string for the compiled node. Filled in at build time, output allocated at runtime.
     pub static ref VERSION_STRING: String = {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -20,6 +20,9 @@
     trivial_numeric_casts,
     unused_qualifications
 )]
+#![feature(test)]
+
+extern crate test;
 
 pub mod components;
 pub mod crypto;


### PR DESCRIPTION
This PR implements some performance improvements based on recent discovery of sub-optimal logic.

It adjusts the gossiper to better follow the intent of the termination condition: now gossiping will actually stop once the desired target infection number has been reached, rather than almost double that as per the existing implementation.

The `finished` and `paused` caches in the gossip table have been optimized with purging in mind.  A benchmark has been added for purging which reveals for a cache with 10,000 entries an improvement from 645,073 ns to 12 ns.

Finally, a constant has been added for use by tokio to set the max thread count, and for use by LMDB to set the max reader count to a common value.  This will ensure we avoid LMDB errors caused by excessive read-only transactions.