### PR TITLE
NDRS-541: Add Get block by height

### DIFF
--- a/client/src/block/get.rs
+++ b/client/src/block/get.rs
@@ -2,7 +2,10 @@ use std::str;
 
 use clap::{App, ArgMatches, SubCommand};
 
-use casper_node::rpcs::{RpcWithOptionalParams, chain::{GetBlock, GetBlockParams}};
+use casper_node::rpcs::{
+    chain::{GetBlock, GetBlockParams},
+    RpcWithOptionalParams,
+};
 
 use crate::{command::ClientCommand, common, RpcClient};
 
@@ -32,9 +35,12 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(common::block_parameter_type::arg(DisplayOrder::ParameterType as usize))
-            .arg(common::block_parameter::arg(DisplayOrder::BlockParameter as usize))
-            
+            .arg(common::block_parameter_type::arg(
+                DisplayOrder::ParameterType as usize,
+            ))
+            .arg(common::block_parameter::arg(
+                DisplayOrder::BlockParameter as usize,
+            ))
     }
 
     fn run(matches: &ArgMatches<'_>) {

--- a/client/src/block/get.rs
+++ b/client/src/block/get.rs
@@ -2,10 +2,7 @@ use std::str;
 
 use clap::{App, ArgMatches, SubCommand};
 
-use casper_node::rpcs::{
-    chain::{GetBlock, GetBlockParams},
-    RpcWithOptionalParams,
-};
+use casper_node::rpcs::{RpcWithOptionalParams, chain::{BlockParameters, GetBlock, GetBlockParams}};
 
 use crate::{command::ClientCommand, common, RpcClient};
 
@@ -45,7 +42,8 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
 
         let response = match maybe_block_hash {
             Some(block_hash) => {
-                let params = GetBlockParams { block_hash };
+                let block_parameter = BlockParameters::Hash(block_hash);
+                let params = GetBlockParams { block_parameter };
                 Self::request_with_map_params(verbose, &node_address, rpc_id, params)
             }
             None => Self::request(verbose, &node_address, rpc_id),

--- a/client/src/block/get.rs
+++ b/client/src/block/get.rs
@@ -11,6 +11,7 @@ enum DisplayOrder {
     Verbose,
     NodeAddress,
     RpcId,
+    ParameterType,
     BlockParameter,
 }
 
@@ -31,6 +32,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
+            .arg(common::block_parameter_type::arg(DisplayOrder::ParameterType as usize))
             .arg(common::block_parameter::arg(DisplayOrder::BlockParameter as usize))
             
     }
@@ -39,8 +41,12 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
         let verbose = common::verbose::get(matches);
         let node_address = common::node_address::get(matches);
         let rpc_id = common::rpc_id::get(matches);
-        let maybe_block_parameter = common::block_parameter::get(matches);
-
+        let parameter_type = common::block_parameter_type::get(matches);
+        let maybe_block_parameter = if !parameter_type {
+            common::block_parameter::get_hash(matches)
+        } else {
+            common::block_parameter::get_height(matches)
+        };
         let response = match maybe_block_parameter {
             Some(block_parameter) => {
                 let params = GetBlockParams { block_parameter };

--- a/client/src/block/get.rs
+++ b/client/src/block/get.rs
@@ -2,7 +2,7 @@ use std::str;
 
 use clap::{App, ArgMatches, SubCommand};
 
-use casper_node::rpcs::{RpcWithOptionalParams, chain::{BlockParameters, GetBlock, GetBlockParams}};
+use casper_node::rpcs::{RpcWithOptionalParams, chain::{GetBlock, GetBlockParams}};
 
 use crate::{command::ClientCommand, common, RpcClient};
 
@@ -11,7 +11,7 @@ enum DisplayOrder {
     Verbose,
     NodeAddress,
     RpcId,
-    BlockHash,
+    BlockParameter,
 }
 
 impl RpcClient for GetBlock {
@@ -31,18 +31,18 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(common::block_hash::arg(DisplayOrder::BlockHash as usize))
+            .arg(common::block_parameter::arg(DisplayOrder::BlockParameter as usize))
+            
     }
 
     fn run(matches: &ArgMatches<'_>) {
         let verbose = common::verbose::get(matches);
         let node_address = common::node_address::get(matches);
         let rpc_id = common::rpc_id::get(matches);
-        let maybe_block_hash = common::block_hash::get(matches);
+        let maybe_block_parameter = common::block_parameter::get(matches);
 
-        let response = match maybe_block_hash {
-            Some(block_hash) => {
-                let block_parameter = BlockParameters::Hash(block_hash);
+        let response = match maybe_block_parameter {
+            Some(block_parameter) => {
                 let params = GetBlockParams { block_parameter };
                 Self::request_with_map_params(verbose, &node_address, rpc_id, params)
             }

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -213,6 +213,45 @@ pub mod block_hash {
     }
 }
 
+pub mod block_parameter {
+    use casper_node::rpcs::chain::BlockParameters;
+
+    use super::*;
+
+    const ARG_NAME: &str = "block-parameter";
+    const ARG_SHORT: &str = "b";
+    const ARG_VALUE_NAME: &str = "HEX_STRING OR INTEGER";
+    const ARG_HELP: &str =
+        "Hex-encoded block hash.  If not given, the last block added to the chain as known at the \
+        given node will be used";
+
+    pub(crate) fn arg(order: usize) -> Arg<'static, 'static> {
+        Arg::with_name(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(false)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(order)
+    }
+
+    pub(crate) fn get(matches: &ArgMatches) -> Option<BlockParameters> {
+        if matches.value_of(ARG_VALUE_NAME) == Some("HEX_STRING") {
+            matches.value_of(ARG_NAME).map(|hex_str|{
+                let hash = Digest::from_hex(hex_str)
+                .unwrap_or_else(|error| panic!("cannot parse as a block hash: {}", error));
+                BlockParameters::Hash(BlockHash::new(hash))
+            })
+        } else {
+            matches.value_of(ARG_NAME).map(|height_str| {
+                let height = height_str.parse().unwrap_or_else(|error| panic!("should parse as u64: {}", error));
+                BlockParameters::Height(height)
+            })
+        }
+    }
+}
+
+
 pub fn read_file(path: &str) -> Vec<u8> {
     fs::read(path).unwrap_or_else(|error| panic!("should read {}: {}", path, error))
 }

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -213,6 +213,27 @@ pub mod block_hash {
     }
 }
 
+pub mod block_parameter_type {
+    use super::*;
+
+    const ARG_NAME: &str = "parameter-type";
+    const ARG_NAME_SHORT: &str = "t";
+    const ARG_HELP: &str ="Flag toggle to query by either hash or height";
+
+    pub(crate) fn arg(order: usize) -> Arg<'static, 'static> {
+        Arg::with_name(ARG_NAME)
+            .short(ARG_NAME_SHORT)
+            .required(false)
+            .help(ARG_HELP)
+            .display_order(order)
+    }
+
+    pub(crate) fn get(matches: &ArgMatches) -> bool {
+        matches.is_present(ARG_NAME)
+    }
+    
+}
+
 pub mod block_parameter {
     use casper_node::rpcs::chain::BlockParameters;
 
@@ -220,9 +241,9 @@ pub mod block_parameter {
 
     const ARG_NAME: &str = "block-parameter";
     const ARG_SHORT: &str = "b";
-    const ARG_VALUE_NAME: &str = "HEX_STRING OR INTEGER";
+    const ARG_VALUE_NAME: &str = "HEX_STRING";
     const ARG_HELP: &str =
-        "Hex-encoded block hash.  If not given, the last block added to the chain as known at the \
+        "Hex-encoded block hash or height of the block.  If not given, the last block added to the chain as known at the \
         given node will be used";
 
     pub(crate) fn arg(order: usize) -> Arg<'static, 'static> {
@@ -235,19 +256,25 @@ pub mod block_parameter {
             .display_order(order)
     }
 
-    pub(crate) fn get(matches: &ArgMatches) -> Option<BlockParameters> {
-        if matches.value_of(ARG_VALUE_NAME) == Some("HEX_STRING") {
-            matches.value_of(ARG_NAME).map(|hex_str|{
-                let hash = Digest::from_hex(hex_str)
-                .unwrap_or_else(|error| panic!("cannot parse as a block hash: {}", error));
-                BlockParameters::Hash(BlockHash::new(hash))
-            })
-        } else {
-            matches.value_of(ARG_NAME).map(|height_str| {
-                let height = height_str.parse().unwrap_or_else(|error| panic!("should parse as u64: {}", error));
+    pub(crate) fn get_hash(matches: &ArgMatches) -> Option<BlockParameters> {
+       matches.value_of(ARG_NAME).map(|hex_str| {
+           let hash = Digest::from_hex(hex_str)
+            .unwrap_or_else(|error| {
+               panic!("cannot parse as a block hash: {}", error) 
+            });
+            BlockParameters::Hash(BlockHash::new(hash))
+       })
+    }
+
+    pub(crate)  fn get_height(matches: &ArgMatches) -> Option<BlockParameters> {
+        matches.value_of(ARG_NAME)
+            .map(|height_str| {
+                let height = height_str.parse()
+                    .unwrap_or_else(|error| panic!(
+                        "cannot parse as u64 {}", error )
+                );
                 BlockParameters::Height(height)
             })
-        }
     }
 }
 

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -218,7 +218,7 @@ pub mod block_parameter_type {
 
     const ARG_NAME: &str = "parameter-type";
     const ARG_NAME_SHORT: &str = "t";
-    const ARG_HELP: &str ="Flag toggle to query by either hash or height";
+    const ARG_HELP: &str = "Flag toggle to query by either hash or height";
 
     pub(crate) fn arg(order: usize) -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)
@@ -231,7 +231,6 @@ pub mod block_parameter_type {
     pub(crate) fn get(matches: &ArgMatches) -> bool {
         matches.is_present(ARG_NAME)
     }
-    
 }
 
 pub mod block_parameter {
@@ -257,27 +256,22 @@ pub mod block_parameter {
     }
 
     pub(crate) fn get_hash(matches: &ArgMatches) -> Option<BlockParameters> {
-       matches.value_of(ARG_NAME).map(|hex_str| {
-           let hash = Digest::from_hex(hex_str)
-            .unwrap_or_else(|error| {
-               panic!("cannot parse as a block hash: {}", error) 
-            });
+        matches.value_of(ARG_NAME).map(|hex_str| {
+            let hash = Digest::from_hex(hex_str)
+                .unwrap_or_else(|error| panic!("cannot parse as a block hash: {}", error));
             BlockParameters::Hash(BlockHash::new(hash))
-       })
+        })
     }
 
-    pub(crate)  fn get_height(matches: &ArgMatches) -> Option<BlockParameters> {
-        matches.value_of(ARG_NAME)
-            .map(|height_str| {
-                let height = height_str.parse()
-                    .unwrap_or_else(|error| panic!(
-                        "cannot parse as u64 {}", error )
-                );
-                BlockParameters::Height(height)
-            })
+    pub(crate) fn get_height(matches: &ArgMatches) -> Option<BlockParameters> {
+        matches.value_of(ARG_NAME).map(|height_str| {
+            let height = height_str
+                .parse()
+                .unwrap_or_else(|error| panic!("cannot parse as u64 {}", error));
+            BlockParameters::Height(height)
+        })
     }
 }
-
 
 pub fn read_file(path: &str) -> Vec<u8> {
     fs::read(path).unwrap_or_else(|error| panic!("should read {}: {}", path, error))

--- a/client/src/deploy/list.rs
+++ b/client/src/deploy/list.rs
@@ -4,13 +4,7 @@ use clap::{App, ArgMatches, SubCommand};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use casper_node::{
-    rpcs::{
-        chain::{GetBlock, GetBlockParams, GetBlockResult},
-        RpcWithOptionalParams,
-    },
-    types::DeployHash,
-};
+use casper_node::{rpcs::{RpcWithOptionalParams, chain::{BlockParameters, GetBlock, GetBlockParams, GetBlockResult}}, types::DeployHash};
 
 use crate::{command::ClientCommand, common, RpcClient};
 
@@ -72,7 +66,8 @@ impl<'a, 'b> ClientCommand<'a, 'b> for ListDeploys {
 
         let response = match maybe_block_hash {
             Some(block_hash) => {
-                let params = GetBlockParams { block_hash };
+                let block_parameter = BlockParameters::Hash(block_hash);
+                let params = GetBlockParams { block_parameter };
                 Self::request_with_map_params(verbose, &node_address, rpc_id, params)
             }
             None => Self::request(verbose, &node_address, rpc_id),

--- a/client/src/deploy/list.rs
+++ b/client/src/deploy/list.rs
@@ -4,7 +4,13 @@ use clap::{App, ArgMatches, SubCommand};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use casper_node::{rpcs::{RpcWithOptionalParams, chain::{BlockParameters, GetBlock, GetBlockParams, GetBlockResult}}, types::DeployHash};
+use casper_node::{
+    rpcs::{
+        chain::{BlockParameters, GetBlock, GetBlockParams, GetBlockResult},
+        RpcWithOptionalParams,
+    },
+    types::DeployHash,
+};
 
 use crate::{command::ClientCommand, common, RpcClient};
 

--- a/client/src/get_state_hash.rs
+++ b/client/src/get_state_hash.rs
@@ -2,7 +2,10 @@ use std::str;
 
 use clap::{App, ArgMatches, SubCommand};
 
-use casper_node::rpcs::{RpcWithOptionalParams, chain::{BlockParameters, GetStateRootHash, GetStateRootHashParams}};
+use casper_node::rpcs::{
+    chain::{BlockParameters, GetStateRootHash, GetStateRootHashParams},
+    RpcWithOptionalParams,
+};
 
 use crate::{command::ClientCommand, common, RpcClient};
 

--- a/client/src/get_state_hash.rs
+++ b/client/src/get_state_hash.rs
@@ -2,10 +2,7 @@ use std::str;
 
 use clap::{App, ArgMatches, SubCommand};
 
-use casper_node::rpcs::{
-    chain::{GetStateRootHash, GetStateRootHashParams},
-    RpcWithOptionalParams,
-};
+use casper_node::rpcs::{RpcWithOptionalParams, chain::{BlockParameters, GetStateRootHash, GetStateRootHashParams}};
 
 use crate::{command::ClientCommand, common, RpcClient};
 
@@ -45,7 +42,8 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetStateRootHash {
 
         let response = match maybe_block_hash {
             Some(block_hash) => {
-                let params = GetStateRootHashParams { block_hash };
+                let block_parameter = BlockParameters::Hash(block_hash);
+                let params = GetStateRootHashParams { block_parameter };
                 Self::request_with_map_params(verbose, &node_address, rpc_id, params)
             }
             None => Self::request(verbose, &node_address, rpc_id),

--- a/node/src/components/api_server.rs
+++ b/node/src/components/api_server.rs
@@ -224,13 +224,13 @@ where
                 }),
             Event::ApiRequest(ApiRequest::GetBlock {
                 maybe_parameter: Some(BlockParameters::Height(height)),
-                responder
+                responder,
             }) => effect_builder
                 .get_block_at_height(height)
                 .event(move |result| Event::GetBlockResult {
                     maybe_hash: None,
                     result: Box::new(result),
-                    main_responder: responder
+                    main_responder: responder,
                 }),
             Event::ApiRequest(ApiRequest::GetBlock {
                 maybe_parameter: None,

--- a/node/src/components/api_server.rs
+++ b/node/src/components/api_server.rs
@@ -37,6 +37,8 @@ use casper_execution_engine::{
 };
 use casper_types::{auction::ValidatorWeights, Key, ProtocolVersion, URef};
 
+use self::rpcs::chain::BlockParameters;
+
 use super::Component;
 use crate::{
     components::storage::Storage,
@@ -211,7 +213,7 @@ where
                 effects
             }
             Event::ApiRequest(ApiRequest::GetBlock {
-                maybe_hash: Some(hash),
+                maybe_parameter: Some(BlockParameters::Hash(hash)),
                 responder,
             }) => effect_builder
                 .get_block_from_storage(hash)
@@ -221,7 +223,17 @@ where
                     main_responder: responder,
                 }),
             Event::ApiRequest(ApiRequest::GetBlock {
-                maybe_hash: None,
+                maybe_parameter: Some(BlockParameters::Height(height)),
+                responder
+            }) => effect_builder
+                .get_block_at_height(height)
+                .event(move |result| Event::GetBlockResult {
+                    maybe_hash: None,
+                    result: Box::new(result),
+                    main_responder: responder
+                }),
+            Event::ApiRequest(ApiRequest::GetBlock {
+                maybe_parameter: None,
                 responder,
             }) => effect_builder
                 .get_highest_block()

--- a/node/src/components/api_server/rpcs/chain.rs
+++ b/node/src/components/api_server/rpcs/chain.rs
@@ -1,6 +1,6 @@
 //! RPCs related to the block chain.
 
-use std::str;
+use std::{fmt::{self, Display}, str};
 
 use futures::{future::BoxFuture, FutureExt};
 use http::Response;
@@ -21,11 +21,21 @@ use crate::{
     types::{Block, BlockHash},
 };
 
+/// Enum for Params
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum BlockParameters {
+    /// Get a block by its hash. 
+    Hash(BlockHash),
+    /// Get a block by its height.
+    Height(u64),
+}
+
+
 /// Params for "chain_get_block" RPC request.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetBlockParams {
     /// The block hash.
-    pub block_hash: BlockHash,
+    pub block_parameter: BlockParameters,
 }
 
 /// Result for "chain_get_block" RPC response.
@@ -54,8 +64,8 @@ impl RpcWithOptionalParamsExt for GetBlock {
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
             // Get the block.
-            let maybe_block_hash = maybe_params.map(|params| params.block_hash);
-            let maybe_block = match get_block(maybe_block_hash, effect_builder).await {
+            let maybe_block_parameter = maybe_params.map(|params| params.block_parameter);
+            let maybe_block = match get_block(maybe_block_parameter, effect_builder).await {
                 Ok(maybe_block) => maybe_block,
                 Err(error) => return Ok(response_builder.error(error)?),
             };
@@ -75,7 +85,7 @@ impl RpcWithOptionalParamsExt for GetBlock {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetStateRootHashParams {
     /// The block hash.
-    pub block_hash: BlockHash,
+    pub block_parameter: BlockParameters,
 }
 
 /// Result for "chain_get_state_root_hash" RPC response.
@@ -104,8 +114,8 @@ impl RpcWithOptionalParamsExt for GetStateRootHash {
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
             // Get the block.
-            let maybe_block_hash = maybe_params.map(|params| params.block_hash);
-            let maybe_block = match get_block(maybe_block_hash, effect_builder).await {
+            let maybe_block_parameter = maybe_params.map(|params| params.block_parameter);
+            let maybe_block = match get_block(maybe_block_parameter, effect_builder).await {
                 Ok(maybe_block) => maybe_block,
                 Err(error) => return Ok(response_builder.error(error)?),
             };
@@ -122,15 +132,15 @@ impl RpcWithOptionalParamsExt for GetStateRootHash {
 }
 
 async fn get_block<REv: ReactorEventT>(
-    maybe_hash: Option<BlockHash>,
+    maybe_parameter: Option<BlockParameters>,
     effect_builder: EffectBuilder<REv>,
 ) -> Result<Option<Block>, warp_json_rpc::Error> {
     // Get the block from storage or the latest from the linear chain.
-    let getting_from_storage = maybe_hash.is_some();
+    let getting_from_storage = maybe_parameter.is_some();
     let maybe_block = effect_builder
         .make_request(
             |responder| ApiRequest::GetBlock {
-                maybe_hash,
+                maybe_parameter,
                 responder,
             },
             QueueKind::Api,
@@ -138,7 +148,7 @@ async fn get_block<REv: ReactorEventT>(
         .await;
 
     if maybe_block.is_none() && getting_from_storage {
-        info!("failed to get {} from storage", maybe_hash.unwrap());
+        info!("failed to get {} from storage", maybe_parameter.unwrap());
         return Err(warp_json_rpc::Error::custom(
             ErrorCode::NoSuchBlock as i64,
             "block not known",
@@ -146,4 +156,13 @@ async fn get_block<REv: ReactorEventT>(
     }
 
     Ok(maybe_block)
+}
+
+impl Display for BlockParameters {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            BlockParameters::Hash(hash)=> write!(formatter, "{}", hash),
+            BlockParameters::Height(height)=> write!(formatter, "{}", height)
+        }
+    }
 }

--- a/node/src/components/api_server/rpcs/chain.rs
+++ b/node/src/components/api_server/rpcs/chain.rs
@@ -1,6 +1,9 @@
 //! RPCs related to the block chain.
 
-use std::{fmt::{self, Display}, str};
+use std::{
+    fmt::{self, Display},
+    str,
+};
 
 use futures::{future::BoxFuture, FutureExt};
 use http::Response;
@@ -24,12 +27,11 @@ use crate::{
 /// Enum for Params
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum BlockParameters {
-    /// Get a block by its hash. 
+    /// Get a block by its hash.
     Hash(BlockHash),
     /// Get a block by its height.
     Height(u64),
 }
-
 
 /// Params for "chain_get_block" RPC request.
 #[derive(Serialize, Deserialize, Debug)]
@@ -161,8 +163,8 @@ async fn get_block<REv: ReactorEventT>(
 impl Display for BlockParameters {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            BlockParameters::Hash(hash)=> write!(formatter, "{}", hash),
-            BlockParameters::Height(height)=> write!(formatter, "{}", height)
+            BlockParameters::Hash(hash) => write!(formatter, "{}", hash),
+            BlockParameters::Height(height) => write!(formatter, "{}", height),
         }
     }
 }

--- a/node/src/components/api_server/rpcs/state.rs
+++ b/node/src/components/api_server/rpcs/state.rs
@@ -258,7 +258,7 @@ impl RpcWithParamsExt for GetAuctionInfo {
                 let maybe_block = effect_builder
                     .make_request(
                         |responder| ApiRequest::GetBlock {
-                            maybe_hash: None,
+                            maybe_parameter: None,
                             responder,
                         },
                         QueueKind::Api,

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -72,10 +72,6 @@ impl<C: Context> FinalityDetector<C> {
                 None
             };
 
-            trace!(
-                %block.height,
-                "Depth of the last finalized block"
-            );
             Some(FinalizedBlock {
                 value: block.value.clone(),
                 timestamp: vote.timestamp,

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -72,6 +72,10 @@ impl<C: Context> FinalityDetector<C> {
                 None
             };
 
+            trace!(
+                %block.height,
+                "Depth of the last finalized block"
+            );
             Some(FinalizedBlock {
                 value: block.value.clone(),
                 timestamp: vote.timestamp,

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -122,7 +122,7 @@ pub(crate) struct State<C: Context> {
     faults: HashMap<ValidatorIndex, Fault<C>>,
     /// The full panorama, corresponding to the complete protocol state.
     panorama: Panorama<C>,
-    /// Clock to track state function. 
+    /// Clock to track state function.
     clock: Clock,
 }
 

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -9,6 +9,7 @@ mod weight;
 pub(crate) mod tests;
 
 pub(crate) use params::Params;
+use quanta::Clock;
 pub(crate) use weight::Weight;
 
 pub(super) use panorama::{Observation, Panorama};
@@ -339,7 +340,8 @@ impl<C: Context> State<C> {
     /// children of the previously selected block (or from all blocks at height 0), until a block
     /// is reached that has no children with any votes.
     pub(crate) fn fork_choice<'a>(&'a self, pan: &Panorama<C>) -> Option<&'a C::Hash> {
-        let start_time = Timestamp::now();
+        let clock = Clock::new();
+        let start = clock.start();
         // Collect all correct votes in a `Tallies` map, sorted by height.
         let to_entry = |(obs, w): (&Observation<C>, &Weight)| {
             let bhash = &self.vote(obs.correct()?).block;
@@ -353,8 +355,9 @@ impl<C: Context> State<C> {
             tallies = tallies.filter_descendants(height, bhash, self);
             // If there are no blocks left, `bhash` itself is the fork choice. Otherwise repeat.
             if tallies.is_empty() {
-                let elapsed = start_time.elapsed();
-                trace!(%elapsed,"Time taken for fork-choice to run");
+                let end = clock.end();
+                let delta = clock.delta(start, end).as_nanos();
+                trace!(%delta,"Time taken for fork-choice to run");
                 return Some(bhash);
             }
         }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -30,16 +30,23 @@ use casper_execution_engine::{
 use casper_types::{auction::ValidatorWeights, Key, ProtocolVersion, URef};
 
 use super::Responder;
-use crate::{rpcs::chain::BlockParameters, Chainspec, components::{
+use crate::{
+    components::{
         chainspec_loader::ChainspecInfo,
         fetcher::FetchResult,
         storage::{
             DeployHashes, DeployHeaderResults, DeployMetadata, DeployResults, StorageType, Value,
         },
-    }, crypto::{asymmetric_key::Signature, hash::Digest}, types::{
+    },
+    crypto::{asymmetric_key::Signature, hash::Digest},
+    rpcs::chain::BlockParameters,
+    types::{
         json_compatibility::ExecutionResult, Block as LinearBlock, Block, BlockHash, BlockHeader,
         Deploy, DeployHash, FinalizedBlock, Item, ProtoBlockHash, StatusFeed, Timestamp,
-    }, utils::DisplayIter};
+    },
+    utils::DisplayIter,
+    Chainspec,
+};
 
 type DeployAndMetadata<S> = (
     <S as StorageType>::Deploy,
@@ -435,7 +442,8 @@ impl<I> Display for ApiRequest<I> {
                 ..
             } => write!(formatter, "get {}", hash),
             ApiRequest::GetBlock {
-                maybe_parameter: None, ..
+                maybe_parameter: None,
+                ..
             } => write!(formatter, "get latest block"),
             ApiRequest::QueryProtocolData {
                 protocol_version, ..

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -30,22 +30,16 @@ use casper_execution_engine::{
 use casper_types::{auction::ValidatorWeights, Key, ProtocolVersion, URef};
 
 use super::Responder;
-use crate::{
-    components::{
+use crate::{rpcs::chain::BlockParameters, Chainspec, components::{
         chainspec_loader::ChainspecInfo,
         fetcher::FetchResult,
         storage::{
             DeployHashes, DeployHeaderResults, DeployMetadata, DeployResults, StorageType, Value,
         },
-    },
-    crypto::{asymmetric_key::Signature, hash::Digest},
-    types::{
+    }, crypto::{asymmetric_key::Signature, hash::Digest}, types::{
         json_compatibility::ExecutionResult, Block as LinearBlock, Block, BlockHash, BlockHeader,
         Deploy, DeployHash, FinalizedBlock, Item, ProtoBlockHash, StatusFeed, Timestamp,
-    },
-    utils::DisplayIter,
-    Chainspec,
-};
+    }, utils::DisplayIter};
 
 type DeployAndMetadata<S> = (
     <S as StorageType>::Deploy,
@@ -366,7 +360,7 @@ pub enum ApiRequest<I> {
     /// `maybe_hash` is `None`, return the latest block.
     GetBlock {
         /// The hash of the block to be retrieved.
-        maybe_hash: Option<BlockHash>,
+        maybe_parameter: Option<BlockParameters>,
         /// Responder to call with the result.
         responder: Responder<Option<LinearBlock>>,
     },
@@ -437,11 +431,11 @@ impl<I> Display for ApiRequest<I> {
         match self {
             ApiRequest::SubmitDeploy { deploy, .. } => write!(formatter, "submit {}", *deploy),
             ApiRequest::GetBlock {
-                maybe_hash: Some(hash),
+                maybe_parameter: Some(hash),
                 ..
             } => write!(formatter, "get {}", hash),
             ApiRequest::GetBlock {
-                maybe_hash: None, ..
+                maybe_parameter: None, ..
             } => write!(formatter, "get latest block"),
             ApiRequest::QueryProtocolData {
                 protocol_version, ..


### PR DESCRIPTION
Set it up such that you can query by either a block hash or height. A flag toggles where the query happens by hash on the node side or by height.

This shows a query with block hash
![Screenshot from 2020-10-26 17-38-15](https://user-images.githubusercontent.com/42871449/97236302-cd3ee200-17b2-11eb-91fd-72360c8c6360.png)

This shows a query by height on the same block using the flag
![Screenshot from 2020-10-26 17-38-30](https://user-images.githubusercontent.com/42871449/97236323-d8920d80-17b2-11eb-8b91-b919f7863a99.png)

Let me know if there is a smarter way to implement certain things. I'm sure the way the args are passed by the client can be improved. 

