### PR TITLE
EE-1063: Remove purse return value.

### DIFF
--- a/smart_contracts/contracts/client/add-bid/src/main.rs
+++ b/smart_contracts/contracts/client/add-bid/src/main.rs
@@ -27,7 +27,7 @@ fn add_bid(
         auction::ARG_AMOUNT => bond_amount,
         auction::ARG_DELEGATION_RATE => delegation_rate,
     };
-    runtime::call_contract::<(URef, U512)>(contract_hash, auction::METHOD_ADD_BID, args);
+    runtime::call_contract::<U512>(contract_hash, auction::METHOD_ADD_BID, args);
 }
 
 // Bidding contract.

--- a/smart_contracts/contracts/client/delegate/src/main.rs
+++ b/smart_contracts/contracts/client/delegate/src/main.rs
@@ -22,7 +22,7 @@ fn delegate(delegator: PublicKey, validator: PublicKey, source_purse: URef, amou
         auction::ARG_SOURCE_PURSE => source_purse,
         auction::ARG_AMOUNT => amount,
     };
-    runtime::call_contract::<(URef, U512)>(contract_hash, auction::METHOD_DELEGATE, args);
+    runtime::call_contract::<U512>(contract_hash, auction::METHOD_DELEGATE, args);
 }
 
 // Delegate contract.

--- a/smart_contracts/contracts/system/auction/src/lib.rs
+++ b/smart_contracts/contracts/system/auction/src/lib.rs
@@ -295,7 +295,7 @@ pub fn get_entry_points() -> EntryPoints {
             Parameter::new(ARG_DELEGATION_RATE, DelegationRate::cl_type()),
             Parameter::new(ARG_AMOUNT, U512::cl_type()),
         ],
-        <(URef, U512)>::cl_type(),
+        U512::cl_type(),
         EntryPointAccess::Public,
         EntryPointType::Contract,
     );
@@ -322,7 +322,7 @@ pub fn get_entry_points() -> EntryPoints {
             Parameter::new(ARG_VALIDATOR, PublicKey::cl_type()),
             Parameter::new(ARG_AMOUNT, U512::cl_type()),
         ],
-        <(URef, U512)>::cl_type(),
+        U512::cl_type(),
         EntryPointAccess::Public,
         EntryPointType::Contract,
     );

--- a/smart_contracts/contracts/test/auction-bidding/src/main.rs
+++ b/smart_contracts/contracts/test/auction-bidding/src/main.rs
@@ -60,7 +60,7 @@ fn call_bond(auction: ContractHash, public_key: PublicKey, bond_amount: U512, bo
         auction::ARG_AMOUNT => bond_amount,
     };
 
-    let (_purse, _amount): (URef, U512) = runtime::call_contract(auction, METHOD_ADD_BID, args);
+    let _amount: U512 = runtime::call_contract(auction, METHOD_ADD_BID, args);
 }
 
 fn seed_new_account() {

--- a/smart_contracts/contracts/test/ee-597-regression/src/main.rs
+++ b/smart_contracts/contracts/test/ee-597-regression/src/main.rs
@@ -16,7 +16,7 @@ fn bond(contract_hash: ContractHash, bond_amount: U512, bonding_purse: URef) {
         auction::ARG_DELEGATION_RATE => DelegationRate::from(42u8),
         auction::ARG_AMOUNT => bond_amount,
     };
-    runtime::call_contract::<(URef, U512)>(contract_hash, auction::METHOD_ADD_BID, runtime_args);
+    runtime::call_contract::<U512>(contract_hash, auction::METHOD_ADD_BID, runtime_args);
 }
 
 #[no_mangle]

--- a/smart_contracts/contracts/test/ee-598-regression/src/main.rs
+++ b/smart_contracts/contracts/test/ee-598-regression/src/main.rs
@@ -20,7 +20,7 @@ fn add_bid(
         auction::ARG_DELEGATION_RATE => DelegationRate::from(42u8),
         auction::ARG_AMOUNT => bond_amount,
     };
-    runtime::call_contract::<(URef, U512)>(contract_hash, auction::METHOD_ADD_BID, runtime_args);
+    runtime::call_contract::<U512>(contract_hash, auction::METHOD_ADD_BID, runtime_args);
 }
 
 fn withdraw_bid(

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -79,7 +79,7 @@ pub trait Auction:
         source: URef,
         delegation_rate: DelegationRate,
         amount: U512,
-    ) -> Result<(URef, U512)> {
+    ) -> Result<U512> {
         let account_hash = AccountHash::from_public_key(public_key, |x| self.blake2b(x));
         if self.get_caller() != account_hash {
             return Err(Error::InvalidCaller);
@@ -114,7 +114,7 @@ pub trait Auction:
         let new_amount = bid.staked_amount;
         internal::set_bids(self, validators)?;
 
-        Ok((bonding_purse, new_amount))
+        Ok(new_amount)
     }
 
     /// For a non-founder validator, implements essentially the same logic as add_bid, but reducing
@@ -177,7 +177,7 @@ pub trait Auction:
         source: URef,
         validator_public_key: PublicKey,
         amount: U512,
-    ) -> Result<(URef, U512)> {
+    ) -> Result<U512> {
         let account_hash = AccountHash::from_public_key(delegator_public_key, |x| self.blake2b(x));
         if self.get_caller() != account_hash {
             return Err(Error::InvalidCaller);
@@ -189,7 +189,7 @@ pub trait Auction:
             return Err(Error::ValidatorNotFound);
         }
 
-        let (bonding_purse, _total_amount) =
+        let (_bonding_purse, _total_amount) =
             detail::bond(self, delegator_public_key, source, amount)?;
 
         let new_delegation_amount =
@@ -206,7 +206,7 @@ pub trait Auction:
             internal::set_delegator_reward_map(self, delegator_reward_map)?;
         }
 
-        Ok((bonding_purse, new_delegation_amount))
+        Ok(new_delegation_amount)
     }
 
     /// Removes an amount of motes (or the entry altogether, if the remaining amount is 0) from


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1063

Removes `URef` value from return of `add_bid` and `delegate` entrypoints.