### PR TITLE
Add Missing Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ libssl-dev
 
 pkg-config
 
+gcc
+
+g++
+
 ### Setup
 
 Before building a node, prepare your Rust build environment, and build the required system smart contracts:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ cmake 3.1.4 or greater
 
 [Rust](https://www.rust-lang.org/tools/install)
 
+libssl-dev
+
+pkg-config
+
 ### Setup
 
 Before building a node, prepare your Rust build environment, and build the required system smart contracts:


### PR DESCRIPTION
Add two missing dependencies found while installing on Ubuntu 20.04 
pkg-config
libssl-dev
gcc
g++