### PR TITLE
EE-1068: Introducing Merkle Proofs

### DIFF
--- a/execution_engine/src/storage/error/in_memory.rs
+++ b/execution_engine/src/storage/error/in_memory.rs
@@ -4,8 +4,6 @@ use thiserror::Error;
 
 use casper_types::bytesrepr;
 
-use crate::storage::trie::merkle_proof;
-
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum Error {
     #[error("{0}")]
@@ -32,20 +30,5 @@ impl From<bytesrepr::Error> for Error {
 impl<T> From<sync::PoisonError<T>> for Error {
     fn from(_error: sync::PoisonError<T>) -> Self {
         Error::Poison
-    }
-}
-
-impl From<merkle_proof::Error> for Error {
-    fn from(error: merkle_proof::Error) -> Self {
-        match error {
-            merkle_proof::Error::HoleIndexOutOfRange {
-                hole_index,
-                proof_step_index,
-            } => Error::HoleIndexOutOfRange {
-                hole_index,
-                proof_step_index,
-            },
-            merkle_proof::Error::BytesRepr(error) => Error::BytesRepr(error),
-        }
     }
 }

--- a/execution_engine/src/storage/error/in_memory.rs
+++ b/execution_engine/src/storage/error/in_memory.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 
 use casper_types::bytesrepr;
 
+use crate::storage::trie::merkle_proof;
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum Error {
     #[error("{0}")]
@@ -11,6 +13,14 @@ pub enum Error {
 
     #[error("Another thread panicked while holding a lock")]
     Poison,
+
+    #[error(
+    "`hole_index` with value {hole_index:?} must be less than RADIX (proof step {proof_step_index:?})"
+    )]
+    HoleIndexOutOfRange {
+        hole_index: u8,
+        proof_step_index: u8,
+    },
 }
 
 impl From<bytesrepr::Error> for Error {
@@ -22,5 +32,20 @@ impl From<bytesrepr::Error> for Error {
 impl<T> From<sync::PoisonError<T>> for Error {
     fn from(_error: sync::PoisonError<T>) -> Self {
         Error::Poison
+    }
+}
+
+impl From<merkle_proof::Error> for Error {
+    fn from(error: merkle_proof::Error) -> Self {
+        match error {
+            merkle_proof::Error::HoleIndexOutOfRange {
+                hole_index,
+                proof_step_index,
+            } => Error::HoleIndexOutOfRange {
+                hole_index,
+                proof_step_index,
+            },
+            merkle_proof::Error::BytesRepr(error) => Error::BytesRepr(error),
+        }
     }
 }

--- a/execution_engine/src/storage/error/lmdb.rs
+++ b/execution_engine/src/storage/error/lmdb.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use casper_types::bytesrepr;
 
-use crate::storage::{error::in_memory, trie::merkle_proof};
+use crate::storage::error::in_memory;
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum Error {
@@ -38,21 +38,6 @@ impl From<bytesrepr::Error> for Error {
 impl<T> From<sync::PoisonError<T>> for Error {
     fn from(_error: sync::PoisonError<T>) -> Self {
         Error::Poison
-    }
-}
-
-impl From<merkle_proof::Error> for Error {
-    fn from(error: merkle_proof::Error) -> Self {
-        match error {
-            merkle_proof::Error::HoleIndexOutOfRange {
-                hole_index,
-                proof_step_index,
-            } => Error::HoleIndexOutOfRange {
-                hole_index,
-                proof_step_index,
-            },
-            merkle_proof::Error::BytesRepr(error) => Error::BytesRepr(error),
-        }
     }
 }
 

--- a/execution_engine/src/storage/trie/merkle_proof.rs
+++ b/execution_engine/src/storage/trie/merkle_proof.rs
@@ -1,0 +1,323 @@
+use std::{collections::VecDeque, convert::TryInto};
+
+use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+
+use crate::{
+    shared::newtypes::Blake2bHash,
+    storage::trie::{Pointer, Trie, RADIX, USIZE_EXCEEDS_U8},
+};
+
+const TRIE_MERKLE_PROOF_STEP_NODE_ID: u8 = 0;
+const TRIE_MERKLE_PROOF_STEP_EXTENSION_ID: u8 = 1;
+
+/// A component of a proof that an entry exists in the Merkle trie.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TrieMerkleProofStep {
+    /// Corresponds to [`Trie::Node`]
+    Node {
+        hole_index: u8,
+        indexed_pointers_with_hole: Vec<(u8, Pointer)>,
+    },
+    /// Corresponds to [`Trie::Extension`]
+    Extension { affix: Vec<u8> },
+}
+
+impl TrieMerkleProofStep {
+    /// Constructor for  [`TrieMerkleProofStep::Node`]
+    pub fn node(hole_index: u8, indexed_pointers_with_hole: Vec<(u8, Pointer)>) -> Self {
+        Self::Node {
+            hole_index,
+            indexed_pointers_with_hole,
+        }
+    }
+
+    /// Constructor for  [`TrieMerkleProofStep::Extension`]
+    pub fn extension(affix: Vec<u8>) -> Self {
+        Self::Extension { affix }
+    }
+}
+
+impl ToBytes for TrieMerkleProofStep {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut ret: Vec<u8> = bytesrepr::allocate_buffer(self)?;
+        match self {
+            TrieMerkleProofStep::Node {
+                hole_index,
+                indexed_pointers_with_hole,
+            } => {
+                ret.push(TRIE_MERKLE_PROOF_STEP_NODE_ID);
+                ret.push(*hole_index);
+                ret.extend(indexed_pointers_with_hole.to_bytes()?)
+            }
+            TrieMerkleProofStep::Extension { affix } => {
+                ret.push(TRIE_MERKLE_PROOF_STEP_EXTENSION_ID);
+                ret.extend(affix.to_bytes()?)
+            }
+        };
+        Ok(ret)
+    }
+
+    fn serialized_length(&self) -> usize {
+        std::mem::size_of::<u8>()
+            + match self {
+                TrieMerkleProofStep::Node {
+                    hole_index,
+                    indexed_pointers_with_hole,
+                } => {
+                    (*hole_index).serialized_length()
+                        + (*indexed_pointers_with_hole).serialized_length()
+                }
+                TrieMerkleProofStep::Extension { affix } => affix.serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for TrieMerkleProofStep {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, rem): (u8, &[u8]) = FromBytes::from_bytes(bytes)?;
+        match tag {
+            TRIE_MERKLE_PROOF_STEP_NODE_ID => {
+                let (hole_index, rem): (u8, &[u8]) = FromBytes::from_bytes(rem)?;
+                let (indexed_pointers_with_hole, rem): (Vec<(u8, Pointer)>, &[u8]) =
+                    FromBytes::from_bytes(rem)?;
+                Ok((
+                    TrieMerkleProofStep::Node {
+                        hole_index,
+                        indexed_pointers_with_hole,
+                    },
+                    rem,
+                ))
+            }
+            TRIE_MERKLE_PROOF_STEP_EXTENSION_ID => {
+                let (affix, rem): (Vec<u8>, &[u8]) = FromBytes::from_bytes(rem)?;
+                Ok((TrieMerkleProofStep::Extension { affix }, rem))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+/// A proof that a node with a specified `key` and `value` is present in the Merkle trie.
+/// Given a state hash `x`, one can validate a proof `p` by checking `x == p.compute_state_hash()`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct TrieMerkleProof<K, V> {
+    key: K,
+    value: V,
+    proof_steps: VecDeque<TrieMerkleProofStep>,
+}
+
+impl<K, V> TrieMerkleProof<K, V> {
+    /// Constructor for [`TrieMerkleProof`]
+    pub fn new(key: K, value: V, proof_steps: VecDeque<TrieMerkleProofStep>) -> Self {
+        TrieMerkleProof {
+            key,
+            value,
+            proof_steps,
+        }
+    }
+
+    /// Getter for the value in [`TrieMerkleProof`]
+    pub fn value(&self) -> &V {
+        &self.value
+    }
+}
+
+impl<K, V> TrieMerkleProof<K, V>
+where
+    K: ToBytes + Copy,
+    V: ToBytes + Copy,
+{
+    /// Recomputes a state root hash from a [`TrieMerkleProof`].
+    /// This is done in the following steps:
+    ///
+    /// 1. Using [`TrieMerkleProof::key`] and [`TrieMerkleProof::value`], construct a
+    /// [`Trie::Leaf`] and compute a hash for that leaf.
+    ///
+    /// 2. We then iterate over [`TrieMerkleProof::proof_steps`] left to right, using the hash from
+    /// the previous step combined with the next step to compute a new hash.
+    ///
+    /// 3. When there are no more steps, we return the final hash we have computed.
+    ///
+    /// The steps in this function reflect `operations::rehash`.
+    pub fn compute_state_hash(&self) -> Result<Blake2bHash, Error> {
+        let mut hash = {
+            let leaf_bytes = Trie::leaf(self.key, self.value).to_bytes()?;
+            Blake2bHash::new(&leaf_bytes)
+        };
+
+        for (proof_step_index, proof_step) in self.proof_steps.iter().enumerate() {
+            let pointer = if proof_step_index == 0 {
+                Pointer::LeafPointer(hash)
+            } else {
+                Pointer::NodePointer(hash)
+            };
+            let proof_step_bytes = match proof_step {
+                TrieMerkleProofStep::Node {
+                    hole_index,
+                    indexed_pointers_with_hole,
+                } => {
+                    let hole_index = *hole_index;
+                    if hole_index as usize > RADIX {
+                        let proof_step_index = proof_step_index.try_into().expect(USIZE_EXCEEDS_U8);
+                        return Err(Error::HoleIndexOutOfRange {
+                            hole_index,
+                            proof_step_index,
+                        });
+                    }
+                    let mut indexed_pointers = indexed_pointers_with_hole.to_owned();
+                    indexed_pointers.push((hole_index, pointer));
+                    Trie::<K, V>::node(&indexed_pointers).to_bytes()?
+                }
+                TrieMerkleProofStep::Extension { affix } => {
+                    Trie::<K, V>::extension(affix.to_owned(), pointer).to_bytes()?
+                }
+            };
+            hash = Blake2bHash::new(&proof_step_bytes);
+        }
+        Ok(hash)
+    }
+}
+
+impl<K, V> ToBytes for TrieMerkleProof<K, V>
+where
+    K: ToBytes,
+    V: ToBytes,
+{
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut ret: Vec<u8> = bytesrepr::allocate_buffer(self)?;
+        ret.extend(self.key.to_bytes()?);
+        ret.extend(self.value.to_bytes()?);
+        ret.extend(self.proof_steps.to_bytes()?);
+        Ok(ret)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.key.serialized_length()
+            + self.value.serialized_length()
+            + self.proof_steps.serialized_length()
+    }
+}
+
+impl<K, V> FromBytes for TrieMerkleProof<K, V>
+where
+    K: FromBytes,
+    V: FromBytes,
+{
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (key, rem): (K, &[u8]) = FromBytes::from_bytes(bytes)?;
+        let (value, rem): (V, &[u8]) = FromBytes::from_bytes(rem)?;
+        let (proof_steps, rem): (VecDeque<TrieMerkleProofStep>, &[u8]) =
+            FromBytes::from_bytes(rem)?;
+        Ok((
+            TrieMerkleProof {
+                key,
+                value,
+                proof_steps,
+            },
+            rem,
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Error {
+    BytesRepr(bytesrepr::Error),
+    HoleIndexOutOfRange {
+        hole_index: u8,
+        proof_step_index: u8,
+    },
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::BytesRepr(cause) => write!(f, "Byte representation error: {}", cause),
+            Error::HoleIndexOutOfRange{ proof_step_index: proof_step, hole_index} => write!(
+                f,
+                "`hole_index` with value {hole_index} must be less than {RADIX} (proof step {proof_step})",
+                hole_index = hole_index,
+                RADIX = RADIX,
+                proof_step = proof_step
+            ),
+        }
+    }
+}
+
+impl From<bytesrepr::Error> for Error {
+    fn from(cause: bytesrepr::Error) -> Self {
+        Error::BytesRepr(cause)
+    }
+}
+
+#[cfg(test)]
+mod gens {
+    use proptest::{collection::vec, prelude::*};
+
+    use casper_types::{gens::key_arb, Key};
+
+    use crate::{
+        shared::stored_value::{gens::stored_value_arb, StoredValue},
+        storage::trie::{
+            gens::trie_pointer_arb,
+            merkle_proof::{TrieMerkleProof, TrieMerkleProofStep},
+            RADIX,
+        },
+    };
+
+    const POINTERS_SIZE: usize = RADIX / 8;
+    const AFFIX_SIZE: usize = 6;
+    const STEPS_SIZE: usize = 6;
+
+    pub fn trie_merkle_proof_step_arb() -> impl Strategy<Value = TrieMerkleProofStep> {
+        prop_oneof![
+            (
+                <u8>::arbitrary(),
+                vec((<u8>::arbitrary(), trie_pointer_arb()), POINTERS_SIZE)
+            )
+                .prop_map(|(hole_index, indexed_pointers_with_hole)| {
+                    TrieMerkleProofStep::Node {
+                        hole_index,
+                        indexed_pointers_with_hole,
+                    }
+                }),
+            vec(<u8>::arbitrary(), AFFIX_SIZE)
+                .prop_map(|affix| { TrieMerkleProofStep::Extension { affix } })
+        ]
+    }
+
+    pub fn trie_merkle_proof_arb() -> impl Strategy<Value = TrieMerkleProof<Key, StoredValue>> {
+        (
+            key_arb(),
+            stored_value_arb(),
+            vec(trie_merkle_proof_step_arb(), STEPS_SIZE),
+        )
+            .prop_map(|(key, value, proof_steps)| {
+                TrieMerkleProof::new(key, value, proof_steps.into())
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use casper_types::bytesrepr;
+
+    use super::gens;
+
+    proptest! {
+        #[test]
+        fn trie_merkle_proof_step_serialization_is_correct(
+            step in gens::trie_merkle_proof_step_arb()
+        ) {
+            bytesrepr::test_serialization_roundtrip(&step)
+        }
+
+        #[test]
+        fn trie_merkle_proof_serialization_is_correct(
+            proof in gens::trie_merkle_proof_arb()
+        ) {
+            bytesrepr::test_serialization_roundtrip(&proof)
+        }
+    }
+}

--- a/execution_engine/src/storage/trie_store/operations/tests/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/mod.rs
@@ -18,7 +18,7 @@ use crate::storage::{
         in_memory::InMemoryEnvironment, lmdb::LmdbEnvironment, Readable, Transaction,
         TransactionSource,
     },
-    trie::{merkle_proof, merkle_proof::TrieMerkleProof, Pointer, Trie},
+    trie::{merkle_proof::TrieMerkleProof, Pointer, Trie},
     trie_store::{
         self,
         in_memory::InMemoryTrieStore,
@@ -609,7 +609,7 @@ where
     T: Readable<Handle = S::Handle>,
     S: TrieStore<K, V>,
     S::Error: From<T::Error>,
-    E: From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+    E: From<S::Error> + From<bytesrepr::Error>,
 {
     let mut ret = Vec::new();
 
@@ -682,7 +682,7 @@ where
     R: TransactionSource<'a, Handle = S::Handle>,
     S: TrieStore<K, V>,
     S::Error: From<R::Error>,
-    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
 {
     let txn: R::ReadTransaction = environment.create_read_txn()?;
 
@@ -777,7 +777,7 @@ where
     R: TransactionSource<'a, Handle = S::Handle>,
     S: TrieStore<K, V>,
     S::Error: From<R::Error>,
-    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
 {
     let txn = environment.create_read_txn()?;
     for (index, root_hash) in root_hashes.iter().enumerate() {
@@ -894,7 +894,7 @@ where
     R: TransactionSource<'a, Handle = S::Handle>,
     S: TrieStore<K, V>,
     S::Error: From<R::Error>,
-    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
 {
     let mut states = states.to_vec();
 

--- a/execution_engine/src/storage/trie_store/operations/tests/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/mod.rs
@@ -18,16 +18,17 @@ use crate::storage::{
         in_memory::InMemoryEnvironment, lmdb::LmdbEnvironment, Readable, Transaction,
         TransactionSource,
     },
-    trie::{Pointer, Trie},
+    trie::{merkle_proof, merkle_proof::TrieMerkleProof, Pointer, Trie},
     trie_store::{
         self,
         in_memory::InMemoryTrieStore,
         lmdb::LmdbTrieStore,
-        operations::{self, read, write, ReadResult, WriteResult},
+        operations::{self, read, read_with_proof, write, ReadResult, WriteResult},
         TrieStore,
     },
     DEFAULT_TEST_MAX_DB_SIZE,
 };
+use std::ops::Not;
 
 const TEST_KEY_LENGTH: usize = 7;
 
@@ -594,6 +595,45 @@ where
     Ok(ret)
 }
 
+/// For a given vector of leaves check the merkle proofs exist and are correct
+fn check_merkle_proofs<K, V, T, S, E>(
+    correlation_id: CorrelationId,
+    txn: &T,
+    store: &S,
+    root: &Blake2bHash,
+    leaves: &[Trie<K, V>],
+) -> Result<Vec<bool>, E>
+where
+    K: ToBytes + FromBytes + Eq + std::fmt::Debug + Copy,
+    V: ToBytes + FromBytes + Eq + Copy,
+    T: Readable<Handle = S::Handle>,
+    S: TrieStore<K, V>,
+    S::Error: From<T::Error>,
+    E: From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+{
+    let mut ret = Vec::new();
+
+    for leaf in leaves {
+        if let Trie::Leaf { key, value } = leaf {
+            let maybe_proof: ReadResult<TrieMerkleProof<K, V>> =
+                read_with_proof::<_, _, _, _, E>(correlation_id, txn, store, root, key)?;
+            match maybe_proof {
+                ReadResult::Found(proof) => {
+                    let hash = proof.compute_state_hash()?;
+                    ret.push(hash == *root && proof.value() == value);
+                }
+                ReadResult::NotFound => {
+                    ret.push(false);
+                }
+                ReadResult::RootNotFound => panic!("Root not found!"),
+            };
+        } else {
+            panic!("leaves should only contain leaves")
+        }
+    }
+    Ok(ret)
+}
+
 fn check_keys<K, V, T, S, E>(
     correlation_id: CorrelationId,
     txn: &T,
@@ -637,12 +677,12 @@ fn check_leaves<'a, K, V, R, S, E>(
     absent: &[Trie<K, V>],
 ) -> Result<(), E>
 where
-    K: ToBytes + FromBytes + Eq + std::fmt::Debug + Clone + Ord,
+    K: ToBytes + FromBytes + Eq + std::fmt::Debug + Copy + Clone + Ord,
     V: ToBytes + FromBytes + Eq + std::fmt::Debug + Copy,
     R: TransactionSource<'a, Handle = S::Handle>,
     S: TrieStore<K, V>,
     S::Error: From<R::Error>,
-    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
 {
     let txn: R::ReadTransaction = environment.create_read_txn()?;
 
@@ -653,9 +693,21 @@ where
     );
 
     assert!(
+        check_merkle_proofs::<_, _, _, _, E>(correlation_id, &txn, store, root, present)?
+            .into_iter()
+            .all(convert::identity)
+    );
+
+    assert!(
         check_leaves_exist::<_, _, _, _, E>(correlation_id, &txn, store, root, absent)?
             .into_iter()
-            .all(|b| !b)
+            .all(bool::not)
+    );
+
+    assert!(
+        check_merkle_proofs::<_, _, _, _, E>(correlation_id, &txn, store, root, absent)?
+            .into_iter()
+            .all(bool::not)
     );
 
     assert!(check_keys::<_, _, _, _, E>(
@@ -710,6 +762,41 @@ where
     }
     txn.commit()?;
     Ok(results)
+}
+
+fn check_pairs_proofs<'a, K, V, R, S, E>(
+    correlation_id: CorrelationId,
+    environment: &'a R,
+    store: &S,
+    root_hashes: &[Blake2bHash],
+    pairs: &[(K, V)],
+) -> Result<bool, E>
+where
+    K: ToBytes + FromBytes + Eq + std::fmt::Debug + Copy + Clone + Ord,
+    V: ToBytes + FromBytes + Eq + std::fmt::Debug + Copy,
+    R: TransactionSource<'a, Handle = S::Handle>,
+    S: TrieStore<K, V>,
+    S::Error: From<R::Error>,
+    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+{
+    let txn = environment.create_read_txn()?;
+    for (index, root_hash) in root_hashes.iter().enumerate() {
+        for (key, value) in &pairs[..=index] {
+            let maybe_proof =
+                read_with_proof::<_, _, _, _, E>(correlation_id, &txn, store, root_hash, key)?;
+            match maybe_proof {
+                ReadResult::Found(proof) => {
+                    let hash = proof.compute_state_hash()?;
+                    if hash != *root_hash || proof.value() != value {
+                        return Ok(false);
+                    }
+                }
+                ReadResult::NotFound => return Ok(false),
+                ReadResult::RootNotFound => panic!("Root not found!"),
+            };
+        }
+    }
+    Ok(true)
 }
 
 fn check_pairs<'a, K, V, R, S, E>(
@@ -802,12 +889,12 @@ fn writes_to_n_leaf_empty_trie_had_expected_results<'a, K, V, R, S, E>(
     test_leaves: &[Trie<K, V>],
 ) -> Result<Vec<Blake2bHash>, E>
 where
-    K: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug + Ord,
+    K: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug + Copy + Ord,
     V: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug + Copy,
     R: TransactionSource<'a, Handle = S::Handle>,
     S: TrieStore<K, V>,
     S::Error: From<R::Error>,
-    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
 {
     let mut states = states.to_vec();
 

--- a/execution_engine/src/storage/trie_store/operations/tests/proptests.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/proptests.rs
@@ -46,6 +46,15 @@ fn lmdb_roundtrip_succeeds(pairs: &[(TestKey, TestValue)]) -> bool {
         &states_to_check,
         &pairs,
     )
+    .unwrap();
+
+    check_pairs_proofs::<_, _, _, _, error::Error>(
+        correlation_id,
+        &context.environment,
+        &context.store,
+        &states_to_check,
+        &pairs,
+    )
     .unwrap()
 }
 
@@ -67,6 +76,15 @@ fn in_memory_roundtrip_succeeds(pairs: &[(TestKey, TestValue)]) -> bool {
     states_to_check.extend(root_hashes);
 
     check_pairs::<_, _, _, _, in_memory::Error>(
+        correlation_id,
+        &context.environment,
+        &context.store,
+        &states_to_check,
+        &pairs,
+    )
+    .unwrap();
+
+    check_pairs_proofs::<_, _, _, _, in_memory::Error>(
         correlation_id,
         &context.environment,
         &context.store,

--- a/execution_engine/src/storage/trie_store/operations/tests/write.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/write.rs
@@ -129,7 +129,7 @@ mod partial_tries {
         R: TransactionSource<'a, Handle = S::Handle>,
         S: TrieStore<TestKey, TestValue>,
         S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
     {
         // Check that the expected set of leaves is in the trie
         check_leaves::<_, _, _, _, E>(
@@ -214,7 +214,7 @@ mod partial_tries {
         R: TransactionSource<'a, Handle = S::Handle>,
         S: TrieStore<TestKey, TestValue>,
         S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
     {
         let mut states = states.to_owned();
 
@@ -324,7 +324,7 @@ mod full_tries {
         R: TransactionSource<'a, Handle = S::Handle>,
         S: TrieStore<TestKey, TestValue>,
         S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
     {
         // Check that the expected set of leaves is in the trie at every state reference
         for (num_leaves, state) in states[..index].iter().enumerate() {
@@ -421,7 +421,7 @@ mod full_tries {
         R: TransactionSource<'a, Handle = S::Handle>,
         S: TrieStore<TestKey, TestValue>,
         S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
     {
         let mut states = states.to_vec();
 
@@ -544,7 +544,7 @@ mod full_tries {
         R: TransactionSource<'a, Handle = S::Handle>,
         S: TrieStore<TestKey, TestValue>,
         S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
     {
         let mut states = states.to_vec();
         let num_leaves = TEST_LEAVES_LENGTH;

--- a/execution_engine/src/storage/trie_store/operations/tests/write.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/write.rs
@@ -129,7 +129,7 @@ mod partial_tries {
         R: TransactionSource<'a, Handle = S::Handle>,
         S: TrieStore<TestKey, TestValue>,
         S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
     {
         // Check that the expected set of leaves is in the trie
         check_leaves::<_, _, _, _, E>(
@@ -214,7 +214,7 @@ mod partial_tries {
         R: TransactionSource<'a, Handle = S::Handle>,
         S: TrieStore<TestKey, TestValue>,
         S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
     {
         let mut states = states.to_owned();
 
@@ -324,7 +324,7 @@ mod full_tries {
         R: TransactionSource<'a, Handle = S::Handle>,
         S: TrieStore<TestKey, TestValue>,
         S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
     {
         // Check that the expected set of leaves is in the trie at every state reference
         for (num_leaves, state) in states[..index].iter().enumerate() {
@@ -421,7 +421,7 @@ mod full_tries {
         R: TransactionSource<'a, Handle = S::Handle>,
         S: TrieStore<TestKey, TestValue>,
         S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
     {
         let mut states = states.to_vec();
 
@@ -544,7 +544,7 @@ mod full_tries {
         R: TransactionSource<'a, Handle = S::Handle>,
         S: TrieStore<TestKey, TestValue>,
         S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<merkle_proof::Error>,
     {
         let mut states = states.to_vec();
         let num_leaves = TEST_LEAVES_LENGTH;

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -8,7 +8,7 @@ use alloc::alloc::{alloc, Layout};
 #[cfg(not(feature = "no-unstable-features"))]
 use alloc::collections::TryReserveError;
 use alloc::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     string::String,
     vec::Vec,
 };
@@ -330,8 +330,8 @@ fn vec_into_bytes<T: ToBytes>(vec: Vec<T>) -> Result<Vec<u8>, Error> {
     Ok(result)
 }
 
-fn vec_serialized_length<T: ToBytes>(vec: &[T]) -> usize {
-    U32_SERIALIZED_LENGTH + vec.iter().map(ToBytes::serialized_length).sum::<usize>()
+fn iterator_serialized_length<'a, T: 'a + ToBytes>(ts: impl Iterator<Item = &'a T>) -> usize {
+    U32_SERIALIZED_LENGTH + ts.map(ToBytes::serialized_length).sum::<usize>()
 }
 
 #[cfg(feature = "no-unstable-features")]
@@ -345,7 +345,7 @@ impl<T: ToBytes> ToBytes for Vec<T> {
     }
 
     fn serialized_length(&self) -> usize {
-        vec_serialized_length(self)
+        iterator_serialized_length(self.iter())
     }
 }
 
@@ -360,7 +360,7 @@ impl<T: ToBytes> ToBytes for Vec<T> {
     }
 
     default fn serialized_length(&self) -> usize {
-        vec_serialized_length(self)
+        iterator_serialized_length(self.iter())
     }
 }
 
@@ -427,6 +427,110 @@ impl<T: FromBytes> FromBytes for Vec<T> {
 
     default fn from_vec(bytes: Vec<u8>) -> Result<(Self, Vec<u8>), Error> {
         vec_from_vec(bytes)
+    }
+}
+
+#[allow(clippy::ptr_arg)]
+fn vec_deque_to_bytes<T: ToBytes>(vec: &VecDeque<T>) -> Result<Vec<u8>, Error> {
+    let mut result = allocate_buffer(vec)?;
+    result.append(&mut (vec.len() as u32).to_bytes()?);
+
+    for item in vec.iter() {
+        result.append(&mut item.to_bytes()?);
+    }
+
+    Ok(result)
+}
+
+fn vec_deque_into_bytes<T: ToBytes>(vec: VecDeque<T>) -> Result<Vec<u8>, Error> {
+    let mut result = allocate_buffer(&vec)?;
+    result.append(&mut (vec.len() as u32).to_bytes()?);
+
+    for item in vec {
+        result.append(&mut item.into_bytes()?);
+    }
+
+    Ok(result)
+}
+
+#[cfg(feature = "no-unstable-features")]
+impl<T: ToBytes> ToBytes for VecDeque<T> {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        vec_deque_to_bytes(self)
+    }
+
+    fn into_bytes(self) -> Result<Vec<u8>, Error> {
+        vec_deque_into_bytes(self)
+    }
+
+    fn serialized_length(&self) -> usize {
+        iterator_serialized_length(self.iter())
+    }
+}
+
+#[cfg(not(feature = "no-unstable-features"))]
+impl<T: ToBytes> ToBytes for VecDeque<T> {
+    default fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        vec_deque_to_bytes(self)
+    }
+
+    default fn into_bytes(self) -> Result<Vec<u8>, Error> {
+        vec_deque_into_bytes(self)
+    }
+
+    default fn serialized_length(&self) -> usize {
+        iterator_serialized_length(self.iter())
+    }
+}
+
+#[cfg(feature = "no-unstable-features")]
+fn try_vec_deque_with_capacity<T>(capacity: usize) -> Result<VecDeque<T>, Error> {
+    Ok(VecDeque::with_capacity(capacity))
+}
+
+#[cfg(not(feature = "no-unstable-features"))]
+fn try_vec_deque_with_capacity<T>(capacity: usize) -> Result<VecDeque<T>, Error> {
+    let mut result: VecDeque<T> = VecDeque::new();
+    result.try_reserve_exact(capacity)?;
+    Ok(result)
+}
+
+fn vec_deque_from_bytes<T: FromBytes>(bytes: &[u8]) -> Result<(VecDeque<T>, &[u8]), Error> {
+    let (count, mut stream) = u32::from_bytes(bytes)?;
+
+    let mut result = try_vec_deque_with_capacity(count as usize)?;
+    for _ in 0..count {
+        let (value, remainder) = T::from_bytes(stream)?;
+        result.push_back(value);
+        stream = remainder;
+    }
+
+    Ok((result, stream))
+}
+
+fn vec_deque_from_vec<T: FromBytes>(bytes: Vec<u8>) -> Result<(VecDeque<T>, Vec<u8>), Error> {
+    VecDeque::<T>::from_bytes(bytes.as_slice()).map(|(x, remainder)| (x, Vec::from(remainder)))
+}
+
+#[cfg(feature = "no-unstable-features")]
+impl<T: FromBytes> FromBytes for VecDeque<T> {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        vec_deque_from_bytes(bytes)
+    }
+
+    fn from_vec(bytes: Vec<u8>) -> Result<(Self, Vec<u8>), Error> {
+        vec_deque_from_vec(bytes)
+    }
+}
+
+#[cfg(not(feature = "no-unstable-features"))]
+impl<T: FromBytes> FromBytes for VecDeque<T> {
+    default fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        vec_deque_from_bytes(bytes)
+    }
+
+    default fn from_vec(bytes: Vec<u8>) -> Result<(Self, Vec<u8>), Error> {
+        vec_deque_from_vec(bytes)
     }
 }
 


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1068

This is only the first part of the work, introducing the core proof types along with code for creating them and validating them.

Subsequent PRs will integrate this work into the querying mechanism and client.