### PR TITLE
NO-TICKET: Change default fetch timeout to 5 seconds.

### DIFF
--- a/resources/charlie/config-example.toml
+++ b/resources/charlie/config-example.toml
@@ -151,7 +151,7 @@ gossip_request_timeout_secs = 10
 
 # The timeout duration in seconds for retrieving the remaining part(s) of newly-discovered data
 # from a peer which gossiped information about that data to this node.
-get_remainder_timeout_secs = 60
+get_remainder_timeout_secs = 5
 
 
 # ========================================================

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -159,7 +159,7 @@ gossip_request_timeout_secs = 10
 
 # The timeout duration in seconds for retrieving the remaining part(s) of newly-discovered data
 # from a peer which gossiped information about that data to this node.
-get_remainder_timeout_secs = 60
+get_remainder_timeout_secs = 5
 
 
 # ========================================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -140,7 +140,7 @@ gossip_request_timeout_secs = 30
 
 # The timeout duration in seconds for retrieving the remaining part(s) of newly-discovered data
 # from a peer which gossiped information about that data to this node.
-get_remainder_timeout_secs = 60
+get_remainder_timeout_secs = 5
 
 # ========================================================
 # Configuration options for the contract runtime component

--- a/utils/nctl/templates/node-config.toml
+++ b/utils/nctl/templates/node-config.toml
@@ -156,7 +156,7 @@ gossip_request_timeout_secs = 10
 
 # The timeout duration in seconds for retrieving the remaining part(s) of newly-discovered data
 # from a peer which gossiped information about that data to this node.
-get_remainder_timeout_secs = 60
+get_remainder_timeout_secs = 5
 
 
 # ========================================================


### PR DESCRIPTION
When a user tried to join the Charlie network it took 4h:50min to synchronize with a chain that has 2700 blocks. Most of the requests to download block headers were finished in <0.5s but there were 280+ that took more than 1 minute. This was due to the `get_remainder_timeout_secs` that defaults to 60 seconds. After updating the value to 5seconds, the joining process took ~22minutes. Most (if not all) validators will never change configuration parameters if they are not told to do so, we want the defaults to be sane and work for most cases.