### PR TITLE
NDRS-511 - fix storage component's put() return value

### DIFF
--- a/node/src/components/storage/lmdb_store.rs
+++ b/node/src/components/storage/lmdb_store.rs
@@ -113,8 +113,7 @@ impl<V: Value, M: Send + Sync> Store for LmdbStore<V, M> {
             //        execution results.
             WriteFlags::default(),
         ) {
-            Ok(()) => !has_existing_value, /* TODO: when the above notes are fixed, return true
-                                             * here */
+            Ok(()) => !has_existing_value, /* TODO: `true` when the above notes are fixed */
             Err(lmdb::Error::KeyExist) => false,
             Err(error) => panic!("should put: {:?}", error),
         };

--- a/node/src/components/storage/lmdb_store.rs
+++ b/node/src/components/storage/lmdb_store.rs
@@ -97,6 +97,13 @@ impl<V: Value, M: Send + Sync> Store for LmdbStore<V, M> {
         let serialized_value =
             bincode::serialize(&value).map_err(|error| Error::from_serialization(*error))?;
         let mut txn = self.env.begin_rw_txn().expect("should create rw txn");
+
+        // TODO: this get() call should be removed when we pass WriteFlags::NO_OVERWRITE as below
+        let has_existing_value = match txn.get(self.db, &serialized_id) {
+            Ok(_) => true,
+            Err(lmdb::Error::NotFound) => false,
+            Err(error) => panic!("should get: {:?}", error),
+        };
         let result = match txn.put(
             self.db,
             &serialized_id,
@@ -106,7 +113,8 @@ impl<V: Value, M: Send + Sync> Store for LmdbStore<V, M> {
             //        execution results.
             WriteFlags::default(),
         ) {
-            Ok(()) => true,
+            Ok(()) => !has_existing_value, /* TODO: when the above notes are fixed, return true
+                                             * here */
             Err(lmdb::Error::KeyExist) => false,
             Err(error) => panic!("should put: {:?}", error),
         };

--- a/node/src/components/storage/store.rs
+++ b/node/src/components/storage/store.rs
@@ -88,4 +88,26 @@ mod tests {
         let mut in_mem_deploy_store = InMemStore::<Deploy, DeployMetadata<Block>>::new();
         should_put_then_get(&mut in_mem_deploy_store);
     }
+
+    fn second_put_should_return_false<T: Store<Value = Deploy>>(store: &mut T) {
+        let mut rng = TestRng::new();
+        let deploy = Deploy::random(&mut rng);
+        assert!(store.put(deploy.clone()).unwrap());
+        assert!(!store.put(deploy).unwrap());
+    }
+    #[test]
+    fn lmdb_deploy_store_second_put_should_return_false() {
+        let (config, _tempdir) = Config::default_for_tests();
+        let mut lmdb_deploy_store = LmdbStore::<Deploy, DeployMetadata<Block>>::new(
+            config.path(),
+            config.max_deploy_store_size(),
+        )
+        .unwrap();
+        second_put_should_return_false(&mut lmdb_deploy_store);
+    }
+    #[test]
+    fn in_mem_deploy_store_second_put_should_return_false() {
+        let mut in_mem_deploy_store = InMemStore::<Deploy, DeployMetadata<Block>>::new();
+        second_put_should_return_false(&mut in_mem_deploy_store);
+    }
 }


### PR DESCRIPTION
Solves NDRS-511

This PR adds a query `get()` first before lmdb_store's `put()` to check for the existence of a value. This should be unwinded when we no longer pass WriteFlags::default() and instead pass `NO_OVERWRITE`, and that's left as TODO's in this code.