### PR TITLE
NDRS-535: add more fields to DeployProcessed server sent event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "assert_cmd"
@@ -305,15 +305,13 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
+checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
 dependencies = [
- "byte-tools",
- "byteorder",
  "crypto-mac",
  "digest 0.9.0",
- "opaque-debug 0.2.3",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -442,7 +440,7 @@ dependencies = [
  "casper-node",
  "casper-types",
  "clap",
- "futures 0.3.6",
+ "futures 0.3.7",
  "hex",
  "jsonrpc-lite",
  "lazy_static",
@@ -598,7 +596,7 @@ dependencies = [
  "either",
  "enum-iterator",
  "fake_instant",
- "futures 0.3.6",
+ "futures 0.3.7",
  "getrandom 0.2.0",
  "hex",
  "hex-buffer-serde",
@@ -669,8 +667,8 @@ version = "0.1.0"
 dependencies = [
  "Inflector",
  "indexmap",
- "proc-macro2 1.0.24",
- "syn 1.0.44",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1089,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057b7146d02fb50175fd7dbe5158f6097f33d02831f43b4ee8ae4ddf67b68f5c"
+checksum = "c2265c3f8e080075d9b6417aa72293fc71662f34b4af2612d8d1b074d29510db"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -1175,7 +1173,7 @@ checksum = "58c5e012182a90c786b933cba854193b6db170aae744e60402708e9f64c73af2"
 dependencies = [
  "datasize_derive",
  "fake_instant",
- "futures 0.3.6",
+ "futures 0.3.7",
  "smallvec 1.4.2",
  "tokio 0.2.22",
 ]
@@ -1715,9 +1713,9 @@ checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8e3078b7b2a8a671cb7a3d17b4760e4181ea243227776ba83fd043b4ca034e"
+checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1730,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
+checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1740,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
+checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
 
 [[package]]
 name = "futures-cpupool"
@@ -1756,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc709ca1da6f66143b8c9bec8e6260181869893714e9b5a490b169b0414144ab"
+checksum = "f5f8e0c9258abaea85e78ebdda17ef9666d390e987f006be6080dfe354b708cb"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1767,15 +1765,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
+checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57ed14da4603b2554682e9f2ff3c65d7567b53188db96cb71538217fc64581b"
+checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1785,24 +1783,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8764258ed64ebc5d9ed185cf86a95db5cac810269c5d20ececb32e0088abbd"
+checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
+checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
+checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1811,7 +1809,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project 1.0.1",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1988,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -2003,6 +2001,7 @@ dependencies = [
  "tokio 0.2.22",
  "tokio-util",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -2190,7 +2189,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 0.4.27",
  "socket2",
  "tokio 0.2.22",
  "tower-service",
@@ -2243,11 +2242,11 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2353,9 +2352,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "linked-hash-map"
@@ -3122,7 +3121,16 @@ version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.27",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+dependencies = [
+ "pin-project-internal 1.0.1",
 ]
 
 [[package]]
@@ -3130,6 +3138,17 @@ name = "pin-project-internal"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4371,9 +4390,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.46"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad5de3220ea04da322618ded2c42233d02baca219d6f160a3e9c87cda16c942"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4756,8 +4775,8 @@ checksum = "ebdd897b01021779294eb09bb3b52b6e11b0747f9f7e333a84bef532b656de99"
 dependencies = [
  "bytes 0.5.6",
  "derivative",
- "futures 0.3.6",
- "pin-project",
+ "futures 0.3.7",
+ "pin-project 0.4.27",
  "rmp-serde",
  "serde",
 ]
@@ -4854,7 +4873,7 @@ checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
 dependencies = [
  "futures-util",
  "log 0.4.11",
- "pin-project",
+ "pin-project 0.4.27",
  "tokio 0.2.22",
  "tungstenite",
 ]
@@ -4977,7 +4996,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
- "pin-project",
+ "pin-project 0.4.27",
  "tracing",
 ]
 
@@ -5429,7 +5448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.6",
+ "futures 0.3.7",
  "headers",
  "http",
  "hyper",
@@ -5437,7 +5456,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "multipart",
- "pin-project",
+ "pin-project 0.4.27",
  "scoped-tls 1.0.0",
  "serde",
  "serde_json",
@@ -5458,7 +5477,7 @@ checksum = "b8f47179c6df70470fb9f77d6624a825943539d792ab123f63d0dadfa0f1864c"
 dependencies = [
  "anyhow",
  "erased-serde",
- "futures 0.3.6",
+ "futures 0.3.7",
  "http",
  "hyper",
  "lazycell",

--- a/node/src/components/api_server.rs
+++ b/node/src/components/api_server.rs
@@ -333,10 +333,15 @@ where
             }),
             Event::DeployProcessed {
                 deploy_hash,
+                deploy_header,
                 block_hash,
                 execution_result,
             } => self.broadcast(SseData::DeployProcessed {
                 deploy_hash,
+                account: *deploy_header.account(),
+                timestamp: deploy_header.timestamp(),
+                ttl: deploy_header.ttl(),
+                dependencies: deploy_header.dependencies().clone(),
                 block_hash,
                 execution_result,
             }),

--- a/node/src/components/api_server/event.rs
+++ b/node/src/components/api_server/event.rs
@@ -17,7 +17,7 @@ use crate::{
     effect::{requests::ApiRequest, Responder},
     types::{
         json_compatibility::ExecutionResult, Block, BlockHash, BlockHeader, Deploy, DeployHash,
-        FinalizedBlock,
+        DeployHeader, FinalizedBlock,
     },
 };
 
@@ -66,6 +66,7 @@ pub enum Event {
     },
     DeployProcessed {
         deploy_hash: DeployHash,
+        deploy_header: Box<DeployHeader>,
         block_hash: BlockHash,
         execution_result: ExecutionResult,
     },

--- a/node/src/components/api_server/sse_server.rs
+++ b/node/src/components/api_server/sse_server.rs
@@ -14,8 +14,12 @@ use warp::{
 };
 
 use super::CLIENT_API_VERSION;
-use crate::types::{
-    json_compatibility::ExecutionResult, BlockHash, BlockHeader, DeployHash, FinalizedBlock,
+use crate::{
+    crypto::asymmetric_key::PublicKey,
+    types::{
+        json_compatibility::ExecutionResult, BlockHash, BlockHeader, DeployHash, FinalizedBlock,
+        TimeDiff, Timestamp,
+    },
 };
 
 /// The URL path.
@@ -53,6 +57,10 @@ pub enum SseData {
     /// The given deploy has been executed, committed and forms part of the given block.
     DeployProcessed {
         deploy_hash: DeployHash,
+        account: PublicKey,
+        timestamp: Timestamp,
+        ttl: TimeDiff,
+        dependencies: Vec<DeployHash>,
         block_hash: BlockHash,
         execution_result: ExecutionResult,
     },

--- a/node/src/components/block_executor/event.rs
+++ b/node/src/components/block_executor/event.rs
@@ -1,8 +1,10 @@
-use crate::{
-    crypto::hash::Digest,
-    effect::requests::BlockExecutorRequest,
-    types::{json_compatibility::ExecutionResult, BlockHash, Deploy, DeployHash, FinalizedBlock},
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::Display,
 };
+
+use derive_more::From;
+
 use casper_execution_engine::{
     core::{
         engine_state,
@@ -10,10 +12,14 @@ use casper_execution_engine::{
     },
     storage::global_state::CommitResult,
 };
-use derive_more::From;
-use std::{
-    collections::{HashMap, VecDeque},
-    fmt::Display,
+
+use crate::{
+    crypto::hash::Digest,
+    effect::requests::BlockExecutorRequest,
+    types::{
+        json_compatibility::ExecutionResult, BlockHash, Deploy, DeployHash, DeployHeader,
+        FinalizedBlock,
+    },
 };
 
 /// Block executor component event.
@@ -44,6 +50,8 @@ pub enum Event {
         state: Box<State>,
         /// The ID of the deploy currently being executed.
         deploy_hash: DeployHash,
+        /// The header of the deploy currently being executed.
+        deploy_header: DeployHeader,
         /// Result of deploy execution.
         result: Result<ExecutionResults, RootNotFound>,
     },
@@ -90,6 +98,7 @@ impl Display for Event {
                 state,
                 deploy_hash,
                 result: Ok(_),
+                ..
             } => write!(
                 f,
                 "execution result for {} of finalized block with height {} with \
@@ -102,6 +111,7 @@ impl Display for Event {
                 state,
                 deploy_hash,
                 result: Err(_),
+                ..
             } => write!(
                 f,
                 "execution result for {} of finalized block with height {} with \
@@ -151,7 +161,7 @@ pub struct State {
     /// Deploys which have still to be executed.
     pub remaining_deploys: VecDeque<Deploy>,
     /// A collection of results of executing the deploys.
-    pub execution_results: HashMap<DeployHash, ExecutionResult>,
+    pub execution_results: HashMap<DeployHash, (DeployHeader, ExecutionResult)>,
     /// Current state root hash of global storage.  Is initialized with the parent block's
     /// state hash, and is updated after each commit.
     pub state_root_hash: Digest,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -105,7 +105,7 @@ use crate::{
     reactor::{EventQueueHandle, QueueKind},
     types::{
         json_compatibility::ExecutionResult, Block, BlockByHeight, BlockHash, BlockHeader,
-        BlockLike, Deploy, DeployHash, FinalizedBlock, Item, ProtoBlock,
+        BlockLike, Deploy, DeployHash, DeployHeader, FinalizedBlock, Item, ProtoBlock,
     },
     utils::Source,
     Chainspec,
@@ -576,7 +576,7 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn announce_linear_chain_block(
         self,
         block: Block,
-        execution_results: HashMap<DeployHash, ExecutionResult>,
+        execution_results: HashMap<DeployHash, (DeployHeader, ExecutionResult)>,
     ) where
         REv: From<BlockExecutorAnnouncement>,
     {

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -12,7 +12,7 @@ use crate::{
     components::small_network::GossipedAddress,
     types::{
         json_compatibility::ExecutionResult, Block, BlockHash, BlockHeader, Deploy, DeployHash,
-        FinalizedBlock, Item, ProtoBlock,
+        DeployHeader, FinalizedBlock, Item, ProtoBlock,
     },
     utils::Source,
 };
@@ -156,7 +156,7 @@ pub enum BlockExecutorAnnouncement {
         /// The block.
         block: Block,
         /// The results of executing the deploys in this block.
-        execution_results: HashMap<DeployHash, ExecutionResult>,
+        execution_results: HashMap<DeployHash, (DeployHeader, ExecutionResult)>,
     },
 }
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -578,6 +578,10 @@ impl reactor::Reactor for Reactor {
                 block,
                 execution_results,
             }) => {
+                let execution_results = execution_results
+                    .into_iter()
+                    .map(|(hash, (_header, results))| (hash, results))
+                    .collect();
                 let reactor_event = Event::LinearChain(linear_chain::Event::LinearChainBlock {
                     block: Box::new(block),
                     execution_results,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -679,13 +679,17 @@ impl reactor::Reactor for Reactor {
                 let block_hash = *block.hash();
                 let reactor_event = Event::LinearChain(linear_chain::Event::LinearChainBlock {
                     block: Box::new(block),
-                    execution_results: execution_results.clone(),
+                    execution_results: execution_results
+                        .iter()
+                        .map(|(hash, (_header, results))| (*hash, results.clone()))
+                        .collect(),
                 });
                 let mut effects = self.dispatch_event(effect_builder, rng, reactor_event);
 
-                for (deploy_hash, execution_result) in execution_results {
+                for (deploy_hash, (deploy_header, execution_result)) in execution_results {
                     let reactor_event = Event::ApiServer(api_server::Event::DeployProcessed {
                         deploy_hash,
+                        deploy_header: Box::new(deploy_header),
                         block_hash,
                         execution_result,
                     });


### PR DESCRIPTION
The output of a `DeployProcessed` event in the event stream is now equivalent to the following:
```
{
   "DeployProcessed": {
      "deploy_hash": "871f50ca3cc5627947e4310850b03e0a105a2ae4d028a2a85a9258455da30114",
      "account": "010c801c47ed20a9ec40a899ddc7b51a15db2a6c55041313eb0201ae04ee9bf932",
      "timestamp": "2020-10-27T01:55:17.276Z",
      "ttl": "1day",
      "dependencies": [],
      "block_hash": "d233ce4865db29eea5c54bb2074ea11b51d736ba46082d62f299323e10f36601",
      "execution_result": {
          ...
      }
   }
}
```