### PR TITLE
HWY-166: Add all of an era's accusations to the switch block.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -643,19 +643,13 @@ where
                 equivocators,
                 proposer,
             }) => {
+                self.era_mut(era_id).add_accusations(&equivocators);
+                self.era_mut(era_id).add_accusations(value.accusations());
                 // If this is the era's last block, it contains rewards. Everyone who is accused in
                 // the block or seen as equivocating via the consensus protocol gets slashed.
                 let era_end = rewards.map(|rewards| EraEnd {
                     rewards,
-                    equivocators: value
-                        .accusations()
-                        .iter()
-                        .cloned()
-                        .chain(equivocators)
-                        .filter(|pub_key| !self.era(era_id).slashed.contains(&pub_key))
-                        .sorted()
-                        .dedup()
-                        .collect(),
+                    equivocators: self.era(era_id).accusations(),
                 });
                 let finalized_block = FinalizedBlock::new(
                     value.proto_block().clone(),


### PR DESCRIPTION
This collects all accusations of finalized blocks over the course of an era, and when finalizing the switch block, takes their union.

That way you can't remove someone from the list of to-be-slashed validators anymore, by omitting them from the explicit accusations list in a block you propose.

https://casperlabs.atlassian.net/browse/HWY-166