### PR TITLE
OP-1630 docker_make.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ CRATES_WITH_DOCS_RS_MANIFEST_TABLE = \
 
 CRATES_WITH_DOCS_RS_MANIFEST_TABLE := $(patsubst %, doc-stable/%, $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE))
 
+.PHONY: list
+list:
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
+
 .PHONY: all
 all: build build-contracts
 

--- a/docker_make.sh
+++ b/docker_make.sh
@@ -1,0 +1,64 @@
+
+# Images used in this script are build in CasperLabs/buildenv repo
+
+# This allows make commands without local build environment setup or
+# using an OS version other than locally installed.
+
+set -e
+
+package="docker_make.sh"
+valid_docker_images=("node-build-u1804" "node-build-u2004")
+default_image=${valid_docker_images[0]}
+function help {
+  echo "$package - issue make commands in docker environment"
+  echo " "
+  echo "$package [options] command"
+  echo " "
+  echo "options:"
+  echo "-h, --help             show brief help"
+  echo "--image=DOCKER_IMAGE   specify docker image to use: ${valid_docker_images[*]}"
+  echo "                       Image will default to ${default_image} if not given"
+  echo
+  echo "Ex: '$package all' will execute 'make all' on ${default_image}."
+  exit 0
+}
+
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+      help
+      ;;
+    --image*)
+      image=`echo $1 | sed -e 's/^[^=]*=//g'`
+      if [[ " ${valid_docker_images[*]} " == *" $image "* ]]; then
+        docker_image=$image
+      else
+        echo "Invalid docker image passed in: $image"
+        echo "Possible images are: ${valid_docker_images[*]}."
+      fi
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ -z "$1" ]; then
+  echo "make command not given."
+  echo "Using 'list' to show targets."
+  make_command="list"
+else
+  make_command="$1"
+fi
+
+if [ -z "$docker_image" ]; then
+  docker_image=${default_image}
+fi
+
+#docker pull casperlabs/${docker_image}:latest
+
+# Getting user and group to chown/chgrp target folder from root at end.
+# Cannot use the --user trick as cached .cargo in image is owned by root.
+command="cd /casper-node; make ${make_command}; chown -R -f $(id -u):$(id -g) ./target ./target-as;"
+docker run --rm -it --volume $(pwd):/casper-node casperlabs/${docker_image}:latest /bin/bash -c "${command}"

--- a/docker_make.sh
+++ b/docker_make.sh
@@ -56,7 +56,7 @@ if [ -z "$docker_image" ]; then
   docker_image=${default_image}
 fi
 
-#docker pull casperlabs/${docker_image}:latest
+docker pull casperlabs/${docker_image}:latest
 
 # Getting user and group to chown/chgrp target folder from root at end.
 # Cannot use the --user trick as cached .cargo in image is owned by root.

--- a/docker_make.sh
+++ b/docker_make.sh
@@ -20,6 +20,9 @@ function help {
   echo "                       Image will default to ${default_image} if not given"
   echo
   echo "Ex: '$package all' will execute 'make all' on ${default_image}."
+  echo
+  echo "Note: The results will be in your ./target or ./target-as directory and"
+  echo "      might not be compatible with your local system"
   exit 0
 }
 
@@ -56,9 +59,9 @@ if [ -z "$docker_image" ]; then
   docker_image=${default_image}
 fi
 
-docker pull casperlabs/${docker_image}:latest
+#docker pull casperlabs/${docker_image}:latest
 
 # Getting user and group to chown/chgrp target folder from root at end.
 # Cannot use the --user trick as cached .cargo in image is owned by root.
-command="cd /casper-node; make ${make_command}; chown -R -f $(id -u):$(id -g) ./target ./target-as;"
+command="cd /casper-node; make ${make_command}; chown -R -f $(id -u):$(id -g) ./target ./target_as;"
 docker run --rm -it --volume $(pwd):/casper-node casperlabs/${docker_image}:latest /bin/bash -c "${command}"

--- a/docker_make.sh
+++ b/docker_make.sh
@@ -56,6 +56,7 @@ else
 fi
 
 if [ -z "$docker_image" ]; then
+  echo "Defaulting build image to ${default_image}."
   docker_image=${default_image}
 fi
 
@@ -64,4 +65,4 @@ fi
 # Getting user and group to chown/chgrp target folder from root at end.
 # Cannot use the --user trick as cached .cargo in image is owned by root.
 command="cd /casper-node; make ${make_command}; chown -R -f $(id -u):$(id -g) ./target ./target_as;"
-docker run --rm -it --volume $(pwd):/casper-node casperlabs/${docker_image}:latest /bin/bash -c "${command}"
+docker run --rm --volume $(pwd):/casper-node casperlabs/${docker_image}:latest /bin/bash -c "${command}"


### PR DESCRIPTION
Added list target to Makefile to list all endpoints.
Added docker_make.sh to allow execution of make targets on docker images for u1804 or u2004 builds (and deb packaging) with either no full local setup or on different OS version.