### PR TITLE
NDRS-440: Add information from the consensus protocol to accusations.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -57,6 +57,8 @@ pub(crate) struct FinalizedBlock<C: ConsensusValueT, VID> {
     pub(crate) height: u64,
     /// If this is a terminal block, i.e. the last one to be finalized, this includes rewards.
     pub(crate) rewards: Option<BTreeMap<VID, u64>>,
+    /// The validators known to be faulty as seen by this block.
+    pub(crate) equivocators: Vec<VID>,
     /// Proposer of this value
     pub(crate) proposer: VID,
 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -640,11 +640,21 @@ where
                 timestamp,
                 height,
                 rewards,
+                equivocators,
                 proposer,
             }) => {
+                // If this is the era's last block, it contains rewards. Everyone who is accused in
+                // the block or seen as equivocating via the consensus protocol gets slashed.
                 let era_end = rewards.map(|rewards| EraEnd {
-                    equivocators: value.accusations().clone(),
                     rewards,
+                    equivocators: value
+                        .accusations()
+                        .iter()
+                        .cloned()
+                        .chain(equivocators)
+                        .sorted()
+                        .dedup()
+                        .collect(),
                 });
                 let finalized_block = FinalizedBlock::new(
                     value.proto_block().clone(),

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -652,6 +652,7 @@ where
                         .iter()
                         .cloned()
                         .chain(equivocators)
+                        .filter(|pub_key| !self.era(era_id).slashed.contains(&pub_key))
                         .sorted()
                         .dedup()
                         .collect(),

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -71,12 +71,14 @@ impl<C: Context> FinalityDetector<C> {
             } else {
                 None
             };
+            let faulty_iter = vote.panorama.enumerate().filter(|(_, obs)| obs.is_faulty());
 
             Some(FinalizedBlock {
                 value: block.value.clone(),
                 timestamp: vote.timestamp,
                 height: block.height,
                 rewards,
+                equivocators: faulty_iter.map(|(vidx, _)| to_id(vidx)).collect(),
                 proposer: to_id(vote.creator),
             })
         }))

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -478,6 +478,7 @@ where
             timestamp: _,
             height,
             rewards,
+            equivocators: _,
             proposer: _,
         } in finalized_values
         {


### PR DESCRIPTION
Add equivocators seen from a block to the accusations on finalization, even if they weren't included in the candidate block explicitly.

https://casperlabs.atlassian.net/browse/NDRS-440