### PR TITLE
EE-1079: enrich balance with merkle proofs, validate

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -6,6 +6,7 @@ mod deploy;
 mod generate_completion;
 mod get_state_hash;
 mod keygen;
+mod merkle_proofs;
 mod query_state;
 mod rpc;
 

--- a/client/src/merkle_proofs.rs
+++ b/client/src/merkle_proofs.rs
@@ -117,7 +117,7 @@ pub fn validate_get_balance_response(
         .as_object()
         .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
 
-    let (main_purse_proof, balance_proof): (
+    let (purse_proof, balance_proof): (
         TrieMerkleProof<Key, StoredValue>,
         TrieMerkleProof<Key, StoredValue>,
     ) = {
@@ -145,7 +145,7 @@ pub fn validate_get_balance_response(
 
     core::validate_balance_proof(
         &state_root_hash.to_owned().into(),
-        &main_purse_proof,
+        &purse_proof,
         &balance_proof,
         *key,
         &balance,

--- a/client/src/merkle_proofs.rs
+++ b/client/src/merkle_proofs.rs
@@ -1,0 +1,154 @@
+use std::convert::TryFrom;
+
+use jsonrpc_lite::JsonRpc;
+use thiserror::Error;
+
+use casper_execution_engine::{
+    core, core::ValidationError, shared::stored_value::StoredValue,
+    storage::trie::merkle_proof::TrieMerkleProof,
+};
+use casper_node::{crypto::hash::Digest, types::json_compatibility};
+use casper_types::{bytesrepr, Key, U512};
+
+const GET_ITEM_RESULT_BALANCE_VALUE: &str = "balance_value";
+const GET_ITEM_RESULT_STORED_VALUE: &str = "stored_value";
+const GET_ITEM_RESULT_MERKLE_PROOF: &str = "merkle_proof";
+
+/// Error that can be returned by validate_response.
+#[derive(Error, Debug)]
+pub enum ValidateResponseError {
+    /// Failed to marshall value
+    #[error("Failed to marshall value {0}")]
+    BytesRepr(bytesrepr::Error),
+
+    /// Error from serde.
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+
+    /// [`validate_response`] failed to parse JSON
+    #[error("validate_response failed to parse")]
+    ValidateResponseFailedToParse,
+
+    /// [`validate_response`] failed to validate
+    #[error(transparent)]
+    ValidationError(#[from] ValidationError),
+
+    /// Serialized value not contained in proof
+    #[error("serialized value not contained in proof")]
+    SerializedValueNotContainedInProof,
+}
+
+impl From<bytesrepr::Error> for ValidateResponseError {
+    fn from(e: bytesrepr::Error) -> Self {
+        ValidateResponseError::BytesRepr(e)
+    }
+}
+
+pub fn validate_query_response(
+    response: &JsonRpc,
+    state_root_hash: &Digest,
+    key: &Key,
+    path: &[String],
+) -> Result<(), ValidateResponseError> {
+    let value = response
+        .get_result()
+        .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+
+    let object = value
+        .as_object()
+        .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+
+    let proofs: Vec<TrieMerkleProof<Key, StoredValue>> = {
+        let proof = object
+            .get(GET_ITEM_RESULT_MERKLE_PROOF)
+            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+        let proof_str = proof
+            .as_str()
+            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+        let proof_bytes = hex::decode(proof_str)
+            .map_err(|_| ValidateResponseError::ValidateResponseFailedToParse)?;
+        bytesrepr::deserialize(proof_bytes)?
+    };
+
+    let proof_value: &StoredValue = {
+        let last_proof = proofs
+            .last()
+            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+        last_proof.value()
+    };
+
+    // Here we need to validate that JSON `stored_value` is contained in the proof.
+    //
+    // Possible to deserialize that field into a `StoredValue` and pass below to
+    // `validate_query_proof` instead of using this approach?
+    {
+        let value: json_compatibility::StoredValue = {
+            let value = object
+                .get(GET_ITEM_RESULT_STORED_VALUE)
+                .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+            serde_json::from_value(value.to_owned())?
+        };
+        match json_compatibility::StoredValue::try_from(proof_value) {
+            Ok(json_proof_value) if json_proof_value == value => (),
+            _ => return Err(ValidateResponseError::SerializedValueNotContainedInProof),
+        }
+    }
+
+    core::validate_query_proof(
+        &state_root_hash.to_owned().into(),
+        &proofs,
+        key,
+        path,
+        proof_value,
+    )
+    .map_err(Into::into)
+}
+
+pub fn validate_get_balance_response(
+    response: &JsonRpc,
+    state_root_hash: &Digest,
+    key: &Key,
+) -> Result<(), ValidateResponseError> {
+    let value = response
+        .get_result()
+        .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+
+    let object = value
+        .as_object()
+        .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+
+    let (main_purse_proof, balance_proof): (
+        TrieMerkleProof<Key, StoredValue>,
+        TrieMerkleProof<Key, StoredValue>,
+    ) = {
+        let proof = object
+            .get(GET_ITEM_RESULT_MERKLE_PROOF)
+            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+        let proof_str = proof
+            .as_str()
+            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+        let proof_bytes = hex::decode(proof_str)
+            .map_err(|_| ValidateResponseError::ValidateResponseFailedToParse)?;
+        bytesrepr::deserialize(proof_bytes)?
+    };
+
+    let balance: U512 = {
+        let value = object
+            .get(GET_ITEM_RESULT_BALANCE_VALUE)
+            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+        let value_str = value
+            .as_str()
+            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
+        U512::from_dec_str(value_str)
+            .map_err(|_| ValidateResponseError::ValidateResponseFailedToParse)?
+    };
+
+    core::validate_balance_proof(
+        &state_root_hash.to_owned().into(),
+        &main_purse_proof,
+        &balance_proof,
+        *key,
+        &balance,
+    )
+    .map_err(Into::into)
+}

--- a/client/src/query_state.rs
+++ b/client/src/query_state.rs
@@ -11,7 +11,7 @@ use casper_node::{
 };
 use casper_types::Key;
 
-use crate::{command::ClientCommand, common, RpcClient};
+use crate::{command::ClientCommand, common, merkle_proofs, RpcClient};
 
 /// This struct defines the order in which the args are shown for this subcommand's help message.
 enum DisplayOrder {
@@ -146,13 +146,13 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
 
         let params = GetItemParams {
             state_root_hash: state_root_hash.to_owned(),
-            key: key.to_owned(),
+            key,
             path: path.to_owned(),
         };
 
+        let key = Key::from_formatted_str(&params.key).expect("key should convert to key");
         let response = Self::request_with_map_params(verbose, &node_address, rpc_id, params);
-        let key = Key::from_formatted_str(&key).expect("key should convert to key");
-        match merkle_proofs::validate_response(&response, &state_root_hash, &key, &path) {
+        match merkle_proofs::validate_query_response(&response, &state_root_hash, &key, &path) {
             Ok(_) => {
                 println!(
                     "{}",
@@ -161,112 +161,5 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
             }
             Err(error) => panic!("{:?}", error),
         }
-    }
-}
-
-mod merkle_proofs {
-    use std::convert::TryFrom;
-
-    use jsonrpc_lite::JsonRpc;
-    use thiserror::Error;
-
-    use casper_execution_engine::{
-        core, core::ValidationError, shared::stored_value::StoredValue,
-        storage::trie::merkle_proof::TrieMerkleProof,
-    };
-    use casper_node::{crypto::hash::Digest, types::json_compatibility};
-    use casper_types::{bytesrepr, Key};
-
-    const GET_ITEM_RESULT_STORED_VALUE: &str = "stored_value";
-    const GET_ITEM_RESULT_MERKLE_PROOF: &str = "merkle_proof";
-
-    /// Error that can be returned by validate_response.
-    #[derive(Error, Debug)]
-    pub enum ValidateResponseError {
-        /// Failed to marshall value
-        #[error("Failed to marshall value {0}")]
-        BytesRepr(bytesrepr::Error),
-
-        /// Error from serde.
-        #[error(transparent)]
-        Serde(#[from] serde_json::Error),
-
-        /// [`validate_response`] failed to parse JSON
-        #[error("validate_response failed to parse")]
-        ValidateResponseFailedToParse,
-
-        /// [`validate_response`] failed to validate
-        #[error(transparent)]
-        ValidationError(#[from] ValidationError),
-
-        /// Serialized value not contained in proof
-        #[error("serialized value not contained in proof")]
-        SerializedValueNotContainedInProof,
-    }
-
-    impl From<bytesrepr::Error> for ValidateResponseError {
-        fn from(e: bytesrepr::Error) -> Self {
-            ValidateResponseError::BytesRepr(e)
-        }
-    }
-
-    pub fn validate_response(
-        response: &JsonRpc,
-        state_root_hash: &Digest,
-        key: &Key,
-        path: &[String],
-    ) -> Result<(), ValidateResponseError> {
-        let value = response
-            .get_result()
-            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
-
-        let object = value
-            .as_object()
-            .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
-
-        let proofs: Vec<TrieMerkleProof<Key, StoredValue>> = {
-            let proof = object
-                .get(GET_ITEM_RESULT_MERKLE_PROOF)
-                .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
-            let proof_str = proof
-                .as_str()
-                .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
-            let proof_bytes = hex::decode(proof_str)
-                .map_err(|_| ValidateResponseError::ValidateResponseFailedToParse)?;
-            bytesrepr::deserialize(proof_bytes)?
-        };
-
-        let proof_value: &StoredValue = {
-            let last_proof = proofs
-                .last()
-                .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
-            last_proof.value()
-        };
-
-        // Here we need to validate that JSON `stored_value` is contained in the proof.
-        //
-        // Possible to deserialize that field into a `StoredValue` and pass below to
-        // `validate_query_proof` instead of using this approach?
-        {
-            let value: json_compatibility::StoredValue = {
-                let value = object
-                    .get(GET_ITEM_RESULT_STORED_VALUE)
-                    .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
-                serde_json::from_value(value.to_owned())?
-            };
-            match json_compatibility::StoredValue::try_from(proof_value) {
-                Ok(json_proof_value) if json_proof_value == value => (),
-                _ => return Err(ValidateResponseError::SerializedValueNotContainedInProof),
-            }
-        }
-
-        core::validate_query_proof(
-            &state_root_hash.to_owned().into(),
-            &proofs,
-            key,
-            path,
-            proof_value,
-        )
-        .map_err(Into::into)
     }
 }

--- a/execution_engine/src/core.rs
+++ b/execution_engine/src/core.rs
@@ -7,7 +7,7 @@ pub mod runtime;
 pub mod runtime_context;
 pub(crate) mod tracking_copy;
 
-pub use tracking_copy::{validate_query_proof, ValidationError};
+pub use tracking_copy::{validate_balance_proof, validate_query_proof, ValidationError};
 
 pub const ADDRESS_LENGTH: usize = 32;
 

--- a/execution_engine/src/core/engine_state/balance.rs
+++ b/execution_engine/src/core/engine_state/balance.rs
@@ -10,7 +10,7 @@ pub enum BalanceResult {
     RootNotFound,
     Success {
         motes: U512,
-        main_purse_proof: Box<TrieMerkleProof<Key, StoredValue>>,
+        purse_proof: Box<TrieMerkleProof<Key, StoredValue>>,
         balance_proof: Box<TrieMerkleProof<Key, StoredValue>>,
     },
 }
@@ -31,7 +31,7 @@ impl BalanceResult {
     )> {
         match self {
             BalanceResult::Success {
-                main_purse_proof,
+                purse_proof: main_purse_proof,
                 balance_proof,
                 ..
             } => Some((*main_purse_proof, *balance_proof)),

--- a/execution_engine/src/core/engine_state/balance.rs
+++ b/execution_engine/src/core/engine_state/balance.rs
@@ -31,10 +31,10 @@ impl BalanceResult {
     )> {
         match self {
             BalanceResult::Success {
-                purse_proof: main_purse_proof,
+                purse_proof,
                 balance_proof,
                 ..
-            } => Some((*main_purse_proof, *balance_proof)),
+            } => Some((*purse_proof, *balance_proof)),
             _ => None,
         }
     }

--- a/execution_engine/src/core/engine_state/balance.rs
+++ b/execution_engine/src/core/engine_state/balance.rs
@@ -1,11 +1,43 @@
-use casper_types::{URef, U512};
+use casper_types::{Key, URef, U512};
 
-use crate::shared::newtypes::Blake2bHash;
+use crate::{
+    shared::{newtypes::Blake2bHash, stored_value::StoredValue},
+    storage::trie::merkle_proof::TrieMerkleProof,
+};
 
 #[derive(Debug)]
 pub enum BalanceResult {
     RootNotFound,
-    Success(U512),
+    Success {
+        motes: U512,
+        main_purse_proof: Box<TrieMerkleProof<Key, StoredValue>>,
+        balance_proof: Box<TrieMerkleProof<Key, StoredValue>>,
+    },
+}
+
+impl BalanceResult {
+    pub fn motes(&self) -> Option<&U512> {
+        match self {
+            BalanceResult::Success { motes, .. } => Some(motes),
+            _ => None,
+        }
+    }
+
+    pub fn proofs(
+        self,
+    ) -> Option<(
+        TrieMerkleProof<Key, StoredValue>,
+        TrieMerkleProof<Key, StoredValue>,
+    )> {
+        match self {
+            BalanceResult::Success {
+                main_purse_proof,
+                balance_proof,
+                ..
+            } => Some((*main_purse_proof, *balance_proof)),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1055,7 +1055,7 @@ where
         let motes = balance.value();
         Ok(BalanceResult::Success {
             motes,
-            main_purse_proof,
+            purse_proof: main_purse_proof,
             balance_proof,
         })
     }

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1046,16 +1046,16 @@ where
             Some(tracking_copy) => tracking_copy,
             None => return Ok(BalanceResult::RootNotFound),
         };
-        let (purse_balance_key, main_purse_proof) =
+        let (purse_balance_key, purse_proof) =
             tracking_copy.get_purse_balance_key_with_proof(correlation_id, purse_uref.into())?;
         let (balance, balance_proof) =
             tracking_copy.get_purse_balance_with_proof(correlation_id, purse_balance_key)?;
-        let main_purse_proof = Box::new(main_purse_proof);
+        let purse_proof = Box::new(purse_proof);
         let balance_proof = Box::new(balance_proof);
         let motes = balance.value();
         Ok(BalanceResult::Success {
             motes,
-            purse_proof: main_purse_proof,
+            purse_proof,
             balance_proof,
         })
     }

--- a/execution_engine/src/core/execution/error.rs
+++ b/execution_engine/src/core/execution/error.rs
@@ -34,7 +34,7 @@ pub enum Error {
     #[error("Forged reference: {}", _0)]
     ForgedReference(URef),
     #[error("URef not found: {}", _0)]
-    URefNotFound(String),
+    URefNotFound(URef),
     #[error("Function not found: {}", _0)]
     FunctionNotFound(String),
     #[error("{}", _0)]
@@ -86,6 +86,8 @@ pub enum Error {
     WasmPreprocessing(wasm_prep::PreprocessingError),
     #[error("Unexpected Key length. Expected length {expected} but actual length is {actual}")]
     InvalidKeyLength { expected: usize, actual: usize },
+    #[error("Key is not a URef: {}", _0)]
+    KeyIsNotAURef(Key),
 }
 
 impl From<wasm_prep::PreprocessingError> for Error {

--- a/execution_engine/src/core/tracking_copy/ext.rs
+++ b/execution_engine/src/core/tracking_copy/ext.rs
@@ -4,7 +4,7 @@ use parity_wasm::elements::Module;
 
 use casper_types::{
     account::AccountHash, CLValue, Contract, ContractHash, ContractPackage, ContractPackageHash,
-    ContractWasm, ContractWasmHash, Key, U512,
+    ContractWasm, ContractWasmHash, Key,
 };
 
 use crate::{
@@ -18,20 +18,20 @@ use crate::{
         wasm_prep::{self, Preprocessor},
         TypeMismatch,
     },
-    storage::global_state::StateReader,
+    storage::{global_state::StateReader, trie::merkle_proof::TrieMerkleProof},
 };
 
 pub trait TrackingCopyExt<R> {
     type Error;
 
-    /// Gets the account at a given account address.
+    /// Gets the account at a given account address
     fn get_account(
         &mut self,
         correlation_id: CorrelationId,
         account_hash: AccountHash,
     ) -> Result<Account, Self::Error>;
 
-    /// Reads the account at a given account address.
+    /// Reads the account at a given account address
     fn read_account(
         &mut self,
         correlation_id: CorrelationId,
@@ -51,6 +51,20 @@ pub trait TrackingCopyExt<R> {
         correlation_id: CorrelationId,
         balance_key: Key,
     ) -> Result<Motes, Self::Error>;
+
+    /// Gets the purse balance key for a given purse id and provides a Merkle proof
+    fn get_purse_balance_key_with_proof(
+        &self,
+        correlation_id: CorrelationId,
+        purse_key: Key,
+    ) -> Result<(Key, TrieMerkleProof<Key, StoredValue>), Self::Error>;
+
+    /// Gets the balance at a given balance key and provides a Merkle proof
+    fn get_purse_balance_with_proof(
+        &self,
+        correlation_id: CorrelationId,
+        balance_key: Key,
+    ) -> Result<(Motes, TrieMerkleProof<Key, StoredValue>), Self::Error>;
 
     /// Gets a contract by Key
     fn get_contract_wasm(
@@ -129,25 +143,18 @@ where
         correlation_id: CorrelationId,
         purse_key: Key,
     ) -> Result<Key, Self::Error> {
-        let uref = purse_key
-            .as_uref()
-            .ok_or_else(|| execution::Error::URefNotFound("public purse balance 1".to_string()))?;
-        let local_key_bytes = uref.addr();
-        let balance_mapping_key = Key::Hash(local_key_bytes);
-        match self
-            .read(correlation_id, &balance_mapping_key)
+        let balance_key: Key = purse_key
+            .uref_to_hash()
+            .ok_or_else(|| execution::Error::KeyIsNotAURef(purse_key))?;
+        let stored_value: StoredValue = self
+            .read(correlation_id, &balance_key)
             .map_err(Into::into)?
-        {
-            Some(stored_value) => {
-                let cl_value: CLValue = stored_value
-                    .try_into()
-                    .map_err(execution::Error::TypeMismatch)?;
-                Ok(cl_value.into_t()?)
-            }
-            None => Err(execution::Error::URefNotFound(
-                "public purse balance 21".to_string(),
-            )),
-        }
+            .ok_or(execution::Error::KeyNotFound(purse_key))?;
+        let cl_value: CLValue = stored_value
+            .try_into()
+            .map_err(execution::Error::TypeMismatch)?;
+        let balance_key: Key = cl_value.into_t()?;
+        Ok(balance_key)
     }
 
     fn get_purse_balance(
@@ -155,20 +162,54 @@ where
         correlation_id: CorrelationId,
         key: Key,
     ) -> Result<Motes, Self::Error> {
-        let read_result = match self.read(correlation_id, &key) {
-            Ok(read_result) => read_result,
-            Err(_) => return Err(execution::Error::KeyNotFound(key)),
-        };
-        match read_result {
-            Some(stored_value) => {
-                let cl_value: CLValue = stored_value
-                    .try_into()
-                    .map_err(execution::Error::TypeMismatch)?;
-                let balance: U512 = cl_value.into_t()?;
-                Ok(Motes::new(balance))
-            }
-            None => Err(execution::Error::KeyNotFound(key)),
-        }
+        let stored_value: StoredValue = self
+            .read(correlation_id, &key)
+            .map_err(Into::into)?
+            .ok_or(execution::Error::KeyNotFound(key))?;
+        let cl_value: CLValue = stored_value
+            .try_into()
+            .map_err(execution::Error::TypeMismatch)?;
+        let balance = Motes::new(cl_value.into_t()?);
+        Ok(balance)
+    }
+
+    fn get_purse_balance_key_with_proof(
+        &self,
+        correlation_id: CorrelationId,
+        purse_key: Key,
+    ) -> Result<(Key, TrieMerkleProof<Key, StoredValue>), Self::Error> {
+        let balance_key: Key = purse_key
+            .uref_to_hash()
+            .ok_or_else(|| execution::Error::KeyIsNotAURef(purse_key))?;
+        let proof: TrieMerkleProof<Key, StoredValue> = self
+            .read_with_proof(correlation_id, &balance_key) // Key::Hash, so no need to normalize
+            .map_err(Into::into)?
+            .ok_or(execution::Error::KeyNotFound(purse_key))?;
+        let stored_value_ref: &StoredValue = proof.value();
+        let cl_value: CLValue = stored_value_ref
+            .to_owned()
+            .try_into()
+            .map_err(execution::Error::TypeMismatch)?;
+        let balance_key: Key = cl_value.into_t()?;
+        Ok((balance_key, proof))
+    }
+
+    fn get_purse_balance_with_proof(
+        &self,
+        correlation_id: CorrelationId,
+        key: Key,
+    ) -> Result<(Motes, TrieMerkleProof<Key, StoredValue>), Self::Error> {
+        let proof: TrieMerkleProof<Key, StoredValue> = self
+            .read_with_proof(correlation_id, &key.normalize())
+            .map_err(Into::into)?
+            .ok_or(execution::Error::KeyNotFound(key))?;
+        let cl_value: CLValue = proof
+            .value()
+            .to_owned()
+            .try_into()
+            .map_err(execution::Error::TypeMismatch)?;
+        let balance = Motes::new(cl_value.into_t()?);
+        Ok((balance, proof))
     }
 
     /// Gets a contract wasm by Key

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -482,7 +482,7 @@ pub enum ValidationError {
     BytesRepr(bytesrepr::Error),
 
     #[error("Key is not a URef")]
-    KeyIsNotAUref(Key),
+    KeyIsNotAURef(Key),
 
     #[error("Failed to convert stored value to key")]
     ValueToCLValueConversion,
@@ -569,7 +569,7 @@ pub fn validate_balance_proof(
 ) -> Result<(), ValidationError> {
     let expected_balance_key = expected_purse_key
         .uref_to_hash()
-        .ok_or_else(|| ValidationError::KeyIsNotAUref(expected_purse_key.to_owned()))?;
+        .ok_or_else(|| ValidationError::KeyIsNotAURef(expected_purse_key.to_owned()))?;
 
     if main_purse_proof.key() != &expected_balance_key {
         return Err(ValidationError::UnexpectedKey);

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -562,7 +562,7 @@ pub fn validate_query_proof(
 #[allow(unused)]
 pub fn validate_balance_proof(
     hash: &Blake2bHash,
-    main_purse_proof: &TrieMerkleProof<Key, StoredValue>,
+    purse_proof: &TrieMerkleProof<Key, StoredValue>,
     balance_proof: &TrieMerkleProof<Key, StoredValue>,
     expected_purse_key: Key,
     expected_motes: &U512,
@@ -571,17 +571,17 @@ pub fn validate_balance_proof(
         .uref_to_hash()
         .ok_or_else(|| ValidationError::KeyIsNotAURef(expected_purse_key.to_owned()))?;
 
-    if main_purse_proof.key() != &expected_balance_key {
+    if purse_proof.key() != &expected_balance_key {
         return Err(ValidationError::UnexpectedKey);
     }
 
-    if hash != &main_purse_proof.compute_state_hash()? {
+    if hash != &purse_proof.compute_state_hash()? {
         return Err(ValidationError::InvalidProofHash);
     }
 
-    let main_purse_proof_stored_value = main_purse_proof.value().to_owned();
+    let purse_proof_stored_value = purse_proof.value().to_owned();
 
-    let purse_balance_clvalue: CLValue = main_purse_proof_stored_value
+    let purse_balance_clvalue: CLValue = purse_proof_stored_value
         .try_into()
         .map_err(|_| ValidationError::ValueToCLValueConversion)?;
 

--- a/grpc/test_support/src/internal/wasm_test_builder.rs
+++ b/grpc/test_support/src/internal/wasm_test_builder.rs
@@ -26,7 +26,7 @@ use casper_execution_engine::{
         engine_state::{
             era_validators::GetEraValidatorsRequest, execute_request::ExecuteRequest,
             execution_result::ExecutionResult, run_genesis_request::RunGenesisRequest,
-            EngineConfig, EngineState, SYSTEM_ACCOUNT_ADDR,
+            BalanceResult, EngineConfig, EngineState, SYSTEM_ACCOUNT_ADDR,
         },
         execution,
     },
@@ -682,6 +682,21 @@ where
             .and_then(|v| CLValue::try_from(v).map_err(|error| format!("{:?}", error)))
             .and_then(|cl_value| cl_value.into_t().map_err(|error| format!("{:?}", error)))
             .expect("should parse balance into a U512")
+    }
+
+    pub fn get_purse_balance_result(&self, purse: URef) -> BalanceResult {
+        let correlation_id = CorrelationId::new();
+        let state_root_hash_slice: &Vec<u8> = self
+            .post_state_hash
+            .as_ref()
+            .expect("should have post_state_hash");
+        let state_root_hash: Blake2bHash = state_root_hash_slice
+            .as_slice()
+            .try_into()
+            .expect("should convert");
+        self.engine_state
+            .get_purse_balance(correlation_id, state_root_hash, purse)
+            .expect("should get purse balance")
     }
 
     pub fn get_proposer_purse_balance(&self) -> U512 {

--- a/grpc/tests/src/test/get_balance.rs
+++ b/grpc/tests/src/test/get_balance.rs
@@ -1,0 +1,180 @@
+use std::convert::TryFrom;
+
+use lazy_static::lazy_static;
+
+use casper_engine_test_support::{
+    internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
+    DEFAULT_ACCOUNT_ADDR,
+};
+use casper_execution_engine::{core, core::ValidationError, shared::newtypes::Blake2bHash};
+use casper_types::{
+    account::AccountHash, runtime_args, AccessRights, Key, PublicKey, RuntimeArgs, URef, U512,
+};
+
+const TRANSFER_ARG_TARGET: &str = "target";
+const TRANSFER_ARG_AMOUNT: &str = "amount";
+
+const ALICE_KEY: PublicKey = PublicKey::Ed25519([3; 32]);
+const BOB_KEY: PublicKey = PublicKey::Ed25519([5; 32]);
+const CAROL_KEY: PublicKey = PublicKey::Ed25519([7; 32]);
+
+lazy_static! {
+    static ref ALICE_ADDR: AccountHash = ALICE_KEY.into();
+    static ref BOB_ADDR: AccountHash = BOB_KEY.into();
+    static ref CAROL_ADDR: AccountHash = CAROL_KEY.into();
+    static ref TRANSFER_AMOUNT_1: U512 = U512::from(100_000_000);
+    static ref TRANSFER_AMOUNT_2: U512 = U512::from(200_000_000);
+    static ref TRANSFER_AMOUNT_3: U512 = U512::from(300_000_000);
+}
+
+#[ignore]
+#[test]
+fn get_balance_should_work() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    let transfer_request = ExecuteRequestBuilder::transfer(
+        *DEFAULT_ACCOUNT_ADDR,
+        runtime_args! {
+            TRANSFER_ARG_TARGET => *ALICE_ADDR,
+            TRANSFER_ARG_AMOUNT => *TRANSFER_AMOUNT_1
+
+        },
+    )
+    .build();
+
+    builder.exec(transfer_request).commit().expect_success();
+
+    let alice_account = builder
+        .get_account(*ALICE_ADDR)
+        .expect("should have Alice's account");
+
+    let alice_main_purse = alice_account.main_purse();
+
+    let alice_balance_result = builder.get_purse_balance_result(alice_main_purse);
+
+    let alice_balance = alice_balance_result
+        .motes()
+        .cloned()
+        .expect("should have motes");
+
+    assert_eq!(alice_balance, *TRANSFER_AMOUNT_1);
+
+    let state_root_hash = {
+        let post_state_hash = builder.get_post_state_hash();
+        Blake2bHash::try_from(post_state_hash.as_slice()).expect("should convert")
+    };
+
+    let (main_purse_proof, balance_proof) =
+        alice_balance_result.proofs().expect("should have proofs");
+
+    assert!(core::validate_balance_proof(
+        &state_root_hash,
+        &main_purse_proof,
+        &balance_proof,
+        alice_main_purse.into(),
+        &alice_balance,
+    )
+    .is_ok());
+
+    let bogus_key = Key::Hash([1u8; 32]);
+    assert_eq!(
+        core::validate_balance_proof(
+            &state_root_hash,
+            &main_purse_proof,
+            &balance_proof,
+            bogus_key.to_owned(),
+            &alice_balance,
+        ),
+        Err(ValidationError::KeyIsNotAUref(bogus_key))
+    );
+
+    let bogus_uref: Key = Key::URef(URef::new([3u8; 32], AccessRights::READ_ADD_WRITE));
+    assert_eq!(
+        core::validate_balance_proof(
+            &state_root_hash,
+            &main_purse_proof,
+            &balance_proof,
+            bogus_uref,
+            &alice_balance,
+        ),
+        Err(ValidationError::UnexpectedKey)
+    );
+
+    let bogus_hash = Blake2bHash::new(&[5u8; 32]);
+    assert_eq!(
+        core::validate_balance_proof(
+            &bogus_hash,
+            &main_purse_proof,
+            &balance_proof,
+            alice_main_purse.into(),
+            &alice_balance,
+        ),
+        Err(ValidationError::InvalidProofHash)
+    );
+
+    assert_eq!(
+        core::validate_balance_proof(
+            &state_root_hash,
+            &main_purse_proof,
+            &main_purse_proof,
+            alice_main_purse.into(),
+            &alice_balance,
+        ),
+        Err(ValidationError::UnexpectedKey)
+    );
+
+    let bogus_motes = U512::from(1337);
+    assert_eq!(
+        core::validate_balance_proof(
+            &state_root_hash,
+            &main_purse_proof,
+            &balance_proof,
+            alice_main_purse.into(),
+            &bogus_motes,
+        ),
+        Err(ValidationError::UnexpectedValue)
+    );
+
+    ////////////////////////////////////////////
+
+    let transfer_request = ExecuteRequestBuilder::transfer(
+        *DEFAULT_ACCOUNT_ADDR,
+        runtime_args! {
+            TRANSFER_ARG_TARGET => *BOB_ADDR,
+            TRANSFER_ARG_AMOUNT => *TRANSFER_AMOUNT_1
+
+        },
+    )
+    .build();
+
+    builder.exec(transfer_request).commit().expect_success();
+
+    let alice_account = builder
+        .get_account(*ALICE_ADDR)
+        .expect("should have Alice's account");
+
+    let alice_main_purse = alice_account.main_purse();
+
+    let alice_balance_result_new = builder.get_purse_balance_result(alice_main_purse);
+
+    let state_root_hash = {
+        let post_state_hash = builder.get_post_state_hash();
+        Blake2bHash::try_from(post_state_hash.as_slice()).expect("should convert")
+    };
+
+    let (_main_purse_proof_new, balance_proof_new) = alice_balance_result_new
+        .proofs()
+        .expect("should have proofs");
+
+    assert_eq!(
+        core::validate_balance_proof(
+            &state_root_hash,
+            &main_purse_proof,
+            &balance_proof_new,
+            alice_main_purse.into(),
+            &alice_balance,
+        ),
+        Err(ValidationError::InvalidProofHash)
+    );
+}

--- a/grpc/tests/src/test/get_balance.rs
+++ b/grpc/tests/src/test/get_balance.rs
@@ -65,12 +65,11 @@ fn get_balance_should_work() {
         Blake2bHash::try_from(post_state_hash.as_slice()).expect("should convert")
     };
 
-    let (main_purse_proof, balance_proof) =
-        alice_balance_result.proofs().expect("should have proofs");
+    let (purse_proof, balance_proof) = alice_balance_result.proofs().expect("should have proofs");
 
     assert!(core::validate_balance_proof(
         &state_root_hash,
-        &main_purse_proof,
+        &purse_proof,
         &balance_proof,
         alice_main_purse.into(),
         &alice_balance,
@@ -81,7 +80,7 @@ fn get_balance_should_work() {
     assert_eq!(
         core::validate_balance_proof(
             &state_root_hash,
-            &main_purse_proof,
+            &purse_proof,
             &balance_proof,
             bogus_key.to_owned(),
             &alice_balance,
@@ -93,7 +92,7 @@ fn get_balance_should_work() {
     assert_eq!(
         core::validate_balance_proof(
             &state_root_hash,
-            &main_purse_proof,
+            &purse_proof,
             &balance_proof,
             bogus_uref,
             &alice_balance,
@@ -105,7 +104,7 @@ fn get_balance_should_work() {
     assert_eq!(
         core::validate_balance_proof(
             &bogus_hash,
-            &main_purse_proof,
+            &purse_proof,
             &balance_proof,
             alice_main_purse.into(),
             &alice_balance,
@@ -116,8 +115,8 @@ fn get_balance_should_work() {
     assert_eq!(
         core::validate_balance_proof(
             &state_root_hash,
-            &main_purse_proof,
-            &main_purse_proof,
+            &purse_proof,
+            &purse_proof,
             alice_main_purse.into(),
             &alice_balance,
         ),
@@ -128,7 +127,7 @@ fn get_balance_should_work() {
     assert_eq!(
         core::validate_balance_proof(
             &state_root_hash,
-            &main_purse_proof,
+            &purse_proof,
             &balance_proof,
             alice_main_purse.into(),
             &bogus_motes,
@@ -163,14 +162,14 @@ fn get_balance_should_work() {
         Blake2bHash::try_from(post_state_hash.as_slice()).expect("should convert")
     };
 
-    let (_main_purse_proof_new, balance_proof_new) = alice_balance_result_new
+    let (_purse_proof_new, balance_proof_new) = alice_balance_result_new
         .proofs()
         .expect("should have proofs");
 
     assert_eq!(
         core::validate_balance_proof(
             &state_root_hash,
-            &main_purse_proof,
+            &purse_proof,
             &balance_proof_new,
             alice_main_purse.into(),
             &alice_balance,

--- a/grpc/tests/src/test/get_balance.rs
+++ b/grpc/tests/src/test/get_balance.rs
@@ -86,7 +86,7 @@ fn get_balance_should_work() {
             bogus_key.to_owned(),
             &alice_balance,
         ),
-        Err(ValidationError::KeyIsNotAUref(bogus_key))
+        Err(ValidationError::KeyIsNotAURef(bogus_key))
     );
 
     let bogus_uref: Key = Key::URef(URef::new([3u8; 32], AccessRights::READ_ADD_WRITE));

--- a/grpc/tests/src/test/mod.rs
+++ b/grpc/tests/src/test/mod.rs
@@ -4,6 +4,7 @@ mod contract_context;
 mod counter;
 mod deploy;
 mod explorer;
+mod get_balance;
 mod groups;
 mod host_function_costs;
 mod manage_groups;

--- a/node/src/components/api_server/rpcs/state.rs
+++ b/node/src/components/api_server/rpcs/state.rs
@@ -159,6 +159,8 @@ pub struct GetBalanceResult {
     pub api_version: Version,
     /// The balance value.
     pub balance_value: U512,
+    /// The merkle proof.
+    pub merkle_proof: String,
 }
 
 /// "state_get_balance" RPC.
@@ -203,8 +205,12 @@ impl RpcWithParamsExt for GetBalance {
                 )
                 .await;
 
-            let balance_value = match balance_result {
-                Ok(BalanceResult::Success(value)) => value,
+            let (balance_value, main_purse_proof, balance_proof) = match balance_result {
+                Ok(BalanceResult::Success {
+                    motes,
+                    main_purse_proof,
+                    balance_proof,
+                }) => (motes, main_purse_proof, balance_proof),
                 Ok(balance_result) => {
                     let error_msg = format!("get-balance failed: {:?}", balance_result);
                     info!("{}", error_msg);
@@ -223,10 +229,21 @@ impl RpcWithParamsExt for GetBalance {
                 }
             };
 
+            let proof_bytes = match (*main_purse_proof, *balance_proof).to_bytes() {
+                Ok(proof_bytes) => proof_bytes,
+                Err(error) => {
+                    info!("failed to encode stored value: {}", error);
+                    return Ok(response_builder.error(warp_json_rpc::Error::INTERNAL_ERROR)?);
+                }
+            };
+
+            let merkle_proof = hex::encode(proof_bytes);
+
             // Return the result.
             let result = Self::ResponseResult {
                 api_version: CLIENT_API_VERSION.clone(),
                 balance_value,
+                merkle_proof,
             };
             Ok(response_builder.success(result)?)
         }

--- a/node/src/components/api_server/rpcs/state.rs
+++ b/node/src/components/api_server/rpcs/state.rs
@@ -208,7 +208,7 @@ impl RpcWithParamsExt for GetBalance {
             let (balance_value, main_purse_proof, balance_proof) = match balance_result {
                 Ok(BalanceResult::Success {
                     motes,
-                    main_purse_proof,
+                    purse_proof: main_purse_proof,
                     balance_proof,
                 }) => (motes, main_purse_proof, balance_proof),
                 Ok(balance_result) => {

--- a/node/src/components/api_server/rpcs/state.rs
+++ b/node/src/components/api_server/rpcs/state.rs
@@ -205,12 +205,12 @@ impl RpcWithParamsExt for GetBalance {
                 )
                 .await;
 
-            let (balance_value, main_purse_proof, balance_proof) = match balance_result {
+            let (balance_value, purse_proof, balance_proof) = match balance_result {
                 Ok(BalanceResult::Success {
                     motes,
-                    purse_proof: main_purse_proof,
+                    purse_proof,
                     balance_proof,
-                }) => (motes, main_purse_proof, balance_proof),
+                }) => (motes, purse_proof, balance_proof),
                 Ok(balance_result) => {
                     let error_msg = format!("get-balance failed: {:?}", balance_result);
                     info!("{}", error_msg);
@@ -229,7 +229,7 @@ impl RpcWithParamsExt for GetBalance {
                 }
             };
 
-            let proof_bytes = match (*main_purse_proof, *balance_proof).to_bytes() {
+            let proof_bytes = match (*purse_proof, *balance_proof).to_bytes() {
                 Ok(proof_bytes) => proof_bytes,
                 Err(error) => {
                     info!("failed to encode stored value: {}", error);

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -223,6 +223,13 @@ impl Key {
             Key::DeployInfo(addr) => addr,
         }
     }
+
+    /// Casts a [`Key::URef`] to a [`Key::Hash`]
+    pub fn uref_to_hash(&self) -> Option<Key> {
+        let uref = self.as_uref()?;
+        let addr = uref.addr();
+        Some(Key::Hash(addr))
+    }
 }
 
 impl Display for Key {


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1079

Followed a similar approach to what we did with `query-state` here (using the purse lookup scheme as opposed to the query recursion), so nothing should be terribly surprising.  