### PR TITLE
NDRS-495: Don't slash validators twice.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -628,7 +628,7 @@ where
             .iter_bonded()
             .flat_map(|e_id| self.era(e_id).consensus.validators_with_evidence())
             .unique()
-            .filter(|pub_key| self.era(era_id).slashed.contains(pub_key))
+            .filter(|pub_key| !self.era(era_id).slashed.contains(pub_key))
             .cloned()
             .collect();
         let candidate_block = CandidateBlock::new(proto_block, accusations);


### PR DESCRIPTION
This avoids adding validators to `accusations` in several subsequent eras after they equivocated, which would cause them to be included in the slashing instructions multiple times.

https://casperlabs.atlassian.net/browse/NDRS-495