### PR TITLE
EE-1068: enrich queries with merkle proofs, validate

### DIFF
--- a/client/src/query_state.rs
+++ b/client/src/query_state.rs
@@ -165,8 +165,9 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
 }
 
 mod merkle_proofs {
-    use jsonrpc_lite::JsonRpc;
+    use std::convert::TryFrom;
 
+    use jsonrpc_lite::JsonRpc;
     use thiserror::Error;
 
     use casper_execution_engine::{
@@ -175,7 +176,6 @@ mod merkle_proofs {
     };
     use casper_node::{crypto::hash::Digest, types::json_compatibility};
     use casper_types::{bytesrepr, Key};
-    use std::convert::TryFrom;
 
     const GET_ITEM_RESULT_STORED_VALUE: &str = "stored_value";
     const GET_ITEM_RESULT_MERKLE_PROOF: &str = "merkle_proof";

--- a/client/src/query_state.rs
+++ b/client/src/query_state.rs
@@ -145,15 +145,128 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
         let path = path::get(matches);
 
         let params = GetItemParams {
-            state_root_hash,
-            key,
-            path,
+            state_root_hash: state_root_hash.to_owned(),
+            key: key.to_owned(),
+            path: path.to_owned(),
         };
 
         let response = Self::request_with_map_params(verbose, &node_address, rpc_id, params);
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+        let key = Key::from_formatted_str(&key).expect("key should convert to key");
+        match merkle_proofs::validate_response(&response, &state_root_hash, &key, &path) {
+            Ok(_) => {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&response).expect("should encode to JSON")
+                );
+            }
+            Err(error) => panic!("{:?}", error),
+        }
+    }
+}
+
+mod merkle_proofs {
+    use jsonrpc_lite::JsonRpc;
+
+    use thiserror::Error;
+
+    use casper_execution_engine::{
+        core, core::ValidationError, shared::stored_value::StoredValue,
+        storage::trie::merkle_proof::TrieMerkleProof,
+    };
+    use casper_node::{crypto::hash::Digest, types::json_compatibility};
+    use casper_types::{bytesrepr, Key};
+    use std::convert::TryFrom;
+
+    const GET_ITEM_RESULT_STORED_VALUE: &str = "stored_value";
+    const GET_ITEM_RESULT_MERKLE_PROOF: &str = "merkle_proof";
+
+    /// Error that can be returned by validate_response.
+    #[derive(Error, Debug)]
+    pub enum ValidateResponseError {
+        /// Failed to marshall value
+        #[error("Failed to marshall value {0}")]
+        BytesRepr(bytesrepr::Error),
+
+        /// Error from serde.
+        #[error(transparent)]
+        Serde(#[from] serde_json::Error),
+
+        /// [`validate_response`] failed to parse JSON
+        #[error("validate_response failed to parse")]
+        ValidateResponseFailedToParse,
+
+        /// [`validate_response`] failed to validate
+        #[error(transparent)]
+        ValidationError(#[from] ValidationError),
+
+        /// Serialized value not contained in proof
+        #[error("serialized value not contained in proof")]
+        SerializedValueNotContainedInProof,
+    }
+
+    impl From<bytesrepr::Error> for ValidateResponseError {
+        fn from(e: bytesrepr::Error) -> Self {
+            ValidateResponseError::BytesRepr(e)
+        }
+    }
+
+    pub fn validate_response(
+        response: &JsonRpc,
+        state_root_hash: &Digest,
+        key: &Key,
+        path: &[String],
+    ) -> Result<(), ValidateResponseError> {
+        let value = response
+            .get_result()
+            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+
+        let object = value
+            .as_object()
+            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+
+        let proofs: Vec<TrieMerkleProof<Key, StoredValue>> = {
+            let proof = object
+                .get(GET_ITEM_RESULT_MERKLE_PROOF)
+                .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+            let proof_str = proof
+                .as_str()
+                .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+            let proof_bytes = hex::decode(proof_str)
+                .map_err(|_| ValidateResponseError::ValidateResponseFailedToParse)?;
+            bytesrepr::deserialize(proof_bytes)?
+        };
+
+        let proof_value: &StoredValue = {
+            let last_proof = proofs
+                .last()
+                .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+            last_proof.value()
+        };
+
+        // Here we need to validate that JSON `stored_value` is contained in the proof.
+        //
+        // Possible to deserialize that field into a `StoredValue` and pass below to
+        // `validate_query_proof` instead of using this approach?
+        {
+            let value: json_compatibility::StoredValue = {
+                let value = object
+                    .get(GET_ITEM_RESULT_STORED_VALUE)
+                    .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+                serde_json::from_value(value.to_owned())?
+            };
+            match json_compatibility::StoredValue::try_from(proof_value) {
+                Ok(json_proof_value) if json_proof_value == value => (),
+                _ => return Err(ValidateResponseError::SerializedValueNotContainedInProof),
+            }
+        }
+
+        core::validate_query_proof(
+            &state_root_hash.to_owned().into(),
+            &proofs,
+            key,
+            path,
+            proof_value,
+        )
+        .map_err(Into::into)
     }
 }

--- a/execution_engine/src/core.rs
+++ b/execution_engine/src/core.rs
@@ -7,6 +7,8 @@ pub mod runtime;
 pub mod runtime_context;
 pub(crate) mod tracking_copy;
 
+pub use tracking_copy::{validate_query_proof, ValidationError};
+
 pub const ADDRESS_LENGTH: usize = 32;
 
 pub type Address = [u8; ADDRESS_LENGTH];

--- a/execution_engine/src/core/engine_state/query.rs
+++ b/execution_engine/src/core/engine_state/query.rs
@@ -3,15 +3,18 @@ use casper_types::Key;
 use crate::{
     core::tracking_copy::TrackingCopyQueryResult,
     shared::{newtypes::Blake2bHash, stored_value::StoredValue},
+    storage::trie::merkle_proof::TrieMerkleProof,
 };
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum QueryResult {
     RootNotFound,
     ValueNotFound(String),
     CircularReference(String),
-    Success(StoredValue),
+    Success {
+        value: Box<StoredValue>,
+        proofs: Vec<TrieMerkleProof<Key, StoredValue>>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,7 +53,10 @@ impl From<TrackingCopyQueryResult> for QueryResult {
             TrackingCopyQueryResult::CircularReference(message) => {
                 QueryResult::CircularReference(message)
             }
-            TrackingCopyQueryResult::Success(value) => QueryResult::Success(value),
+            TrackingCopyQueryResult::Success { value, proofs } => {
+                let value = Box::new(value);
+                QueryResult::Success { value, proofs }
+            }
         }
     }
 }

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use linked_hash_map::LinkedHashMap;
+use thiserror::Error;
 
 use casper_types::{bytesrepr, CLType, CLValueError, Key};
 
@@ -20,17 +21,20 @@ use crate::{
     core::engine_state::{execution_effect::ExecutionEffect, op::Op},
     shared::{
         additive_map::AdditiveMap,
-        newtypes::CorrelationId,
+        newtypes::{Blake2bHash, CorrelationId},
         stored_value::StoredValue,
         transform::{self, Transform},
         TypeMismatch,
     },
-    storage::global_state::StateReader,
+    storage::{global_state::StateReader, trie::merkle_proof::TrieMerkleProof},
 };
 
 #[derive(Debug)]
 pub enum TrackingCopyQueryResult {
-    Success(StoredValue),
+    Success {
+        value: StoredValue,
+        proofs: Vec<TrieMerkleProof<Key, StoredValue>>,
+    },
     ValueNotFound(String),
     CircularReference(String),
 }
@@ -345,20 +349,34 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
     ) -> Result<TrackingCopyQueryResult, R::Error> {
         let mut query = Query::new(base_key, path);
 
+        let mut proofs = Vec::new();
+
         loop {
             if !query.visited_keys.insert(query.current_key) {
                 return Ok(query.into_circular_ref_result());
             }
-            let stored_value = match self.reader.read(correlation_id, &query.current_key)? {
+            let stored_value = match self
+                .reader
+                .read_with_proof(correlation_id, &query.current_key)?
+            {
                 None => {
                     return Ok(query.into_not_found_result("Failed to find base key"));
                 }
                 Some(stored_value) => stored_value,
             };
 
+            let value = stored_value.value().to_owned();
+
+            proofs.push(stored_value);
+
             if query.unvisited_names.is_empty() {
-                return Ok(TrackingCopyQueryResult::Success(stored_value));
+                return Ok(TrackingCopyQueryResult::Success { value, proofs });
             }
+
+            let stored_value: &StoredValue = proofs
+                .last()
+                .map(|r| r.value())
+                .expect("but we just pushed");
 
             match stored_value {
                 StoredValue::Account(account) => {
@@ -371,7 +389,7 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
                     }
                 }
                 StoredValue::CLValue(cl_value) if cl_value.cl_type() == &CLType::Key => {
-                    if let Ok(key) = cl_value.into_t::<Key>() {
+                    if let Ok(key) = cl_value.to_owned().into_t::<Key>() {
                         query.current_key = key.normalize();
                     } else {
                         return Ok(query.into_not_found_result("Failed to parse CLValue as Key"));
@@ -433,4 +451,96 @@ impl<R: StateReader<Key, StoredValue>> StateReader<Key, StoredValue> for &Tracki
             Ok(None)
         }
     }
+
+    fn read_with_proof(
+        &self,
+        correlation_id: CorrelationId,
+        key: &Key,
+    ) -> Result<Option<TrieMerkleProof<Key, StoredValue>>, Self::Error> {
+        self.reader.read_with_proof(correlation_id, key)
+    }
+}
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ValidationError {
+    #[error("The path should not have a different length than the proof less one.")]
+    PathLengthDifferentThanProofLessOne,
+
+    #[error("The provided key does not match the key in the proof.")]
+    UnexpectedKey,
+
+    #[error("The provided value does not match the value in the proof.")]
+    UnexpectedValue,
+
+    #[error("The proof hash is invalid.")]
+    InvalidProofHash,
+
+    #[error("The path went cold.")]
+    PathCold,
+
+    #[error("Serialization error: {0}")]
+    BytesRepr(bytesrepr::Error),
+}
+
+impl From<bytesrepr::Error> for ValidationError {
+    fn from(error: bytesrepr::Error) -> Self {
+        Self::BytesRepr(error)
+    }
+}
+
+#[allow(unused)]
+pub fn validate_query_proof(
+    hash: &Blake2bHash,
+    proofs: &[TrieMerkleProof<Key, StoredValue>],
+    key: &Key,
+    path: &[String],
+    value: &StoredValue,
+) -> Result<(), ValidationError> {
+    if proofs.len() != path.len() + 1 {
+        return Err(ValidationError::PathLengthDifferentThanProofLessOne);
+    }
+
+    let mut proofs_iter = proofs.iter();
+
+    // length check above means we are safe to unwrap here
+    let first_proof = proofs_iter.next().unwrap();
+
+    if first_proof.key() != &key.normalize() {
+        return Err(ValidationError::UnexpectedKey);
+    }
+
+    if hash != &first_proof.compute_state_hash()? {
+        return Err(ValidationError::InvalidProofHash);
+    }
+
+    let mut proof_value = first_proof.value();
+
+    for (proof, path_component) in proofs_iter.zip(path.iter()) {
+        let named_keys = match proof_value {
+            StoredValue::Account(account) => account.named_keys(),
+            StoredValue::Contract(contract) => contract.named_keys(),
+            _ => return Err(ValidationError::PathCold),
+        };
+
+        let key = match named_keys.get(path_component) {
+            Some(key) => key,
+            None => return Err(ValidationError::PathCold),
+        };
+
+        if proof.key() != &key.normalize() {
+            return Err(ValidationError::UnexpectedKey);
+        }
+
+        if hash != &proof.compute_state_hash()? {
+            return Err(ValidationError::InvalidProofHash);
+        }
+
+        proof_value = proof.value();
+    }
+
+    if proof_value != value {
+        return Err(ValidationError::UnexpectedValue);
+    }
+
+    Ok(())
 }

--- a/execution_engine/src/storage/global_state/mod.rs
+++ b/execution_engine/src/storage/global_state/mod.rs
@@ -15,7 +15,7 @@ use casper_types::{bytesrepr, Key, ProtocolVersion};
 use crate::storage::{
     protocol_data::ProtocolData,
     transaction_source::{Transaction, TransactionSource},
-    trie::Trie,
+    trie::{merkle_proof::TrieMerkleProof, Trie},
     trie_store::{
         operations::{read, write, ReadResult, WriteResult},
         TrieStore,
@@ -29,6 +29,13 @@ pub trait StateReader<K, V> {
 
     /// Returns the state value from the corresponding key
     fn read(&self, correlation_id: CorrelationId, key: &K) -> Result<Option<V>, Self::Error>;
+
+    /// Returns the merkle proof of the state value from the corresponding key
+    fn read_with_proof(
+        &self,
+        correlation_id: CorrelationId,
+        key: &K,
+    ) -> Result<Option<TrieMerkleProof<K, V>>, Self::Error>;
 }
 
 #[derive(Debug)]

--- a/grpc/server/protobuf/casper/ipc.proto
+++ b/grpc/server/protobuf/casper/ipc.proto
@@ -218,7 +218,7 @@ message QueryRequest {
 message QueryResponse {
     reserved 1; // previously `casper.state.Value`
     oneof result {
-        // serialized `StoredValue`
+        // serialized `(StoredValue, Vec<TrieMerkleProof<Key, StoredValue>>)`
         bytes success = 3;
         //TODO: ADT for errors
         string failure = 2;

--- a/grpc/test_support/src/internal/wasm_test_builder.rs
+++ b/grpc/test_support/src/internal/wasm_test_builder.rs
@@ -44,6 +44,7 @@ use casper_execution_engine::{
         global_state::{in_memory::InMemoryGlobalState, lmdb::LmdbGlobalState, StateProvider},
         protocol_data_store::lmdb::LmdbProtocolDataStore,
         transaction_source::lmdb::LmdbEnvironment,
+        trie::merkle_proof::TrieMerkleProof,
         trie_store::lmdb::LmdbTrieStore,
     },
 };
@@ -383,21 +384,27 @@ where
         if query_response.has_failure() {
             return Err(query_response.take_failure());
         }
-        bytesrepr::deserialize(query_response.take_success()).map_err(|err| format!("{}", err))
+
+        let (value, _proofs): (StoredValue, Vec<TrieMerkleProof<Key, StoredValue>>) =
+            bytesrepr::deserialize(query_response.take_success())
+                .map_err(|err| format!("{:?}", err))?;
+
+        Ok(value)
     }
 
-    pub fn total_supply(&self, maybe_post_state: Option<Vec<u8>>) -> U512 {
+    pub fn query_with_proof(
+        &self,
+        maybe_post_state: Option<Vec<u8>>,
+        base_key: Key,
+        path: &[String],
+    ) -> Result<(StoredValue, Vec<TrieMerkleProof<Key, StoredValue>>), String> {
         let post_state = maybe_post_state
             .or_else(|| self.post_state_hash.clone())
             .expect("builder must have a post-state hash");
 
-        let mint_key: Key = self
-            .mint_contract_hash
-            .expect("should have mint_contract_hash")
-            .into();
+        let path_vec: Vec<String> = path.to_vec();
 
-        let query_request =
-            create_query_request(post_state, mint_key, vec![TOTAL_SUPPLY_KEY.to_string()]);
+        let query_request = create_query_request(post_state, base_key, path_vec);
 
         let mut query_response = self
             .engine_state
@@ -406,10 +413,23 @@ where
             .expect("should get query response");
 
         if query_response.has_failure() {
-            panic!("mint error: {}", query_response.take_failure());
+            return Err(query_response.take_failure());
         }
 
-        let result = bytesrepr::deserialize(query_response.take_success());
+        let (value, proofs): (StoredValue, Vec<TrieMerkleProof<Key, StoredValue>>) =
+            bytesrepr::deserialize(query_response.take_success())
+                .map_err(|err| format!("{:?}", err))?;
+
+        Ok((value, proofs))
+    }
+
+    pub fn total_supply(&self, maybe_post_state: Option<Vec<u8>>) -> U512 {
+        let mint_key: Key = self
+            .mint_contract_hash
+            .expect("should have mint_contract_hash")
+            .into();
+
+        let result = self.query(maybe_post_state, mint_key, &[TOTAL_SUPPLY_KEY]);
 
         let total_supply: U512 = if let Ok(StoredValue::CLValue(total_supply)) = result {
             total_supply.into_t().expect("total supply should be U512")


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1068 (also 1072, 1073, 1074)

**Note:**
Originally planned to base off @dwerner's branch for #374, but touched base with him and he still has some work to do over there, so decided to open against master here.  The code here should be relatively easy to port to that branch.  Happy to help with that if need be.