### PR TITLE
NDRS-541: Add Get-Block by height

### DIFF
--- a/client/src/block/get.rs
+++ b/client/src/block/get.rs
@@ -34,7 +34,9 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(common::block_identifier::arg(DisplayOrder::BlockIdentifier as usize))
+            .arg(common::block_identifier::arg(
+                DisplayOrder::BlockIdentifier as usize,
+            ))
     }
 
     fn run(matches: &ArgMatches<'_>) {

--- a/client/src/block/get.rs
+++ b/client/src/block/get.rs
@@ -14,7 +14,7 @@ enum DisplayOrder {
     Verbose,
     NodeAddress,
     RpcId,
-    BlockHash,
+    BlockIdentifier,
 }
 
 impl RpcClient for GetBlock {
@@ -34,18 +34,18 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(common::block_hash::arg(DisplayOrder::BlockHash as usize))
+            .arg(common::block_identifier::arg(DisplayOrder::BlockIdentifier as usize))
     }
 
     fn run(matches: &ArgMatches<'_>) {
         let verbose = common::verbose::get(matches);
         let node_address = common::node_address::get(matches);
         let rpc_id = common::rpc_id::get(matches);
-        let maybe_block_hash = common::block_hash::get(matches);
+        let maybe_block_id = common::block_identifier::get(matches);
 
-        let response = match maybe_block_hash {
-            Some(block_hash) => {
-                let params = GetBlockParams { block_hash };
+        let response = match maybe_block_id {
+            Some(block_identifier) => {
+                let params = GetBlockParams { block_identifier };
                 Self::request_with_map_params(verbose, &node_address, rpc_id, params)
             }
             None => Self::request(verbose, &node_address, rpc_id),

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -183,7 +183,7 @@ pub mod state_root_hash {
     }
 }
 
-/// Handles providing the arg for and retrieval of the block hash.
+/// Handles providing the arg for and retrieval of the block hash or block height.
 pub mod block_identifier {
     use casper_node::rpcs::chain::BlockIdentifier;
 

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -215,7 +215,7 @@ pub mod block_identifier {
             } else {
                 let height = hex_str
                     .parse()
-                    .unwrap_or_else(|error| panic!("could not parse u64: {}", error));
+                    .unwrap_or_else(|error| panic!("cannot parse as a u64: {}", error));
                 BlockIdentifier::Height(height)
             }
         })

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -207,13 +207,13 @@ pub mod block_identifier {
     }
 
     pub(crate) fn get(matches: &ArgMatches) -> Option<BlockIdentifier> {
-        matches.value_of(ARG_NAME).map(|hex_str| {
-            if hex_str.len() == 64 {
-                let hash = Digest::from_hex(hex_str)
+        matches.value_of(ARG_NAME).map(|value| {
+            if value.len() == (Digest::LENGTH * 2) {
+                let hash = Digest::from_hex(value)
                     .unwrap_or_else(|error| panic!("cannot parse as a block hash: {}", error));
                 BlockIdentifier::Hash(BlockHash::new(hash))
             } else {
-                let height = hex_str
+                let height = value
                     .parse()
                     .unwrap_or_else(|error| panic!("cannot parse as a u64: {}", error));
                 BlockIdentifier::Height(height)

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -193,8 +193,8 @@ pub mod block_identifier {
     const ARG_SHORT: &str = "b";
     const ARG_VALUE_NAME: &str = super::ARG_HEX_STRING;
     const ARG_HELP: &str =
-        "Hex-encoded block hash or the height of the block.  If not given, the last block added to the chain as known at the \
-        given node will be used";
+        "Hex-encoded block hash or height of the block.  If not given, the last block added to the \
+        chain as known at the given node will be used";
 
     pub(crate) fn arg(order: usize) -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -210,13 +210,14 @@ pub mod block_identifier {
         matches.value_of(ARG_NAME).map(|hex_str| {
             if hex_str.len() == 64 {
                 let hash = Digest::from_hex(hex_str)
-                .unwrap_or_else(|error| panic!("cannot parse as a block hash: {}", error));
+                    .unwrap_or_else(|error| panic!("cannot parse as a block hash: {}", error));
                 BlockIdentifier::Hash(BlockHash::new(hash))
             } else {
-                let height = hex_str.parse().unwrap_or_else(|error| panic!("could not parse u64: {}", error));
+                let height = hex_str
+                    .parse()
+                    .unwrap_or_else(|error| panic!("could not parse u64: {}", error));
                 BlockIdentifier::Height(height)
             }
-            
         })
     }
 }

--- a/client/src/deploy/list.rs
+++ b/client/src/deploy/list.rs
@@ -61,18 +61,18 @@ impl<'a, 'b> ClientCommand<'a, 'b> for ListDeploys {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(common::block_hash::arg(DisplayOrder::BlockHash as usize))
+            .arg(common::block_identifier::arg(DisplayOrder::BlockHash as usize))
     }
 
     fn run(matches: &ArgMatches<'_>) {
         let verbose = common::verbose::get(matches);
         let node_address = common::node_address::get(matches);
         let rpc_id = common::rpc_id::get(matches);
-        let maybe_block_hash = common::block_hash::get(matches);
+        let maybe_block_id = common::block_identifier::get(matches);
 
-        let response = match maybe_block_hash {
-            Some(block_hash) => {
-                let params = GetBlockParams { block_hash };
+        let response = match maybe_block_id {
+            Some(block_identifier) => {
+                let params = GetBlockParams { block_identifier };
                 Self::request_with_map_params(verbose, &node_address, rpc_id, params)
             }
             None => Self::request(verbose, &node_address, rpc_id),

--- a/client/src/deploy/list.rs
+++ b/client/src/deploy/list.rs
@@ -61,7 +61,9 @@ impl<'a, 'b> ClientCommand<'a, 'b> for ListDeploys {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(common::block_identifier::arg(DisplayOrder::BlockHash as usize))
+            .arg(common::block_identifier::arg(
+                DisplayOrder::BlockHash as usize,
+            ))
     }
 
     fn run(matches: &ArgMatches<'_>) {

--- a/client/src/get_state_hash.rs
+++ b/client/src/get_state_hash.rs
@@ -34,18 +34,18 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetStateRootHash {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(common::block_hash::arg(DisplayOrder::BlockHash as usize))
+            .arg(common::block_identifier::arg(DisplayOrder::BlockHash as usize))
     }
 
     fn run(matches: &ArgMatches<'_>) {
         let verbose = common::verbose::get(matches);
         let node_address = common::node_address::get(matches);
         let rpc_id = common::rpc_id::get(matches);
-        let maybe_block_hash = common::block_hash::get(matches);
+        let maybe_block_id = common::block_identifier::get(matches);
 
-        let response = match maybe_block_hash {
-            Some(block_hash) => {
-                let params = GetStateRootHashParams { block_hash };
+        let response = match maybe_block_id {
+            Some(block_identifier) => {
+                let params = GetStateRootHashParams { block_identifier };
                 Self::request_with_map_params(verbose, &node_address, rpc_id, params)
             }
             None => Self::request(verbose, &node_address, rpc_id),

--- a/client/src/get_state_hash.rs
+++ b/client/src/get_state_hash.rs
@@ -34,7 +34,9 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetStateRootHash {
                 DisplayOrder::NodeAddress as usize,
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(common::block_identifier::arg(DisplayOrder::BlockHash as usize))
+            .arg(common::block_identifier::arg(
+                DisplayOrder::BlockHash as usize,
+            ))
     }
 
     fn run(matches: &ArgMatches<'_>) {

--- a/node/src/components/api_server/event.rs
+++ b/node/src/components/api_server/event.rs
@@ -12,10 +12,15 @@ use casper_execution_engine::{
 };
 use casper_types::auction::ValidatorWeights;
 
-use crate::{rpcs::chain::BlockIdentifier, components::{small_network::NodeId, storage::DeployMetadata}, effect::{requests::ApiRequest, Responder}, types::{
+use crate::{
+    components::{small_network::NodeId, storage::DeployMetadata},
+    effect::{requests::ApiRequest, Responder},
+    rpcs::chain::BlockIdentifier,
+    types::{
         json_compatibility::ExecutionResult, Block, BlockHash, BlockHeader, Deploy, DeployHash,
         FinalizedBlock,
-    }};
+    },
+};
 
 #[derive(Debug, From)]
 pub enum Event {

--- a/node/src/components/api_server/event.rs
+++ b/node/src/components/api_server/event.rs
@@ -12,21 +12,17 @@ use casper_execution_engine::{
 };
 use casper_types::auction::ValidatorWeights;
 
-use crate::{
-    components::{small_network::NodeId, storage::DeployMetadata},
-    effect::{requests::ApiRequest, Responder},
-    types::{
+use crate::{rpcs::chain::BlockIdentifier, components::{small_network::NodeId, storage::DeployMetadata}, effect::{requests::ApiRequest, Responder}, types::{
         json_compatibility::ExecutionResult, Block, BlockHash, BlockHeader, Deploy, DeployHash,
         FinalizedBlock,
-    },
-};
+    }};
 
 #[derive(Debug, From)]
 pub enum Event {
     #[from]
     ApiRequest(ApiRequest<NodeId>),
     GetBlockResult {
-        maybe_hash: Option<BlockHash>,
+        maybe_id: Option<BlockIdentifier>,
         result: Box<Option<Block>>,
         main_responder: Responder<Option<Block>>,
     },
@@ -76,12 +72,17 @@ impl Display for Event {
         match self {
             Event::ApiRequest(request) => write!(formatter, "{}", request),
             Event::GetBlockResult {
-                maybe_hash: Some(hash),
+                maybe_id: Some(BlockIdentifier::Hash(hash)),
                 result,
                 ..
             } => write!(formatter, "get block result for {}: {:?}", hash, result),
             Event::GetBlockResult {
-                maybe_hash: None,
+                maybe_id: Some(BlockIdentifier::Height(height)),
+                result,
+                ..
+            } => write!(formatter, "get block result for {}: {:?}", height, result),
+            Event::GetBlockResult {
+                maybe_id: None,
                 result,
                 ..
             } => write!(formatter, "get latest block result: {:?}", result),

--- a/node/src/components/api_server/rpcs/chain.rs
+++ b/node/src/components/api_server/rpcs/chain.rs
@@ -26,7 +26,7 @@ use crate::{
 pub enum BlockIdentifier {
     /// Identify and retrieve the block with its hash.
     Hash(BlockHash),
-    /// Idenityf and retireve the block with its height.
+    /// Identify and retrieve the block with its height.
     Height(u64),
 }
 

--- a/node/src/components/api_server/rpcs/chain.rs
+++ b/node/src/components/api_server/rpcs/chain.rs
@@ -26,10 +26,9 @@ use crate::{
 pub enum BlockIdentifier {
     /// Identify and retrieve the block with its hash.
     Hash(BlockHash),
-    /// Idenityf and retireve the block with its height. 
-    Height(u64)
+    /// Idenityf and retireve the block with its height.
+    Height(u64),
 }
-
 
 /// Params for "chain_get_block" RPC request.
 #[derive(Serialize, Deserialize, Debug)]
@@ -147,7 +146,7 @@ async fn get_block<REv: ReactorEventT>(
         )
         .await;
 
-    if maybe_block.is_none() && getting_specific_block{
+    if maybe_block.is_none() && getting_specific_block {
         info!("failed to get {:?} from storage", maybe_id.unwrap());
         return Err(warp_json_rpc::Error::custom(
             ErrorCode::NoSuchBlock as i64,

--- a/node/src/components/api_server/rpcs/chain.rs
+++ b/node/src/components/api_server/rpcs/chain.rs
@@ -21,6 +21,16 @@ use crate::{
     types::{Block, BlockHash},
 };
 
+/// Identifier for possible ways to retrieve a block.
+#[derive(Serialize, Deserialize, Debug)]
+pub enum BlockIdentifier {
+    /// Identify and retrieve the block with its hash.
+    Hash(BlockHash),
+    /// Idenityf and retireve the block with its height. 
+    Height(u64)
+}
+
+
 /// Params for "chain_get_block" RPC request.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetBlockParams {

--- a/node/src/components/api_server/rpcs/chain.rs
+++ b/node/src/components/api_server/rpcs/chain.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// Identifier for possible ways to retrieve a block.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum BlockIdentifier {
     /// Identify and retrieve the block with its hash.
     Hash(BlockHash),
@@ -35,7 +35,7 @@ pub enum BlockIdentifier {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetBlockParams {
     /// The block hash.
-    pub block_hash: BlockHash,
+    pub block_identifier: BlockIdentifier,
 }
 
 /// Result for "chain_get_block" RPC response.
@@ -64,8 +64,8 @@ impl RpcWithOptionalParamsExt for GetBlock {
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
             // Get the block.
-            let maybe_block_hash = maybe_params.map(|params| params.block_hash);
-            let maybe_block = match get_block(maybe_block_hash, effect_builder).await {
+            let maybe_block_id = maybe_params.map(|params| params.block_identifier);
+            let maybe_block = match get_block(maybe_block_id, effect_builder).await {
                 Ok(maybe_block) => maybe_block,
                 Err(error) => return Ok(response_builder.error(error)?),
             };
@@ -85,7 +85,7 @@ impl RpcWithOptionalParamsExt for GetBlock {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetStateRootHashParams {
     /// The block hash.
-    pub block_hash: BlockHash,
+    pub block_identifier: BlockIdentifier,
 }
 
 /// Result for "chain_get_state_root_hash" RPC response.
@@ -114,8 +114,8 @@ impl RpcWithOptionalParamsExt for GetStateRootHash {
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
             // Get the block.
-            let maybe_block_hash = maybe_params.map(|params| params.block_hash);
-            let maybe_block = match get_block(maybe_block_hash, effect_builder).await {
+            let maybe_block_id = maybe_params.map(|params| params.block_identifier);
+            let maybe_block = match get_block(maybe_block_id, effect_builder).await {
                 Ok(maybe_block) => maybe_block,
                 Err(error) => return Ok(response_builder.error(error)?),
             };
@@ -132,23 +132,23 @@ impl RpcWithOptionalParamsExt for GetStateRootHash {
 }
 
 async fn get_block<REv: ReactorEventT>(
-    maybe_hash: Option<BlockHash>,
+    maybe_id: Option<BlockIdentifier>,
     effect_builder: EffectBuilder<REv>,
 ) -> Result<Option<Block>, warp_json_rpc::Error> {
     // Get the block from storage or the latest from the linear chain.
-    let getting_from_storage = maybe_hash.is_some();
+    let getting_specific_block = maybe_id.is_some();
     let maybe_block = effect_builder
         .make_request(
             |responder| ApiRequest::GetBlock {
-                maybe_hash,
+                maybe_id,
                 responder,
             },
             QueueKind::Api,
         )
         .await;
 
-    if maybe_block.is_none() && getting_from_storage {
-        info!("failed to get {} from storage", maybe_hash.unwrap());
+    if maybe_block.is_none() && getting_specific_block{
+        info!("failed to get {:?} from storage", maybe_id.unwrap());
         return Err(warp_json_rpc::Error::custom(
             ErrorCode::NoSuchBlock as i64,
             "block not known",

--- a/node/src/components/api_server/rpcs/state.rs
+++ b/node/src/components/api_server/rpcs/state.rs
@@ -269,7 +269,7 @@ impl RpcWithParamsExt for GetAuctionInfo {
                 let maybe_block = effect_builder
                     .make_request(
                         |responder| ApiRequest::GetBlock {
-                            maybe_hash: None,
+                            maybe_id: None,
                             responder,
                         },
                         QueueKind::Api,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -30,16 +30,23 @@ use casper_execution_engine::{
 use casper_types::{auction::ValidatorWeights, Key, ProtocolVersion, URef};
 
 use super::Responder;
-use crate::{rpcs::chain::BlockIdentifier, Chainspec, components::{
+use crate::{
+    components::{
         chainspec_loader::ChainspecInfo,
         fetcher::FetchResult,
         storage::{
             DeployHashes, DeployHeaderResults, DeployMetadata, DeployResults, StorageType, Value,
         },
-    }, crypto::{asymmetric_key::Signature, hash::Digest}, types::{
+    },
+    crypto::{asymmetric_key::Signature, hash::Digest},
+    rpcs::chain::BlockIdentifier,
+    types::{
         json_compatibility::ExecutionResult, Block as LinearBlock, Block, BlockHash, BlockHeader,
         Deploy, DeployHash, FinalizedBlock, Item, ProtoBlockHash, StatusFeed, Timestamp,
-    }, utils::DisplayIter};
+    },
+    utils::DisplayIter,
+    Chainspec,
+};
 
 type DeployAndMetadata<S> = (
     <S as StorageType>::Deploy,
@@ -438,9 +445,7 @@ impl<I> Display for ApiRequest<I> {
                 maybe_id: Some(BlockIdentifier::Height(height)),
                 ..
             } => write!(formatter, "get {}", height),
-            ApiRequest::GetBlock {
-                maybe_id: None, ..
-            } => write!(formatter, "get latest block"),
+            ApiRequest::GetBlock { maybe_id: None, .. } => write!(formatter, "get latest block"),
             ApiRequest::QueryProtocolData {
                 protocol_version, ..
             } => write!(formatter, "protocol_version {}", protocol_version),


### PR DESCRIPTION
Expanded the client to query and retrieve a block by its height as well as its hash. Renamed the arg from `block-hash` to `block-identifier`

By Hash
![Screenshot from 2020-10-27 10-48-35](https://user-images.githubusercontent.com/42871449/97336682-468b1300-184d-11eb-9a44-6e6e0864af4f.png)

By Height:
![Screenshot from 2020-10-27 10-48-52](https://user-images.githubusercontent.com/42871449/97336685-468b1300-184d-11eb-869c-98f10134f0da.png)
