### PR TITLE
NDRS-453 - carry over finalized deploys from joiner to validator phase

### DIFF
--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -1,16 +1,22 @@
 //! Reactor used to join the network.
 
-use std::fmt::{self, Display, Formatter};
+use std::{
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+};
 
 use datasize::DataSize;
+use derive_more::From;
+use prometheus::Registry;
+use smallvec::SmallVec;
+use tokio::task;
+use tracing::{error, info, warn};
 
 use block_executor::BlockExecutor;
 use consensus::EraSupervisor;
 use deploy_acceptor::DeployAcceptor;
-use derive_more::From;
-use prometheus::Registry;
 use small_network::GossipedAddress;
-use tracing::{error, info, warn};
+use storage::StorageType;
 
 use crate::{
     components::{
@@ -20,6 +26,7 @@ use crate::{
         consensus::{self},
         contract_runtime::{self, ContractRuntime},
         deploy_acceptor,
+        deploy_buffer::ProtoBlockCollection,
         fetcher::{self, Fetcher},
         gossiper::{self, Gossiper},
         linear_chain,
@@ -48,7 +55,10 @@ use crate::{
         validator::{self, Error, ValidatorInitConfig},
         EventQueueHandle, Finalize,
     },
-    types::{Block, BlockByHeight, BlockHeader, CryptoRngCore, Deploy, ProtoBlock, Tag, Timestamp},
+    types::{
+        Block, BlockByHeight, BlockHeader, CryptoRngCore, Deploy, ProtoBlock, ProtoBlockHash, Tag,
+        Timestamp,
+    },
     utils::{Source, WithDir},
 };
 
@@ -647,6 +657,7 @@ impl Reactor {
     /// the network, closing all incoming and outgoing connections, and frees up the listening
     /// socket.
     pub async fn into_validator_config(self) -> ValidatorInitConfig {
+        let finalized_deploys = self.get_finalized_deploys_from_storage().await;
         let (net, config) = (
             self.net,
             ValidatorInitConfig {
@@ -657,9 +668,36 @@ impl Reactor {
                 consensus: self.consensus,
                 init_consensus_effects: self.init_consensus_effects,
                 linear_chain: self.linear_chain.linear_chain().clone(),
+                finalized_deploys,
             },
         );
         net.finalize().await;
         config
+    }
+
+    async fn get_finalized_deploys_from_storage(&self) -> ProtoBlockCollection {
+        let mut finalized = HashMap::new();
+        let linear_chain = self.linear_chain.linear_chain();
+        let deploy_store = self.storage.deploy_store();
+        for block in linear_chain.iter() {
+            let deploy_store = deploy_store.clone();
+            let deploy_hash_vec = block.deploy_hashes();
+            let mut deploy_hashes = SmallVec::with_capacity(deploy_hash_vec.len());
+            let block_hash =
+                ProtoBlockHash::from_parts(&deploy_hashes, block.header().random_bit());
+            deploy_hashes.extend(deploy_hash_vec.iter().cloned());
+            let deploys = task::spawn_blocking(move || deploy_store.get(deploy_hashes))
+                .await
+                .expect("should run")
+                .into_iter()
+                .map(|result| {
+                    result.unwrap_or_else(|error| panic!("failed to get deploy: {}", error))
+                })
+                .flatten()
+                .map(|deploy| (*deploy.id(), deploy.header().clone()))
+                .collect::<HashMap<_, _>>();
+            finalized.insert(block_hash, deploys);
+        }
+        finalized
     }
 }

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -345,7 +345,8 @@ impl reactor::Reactor for Reactor {
             gossiper::get_deploy_from_storage::<Deploy, Event>,
             registry,
         )?;
-        let (deploy_buffer, deploy_buffer_effects) = DeployBuffer::new(registry, effect_builder)?;
+        let (deploy_buffer, deploy_buffer_effects) =
+            DeployBuffer::new(registry, effect_builder, &linear_chain)?;
         let mut effects = reactor::wrap_effects(Event::DeployBuffer, deploy_buffer_effects);
         // Post state hash is expected to be present.
         let genesis_post_state_hash = chainspec_loader

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -92,6 +92,12 @@ impl ProtoBlockHash {
         ProtoBlockHash(hash)
     }
 
+    pub fn from_parts(deploys: &[DeployHash], random_bit: bool) -> Self {
+        ProtoBlockHash::new(hash::hash(
+            &bincode::serialize(&(deploys, random_bit)).expect("serialize ProtoBlock"),
+        ))
+    }
+
     /// Returns the wrapped inner hash.
     pub fn inner(&self) -> &Digest {
         &self.0


### PR DESCRIPTION
This PR adds the `linear_chain` as an argument to the `DeployBuffer`'s constructor, allowing it to load the finalized deploys from storage.