### PR TITLE
EE-1070: persist Transfer + DeployInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5001,6 +5001,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "transfer-purse-to-accounts"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
+name = "transfer-purse-to-accounts-stored"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+ "transfer-purse-to-accounts",
+]
+
+[[package]]
+name = "transfer-purse-to-accounts-subcall"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "transfer-purse-to-purse"
 version = "0.1.0"
 dependencies = [

--- a/execution_engine/src/core.rs
+++ b/execution_engine/src/core.rs
@@ -8,8 +8,5 @@ pub mod runtime_context;
 pub(crate) mod tracking_copy;
 
 pub const ADDRESS_LENGTH: usize = 32;
-pub const DEPLOY_HASH_LENGTH: usize = 32;
 
 pub type Address = [u8; ADDRESS_LENGTH];
-
-pub type DeployHash = [u8; DEPLOY_HASH_LENGTH];

--- a/execution_engine/src/core/engine_state/deploy_item.rs
+++ b/execution_engine/src/core/engine_state/deploy_item.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeSet;
 
-use casper_types::account::AccountHash;
+use casper_types::{account::AccountHash, DeployHash};
 
-use crate::core::{engine_state::executable_deploy_item::ExecutableDeployItem, DeployHash};
+use crate::core::engine_state::executable_deploy_item::ExecutableDeployItem;
 
 type GasPrice = u64;
 

--- a/execution_engine/src/core/engine_state/execute_request.rs
+++ b/execution_engine/src/core/engine_state/execute_request.rs
@@ -31,6 +31,10 @@ impl ExecuteRequest {
     pub fn take_deploys(&mut self) -> Vec<Result<DeployItem, ExecutionResult>> {
         mem::replace(&mut self.deploys, vec![])
     }
+
+    pub fn deploys(&self) -> &Vec<Result<DeployItem, ExecutionResult>> {
+        &self.deploys
+    }
 }
 
 impl Default for ExecuteRequest {

--- a/execution_engine/src/core/engine_state/execution_result.rs
+++ b/execution_engine/src/core/engine_state/execution_result.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use casper_types::{bytesrepr::FromBytes, CLTyped, CLValue, Key};
+use casper_types::{bytesrepr::FromBytes, CLTyped, CLValue, Key, TransferAddr};
 
 use super::{error, execution_effect::ExecutionEffect, op::Op, CONV_RATE};
 use crate::{
@@ -49,10 +49,25 @@ pub enum ExecutionResult {
     Failure {
         error: error::Error,
         effect: ExecutionEffect,
+        transfers: Vec<TransferAddr>,
         cost: Gas,
     },
     /// Execution was finished successfully
-    Success { effect: ExecutionEffect, cost: Gas },
+    Success {
+        effect: ExecutionEffect,
+        transfers: Vec<TransferAddr>,
+        cost: Gas,
+    },
+}
+
+impl Default for ExecutionResult {
+    fn default() -> Self {
+        ExecutionResult::Success {
+            effect: ExecutionEffect::default(),
+            transfers: Vec::default(),
+            cost: Gas::default(),
+        }
+    }
 }
 
 /// A type alias that represents multiple execution results.
@@ -73,6 +88,7 @@ impl ExecutionResult {
         ExecutionResult::Failure {
             error,
             effect: Default::default(),
+            transfers: Vec::default(),
             cost: Gas::default(),
         }
     }
@@ -114,25 +130,77 @@ impl ExecutionResult {
         }
     }
 
+    pub fn transfers(&self) -> &Vec<TransferAddr> {
+        match self {
+            ExecutionResult::Failure { transfers, .. } => transfers,
+            ExecutionResult::Success { transfers, .. } => transfers,
+        }
+    }
+
     pub fn with_cost(self, cost: Gas) -> Self {
         match self {
-            ExecutionResult::Failure { error, effect, .. } => ExecutionResult::Failure {
+            ExecutionResult::Failure {
                 error,
                 effect,
+                transfers,
+                ..
+            } => ExecutionResult::Failure {
+                error,
+                effect,
+                transfers,
                 cost,
             },
-            ExecutionResult::Success { effect, .. } => ExecutionResult::Success { effect, cost },
+            ExecutionResult::Success {
+                effect, transfers, ..
+            } => ExecutionResult::Success {
+                effect,
+                transfers,
+                cost,
+            },
         }
     }
 
     pub fn with_effect(self, effect: ExecutionEffect) -> Self {
         match self {
-            ExecutionResult::Failure { error, cost, .. } => ExecutionResult::Failure {
+            ExecutionResult::Failure {
+                error,
+                cost,
+                transfers,
+                ..
+            } => ExecutionResult::Failure {
+                error,
+                effect,
+                transfers,
+                cost,
+            },
+            ExecutionResult::Success {
+                cost, transfers, ..
+            } => ExecutionResult::Success {
+                effect,
+                transfers,
+                cost,
+            },
+        }
+    }
+
+    pub fn with_transfers(self, transfers: Vec<TransferAddr>) -> Self {
+        match self {
+            ExecutionResult::Failure {
                 error,
                 effect,
                 cost,
+                ..
+            } => ExecutionResult::Failure {
+                error,
+                effect,
+                transfers,
+                cost,
             },
-            ExecutionResult::Success { cost, .. } => ExecutionResult::Success { effect, cost },
+            ExecutionResult::Success { cost, effect, .. } => ExecutionResult::Success {
+                effect,
+                transfers,
+                cost,
+            },
         }
     }
 
@@ -195,9 +263,11 @@ impl ExecutionResult {
             rewards_purse,
         );
         let cost = Gas::from_motes(max_payment_cost, CONV_RATE).unwrap_or_default();
+        let transfers = Vec::default();
         ExecutionResult::Failure {
             error,
             effect,
+            transfers,
             cost,
         }
     }
@@ -274,17 +344,27 @@ impl ExecutionResultBuilder {
         payment_cost + session_cost
     }
 
+    pub fn transfers(&self) -> Vec<TransferAddr> {
+        self.payment_execution_result
+            .as_ref()
+            .map(ExecutionResult::transfers)
+            .cloned()
+            .unwrap_or_default()
+    }
+
     pub fn build<R: StateReader<Key, StoredValue>>(
         self,
         reader: &R,
         correlation_id: CorrelationId,
     ) -> Result<ExecutionResult, ExecutionResultBuilderError> {
+        let transfers = self.transfers();
         let cost = self.total_cost();
         let mut ops = AdditiveMap::new();
         let mut transforms = AdditiveMap::new();
 
         let mut ret: ExecutionResult = ExecutionResult::Success {
             effect: Default::default(),
+            transfers,
             cost,
         };
 

--- a/execution_engine/src/core/engine_state/query.rs
+++ b/execution_engine/src/core/engine_state/query.rs
@@ -5,6 +5,7 @@ use crate::{
     shared::{newtypes::Blake2bHash, stored_value::StoredValue},
 };
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum QueryResult {
     RootNotFound,

--- a/execution_engine/src/core/engine_state/transfer.rs
+++ b/execution_engine/src/core/engine_state/transfer.rs
@@ -158,9 +158,9 @@ impl TransferRuntimeArgsBuilder {
                             .borrow_mut()
                             .read_account(correlation_id, public_key)
                         {
-                            Ok(account) => {
-                                Ok(TransferTargetMode::PurseExists(account.main_purse()))
-                            }
+                            Ok(account) => Ok(TransferTargetMode::PurseExists(
+                                account.main_purse().with_access_rights(AccessRights::ADD),
+                            )),
                             Err(_) => Ok(TransferTargetMode::CreateAccount(public_key)),
                         }
                     }
@@ -180,9 +180,9 @@ impl TransferRuntimeArgsBuilder {
                             .borrow_mut()
                             .read_account(correlation_id, public_key)
                         {
-                            Ok(account) => {
-                                Ok(TransferTargetMode::PurseExists(account.main_purse()))
-                            }
+                            Ok(account) => Ok(TransferTargetMode::PurseExists(
+                                account.main_purse().with_access_rights(AccessRights::ADD),
+                            )),
                             Err(_) => Ok(TransferTargetMode::CreateAccount(public_key)),
                         }
                     }

--- a/execution_engine/src/core/execution/tests.rs
+++ b/execution_engine/src/core/execution/tests.rs
@@ -15,9 +15,11 @@ fn on_fail_charge_test_helper<T>(
     success_cost: Gas,
     error_cost: Gas,
 ) -> ExecutionResult {
-    let _result = on_fail_charge!(f(), error_cost);
+    let transfers = Vec::default();
+    let _result = on_fail_charge!(f(), error_cost, transfers);
     ExecutionResult::Success {
         effect: Default::default(),
+        transfers,
         cost: success_cost,
     }
 }
@@ -45,18 +47,25 @@ fn on_fail_charge_err_laziness_test() {
 fn on_fail_charge_with_action() {
     let f = || {
         let input: Result<(), Error> = Err(Error::GasLimit);
-        on_fail_charge!(input, Gas::new(U512::from(456)), {
-            let mut effect = ExecutionEffect::default();
+        let transfers = Vec::default();
+        on_fail_charge!(
+            input,
+            Gas::new(U512::from(456)),
+            {
+                let mut effect = ExecutionEffect::default();
 
-            effect.ops.insert(Key::Hash([42u8; 32]), Op::Read);
-            effect
-                .transforms
-                .insert(Key::Hash([42u8; 32]), Transform::Identity);
+                effect.ops.insert(Key::Hash([42u8; 32]), Op::Read);
+                effect
+                    .transforms
+                    .insert(Key::Hash([42u8; 32]), Transform::Identity);
 
-            effect
-        });
+                effect
+            },
+            transfers
+        );
         ExecutionResult::Success {
             effect: Default::default(),
+            transfers: Vec::default(),
             cost: Gas::default(),
         }
     };

--- a/execution_engine/src/core/resolvers/v1_function_index.rs
+++ b/execution_engine/src/core/resolvers/v1_function_index.rs
@@ -50,6 +50,7 @@ pub enum FunctionIndex {
     ExtendContractUserGroupURefsIndex,
     RemoveContractUserGroupURefsIndex,
     Blake2b,
+    RecordTransfer,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution_engine/src/core/resolvers/v1_resolver.rs
+++ b/execution_engine/src/core/resolvers/v1_resolver.rs
@@ -208,6 +208,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::Blake2b.into(),
             ),
+            "record_transfer" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 6][..], Some(ValueType::I32)),
+                FunctionIndex::RecordTransfer.into(),
+            ),
             #[cfg(feature = "test-support")]
             "print" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], None),

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -686,6 +686,25 @@ where
                     .map_err(|error| Error::Interpreter(error.into()))?;
                 Ok(Some(RuntimeValue::I32(0)))
             }
+
+            FunctionIndex::RecordTransfer => {
+                let (source_ptr, source_size, target_ptr, target_size, amount_ptr, amount_size): (
+                    u32,
+                    u32,
+                    u32,
+                    u32,
+                    u32,
+                    u32,
+                ) = Args::parse(args)?;
+                scoped_instrumenter.add_property("source_size", source_size.to_string());
+                scoped_instrumenter.add_property("target_size", target_size.to_string());
+                scoped_instrumenter.add_property("amount_size", amount_size.to_string());
+                let source: URef = self.t_from_mem(source_ptr, source_size)?;
+                let target: URef = self.t_from_mem(target_ptr, target_size)?;
+                let amount: U512 = self.t_from_mem(amount_ptr, amount_size)?;
+                self.record_transfer(source, target, amount)?;
+                Ok(Some(RuntimeValue::I32(0)))
+            }
         }
     }
 }

--- a/execution_engine/src/core/runtime/mint_internal.rs
+++ b/execution_engine/src/core/runtime/mint_internal.rs
@@ -1,9 +1,9 @@
 use casper_types::{
     account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
-    mint::{Mint, RuntimeProvider, StorageProvider},
+    mint::{Mint, RuntimeProvider, StorageProvider, SystemProvider},
     system_contract_errors::mint::Error,
-    CLTyped, CLValue, Key, URef,
+    CLTyped, CLValue, Key, URef, U512,
 };
 
 use super::Runtime;
@@ -97,6 +97,17 @@ where
         self.context
             .add_gs(Key::URef(uref), StoredValue::CLValue(cl_value))
             .map_err(|_| Error::Storage)
+    }
+}
+
+impl<'a, R> SystemProvider for Runtime<'a, R>
+where
+    R: StateReader<Key, StoredValue>,
+    R::Error: Into<execution::Error>,
+{
+    fn record_transfer(&mut self, source: URef, target: URef, amount: U512) -> Result<(), Error> {
+        let result = Runtime::record_transfer(self, source, target, amount);
+        result.map_err(|_| Error::RecordTransferFailure)
     }
 }
 

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -30,9 +30,9 @@ use casper_types::{
     runtime_args, standard_payment,
     standard_payment::StandardPayment,
     system_contract_errors, AccessRights, ApiError, CLType, CLTyped, CLValue, ContractHash,
-    ContractPackageHash, ContractVersionKey, ContractWasm, EntryPointType, Key, ProtocolVersion,
-    PublicKey, RuntimeArgs, SystemContractType, TransferResult, TransferredTo, URef, U128, U256,
-    U512,
+    ContractPackageHash, ContractVersionKey, ContractWasm, DeployHash, EntryPointType, Key,
+    ProtocolVersion, PublicKey, RuntimeArgs, SystemContractType, Transfer, TransferResult,
+    TransferredTo, URef, U128, U256, U512,
 };
 
 use crate::{
@@ -99,6 +99,8 @@ pub fn key_to_tuple(key: Key) -> Option<([u8; 32], AccessRights)> {
         Key::URef(uref) => Some((uref.addr(), uref.access_rights())),
         Key::Account(_) => None,
         Key::Hash(_) => None,
+        Key::Transfer(_) => None,
+        Key::DeployInfo(_) => None,
     }
 }
 
@@ -1706,9 +1708,11 @@ where
         let gas_counter = self.context.gas_counter();
         let hash_address_generator = self.context.hash_address_generator();
         let uref_address_generator = self.context.uref_address_generator();
+        let transfer_address_generator = self.context.transfer_address_generator();
         let correlation_id = self.context.correlation_id();
         let phase = self.context.phase();
         let protocol_data = self.context.protocol_data();
+        let transfers = self.context.transfers().to_owned();
 
         let mint_context = RuntimeContext::new(
             state,
@@ -1725,10 +1729,12 @@ where
             gas_counter,
             hash_address_generator,
             uref_address_generator,
+            transfer_address_generator,
             protocol_version,
             correlation_id,
             phase,
             *protocol_data,
+            transfers,
         );
 
         let mut mint_runtime = Runtime::new(
@@ -1780,6 +1786,10 @@ where
         let urefs = extract_urefs(&ret)?;
         let access_rights = extract_access_rights_from_urefs(urefs);
         self.context.access_rights_extend(access_rights);
+        {
+            let transfers = self.context.transfers_mut();
+            *transfers = mint_runtime.context.transfers().to_owned();
+        }
         Ok(ret)
     }
 
@@ -1808,9 +1818,11 @@ where
         let gas_counter = self.context.gas_counter();
         let fn_store_id = self.context.hash_address_generator();
         let address_generator = self.context.uref_address_generator();
+        let transfer_address_generator = self.context.transfer_address_generator();
         let correlation_id = self.context.correlation_id();
         let phase = self.context.phase();
         let protocol_data = self.context.protocol_data();
+        let transfers = self.context.transfers().to_owned();
 
         let runtime_context = RuntimeContext::new(
             state,
@@ -1827,10 +1839,12 @@ where
             gas_counter,
             fn_store_id,
             address_generator,
+            transfer_address_generator,
             protocol_version,
             correlation_id,
             phase,
             *protocol_data,
+            transfers,
         );
 
         let mut runtime = Runtime::new(
@@ -1872,6 +1886,10 @@ where
         let urefs = extract_urefs(&ret)?;
         let access_rights = extract_access_rights_from_urefs(urefs);
         self.context.access_rights_extend(access_rights);
+        {
+            let transfers = self.context.transfers_mut();
+            *transfers = runtime.context.transfers().to_owned();
+        }
         Ok(ret)
     }
 
@@ -1906,9 +1924,11 @@ where
         let gas_counter = self.context.gas_counter();
         let fn_store_id = self.context.hash_address_generator();
         let address_generator = self.context.uref_address_generator();
+        let transfer_address_generator = self.context.transfer_address_generator();
         let correlation_id = self.context.correlation_id();
         let phase = self.context.phase();
         let protocol_data = self.context.protocol_data();
+        let transfers = self.context.transfers().to_owned();
 
         let runtime_context = RuntimeContext::new(
             state,
@@ -1925,10 +1945,12 @@ where
             gas_counter,
             fn_store_id,
             address_generator,
+            transfer_address_generator,
             protocol_version,
             correlation_id,
             phase,
             *protocol_data,
+            transfers,
         );
 
         let mut runtime = Runtime::new(
@@ -2075,6 +2097,10 @@ where
         let urefs = extract_urefs(&ret)?;
         let access_rights = extract_access_rights_from_urefs(urefs);
         self.context.access_rights_extend(access_rights);
+        {
+            let transfers = self.context.transfers_mut();
+            *transfers = runtime.context.transfers().to_owned();
+        }
         Ok(ret)
     }
 
@@ -2351,10 +2377,12 @@ where
             self.context.gas_counter(),
             self.context.hash_address_generator(),
             self.context.uref_address_generator(),
+            self.context.transfer_address_generator(),
             protocol_version,
             self.context.correlation_id(),
             self.context.phase(),
             *self.context.protocol_data(),
+            self.context.transfers().to_owned(),
         );
 
         let mut runtime = Runtime {
@@ -2372,6 +2400,11 @@ where
         // charged by the sub-call was added to its counter - so let's copy the correct value of the
         // counter from there to our counter
         self.context.set_gas_counter(runtime.context.gas_counter());
+
+        {
+            let transfers = self.context.transfers_mut();
+            *transfers = runtime.context.transfers().to_owned();
+        }
 
         let error = match result {
             Err(error) => error,
@@ -2809,6 +2842,28 @@ where
             .map_err(Into::into)
     }
 
+    /// Records a transfer.
+    fn record_transfer(&mut self, source: URef, target: URef, amount: U512) -> Result<(), Error> {
+        if self.context.base_key() != Key::from(self.protocol_data().mint()) {
+            return Err(Error::InvalidContext);
+        }
+
+        let transfer_addr = self.context.new_transfer_addr()?;
+        let transfer = {
+            let deploy_hash: DeployHash = self.context.get_deploy_hash();
+            let from: AccountHash = self.context.account().account_hash();
+            let fee: U512 = U512::zero(); // TODO
+            Transfer::new(deploy_hash, from, source, target, amount, fee)
+        };
+        {
+            let transfers = self.context.transfers_mut();
+            transfers.push(transfer_addr);
+        }
+        self.context
+            .write_transfer(Key::Transfer(transfer_addr), transfer);
+        Ok(())
+    }
+
     /// Adds `value` to the cell that `key` points at.
     fn add(
         &mut self,
@@ -3106,7 +3161,12 @@ where
             return Ok(Err(ApiError::Transfer));
         }
 
-        match self.mint_transfer(mint_contract_hash, source, target_purse, amount) {
+        match self.mint_transfer(
+            mint_contract_hash,
+            source,
+            target_purse.with_access_rights(AccessRights::ADD),
+            amount,
+        ) {
             Ok(_) => {
                 let account = Account::create(target, Default::default(), target_purse);
                 self.context.write_account(target_key, account)?;

--- a/execution_engine/src/core/runtime/scoped_instrumenter.rs
+++ b/execution_engine/src/core/runtime/scoped_instrumenter.rs
@@ -140,6 +140,7 @@ impl Drop for ScopedInstrumenter {
                 "host_remove_contract_user_group_urefs"
             }
             FunctionIndex::Blake2b => "host_blake2b",
+            FunctionIndex::RecordTransfer => "host_record_transfer",
         };
 
         let mut properties = mem::take(&mut self.properties);

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -19,8 +19,8 @@ use casper_types::{
     bytesrepr,
     contracts::NamedKeys,
     AccessRights, BlockTime, CLType, CLValue, Contract, ContractPackage, ContractPackageHash,
-    EntryPointAccess, EntryPointType, Key, Phase, ProtocolVersion, RuntimeArgs, URef,
-    KEY_HASH_LENGTH,
+    DeployInfo, EntryPointAccess, EntryPointType, Key, Phase, ProtocolVersion, RuntimeArgs,
+    Transfer, TransferAddr, URef, KEY_HASH_LENGTH,
 };
 
 use crate::{
@@ -101,11 +101,13 @@ pub struct RuntimeContext<'a, R> {
     gas_counter: Gas,
     hash_address_generator: Rc<RefCell<AddressGenerator>>,
     uref_address_generator: Rc<RefCell<AddressGenerator>>,
+    transfer_address_generator: Rc<RefCell<AddressGenerator>>,
     protocol_version: ProtocolVersion,
     correlation_id: CorrelationId,
     phase: Phase,
     protocol_data: ProtocolData,
     entry_point_type: EntryPointType,
+    transfers: Vec<TransferAddr>,
 }
 
 impl<'a, R> RuntimeContext<'a, R>
@@ -129,10 +131,12 @@ where
         gas_counter: Gas,
         hash_address_generator: Rc<RefCell<AddressGenerator>>,
         uref_address_generator: Rc<RefCell<AddressGenerator>>,
+        transfer_address_generator: Rc<RefCell<AddressGenerator>>,
         protocol_version: ProtocolVersion,
         correlation_id: CorrelationId,
         phase: Phase,
         protocol_data: ProtocolData,
+        transfers: Vec<TransferAddr>,
     ) -> Self {
         RuntimeContext {
             tracking_copy,
@@ -149,10 +153,12 @@ where
             gas_counter,
             hash_address_generator,
             uref_address_generator,
+            transfer_address_generator,
             protocol_version,
             correlation_id,
             phase,
             protocol_data,
+            transfers,
         }
     }
 
@@ -230,6 +236,18 @@ where
                 self.named_keys.remove(name);
                 self.remove_key_from_contract(contract_hash, contract, name)
             }
+            transfer_addr @ Key::Transfer(_) => {
+                let _transfer: Transfer = self.read_gs_typed(&transfer_addr)?;
+                self.named_keys.remove(name);
+                // Users cannot remove transfers from global state
+                Ok(())
+            }
+            deploy_info_addr @ Key::DeployInfo(_) => {
+                let _deploy_info: DeployInfo = self.read_gs_typed(&deploy_info_addr)?;
+                self.named_keys.remove(name);
+                // Users cannot remove deploy infos from global state
+                Ok(())
+            }
         }
     }
 
@@ -267,6 +285,10 @@ where
 
     pub fn hash_address_generator(&self) -> Rc<RefCell<AddressGenerator>> {
         Rc::clone(&self.hash_address_generator)
+    }
+
+    pub fn transfer_address_generator(&self) -> Rc<RefCell<AddressGenerator>> {
+        Rc::clone(&self.transfer_address_generator)
     }
 
     pub fn state(&self) -> Rc<RefCell<TrackingCopy<R>>> {
@@ -327,6 +349,14 @@ where
     pub(crate) fn new_unit_uref(&mut self) -> Result<URef, Error> {
         let cl_unit = CLValue::from_components(CLType::Unit, Vec::new());
         self.new_uref(StoredValue::CLValue(cl_unit))
+    }
+
+    pub fn new_transfer_addr(&mut self) -> Result<TransferAddr, Error> {
+        let transfer_addr = self
+            .transfer_address_generator
+            .borrow_mut()
+            .create_address();
+        Ok(transfer_addr)
     }
 
     /// Puts `key` to the map of named keys of current context.
@@ -449,6 +479,16 @@ where
         }
     }
 
+    pub fn write_transfer(&mut self, key: Key, value: Transfer) {
+        if let Key::Transfer(_) = key {
+            self.tracking_copy
+                .borrow_mut()
+                .write(key, StoredValue::Transfer(value));
+        } else {
+            panic!("Do not use this function for writing non-transfer keys")
+        }
+    }
+
     pub fn store_function(
         &mut self,
         contract: StoredValue,
@@ -486,6 +526,14 @@ where
 
     pub fn effect(&self) -> ExecutionEffect {
         self.tracking_copy.borrow_mut().effect()
+    }
+
+    pub fn transfers(&self) -> &Vec<TransferAddr> {
+        &self.transfers
+    }
+
+    pub fn transfers_mut(&mut self) -> &mut Vec<TransferAddr> {
+        &mut self.transfers
     }
 
     /// Validates whether keys used in the `value` are not forged.
@@ -541,6 +589,8 @@ where
                 .try_for_each(|key| self.validate_key(key)),
             // TODO: anything to validate here?
             StoredValue::ContractPackage(_) => Ok(()),
+            StoredValue::Transfer(_) => Ok(()),
+            StoredValue::DeployInfo(_) => Ok(()),
         }
     }
 
@@ -624,14 +674,18 @@ where
             Key::Account(_) => &self.base_key() == key,
             Key::Hash(_) => true,
             Key::URef(uref) => uref.is_readable(),
+            Key::Transfer(_) => true,
+            Key::DeployInfo(_) => true,
         }
     }
 
     /// Tests whether addition to `key` is valid.
     pub fn is_addable(&self, key: &Key) -> bool {
         match key {
-            Key::Account(_) | Key::Hash(_) => &self.base_key() == key,
+            Key::Account(_) | Key::Hash(_) => &self.base_key() == key, // ???
             Key::URef(uref) => uref.is_addable(),
+            Key::Transfer(_) => false,
+            Key::DeployInfo(_) => false,
         }
     }
 
@@ -640,6 +694,8 @@ where
         match key {
             Key::Account(_) | Key::Hash(_) => false,
             Key::URef(uref) => uref.is_writeable(),
+            Key::DeployInfo(_) => false,
+            Key::Transfer(_) => false,
         }
     }
 

--- a/execution_engine/src/core/runtime_context/tests.rs
+++ b/execution_engine/src/core/runtime_context/tests.rs
@@ -118,6 +118,7 @@ fn mock_runtime_context<'a>(
     access_rights: HashMap<Address, HashSet<AccessRights>>,
     hash_address_generator: AddressGenerator,
     uref_address_generator: AddressGenerator,
+    transfer_address_generator: AddressGenerator,
 ) -> RuntimeContext<'a, InMemoryGlobalStateView> {
     let tracking_copy = mock_tracking_copy(base_key, account.clone());
     RuntimeContext::new(
@@ -135,10 +136,12 @@ fn mock_runtime_context<'a>(
         Gas::default(),
         Rc::new(RefCell::new(hash_address_generator)),
         Rc::new(RefCell::new(uref_address_generator)),
+        Rc::new(RefCell::new(transfer_address_generator)),
         ProtocolVersion::V1_0_0,
         CorrelationId::new(),
         Phase::Session,
         Default::default(),
+        Vec::default(),
     )
 }
 
@@ -171,6 +174,7 @@ where
     let mut named_keys = NamedKeys::new();
     let uref_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
     let hash_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
+    let transfer_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
     let runtime_context = mock_runtime_context(
         &account,
         base_key,
@@ -178,6 +182,7 @@ where
         access_rights,
         hash_address_generator,
         uref_address_generator,
+        transfer_address_generator,
     );
     query(runtime_context)
 }
@@ -329,6 +334,7 @@ fn contract_key_addable_valid() {
     let authorization_keys = BTreeSet::from_iter(vec![account_hash]);
     let hash_address_generator = AddressGenerator::new(&DEPLOY_HASH, PHASE);
     let mut uref_address_generator = AddressGenerator::new(&DEPLOY_HASH, PHASE);
+    let transfer_address_generator = AddressGenerator::new(&DEPLOY_HASH, PHASE);
 
     let mut rng = rand::thread_rng();
     let contract_key = random_contract_key(&mut rng);
@@ -363,10 +369,12 @@ fn contract_key_addable_valid() {
         Gas::default(),
         Rc::new(RefCell::new(hash_address_generator)),
         Rc::new(RefCell::new(uref_address_generator)),
+        Rc::new(RefCell::new(transfer_address_generator)),
         ProtocolVersion::V1_0_0,
         CorrelationId::new(),
         PHASE,
         Default::default(),
+        Vec::default(),
     );
 
     runtime_context
@@ -399,6 +407,7 @@ fn contract_key_addable_invalid() {
     let authorization_keys = BTreeSet::from_iter(vec![account_hash]);
     let hash_address_generator = AddressGenerator::new(&DEPLOY_HASH, PHASE);
     let mut uref_address_generator = AddressGenerator::new(&DEPLOY_HASH, PHASE);
+    let transfer_address_generator = AddressGenerator::new(&DEPLOY_HASH, PHASE);
     let mut rng = rand::thread_rng();
     let contract_key = random_contract_key(&mut rng);
 
@@ -433,10 +442,12 @@ fn contract_key_addable_invalid() {
         Gas::default(),
         Rc::new(RefCell::new(hash_address_generator)),
         Rc::new(RefCell::new(uref_address_generator)),
+        Rc::new(RefCell::new(transfer_address_generator)),
         ProtocolVersion::V1_0_0,
         CorrelationId::new(),
         PHASE,
         Default::default(),
+        Vec::default(),
     );
 
     let result = runtime_context.add_gs(contract_key, named_uref_tuple);
@@ -770,6 +781,7 @@ fn remove_uref_works() {
     let (base_key, account) = mock_account(AccountHash::new([0u8; 32]));
     let hash_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
     let mut uref_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
+    let transfer_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
     let uref_name = "Foo".to_owned();
     let uref_key = create_uref(&mut uref_address_generator, AccessRights::READ);
     let mut named_keys = iter::once((uref_name.clone(), uref_key)).collect();
@@ -780,6 +792,7 @@ fn remove_uref_works() {
         access_rights,
         hash_address_generator,
         uref_address_generator,
+        transfer_address_generator,
     );
 
     assert!(runtime_context.named_keys_contains_key(&uref_name));
@@ -805,6 +818,7 @@ fn validate_valid_purse_of_an_account() {
     let mut named_keys = NamedKeys::new();
     let hash_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
     let uref_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
+    let transfer_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
     let runtime_context = mock_runtime_context(
         &account,
         base_key,
@@ -812,6 +826,7 @@ fn validate_valid_purse_of_an_account() {
         access_rights,
         hash_address_generator,
         uref_address_generator,
+        transfer_address_generator,
     );
 
     // URef that has the same id as purse of an account gets validated

--- a/execution_engine/src/core/tracking_copy/byte_size.rs
+++ b/execution_engine/src/core/tracking_copy/byte_size.rs
@@ -52,6 +52,8 @@ impl ByteSize for StoredValue {
                 StoredValue::ContractPackage(contract_package) => {
                     contract_package.serialized_length()
                 }
+                StoredValue::DeployInfo(deploy_info) => deploy_info.serialized_length(),
+                StoredValue::Transfer(transfer) => transfer.serialized_length(),
             }
     }
 }

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -400,6 +400,12 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
                 StoredValue::ContractWasm(_) => {
                     return Ok(query.into_not_found_result(&"ContractWasm value found."));
                 }
+                StoredValue::Transfer(_) => {
+                    let _name = query.next_name();
+                }
+                StoredValue::DeployInfo(_) => {
+                    let _name = query.next_name();
+                }
             }
         }
     }

--- a/execution_engine/src/shared/stored_value.rs
+++ b/execution_engine/src/shared/stored_value.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     contracts::ContractPackage,
-    CLValue, Contract, ContractWasm,
+    CLValue, Contract, ContractWasm, DeployInfo, Transfer,
 };
 
 use crate::shared::{account::Account, TypeMismatch};
@@ -15,6 +15,8 @@ enum Tag {
     ContractWasm = 2,
     Contract = 3,
     ContractPackage = 4,
+    Transfer = 5,
+    DeployInfo = 6,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]
@@ -24,6 +26,8 @@ pub enum StoredValue {
     ContractWasm(ContractWasm),
     Contract(Contract),
     ContractPackage(ContractPackage),
+    Transfer(Transfer),
+    DeployInfo(DeployInfo),
 }
 
 impl StoredValue {
@@ -69,6 +73,8 @@ impl StoredValue {
             StoredValue::ContractWasm(_) => "Contract".to_string(),
             StoredValue::Contract(_) => "Contract".to_string(),
             StoredValue::ContractPackage(_) => "ContractPackage".to_string(),
+            StoredValue::Transfer(_) => "Transfer".to_string(),
+            StoredValue::DeployInfo(_) => "DeployInfo".to_string(),
         }
     }
 }
@@ -143,6 +149,31 @@ impl TryFrom<StoredValue> for Contract {
     }
 }
 
+impl TryFrom<StoredValue> for Transfer {
+    type Error = TypeMismatch;
+
+    fn try_from(value: StoredValue) -> Result<Self, Self::Error> {
+        match value {
+            StoredValue::Transfer(transfer) => Ok(transfer),
+            _ => Err(TypeMismatch::new("Transfer".to_string(), value.type_name())),
+        }
+    }
+}
+
+impl TryFrom<StoredValue> for DeployInfo {
+    type Error = TypeMismatch;
+
+    fn try_from(value: StoredValue) -> Result<Self, Self::Error> {
+        match value {
+            StoredValue::DeployInfo(deploy_info) => Ok(deploy_info),
+            _ => Err(TypeMismatch::new(
+                "DeployInfo".to_string(),
+                value.type_name(),
+            )),
+        }
+    }
+}
+
 impl ToBytes for StoredValue {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
@@ -156,6 +187,8 @@ impl ToBytes for StoredValue {
             StoredValue::ContractPackage(contract_package) => {
                 (Tag::ContractPackage, contract_package.to_bytes()?)
             }
+            StoredValue::Transfer(transfer) => (Tag::Transfer, transfer.to_bytes()?),
+            StoredValue::DeployInfo(deploy_info) => (Tag::DeployInfo, deploy_info.to_bytes()?),
         };
         result.push(tag as u8);
         result.append(&mut serialized_data);
@@ -172,6 +205,8 @@ impl ToBytes for StoredValue {
                 StoredValue::ContractPackage(contract_package) => {
                     contract_package.serialized_length()
                 }
+                StoredValue::Transfer(transfer) => transfer.serialized_length(),
+                StoredValue::DeployInfo(deploy_info) => deploy_info.serialized_length(),
             }
     }
 }
@@ -196,6 +231,10 @@ impl FromBytes for StoredValue {
             }
             tag if tag == Tag::Contract as u8 => Contract::from_bytes(remainder)
                 .map(|(contract, remainder)| (StoredValue::Contract(contract), remainder)),
+            tag if tag == Tag::Transfer as u8 => Transfer::from_bytes(remainder)
+                .map(|(transfer, remainder)| (StoredValue::Transfer(transfer), remainder)),
+            tag if tag == Tag::DeployInfo as u8 => DeployInfo::from_bytes(remainder)
+                .map(|(deploy_info, remainder)| (StoredValue::DeployInfo(deploy_info), remainder)),
             _ => Err(bytesrepr::Error::Formatting),
         }
     }

--- a/execution_engine/src/shared/transform.rs
+++ b/execution_engine/src/shared/transform.rs
@@ -58,6 +58,7 @@ impl From<CLValueError> for Error {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Transform {
     Identity,
@@ -176,6 +177,16 @@ impl Transform {
                 StoredValue::ContractWasm(_) => {
                     let expected = "Contract or Account".to_string();
                     let found = "ContractWasm".to_string();
+                    Err(TypeMismatch::new(expected, found).into())
+                }
+                StoredValue::Transfer(_) => {
+                    let expected = "Contract or Account".to_string();
+                    let found = "Transfer".to_string();
+                    Err(TypeMismatch::new(expected, found).into())
+                }
+                StoredValue::DeployInfo(_) => {
+                    let expected = "Contract or Account".to_string();
+                    let found = "DeployInfo".to_string();
                     Err(TypeMismatch::new(expected, found).into())
                 }
             },

--- a/grpc/server/protobuf/casper/state.proto
+++ b/grpc/server/protobuf/casper/state.proto
@@ -242,6 +242,23 @@ message ContractWasm {
     bytes wasm = 1;
 }
 
+message Transfer {
+    DeployHash deploy = 1;
+    AccountHash from = 2;
+    Key.URef source = 3;
+    Key.URef target = 4;
+    BigInt amount = 5;
+    BigInt gas = 6;
+}
+
+message DeployInfo {
+    DeployHash deploy = 1;
+    repeated TransferAddr transfers = 2;
+    AccountHash from = 3;
+    Key.URef source = 4;
+    BigInt gas = 5;
+}
+
 // Value stored under a key in global state.
 message StoredValue {
     oneof variants {
@@ -250,6 +267,8 @@ message StoredValue {
         Contract contract = 3;
         ContractPackage contract_package = 4;
         ContractWasm contract_wasm = 5;
+        Transfer transfer = 6;
+        DeployInfo deploy_info = 7;
     }
 }
 
@@ -269,11 +288,25 @@ message BigInt {
 	uint32 bit_width = 2;
 }
 
+message DeployHash {
+    bytes deploy_hash = 1;
+}
+
+message AccountHash {
+    bytes account_hash = 1;
+}
+
+message TransferAddr {
+    bytes transfer_addr = 1;
+}
+
 message Key {
 	oneof value {
 		Address address = 1;
 		Hash hash = 2;
 		URef uref = 3;
+    TransferAddr transfer = 4;
+		DeployHash deploy_info = 5;
 	}
 
 	message Address {

--- a/grpc/server/src/engine_server/mappings/ipc/deploy_result.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/deploy_result.rs
@@ -14,11 +14,14 @@ use crate::engine_server::ipc::{DeployError_OutOfGasError, DeployResult};
 impl From<ExecutionResult> for DeployResult {
     fn from(execution_result: ExecutionResult) -> DeployResult {
         match execution_result {
-            ExecutionResult::Success { effect, cost } => detail::execution_success(effect, cost),
+            ExecutionResult::Success { effect, cost, .. } => {
+                detail::execution_success(effect, cost)
+            }
             ExecutionResult::Failure {
                 error,
                 effect,
                 cost,
+                ..
             } => (error, effect, cost).into(),
         }
     }
@@ -168,9 +171,11 @@ mod tests {
             tmp_map
         };
         let execution_effect = ExecutionEffect::new(AdditiveMap::new(), input_transforms.clone());
+        let transfers = Vec::default();
         let cost = Gas::new(U512::from(123));
         let execution_result = ExecutionResult::Success {
             effect: execution_effect,
+            transfers,
             cost,
         };
         let mut ipc_deploy_result: DeployResult = execution_result.into();
@@ -196,6 +201,7 @@ mod tests {
         let execution_failure = ExecutionResult::Failure {
             error: error.into(),
             effect: Default::default(),
+            transfers: Vec::default(),
             cost: expected_cost,
         };
         let mut ipc_deploy_result: DeployResult = execution_failure.into();
@@ -241,6 +247,7 @@ mod tests {
         let exec_result = ExecutionResult::Failure {
             error: EngineStateError::Exec(revert_error),
             effect: Default::default(),
+            transfers: Vec::default(),
             cost: Gas::new(amount),
         };
         let mut ipc_result: DeployResult = exec_result.into();

--- a/grpc/server/src/engine_server/mappings/mod.rs
+++ b/grpc/server/src/engine_server/mappings/mod.rs
@@ -10,8 +10,8 @@ use std::{
     string::ToString,
 };
 
-use casper_execution_engine::core::{engine_state, DEPLOY_HASH_LENGTH};
-use casper_types::{account::ACCOUNT_HASH_LENGTH, bytesrepr, KEY_HASH_LENGTH};
+use casper_execution_engine::core::engine_state;
+use casper_types::{account::ACCOUNT_HASH_LENGTH, bytesrepr, DEPLOY_HASH_LENGTH, KEY_HASH_LENGTH};
 
 pub use transforms::TransformMap;
 

--- a/grpc/server/src/engine_server/mappings/state/deploy_info.rs
+++ b/grpc/server/src/engine_server/mappings/state/deploy_info.rs
@@ -1,0 +1,79 @@
+use std::convert::TryFrom;
+
+use crate::engine_server::{mappings, mappings::ParsingError, state};
+
+use casper_types::{account::AccountHash, DeployInfo, TransferAddr, URef, U512};
+
+impl From<DeployInfo> for state::DeployInfo {
+    fn from(deploy_info: DeployInfo) -> Self {
+        let mut ret = state::DeployInfo::new();
+        {
+            let mut pb_deploy_hash = state::DeployHash::new();
+            pb_deploy_hash.deploy_hash = deploy_info.deploy_hash.to_vec();
+            ret.set_deploy(pb_deploy_hash)
+        }
+        {
+            let pb_vec_transfer_addr = deploy_info
+                .transfers
+                .into_iter()
+                .map(|transfer_addr| {
+                    let mut pb_transfer_addr = state::TransferAddr::new();
+                    pb_transfer_addr.transfer_addr = transfer_addr.to_vec();
+                    pb_transfer_addr
+                })
+                .collect::<Vec<state::TransferAddr>>()
+                .into();
+            ret.set_transfers(pb_vec_transfer_addr)
+        }
+        {
+            let mut pb_account_hash = state::AccountHash::new();
+            pb_account_hash.account_hash = deploy_info.from.value().to_vec();
+            ret.set_from(pb_account_hash)
+        }
+        ret.set_source(deploy_info.source.into());
+        ret.set_gas(deploy_info.gas.into());
+        ret
+    }
+}
+
+impl TryFrom<state::DeployInfo> for DeployInfo {
+    type Error = ParsingError;
+
+    fn try_from(pb_deploy_info: state::DeployInfo) -> Result<Self, Self::Error> {
+        let deploy = {
+            let deploy_hash = pb_deploy_info.get_deploy();
+            mappings::vec_to_array(
+                deploy_hash.deploy_hash.to_owned(),
+                "Protobuf DeployInfo.deploy",
+            )?
+        };
+        let transfers = pb_deploy_info
+            .get_transfers()
+            .iter()
+            .map(|pb_transfer_addr| {
+                mappings::vec_to_array(
+                    pb_transfer_addr.transfer_addr.to_owned(),
+                    "Protobuf DeployInfo.transfers",
+                )
+            })
+            .collect::<Result<Vec<TransferAddr>, Self::Error>>()?;
+        let from = {
+            let account_hash = pb_deploy_info.get_from();
+            mappings::vec_to_array(
+                account_hash.account_hash.to_owned(),
+                "Protobuf DeployInfo.from",
+            )
+            .map(AccountHash::new)?
+        };
+        let source = URef::try_from(pb_deploy_info.get_source().to_owned())?;
+        let gas = U512::try_from(pb_deploy_info.get_gas().to_owned())?;
+
+        Ok(DeployInfo {
+            deploy_hash: deploy,
+            transfers,
+            from,
+            source,
+            gas,
+        })
+    }
+}

--- a/grpc/server/src/engine_server/mappings/state/key.rs
+++ b/grpc/server/src/engine_server/mappings/state/key.rs
@@ -24,6 +24,16 @@ impl From<Key> for state::Key {
             Key::URef(uref) => {
                 pb_key.set_uref(uref.into());
             }
+            Key::DeployInfo(deploy_hash) => {
+                let mut pb_deploy_hash = state::DeployHash::new();
+                pb_deploy_hash.set_deploy_hash(deploy_hash.to_vec());
+                pb_key.set_deploy_info(pb_deploy_hash)
+            }
+            Key::Transfer(transfer_addr) => {
+                let mut pb_transfer_addr = state::TransferAddr::new();
+                pb_transfer_addr.set_transfer_addr(transfer_addr.to_vec());
+                pb_key.set_transfer(pb_transfer_addr)
+            }
         }
         pb_key
     }
@@ -49,6 +59,18 @@ impl TryFrom<state::Key> for Key {
             Key_oneof_value::uref(pb_uref) => {
                 let uref = pb_uref.try_into()?;
                 Key::URef(uref)
+            }
+            Key_oneof_value::transfer(pb_transfer_addr) => {
+                let transfer_addr = mappings::vec_to_array(
+                    pb_transfer_addr.transfer_addr,
+                    "Protobuf Key::Transfer",
+                )?;
+                Key::Transfer(transfer_addr)
+            }
+            Key_oneof_value::deploy_info(pb_deploy_hash) => {
+                let deploy_hash =
+                    mappings::vec_to_array(pb_deploy_hash.deploy_hash, "Protobuf Key::DeployInfo")?;
+                Key::DeployInfo(deploy_hash)
             }
         };
         Ok(key)

--- a/grpc/server/src/engine_server/mappings/state/mod.rs
+++ b/grpc/server/src/engine_server/mappings/state/mod.rs
@@ -8,11 +8,13 @@ mod cl_value;
 mod contract;
 mod contract_package;
 mod contract_wasm;
+mod deploy_info;
 mod key;
 mod named_key;
 mod protocol_version;
 mod semver;
 mod stored_value;
+mod transfer;
 mod uref;
 
 pub(crate) use named_key::NamedKeyMap;

--- a/grpc/server/src/engine_server/mappings/state/stored_value.rs
+++ b/grpc/server/src/engine_server/mappings/state/stored_value.rs
@@ -23,6 +23,8 @@ impl From<StoredValue> for state::StoredValue {
             StoredValue::ContractPackage(contract_package) => {
                 pb_value.set_contract_package(contract_package.into())
             }
+            StoredValue::Transfer(transfer) => pb_value.set_transfer(transfer.into()),
+            StoredValue::DeployInfo(deploy_info) => pb_value.set_deploy_info(deploy_info.into()),
         }
 
         pb_value
@@ -52,6 +54,12 @@ impl TryFrom<state::StoredValue> for StoredValue {
             }
             StoredValue_oneof_variants::contract_wasm(pb_contract_wasm) => {
                 StoredValue::ContractWasm(pb_contract_wasm.into())
+            }
+            StoredValue_oneof_variants::transfer(pb_transfer) => {
+                StoredValue::Transfer(pb_transfer.try_into()?)
+            }
+            StoredValue_oneof_variants::deploy_info(pb_deploy_info) => {
+                StoredValue::DeployInfo(pb_deploy_info.try_into()?)
             }
         };
 

--- a/grpc/server/src/engine_server/mappings/state/transfer.rs
+++ b/grpc/server/src/engine_server/mappings/state/transfer.rs
@@ -1,0 +1,60 @@
+use std::convert::TryFrom;
+
+use casper_types::{account::AccountHash, Transfer, URef, U512};
+
+use crate::engine_server::{mappings, mappings::ParsingError, state};
+
+impl From<Transfer> for state::Transfer {
+    fn from(transfer: Transfer) -> Self {
+        let mut ret = Self::new();
+        {
+            let mut pb_deploy_hash = state::DeployHash::new();
+            pb_deploy_hash.deploy_hash = transfer.deploy_hash.to_vec();
+            ret.set_deploy(pb_deploy_hash);
+        }
+        {
+            let mut pb_account_hash = state::AccountHash::new();
+            pb_account_hash.account_hash = transfer.from.value().to_vec();
+            ret.set_from(pb_account_hash);
+        }
+        ret.set_source(transfer.source.into());
+        ret.set_target(transfer.target.into());
+        ret.set_amount(transfer.amount.into());
+        ret.set_gas(transfer.gas.into());
+        ret
+    }
+}
+
+impl TryFrom<state::Transfer> for Transfer {
+    type Error = ParsingError;
+
+    fn try_from(pb_transfer: state::Transfer) -> Result<Self, Self::Error> {
+        let deploy = {
+            let pb_deploy_hash = pb_transfer.get_deploy();
+            mappings::vec_to_array(
+                pb_deploy_hash.deploy_hash.to_owned(),
+                "Protobuf Transfer.deploy",
+            )?
+        };
+        let from = {
+            let pb_account_hash = pb_transfer.get_from();
+            mappings::vec_to_array(
+                pb_account_hash.account_hash.to_owned(),
+                "Protobuf Transfer.from",
+            )
+            .map(AccountHash::new)?
+        };
+        let source = URef::try_from(pb_transfer.get_source().to_owned())?;
+        let target = URef::try_from(pb_transfer.get_target().to_owned())?;
+        let amount = U512::try_from(pb_transfer.get_amount().to_owned())?;
+        let gas = U512::try_from(pb_transfer.get_gas().to_owned())?;
+        Ok(Transfer {
+            deploy_hash: deploy,
+            from,
+            source,
+            target,
+            amount,
+            gas,
+        })
+    }
+}

--- a/grpc/test_support/src/internal/deploy_item_builder.rs
+++ b/grpc/test_support/src/internal/deploy_item_builder.rs
@@ -1,15 +1,12 @@
 use std::{collections::BTreeSet, path::Path};
 
 use casper_execution_engine::{
-    core::{
-        engine_state::{deploy_item::DeployItem, executable_deploy_item::ExecutableDeployItem},
-        DeployHash,
-    },
+    core::engine_state::{deploy_item::DeployItem, executable_deploy_item::ExecutableDeployItem},
     shared::newtypes::Blake2bHash,
 };
 use casper_types::{
-    account::AccountHash, bytesrepr::ToBytes, contracts::ContractVersion, ContractHash, HashAddr,
-    RuntimeArgs,
+    account::AccountHash, bytesrepr::ToBytes, contracts::ContractVersion, ContractHash, DeployHash,
+    HashAddr, RuntimeArgs,
 };
 
 use crate::internal::utils;

--- a/grpc/test_support/src/internal/exec_with_return.rs
+++ b/grpc/test_support/src/internal/exec_with_return.rs
@@ -61,6 +61,10 @@ where
         let address_generator = AddressGenerator::new(&deploy_hash, phase);
         Rc::new(RefCell::new(address_generator))
     };
+    let transfer_address_generator = {
+        let address_generator = AddressGenerator::new(&deploy_hash, phase);
+        Rc::new(RefCell::new(address_generator))
+    };
     let gas_counter = Gas::default();
     let fn_store_id = {
         let fn_store_id = AddressGenerator::new(&deploy_hash, phase);
@@ -90,6 +94,8 @@ where
         ProtocolData::new(*DEFAULT_WASM_CONFIG, mint, pos, standard_payment, auction)
     };
 
+    let transfers = Vec::default();
+
     let context = RuntimeContext::new(
         Rc::clone(&tracking_copy),
         EntryPointType::Session, // Is it always?
@@ -105,10 +111,12 @@ where
         gas_counter,
         fn_store_id,
         address_generator,
+        transfer_address_generator,
         protocol_version,
         correlation_id,
         phase,
         protocol_data,
+        transfers,
     );
 
     let wasm_bytes = utils::read_wasm_file_bytes(wasm_file);

--- a/grpc/test_support/src/internal/execute_request_builder.rs
+++ b/grpc/test_support/src/internal/execute_request_builder.rs
@@ -114,6 +114,21 @@ impl ExecuteRequestBuilder {
 
         ExecuteRequestBuilder::new().push_deploy(deploy)
     }
+
+    pub fn transfer(sender: AccountHash, transfer_args: RuntimeArgs) -> Self {
+        let mut rng = rand::thread_rng();
+        let deploy_hash = rng.gen();
+
+        let deploy_item = DeployItemBuilder::new()
+            .with_address(sender)
+            .with_empty_payment_bytes(runtime_args! {})
+            .with_transfer_args(transfer_args)
+            .with_authorization_keys(&[sender])
+            .with_deploy_hash(deploy_hash)
+            .build();
+
+        ExecuteRequestBuilder::from_deploy_item(deploy_item)
+    }
 }
 
 impl Default for ExecuteRequestBuilder {

--- a/grpc/test_support/src/internal/wasm_test_builder.rs
+++ b/grpc/test_support/src/internal/wasm_test_builder.rs
@@ -52,7 +52,8 @@ use casper_types::{
     auction::{EraId, ValidatorWeights},
     bytesrepr::{self},
     mint::TOTAL_SUPPLY_KEY,
-    CLTyped, CLValue, Contract, ContractHash, ContractWasm, Key, URef, U512,
+    CLTyped, CLValue, Contract, ContractHash, ContractWasm, DeployHash, DeployInfo, Key, Transfer,
+    TransferAddr, URef, U512,
 };
 
 use crate::internal::{utils, DEFAULT_PROTOCOL_VERSION};
@@ -692,6 +693,30 @@ where
 
         if let StoredValue::ContractWasm(contract_wasm) = contract_value {
             Some(contract_wasm)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_transfer(&self, transfer: TransferAddr) -> Option<Transfer> {
+        let transfer_value: StoredValue = self
+            .query(None, Key::Transfer(transfer), &[])
+            .expect("should have transfer value");
+
+        if let StoredValue::Transfer(transfer) = transfer_value {
+            Some(transfer)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_deploy_info(&self, deploy_hash: DeployHash) -> Option<DeployInfo> {
+        let deploy_info_value: StoredValue = self
+            .query(None, Key::DeployInfo(deploy_hash), &[])
+            .expect("should have deploy info value");
+
+        if let StoredValue::DeployInfo(deploy_info) = deploy_info_value {
+            Some(deploy_info)
         } else {
             None
         }

--- a/grpc/tests/src/test/deploy/mod.rs
+++ b/grpc/tests/src/test/deploy/mod.rs
@@ -1,4 +1,5 @@
 mod context_association;
 mod non_standard_payment;
 mod preconditions;
+mod receipts;
 mod stored_contracts;

--- a/grpc/tests/src/test/deploy/receipts.rs
+++ b/grpc/tests/src/test/deploy/receipts.rs
@@ -1,0 +1,440 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use lazy_static::lazy_static;
+
+use casper_engine_test_support::{
+    internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
+    DEFAULT_ACCOUNT_ADDR,
+};
+use casper_types::{
+    account::AccountHash, runtime_args, AccessRights, DeployHash, PublicKey, RuntimeArgs, Transfer,
+    TransferAddr, U512,
+};
+
+const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
+const TRANSFER_ARG_TARGET: &str = "target";
+const TRANSFER_ARG_AMOUNT: &str = "amount";
+
+const CONTRACT_TRANSFER_PURSE_TO_ACCOUNTS: &str = "transfer_purse_to_accounts.wasm";
+const TRANSFER_ARG_SOURCE: &str = "source";
+const TRANSFER_ARG_TARGETS: &str = "targets";
+
+const CONTRACT_TRANSFER_PURSE_TO_ACCOUNTS_STORED: &str = "transfer_purse_to_accounts_stored.wasm";
+const CONTRACT_TRANSFER_PURSE_TO_ACCOUNTS_SUBCALL: &str = "transfer_purse_to_accounts_subcall.wasm";
+
+const ALICE_KEY: PublicKey = PublicKey::Ed25519([3; 32]);
+const BOB_KEY: PublicKey = PublicKey::Ed25519([5; 32]);
+const CAROL_KEY: PublicKey = PublicKey::Ed25519([7; 32]);
+
+lazy_static! {
+    static ref ALICE_ADDR: AccountHash = ALICE_KEY.into();
+    static ref BOB_ADDR: AccountHash = BOB_KEY.into();
+    static ref CAROL_ADDR: AccountHash = CAROL_KEY.into();
+    static ref TRANSFER_AMOUNT_1: U512 = U512::from(100_000_000);
+    static ref TRANSFER_AMOUNT_2: U512 = U512::from(200_000_000);
+    static ref TRANSFER_AMOUNT_3: U512 = U512::from(300_000_000);
+}
+
+#[ignore]
+#[test]
+fn should_record_wasmless_transfer() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    let transfer_request = ExecuteRequestBuilder::transfer(
+        *DEFAULT_ACCOUNT_ADDR,
+        runtime_args! {
+            TRANSFER_ARG_TARGET => *ALICE_ADDR,
+            TRANSFER_ARG_AMOUNT => *TRANSFER_AMOUNT_1
+
+        },
+    )
+    .build();
+
+    let deploy_hash = {
+        let deploy_items: Vec<DeployHash> = transfer_request
+            .deploys()
+            .iter()
+            .map(Result::as_ref)
+            .filter_map(Result::ok)
+            .map(|deploy_item| deploy_item.deploy_hash)
+            .collect();
+        deploy_items[0]
+    };
+
+    builder.exec(transfer_request).commit().expect_success();
+
+    let default_account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have default account");
+
+    let alice_account = builder
+        .get_account(*ALICE_ADDR)
+        .expect("should have Alice's account");
+
+    let alice_attenuated_main_purse = alice_account
+        .main_purse()
+        .with_access_rights(AccessRights::ADD);
+
+    let deploy_info = builder
+        .get_deploy_info(deploy_hash)
+        .expect("should have deploy info");
+
+    assert_eq!(deploy_info.deploy_hash, deploy_hash);
+    assert_eq!(deploy_info.from, *DEFAULT_ACCOUNT_ADDR);
+    assert_eq!(deploy_info.source, default_account.main_purse());
+
+    // TODO: this is borked
+    if !cfg!(feature = "use-system-contracts") {
+        assert_eq!(deploy_info.gas, U512::zero());
+    }
+
+    let transfers = deploy_info.transfers;
+    assert_eq!(transfers.len(), 1);
+
+    let transfer = builder
+        .get_transfer(transfers[0])
+        .expect("should have transfer");
+
+    assert_eq!(transfer.deploy_hash, deploy_hash);
+    assert_eq!(transfer.from, *DEFAULT_ACCOUNT_ADDR);
+    assert_eq!(transfer.source, default_account.main_purse());
+    assert_eq!(transfer.target, alice_attenuated_main_purse);
+    assert_eq!(transfer.amount, *TRANSFER_AMOUNT_1);
+    assert_eq!(transfer.gas, U512::zero()) // TODO
+}
+
+#[ignore]
+#[test]
+fn should_record_wasm_transfer() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    let transfer_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_PURSE_TO_ACCOUNT,
+        runtime_args! {
+            TRANSFER_ARG_TARGET => *ALICE_ADDR,
+            TRANSFER_ARG_AMOUNT => *TRANSFER_AMOUNT_1
+
+        },
+    )
+    .build();
+
+    let deploy_hash = {
+        let deploy_items: Vec<DeployHash> = transfer_request
+            .deploys()
+            .iter()
+            .map(Result::as_ref)
+            .filter_map(Result::ok)
+            .map(|deploy_item| deploy_item.deploy_hash)
+            .collect();
+        deploy_items[0]
+    };
+
+    builder.exec(transfer_request).commit().expect_success();
+
+    let default_account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have default account");
+
+    let alice_account = builder
+        .get_account(*ALICE_ADDR)
+        .expect("should have Alice's account");
+
+    let alice_attenuated_main_purse = alice_account
+        .main_purse()
+        .with_access_rights(AccessRights::ADD);
+
+    let deploy_info = builder
+        .get_deploy_info(deploy_hash)
+        .expect("should have deploy info");
+
+    assert_eq!(deploy_info.deploy_hash, deploy_hash);
+    assert_eq!(deploy_info.from, *DEFAULT_ACCOUNT_ADDR);
+    assert_eq!(deploy_info.source, default_account.main_purse());
+    assert_ne!(deploy_info.gas, U512::zero());
+
+    let transfers = deploy_info.transfers;
+    assert_eq!(transfers.len(), 1);
+
+    let transfer = builder
+        .get_transfer(transfers[0])
+        .expect("should have transfer");
+
+    assert_eq!(transfer.deploy_hash, deploy_hash);
+    assert_eq!(transfer.from, *DEFAULT_ACCOUNT_ADDR);
+    assert_eq!(transfer.source, default_account.main_purse());
+    assert_eq!(transfer.target, alice_attenuated_main_purse);
+    assert_eq!(transfer.amount, *TRANSFER_AMOUNT_1);
+    assert_eq!(transfer.gas, U512::zero()) // TODO
+}
+
+#[ignore]
+#[test]
+fn should_record_wasm_transfers() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    let default_account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have default account");
+
+    let targets: BTreeMap<AccountHash, U512> = {
+        let mut tmp = BTreeMap::new();
+        tmp.insert(*ALICE_ADDR, *TRANSFER_AMOUNT_1);
+        tmp.insert(*BOB_ADDR, *TRANSFER_AMOUNT_2);
+        tmp.insert(*CAROL_ADDR, *TRANSFER_AMOUNT_3);
+        tmp
+    };
+
+    let transfer_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_PURSE_TO_ACCOUNTS,
+        runtime_args! {
+            TRANSFER_ARG_SOURCE => default_account.main_purse(),
+            TRANSFER_ARG_TARGETS => targets,
+        },
+    )
+    .build();
+
+    let deploy_hash = {
+        let deploy_items: Vec<DeployHash> = transfer_request
+            .deploys()
+            .iter()
+            .map(Result::as_ref)
+            .filter_map(Result::ok)
+            .map(|deploy_item| deploy_item.deploy_hash)
+            .collect();
+        deploy_items[0]
+    };
+
+    builder.exec(transfer_request).commit().expect_success();
+
+    let default_account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have default account");
+
+    let alice_account = builder
+        .get_account(*ALICE_ADDR)
+        .expect("should have Alice's account");
+
+    let bob_account = builder
+        .get_account(*BOB_ADDR)
+        .expect("should have Bob's account");
+
+    let carol_account = builder
+        .get_account(*CAROL_ADDR)
+        .expect("should have Carol's account");
+
+    let alice_attenuated_main_purse = alice_account
+        .main_purse()
+        .with_access_rights(AccessRights::ADD);
+
+    let bob_attenuated_main_purse = bob_account
+        .main_purse()
+        .with_access_rights(AccessRights::ADD);
+
+    let carol_attenuated_main_purse = carol_account
+        .main_purse()
+        .with_access_rights(AccessRights::ADD);
+
+    let deploy_info = builder
+        .get_deploy_info(deploy_hash)
+        .expect("should have deploy info");
+
+    assert_eq!(deploy_info.deploy_hash, deploy_hash);
+    assert_eq!(deploy_info.from, *DEFAULT_ACCOUNT_ADDR);
+    assert_eq!(deploy_info.source, default_account.main_purse());
+    assert_ne!(deploy_info.gas, U512::zero());
+
+    const EXPECTED_LENGTH: usize = 3;
+    let transfer_addrs = deploy_info.transfers;
+    assert_eq!(transfer_addrs.len(), EXPECTED_LENGTH);
+    assert_eq!(
+        transfer_addrs
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<TransferAddr>>()
+            .len(),
+        EXPECTED_LENGTH
+    );
+
+    let transfers: BTreeSet<Transfer> = {
+        let mut tmp = BTreeSet::new();
+        for transfer_addr in transfer_addrs {
+            let transfer = builder
+                .get_transfer(transfer_addr)
+                .expect("should have transfer");
+            tmp.insert(transfer);
+        }
+        tmp
+    };
+
+    assert_eq!(transfers.len(), EXPECTED_LENGTH);
+
+    assert!(transfers.contains(&Transfer {
+        deploy_hash,
+        from: *DEFAULT_ACCOUNT_ADDR,
+        source: default_account.main_purse(),
+        target: alice_attenuated_main_purse,
+        amount: *TRANSFER_AMOUNT_1,
+        gas: U512::zero(),
+    }));
+
+    assert!(transfers.contains(&Transfer {
+        deploy_hash,
+        from: *DEFAULT_ACCOUNT_ADDR,
+        source: default_account.main_purse(),
+        target: bob_attenuated_main_purse,
+        amount: *TRANSFER_AMOUNT_2,
+        gas: U512::zero(),
+    }));
+
+    assert!(transfers.contains(&Transfer {
+        deploy_hash,
+        from: *DEFAULT_ACCOUNT_ADDR,
+        source: default_account.main_purse(),
+        target: carol_attenuated_main_purse,
+        amount: *TRANSFER_AMOUNT_3,
+        gas: U512::zero(),
+    }));
+}
+
+#[ignore]
+#[test]
+fn should_record_wasm_transfers_with_subcall() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    let default_account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have default account");
+
+    let store_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_PURSE_TO_ACCOUNTS_STORED,
+        runtime_args! {},
+    )
+    .build();
+
+    let targets: BTreeMap<AccountHash, U512> = {
+        let mut tmp = BTreeMap::new();
+        tmp.insert(*ALICE_ADDR, *TRANSFER_AMOUNT_1);
+        tmp.insert(*BOB_ADDR, *TRANSFER_AMOUNT_2);
+        tmp.insert(*CAROL_ADDR, *TRANSFER_AMOUNT_3);
+        tmp
+    };
+
+    let transfer_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_PURSE_TO_ACCOUNTS_SUBCALL,
+        runtime_args! {
+            TRANSFER_ARG_SOURCE => default_account.main_purse(),
+            TRANSFER_ARG_TARGETS => targets,
+        },
+    )
+    .build();
+
+    let transfer_deploy_hash = {
+        let deploy_items: Vec<DeployHash> = transfer_request
+            .deploys()
+            .iter()
+            .map(Result::as_ref)
+            .filter_map(Result::ok)
+            .map(|deploy_item| deploy_item.deploy_hash)
+            .collect();
+        deploy_items[0]
+    };
+
+    builder.exec(store_request).commit().expect_success();
+    builder.exec(transfer_request).commit().expect_success();
+
+    let alice_account = builder
+        .get_account(*ALICE_ADDR)
+        .expect("should have Alice's account");
+
+    let bob_account = builder
+        .get_account(*BOB_ADDR)
+        .expect("should have Bob's account");
+
+    let carol_account = builder
+        .get_account(*CAROL_ADDR)
+        .expect("should have Carol's account");
+
+    let alice_attenuated_main_purse = alice_account
+        .main_purse()
+        .with_access_rights(AccessRights::ADD);
+
+    let bob_attenuated_main_purse = bob_account
+        .main_purse()
+        .with_access_rights(AccessRights::ADD);
+
+    let carol_attenuated_main_purse = carol_account
+        .main_purse()
+        .with_access_rights(AccessRights::ADD);
+
+    let deploy_info = builder
+        .get_deploy_info(transfer_deploy_hash)
+        .expect("should have deploy info");
+
+    assert_eq!(deploy_info.deploy_hash, transfer_deploy_hash);
+    assert_eq!(deploy_info.from, *DEFAULT_ACCOUNT_ADDR);
+    assert_eq!(deploy_info.source, default_account.main_purse());
+    assert_ne!(deploy_info.gas, U512::zero());
+
+    const EXPECTED_LENGTH: usize = 6;
+    let transfer_addrs = deploy_info.transfers;
+    assert_eq!(transfer_addrs.len(), EXPECTED_LENGTH);
+    assert_eq!(
+        transfer_addrs
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<TransferAddr>>()
+            .len(),
+        EXPECTED_LENGTH
+    );
+
+    let transfer_counts: BTreeMap<Transfer, usize> = {
+        let mut tmp = BTreeMap::new();
+        for transfer_addr in transfer_addrs {
+            let transfer = builder
+                .get_transfer(transfer_addr)
+                .expect("should have transfer");
+            tmp.entry(transfer).and_modify(|i| *i += 1).or_insert(1);
+        }
+        tmp
+    };
+
+    let expected_alice = Transfer {
+        deploy_hash: transfer_deploy_hash,
+        from: *DEFAULT_ACCOUNT_ADDR,
+        source: default_account.main_purse(),
+        target: alice_attenuated_main_purse,
+        amount: *TRANSFER_AMOUNT_1,
+        gas: U512::zero(),
+    };
+
+    let expected_bob = Transfer {
+        deploy_hash: transfer_deploy_hash,
+        from: *DEFAULT_ACCOUNT_ADDR,
+        source: default_account.main_purse(),
+        target: bob_attenuated_main_purse,
+        amount: *TRANSFER_AMOUNT_2,
+        gas: U512::zero(),
+    };
+
+    let expected_carol = Transfer {
+        deploy_hash: transfer_deploy_hash,
+        from: *DEFAULT_ACCOUNT_ADDR,
+        source: default_account.main_purse(),
+        target: carol_attenuated_main_purse,
+        amount: *TRANSFER_AMOUNT_3,
+        gas: U512::zero(),
+    };
+
+    const EXPECTED_COUNT: Option<usize> = Some(2);
+    for expected in &[expected_alice, expected_bob, expected_carol] {
+        assert_eq!(transfer_counts.get(&expected).cloned(), EXPECTED_COUNT);
+    }
+}

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -299,7 +299,7 @@ impl BlockExecutor {
             .insert(deploy_hash, execution_result);
 
         let execution_effect = match ee_execution_result {
-            EngineExecutionResult::Success { effect, cost } => {
+            EngineExecutionResult::Success { effect, cost, .. } => {
                 debug!(?effect, %cost, "execution succeeded");
                 effect
             }
@@ -307,6 +307,7 @@ impl BlockExecutor {
                 error,
                 effect,
                 cost,
+                ..
             } => {
                 error!(?error, ?effect, %cost, "execution failure");
                 effect

--- a/node/src/types/json_compatibility.rs
+++ b/node/src/types/json_compatibility.rs
@@ -6,13 +6,17 @@ use casper_types::Key;
 
 mod account;
 mod cl_value;
+mod deploy_info;
 mod execution_result;
 mod stored_value;
+mod transfer;
 
 pub use account::Account;
 pub use cl_value::CLValue;
+pub use deploy_info::DeployInfo;
 pub use execution_result::ExecutionResult;
 pub use stored_value::StoredValue;
+pub use transfer::Transfer;
 
 fn convert_named_keys(named_keys: &BTreeMap<String, Key>) -> BTreeMap<String, String> {
     named_keys

--- a/node/src/types/json_compatibility/deploy_info.rs
+++ b/node/src/types/json_compatibility/deploy_info.rs
@@ -1,0 +1,37 @@
+//! This file provides types to allow conversion from an EE `DeployInfo` into a similar type
+//! which can be serialized to a valid JSON representation.
+
+use casper_types::{self, U512};
+use hex_fmt::HexFmt;
+use serde::{Deserialize, Serialize};
+
+/// Representation of deploy info
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+pub struct DeployInfo {
+    deploy_hash: String,
+    transfers: Vec<String>,
+    from: String,
+    source: String,
+    gas: U512,
+}
+
+impl From<&casper_types::DeployInfo> for DeployInfo {
+    fn from(types_deploy_info: &casper_types::DeployInfo) -> Self {
+        let deploy_hash = format!("{}", HexFmt(types_deploy_info.deploy_hash));
+        let transfers = types_deploy_info
+            .transfers
+            .iter()
+            .map(|transfer_addr| format!("transfer-{}", HexFmt(transfer_addr)))
+            .collect();
+        let from = types_deploy_info.from.to_formatted_string();
+        let source = types_deploy_info.source.to_formatted_string();
+        let gas = types_deploy_info.gas;
+        DeployInfo {
+            deploy_hash,
+            transfers,
+            from,
+            source,
+            gas,
+        }
+    }
+}

--- a/node/src/types/json_compatibility/execution_result.rs
+++ b/node/src/types/json_compatibility/execution_result.rs
@@ -76,7 +76,7 @@ impl ExecutionResult {
 impl From<&EngineExecutionResult> for ExecutionResult {
     fn from(ee_execution_result: &EngineExecutionResult) -> Self {
         match ee_execution_result {
-            EngineExecutionResult::Success { effect, cost } => ExecutionResult {
+            EngineExecutionResult::Success { effect, cost, .. } => ExecutionResult {
                 effect: effect.into(),
                 cost: cost.value(),
                 error_message: None,
@@ -85,6 +85,7 @@ impl From<&EngineExecutionResult> for ExecutionResult {
                 error,
                 effect,
                 cost,
+                ..
             } => ExecutionResult {
                 effect: effect.into(),
                 cost: cost.value(),
@@ -147,6 +148,8 @@ enum Transform {
     WriteContractWasm,
     WriteContract,
     WriteContractPackage,
+    WriteDeployInfo,
+    WriteTransfer,
     AddInt32(i32),
     AddUInt64(u64),
     AddUInt128(U128),
@@ -205,6 +208,8 @@ impl From<&EngineTransform> for Transform {
             EngineTransform::Write(StoredValue::ContractPackage(_)) => {
                 Transform::WriteContractPackage
             }
+            EngineTransform::Write(StoredValue::Transfer(_)) => Transform::WriteTransfer,
+            EngineTransform::Write(StoredValue::DeployInfo(_)) => Transform::WriteDeployInfo,
             EngineTransform::AddInt32(value) => Transform::AddInt32(*value),
             EngineTransform::AddUInt64(value) => Transform::AddUInt64(*value),
             EngineTransform::AddUInt128(value) => Transform::AddUInt128(*value),

--- a/node/src/types/json_compatibility/stored_value.rs
+++ b/node/src/types/json_compatibility/stored_value.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use casper_execution_engine::shared::stored_value::StoredValue as ExecutionEngineStoredValue;
 use casper_types::bytesrepr::{self, ToBytes};
 
-use super::{Account, CLValue};
+use super::{Account, CLValue, DeployInfo, Transfer};
 
 /// Representation of a value stored in global state.
 ///
@@ -27,6 +27,10 @@ pub enum StoredValue {
     Contract(String),
     /// A contract definition, metadata, and security container.
     ContractPackage(String),
+    /// A record of a transfer
+    Transfer(Transfer),
+    /// A record of a deploy
+    DeployInfo(DeployInfo),
 }
 
 impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
@@ -46,6 +50,12 @@ impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
             }
             ExecutionEngineStoredValue::ContractPackage(contract_package) => {
                 StoredValue::ContractPackage(hex::encode(&contract_package.to_bytes()?))
+            }
+            ExecutionEngineStoredValue::Transfer(transfer) => {
+                StoredValue::Transfer(transfer.into())
+            }
+            ExecutionEngineStoredValue::DeployInfo(deploy_info) => {
+                StoredValue::DeployInfo(deploy_info.into())
             }
         };
 

--- a/node/src/types/json_compatibility/transfer.rs
+++ b/node/src/types/json_compatibility/transfer.rs
@@ -1,0 +1,36 @@
+//! This file provides types to allow conversion from an EE `Transfer` into a similar type
+//! which can be serialized to a valid JSON representation.
+
+use casper_types::U512;
+use hex_fmt::HexFmt;
+use serde::{Deserialize, Serialize};
+
+/// Representation of a transfer.
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+pub struct Transfer {
+    deploy_hash: String,
+    from: String,
+    source: String,
+    target: String,
+    amount: U512,
+    gas: U512,
+}
+
+impl From<&casper_types::Transfer> for Transfer {
+    fn from(types_transfer: &casper_types::Transfer) -> Self {
+        let deploy_hash = format!("{}", HexFmt(types_transfer.deploy_hash));
+        let from = types_transfer.from.to_formatted_string();
+        let source = types_transfer.source.to_formatted_string();
+        let target = types_transfer.target.to_formatted_string();
+        let amount = types_transfer.amount;
+        let gas = types_transfer.gas;
+        Transfer {
+            deploy_hash,
+            from,
+            source,
+            target,
+            amount,
+            gas,
+        }
+    }
+}

--- a/smart_contracts/contract/src/contract_api/system.rs
+++ b/smart_contracts/contract/src/contract_api/system.rs
@@ -159,3 +159,27 @@ pub fn transfer_from_purse_to_purse(
         Err(ApiError::Transfer)
     }
 }
+
+/// Records a transfer.  Can only be called from within the mint contract.
+/// Needed to support system contract-based execution.
+#[doc(hidden)]
+pub fn record_transfer(source: URef, target: URef, amount: U512) -> Result<(), ApiError> {
+    let (source_ptr, source_size, _bytes1) = contract_api::to_ptr(source);
+    let (target_ptr, target_size, _bytes2) = contract_api::to_ptr(target);
+    let (amount_ptr, amount_size, _bytes3) = contract_api::to_ptr(amount);
+    let result = unsafe {
+        ext_ffi::record_transfer(
+            source_ptr,
+            source_size,
+            target_ptr,
+            target_size,
+            amount_ptr,
+            amount_size,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(ApiError::Transfer)
+    }
+}

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -364,6 +364,28 @@ extern "C" {
         amount_ptr: *const u8,
         amount_size: usize,
     ) -> i32;
+    /// Records a transfer.  Can only be called from within the mint contract.
+    /// Needed to support system contract-based execution.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_ptr` - pointer in wasm memory to bytes representing the source
+    ///   [`casper_types::uref::URef`] to transfer from
+    /// * `source_size` - size of the source [`casper_types::uref::URef`] (in bytes)
+    /// * `target_ptr` - pointer in wasm memory to bytes representing the target
+    ///   [`casper_types::uref::URef`] to transfer to
+    /// * `target_size` - size of the target (in bytes)
+    /// * `amount_ptr` - pointer in wasm memory to bytes representing the amount to transfer to the
+    ///   target account
+    /// * `amount_size` - size of the amount (in bytes)
+    pub fn record_transfer(
+        source_ptr: *const u8,
+        source_size: usize,
+        target_ptr: *const u8,
+        target_size: usize,
+        amount_ptr: *const u8,
+        amount_size: usize,
+    ) -> i32;
     /// This function uses the mint contract's balance function to get the balance
     /// of the specified purse. It causes a `Trap` if the bytes in wasm memory
     /// from `purse_ptr` to `purse_ptr + purse_size` cannot be

--- a/smart_contracts/contracts/system/mint-token/src/lib.rs
+++ b/smart_contracts/contracts/system/mint-token/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 
 use casper_contract::{
-    contract_api::{runtime, storage},
+    contract_api::{runtime, storage, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
 use casper_types::{
@@ -14,8 +14,9 @@ use casper_types::{
     bytesrepr::{FromBytes, ToBytes},
     contracts::Parameters,
     mint::{
-        Mint, RuntimeProvider, StorageProvider, ARG_AMOUNT, ARG_PURSE, ARG_SOURCE, ARG_TARGET,
-        METHOD_BALANCE, METHOD_CREATE, METHOD_MINT, METHOD_READ_BASE_ROUND_REWARD, METHOD_TRANSFER,
+        Mint, RuntimeProvider, StorageProvider, SystemProvider, ARG_AMOUNT, ARG_PURSE, ARG_SOURCE,
+        ARG_TARGET, METHOD_BALANCE, METHOD_CREATE, METHOD_MINT, METHOD_READ_BASE_ROUND_REWARD,
+        METHOD_TRANSFER,
     },
     system_contract_errors::mint::Error,
     CLType, CLTyped, CLValue, EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Key,
@@ -65,6 +66,12 @@ impl StorageProvider for MintContract {
     fn add<T: CLTyped + ToBytes>(&mut self, uref: URef, value: T) -> Result<(), Error> {
         storage::add(uref, value);
         Ok(())
+    }
+}
+
+impl SystemProvider for MintContract {
+    fn record_transfer(&mut self, source: URef, target: URef, amount: U512) -> Result<(), Error> {
+        system::record_transfer(source, target, amount).map_err(|_| Error::RecordTransferFailure)
     }
 }
 

--- a/smart_contracts/contracts/test/modified-mint/src/lib.rs
+++ b/smart_contracts/contracts/test/modified-mint/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 
 use casper_contract::{
-    contract_api::{runtime, storage},
+    contract_api::{runtime, storage, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
 use casper_types::{
@@ -14,8 +14,9 @@ use casper_types::{
     bytesrepr::{FromBytes, ToBytes},
     contracts::Parameters,
     mint::{
-        Mint, RuntimeProvider, StorageProvider, ARG_AMOUNT, ARG_PURSE, ARG_SOURCE, ARG_TARGET,
-        METHOD_BALANCE, METHOD_CREATE, METHOD_MINT, METHOD_READ_BASE_ROUND_REWARD, METHOD_TRANSFER,
+        Mint, RuntimeProvider, StorageProvider, SystemProvider, ARG_AMOUNT, ARG_PURSE, ARG_SOURCE,
+        ARG_TARGET, METHOD_BALANCE, METHOD_CREATE, METHOD_MINT, METHOD_READ_BASE_ROUND_REWARD,
+        METHOD_TRANSFER,
     },
     system_contract_errors::mint::Error,
     CLType, CLTyped, CLValue, EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Key,
@@ -66,6 +67,12 @@ impl StorageProvider for MintContract {
     fn add<T: CLTyped + ToBytes>(&mut self, uref: URef, value: T) -> Result<(), Error> {
         storage::add(uref, value);
         Ok(())
+    }
+}
+
+impl SystemProvider for MintContract {
+    fn record_transfer(&mut self, source: URef, target: URef, amount: U512) -> Result<(), Error> {
+        system::record_transfer(source, target, amount).map_err(|_| Error::RecordTransferFailure)
     }
 }
 

--- a/smart_contracts/contracts/test/transfer-purse-to-accounts-stored/Cargo.toml
+++ b/smart_contracts/contracts/test/transfer-purse-to-accounts-stored/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "transfer-purse-to-accounts-stored"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>", "Ed Hastings <ed@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "transfer_purse_to_accounts_stored"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[features]
+std = ["casper-contract/std", "casper-types/std"]
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }
+transfer-purse-to-accounts = { path = "../transfer-purse-to-accounts" }

--- a/smart_contracts/contracts/test/transfer-purse-to-accounts-stored/src/main.rs
+++ b/smart_contracts/contracts/test/transfer-purse-to-accounts-stored/src/main.rs
@@ -1,0 +1,65 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::{string::ToString, vec};
+
+use alloc::boxed::Box;
+use casper_contract::contract_api::{runtime, storage};
+
+use casper_types::{
+    contracts::{EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Parameter},
+    CLType,
+};
+
+const ENTRY_FUNCTION_NAME: &str = "transfer";
+
+const PACKAGE_HASH_KEY_NAME: &str = "transfer_purse_to_accounts";
+const HASH_KEY_NAME: &str = "transfer_purse_to_accounts_hash";
+const ACCESS_KEY_NAME: &str = "transfer_purse_to_accounts_access";
+
+const ARG_SOURCE: &str = "source";
+const ARG_TARGETS: &str = "targets";
+
+const CONTRACT_VERSION: &str = "contract_version";
+
+#[no_mangle]
+pub extern "C" fn transfer() {
+    transfer_purse_to_accounts::delegate();
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let entry_points = {
+        let mut tmp = EntryPoints::new();
+        let entry_point = EntryPoint::new(
+            ENTRY_FUNCTION_NAME.to_string(),
+            vec![
+                Parameter::new(ARG_SOURCE, CLType::URef),
+                Parameter::new(
+                    ARG_TARGETS,
+                    CLType::Map {
+                        key: Box::new(CLType::FixedList(Box::new(CLType::U8), 32)),
+                        value: Box::new(CLType::U512),
+                    },
+                ),
+            ],
+            CLType::Unit,
+            EntryPointAccess::Public,
+            EntryPointType::Contract,
+        );
+        tmp.add_entry_point(entry_point);
+        tmp
+    };
+
+    let (contract_hash, contract_version) = storage::new_contract(
+        entry_points,
+        None,
+        Some(PACKAGE_HASH_KEY_NAME.to_string()),
+        Some(ACCESS_KEY_NAME.to_string()),
+    );
+
+    runtime::put_key(CONTRACT_VERSION, storage::new_uref(contract_version).into());
+    runtime::put_key(HASH_KEY_NAME, contract_hash.into());
+}

--- a/smart_contracts/contracts/test/transfer-purse-to-accounts-subcall/Cargo.toml
+++ b/smart_contracts/contracts/test/transfer-purse-to-accounts-subcall/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "transfer-purse-to-accounts-subcall"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "transfer_purse_to_accounts_subcall"
+path = "src/bin/main.rs"
+bench = false
+doctest = false
+test = false
+
+[features]
+std = ["casper-contract/std", "casper-types/std"]
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/transfer-purse-to-accounts-subcall/src/bin/main.rs
+++ b/smart_contracts/contracts/test/transfer-purse-to-accounts-subcall/src/bin/main.rs
@@ -1,0 +1,7 @@
+#![no_std]
+#![no_main]
+
+#[no_mangle]
+pub extern "C" fn call() {
+    transfer_purse_to_accounts_subcall::delegate();
+}

--- a/smart_contracts/contracts/test/transfer-purse-to-accounts-subcall/src/lib.rs
+++ b/smart_contracts/contracts/test/transfer-purse-to-accounts-subcall/src/lib.rs
@@ -1,0 +1,39 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+
+use casper_contract::{
+    contract_api::{runtime, system},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs, URef, U512};
+
+const ENTRYPOINT: &str = "transfer";
+const ARG_SOURCE: &str = "source";
+const ARG_TARGETS: &str = "targets";
+
+const HASH_KEY_NAME: &str = "transfer_purse_to_accounts_hash";
+
+pub fn delegate() {
+    let source: URef = runtime::get_named_arg(ARG_SOURCE);
+    let targets: BTreeMap<AccountHash, U512> = runtime::get_named_arg(ARG_TARGETS);
+
+    for (target, amount) in &targets {
+        system::transfer_from_purse_to_account(source, *target, *amount).unwrap_or_revert();
+    }
+
+    let contract_hash = runtime::get_key(HASH_KEY_NAME)
+        .and_then(Key::into_hash)
+        .unwrap_or_revert();
+
+    runtime::call_contract(
+        contract_hash,
+        ENTRYPOINT,
+        runtime_args! {
+            ARG_SOURCE => source,
+            ARG_TARGETS => targets
+        },
+    )
+}

--- a/smart_contracts/contracts/test/transfer-purse-to-accounts/Cargo.toml
+++ b/smart_contracts/contracts/test/transfer-purse-to-accounts/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "transfer-purse-to-accounts"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "transfer_purse_to_accounts"
+path = "src/bin/main.rs"
+bench = false
+doctest = false
+test = false
+
+[features]
+std = ["casper-contract/std", "casper-types/std"]
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/transfer-purse-to-accounts/src/bin/main.rs
+++ b/smart_contracts/contracts/test/transfer-purse-to-accounts/src/bin/main.rs
@@ -1,0 +1,7 @@
+#![no_std]
+#![no_main]
+
+#[no_mangle]
+pub extern "C" fn call() {
+    transfer_purse_to_accounts::delegate();
+}

--- a/smart_contracts/contracts/test/transfer-purse-to-accounts/src/lib.rs
+++ b/smart_contracts/contracts/test/transfer-purse-to-accounts/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+
+use casper_contract::{
+    contract_api::{runtime, system},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use casper_types::{account::AccountHash, URef, U512};
+
+const ARG_SOURCE: &str = "source";
+const ARG_TARGETS: &str = "targets";
+
+pub fn delegate() {
+    let source: URef = runtime::get_named_arg(ARG_SOURCE);
+    let targets: BTreeMap<AccountHash, U512> = runtime::get_named_arg(ARG_TARGETS);
+
+    for (target, amount) in targets {
+        system::transfer_from_purse_to_account(source, target, amount).unwrap_or_revert();
+    }
+}

--- a/types/src/deploy_info.rs
+++ b/types/src/deploy_info.rs
@@ -1,0 +1,83 @@
+use alloc::vec::Vec;
+
+use crate::{
+    account::AccountHash,
+    bytesrepr::{self, FromBytes, ToBytes},
+    key::TransferAddr,
+    DeployHash, URef, U512,
+};
+
+/// Represents a transfer from one purse to another
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct DeployInfo {
+    /// Deploy
+    pub deploy_hash: DeployHash,
+    /// Transfers
+    pub transfers: Vec<TransferAddr>,
+    /// Account
+    pub from: AccountHash,
+    /// Source purse
+    pub source: URef,
+    /// Gas
+    pub gas: U512,
+}
+
+impl DeployInfo {
+    /// Creates a [`DeployInfo`].
+    pub fn new(
+        deploy_hash: DeployHash,
+        transfers: &[TransferAddr],
+        from: AccountHash,
+        source: URef,
+        gas: U512,
+    ) -> Self {
+        let transfers = transfers.to_vec();
+        DeployInfo {
+            deploy_hash,
+            transfers,
+            from,
+            source,
+            gas,
+        }
+    }
+}
+
+impl FromBytes for DeployInfo {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (deploy_hash, rem) = DeployHash::from_bytes(bytes)?;
+        let (transfers, rem) = Vec::<TransferAddr>::from_bytes(rem)?;
+        let (from, rem) = AccountHash::from_bytes(rem)?;
+        let (source, rem) = URef::from_bytes(rem)?;
+        let (gas, rem) = U512::from_bytes(rem)?;
+        Ok((
+            DeployInfo {
+                deploy_hash,
+                transfers,
+                from,
+                source,
+                gas,
+            },
+            rem,
+        ))
+    }
+}
+
+impl ToBytes for DeployInfo {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut result = bytesrepr::allocate_buffer(self)?;
+        result.append(&mut self.deploy_hash.to_bytes()?);
+        result.append(&mut self.transfers.to_bytes()?);
+        result.append(&mut self.from.to_bytes()?);
+        result.append(&mut self.source.to_bytes()?);
+        result.append(&mut self.gas.to_bytes()?);
+        Ok(result)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.deploy_hash.serialized_length()
+            + self.transfers.serialized_length()
+            + self.from.serialized_length()
+            + self.source.serialized_length()
+            + self.gas.serialized_length()
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -33,6 +33,7 @@ mod cl_type;
 mod cl_value;
 mod contract_wasm;
 pub mod contracts;
+mod deploy_info;
 #[cfg(any(feature = "gens", test))]
 pub mod gens;
 mod key;
@@ -46,6 +47,7 @@ mod semver;
 pub mod standard_payment;
 pub mod system_contract_errors;
 pub mod system_contract_type;
+mod transfer;
 mod transfer_result;
 mod uint;
 mod uref;
@@ -63,10 +65,11 @@ pub use contracts::{
 };
 //pub use contract_ref::ContractRef;
 pub use contract_wasm::ContractWasm;
+pub use deploy_info::DeployInfo;
 #[doc(inline)]
 pub use key::{
-    ContractHash, ContractPackageHash, ContractWasmHash, HashAddr, Key, BLAKE2B_DIGEST_LENGTH,
-    KEY_HASH_LENGTH,
+    ContractHash, ContractPackageHash, ContractWasmHash, HashAddr, Key, TransferAddr,
+    BLAKE2B_DIGEST_LENGTH, KEY_HASH_LENGTH,
 };
 pub use phase::{Phase, PHASE_SERIALIZED_LENGTH};
 pub use protocol_version::{ProtocolVersion, VersionCheckResult};
@@ -74,5 +77,12 @@ pub use public_key::{PublicKey, Secp256k1Bytes};
 pub use runtime_args::{NamedArg, RuntimeArgs};
 pub use semver::{SemVer, SEM_VER_SERIALIZED_LENGTH};
 pub use system_contract_type::SystemContractType;
+pub use transfer::Transfer;
 pub use transfer_result::{TransferResult, TransferredTo};
 pub use uref::{URef, UREF_ADDR_LENGTH, UREF_SERIALIZED_LENGTH};
+
+/// The length of a deploy hash.
+pub const DEPLOY_HASH_LENGTH: usize = 32;
+
+/// A deploy hash.
+pub type DeployHash = [u8; DEPLOY_HASH_LENGTH];

--- a/types/src/mint.rs
+++ b/types/src/mint.rs
@@ -3,6 +3,7 @@ mod constants;
 mod round_reward;
 mod runtime_provider;
 mod storage_provider;
+mod system_provider;
 
 use core::convert::TryFrom;
 use num_rational::Ratio;
@@ -11,13 +12,13 @@ use crate::{account::AccountHash, system_contract_errors::mint::Error, Key, URef
 
 pub use crate::mint::{
     constants::*, round_reward::*, runtime_provider::RuntimeProvider,
-    storage_provider::StorageProvider,
+    storage_provider::StorageProvider, system_provider::SystemProvider,
 };
 
 const SYSTEM_ACCOUNT: AccountHash = AccountHash::new([0; 32]);
 
 /// Mint trait.
-pub trait Mint: RuntimeProvider + StorageProvider {
+pub trait Mint: RuntimeProvider + StorageProvider + SystemProvider {
     /// Mint new token with given `initial_balance` balance. Returns new purse on success, otherwise
     /// an error.
     fn mint(&mut self, initial_balance: U512) -> Result<URef, Error> {
@@ -90,6 +91,7 @@ pub trait Mint: RuntimeProvider + StorageProvider {
         };
         self.write(source_balance, source_value - amount)?;
         self.add(target_balance, amount)?;
+        self.record_transfer(source, target, amount)?;
         Ok(())
     }
 

--- a/types/src/mint/system_provider.rs
+++ b/types/src/mint/system_provider.rs
@@ -1,0 +1,7 @@
+use crate::{system_contract_errors::mint::Error, URef, U512};
+
+/// Provides functionality of a system module.
+pub trait SystemProvider {
+    /// Records a transfer.
+    fn record_transfer(&mut self, source: URef, target: URef, amount: U512) -> Result<(), Error>;
+}

--- a/types/src/system_contract_errors/mint.rs
+++ b/types/src/system_contract_errors/mint.rs
@@ -44,6 +44,9 @@ pub enum Error {
     /// Total supply not found.
     #[fail(display = "Total supply not found")]
     TotalSupplyNotFound = 9,
+    /// Failed to record transfer.
+    #[fail(display = "Failed to record transfer")]
+    RecordTransferFailure = 10,
 }
 
 impl From<PurseError> for Error {

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -1,0 +1,89 @@
+use alloc::vec::Vec;
+
+use crate::{
+    account::AccountHash,
+    bytesrepr::{self, FromBytes, ToBytes},
+    DeployHash, URef, U512,
+};
+
+/// Represents a transfer from one purse to another
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Transfer {
+    /// Deploy that created the transfer
+    pub deploy_hash: DeployHash,
+    /// Account from which transfer was executed
+    pub from: AccountHash,
+    /// Source purse
+    pub source: URef,
+    /// Target purse
+    pub target: URef,
+    /// Transfer amount
+    pub amount: U512,
+    /// Gas
+    pub gas: U512,
+}
+
+impl Transfer {
+    /// Creates a [`Transfer`].
+    pub fn new(
+        deploy_hash: DeployHash,
+        from: AccountHash,
+        source: URef,
+        target: URef,
+        amount: U512,
+        gas: U512,
+    ) -> Self {
+        Transfer {
+            deploy_hash,
+            from,
+            source,
+            target,
+            amount,
+            gas,
+        }
+    }
+}
+
+impl FromBytes for Transfer {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (deploy_hash, rem) = DeployHash::from_bytes(bytes)?;
+        let (from, rem) = AccountHash::from_bytes(rem)?;
+        let (source, rem) = URef::from_bytes(rem)?;
+        let (target, rem) = URef::from_bytes(rem)?;
+        let (amount, rem) = U512::from_bytes(rem)?;
+        let (gas, rem) = U512::from_bytes(rem)?;
+        Ok((
+            Transfer {
+                deploy_hash,
+                from,
+                source,
+                target,
+                amount,
+                gas,
+            },
+            rem,
+        ))
+    }
+}
+
+impl ToBytes for Transfer {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut result = bytesrepr::allocate_buffer(self)?;
+        result.append(&mut self.deploy_hash.to_bytes()?);
+        result.append(&mut self.from.to_bytes()?);
+        result.append(&mut self.source.to_bytes()?);
+        result.append(&mut self.target.to_bytes()?);
+        result.append(&mut self.amount.to_bytes()?);
+        result.append(&mut self.gas.to_bytes()?);
+        Ok(result)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.deploy_hash.serialized_length()
+            + self.from.serialized_length()
+            + self.source.serialized_length()
+            + self.target.serialized_length()
+            + self.amount.serialized_length()
+            + self.gas.serialized_length()
+    }
+}


### PR DESCRIPTION
a.k.a. "Proof of Transfer"

Ref: 
https://casperlabs.atlassian.net/browse/EE-1070
https://gist.github.com/henrytill/808b009635f02733f88dfc1f4a364482

This PR introduces:
* A `Transfer` struct, which is persisted as a `StoredValue::Transfer` under `Key::Transfer` (address is generated) by every call to the Mint's transfer function.  This contains record of a transfer.
* A `DeployInfo` struct, which is persisted as a `StoredValue::DeployInfo` under `Key::DeployInfo` (address is the deploy hash), containing a record of a deploy and its transfers.

**Sample Workflow:** (see gist for fuller, slightly fictionalized treatment)
```
$ casper-client transfer \     
    --amount 100000 \
    --secret-key resources/local/secret_keys/node-1.pem \
    --chain-name casper-example \
    --payment-amount 10000 \
    --target-account 018f5a3ee4c1221686fcdbe6c0b6168acb24025c5485f59f7c4039ffc444fb7509
...
$ casper-client get-block <deploy_hash>
...
$ casper-client get-block <block_hash>
...
$ casper-client query-state -g <state_root_hash> -k deploy-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
{
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.0.0",
    "stored_value": {
      "DeployInfo": {
        "deploy_hash": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
        "from": "account-hash-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
        "gas": "0",
        "source": "uref-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-007",
        "transfers": [
          "transfer-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
        ]
      }
    }
  },
  "id": 768996209
}

$ casper-client query-state -g <state_root_hash> -k transfer-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
{
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.0.0",
    "stored_value": {
      "Transfer": {
        "amount": "100000",
        "deploy_hash": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
        "from": "account-hash-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
        "gas": "0",
        "source": "uref-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-007",
        "target": "uref-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-004"
      }
    }
  },
  "id": 385326235
}
```