### PR TITLE
NDRS-542: add 'get auction info' subcommand to client-rs

### DIFF
--- a/client/src/get_auction_info.rs
+++ b/client/src/get_auction_info.rs
@@ -1,0 +1,47 @@
+use std::str;
+
+use clap::{App, ArgMatches, SubCommand};
+
+use casper_node::rpcs::{state::GetAuctionInfo, RpcWithoutParams};
+
+use crate::{command::ClientCommand, common, RpcClient};
+
+/// This struct defines the order in which the args are shown for this subcommand's help message.
+enum DisplayOrder {
+    Verbose,
+    NodeAddress,
+    RpcId,
+}
+
+impl RpcClient for GetAuctionInfo {
+    const RPC_METHOD: &'static str = Self::METHOD;
+}
+
+impl<'a, 'b> ClientCommand<'a, 'b> for GetAuctionInfo {
+    const NAME: &'static str = "get-auction-info";
+    const ABOUT: &'static str =
+        "Retrieves the bids and validators as of the most recently added block";
+
+    fn build(display_order: usize) -> App<'a, 'b> {
+        SubCommand::with_name(Self::NAME)
+            .about(Self::ABOUT)
+            .display_order(display_order)
+            .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
+            .arg(common::node_address::arg(
+                DisplayOrder::NodeAddress as usize,
+            ))
+            .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
+    }
+
+    fn run(matches: &ArgMatches<'_>) {
+        let verbose = common::verbose::get(matches);
+        let node_address = common::node_address::get(matches);
+        let rpc_id = common::rpc_id::get(matches);
+
+        let response = Self::request(verbose, &node_address, rpc_id);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&response).expect("should encode to JSON")
+        );
+    }
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -4,6 +4,7 @@ mod command;
 mod common;
 mod deploy;
 mod generate_completion;
+mod get_auction_info;
 mod get_state_hash;
 mod keygen;
 mod query_state;
@@ -15,7 +16,7 @@ use casper_node::rpcs::{
     account::PutDeploy,
     chain::{GetBlock, GetStateRootHash},
     info::GetDeploy,
-    state::{GetBalance, GetItem as QueryState},
+    state::{GetAuctionInfo, GetBalance, GetItem as QueryState},
 };
 
 use deploy::{MakeDeploy, SendDeploy, SignDeploy};
@@ -41,6 +42,7 @@ enum DisplayOrder {
     GetBalance,
     GetStateRootHash,
     QueryState,
+    GetAuctionInfo,
     Keygen,
     GenerateCompletion,
 }
@@ -62,6 +64,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
             DisplayOrder::GetStateRootHash as usize,
         ))
         .subcommand(QueryState::build(DisplayOrder::QueryState as usize))
+        .subcommand(GetAuctionInfo::build(DisplayOrder::GetAuctionInfo as usize))
         .subcommand(Keygen::build(DisplayOrder::Keygen as usize))
         .subcommand(GenerateCompletion::build(
             DisplayOrder::GenerateCompletion as usize,
@@ -83,6 +86,7 @@ async fn main() {
         (GetBalance::NAME, Some(matches)) => GetBalance::run(matches),
         (GetStateRootHash::NAME, Some(matches)) => GetStateRootHash::run(matches),
         (QueryState::NAME, Some(matches)) => QueryState::run(matches),
+        (GetAuctionInfo::NAME, Some(matches)) => GetAuctionInfo::run(matches),
         (Keygen::NAME, Some(matches)) => Keygen::run(matches),
         (GenerateCompletion::NAME, Some(matches)) => GenerateCompletion::run(matches),
         _ => {

--- a/node/src/components/api_server/rpcs/state.rs
+++ b/node/src/components/api_server/rpcs/state.rs
@@ -22,6 +22,7 @@ use crate::{
     crypto::hash::Digest,
     effect::EffectBuilder,
     reactor::QueueKind,
+    rpcs::{RpcWithoutParams, RpcWithoutParamsExt},
     types::{
         json_compatibility::{AuctionState, StoredValue},
         Block,
@@ -236,10 +237,6 @@ impl RpcWithParamsExt for GetBalance {
 
 // auction info
 
-/// Params for "state_get_auction_info" RPC request.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct GetAuctionInfoParams {}
-
 /// Result for "state_get_auction_info" RPC response.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetAuctionInfoResult {
@@ -252,17 +249,15 @@ pub struct GetAuctionInfoResult {
 /// "state_get_auction_info" RPC.
 pub struct GetAuctionInfo {}
 
-impl RpcWithParams for GetAuctionInfo {
+impl RpcWithoutParams for GetAuctionInfo {
     const METHOD: &'static str = "state_get_auction_info";
-    type RequestParams = GetAuctionInfoParams;
     type ResponseResult = GetAuctionInfoResult;
 }
 
-impl RpcWithParamsExt for GetAuctionInfo {
+impl RpcWithoutParamsExt for GetAuctionInfo {
     fn handle_request<REv: ReactorEventT>(
         effect_builder: EffectBuilder<REv>,
         response_builder: Builder,
-        _params: Self::RequestParams,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
             let block: Block = {


### PR DESCRIPTION
This PR adds a get-auction-info subcommand to client-rs.

https://casperlabs.atlassian.net/browse/NDRS-542

`cargo run --release -- get-auction-info`

```
{
  "jsonrpc": "2.0",
  "result": {
    "bids": {
      "0248..6873": {
       ...
      },
    ...
    },
    "era_id": 10,
    "state_root_hash": "42ad1966f4203dbc41ca63da3ab2e99e0da6b5155369cee7e4bbad1f9230463c",
    "validator_weights": {
      "0248..6873": "100000000000001",
       ...
    }
  },
  "id": 572773124
}
```