### PR TITLE
EE-1085: add failing test for auction Error conversions, fix failures

### DIFF
--- a/types/src/system_contract_errors/auction.rs
+++ b/types/src/system_contract_errors/auction.rs
@@ -141,6 +141,9 @@ impl TryFrom<u8> for Error {
             d if d == Error::MissingDelegations as u8 => Ok(Error::MissingDelegations),
             d if d == Error::MismatchedEraValidators as u8 => Ok(Error::MismatchedEraValidators),
             d if d == Error::MintReward as u8 => Ok(Error::MintReward),
+            d if d == Error::InvalidValidatorSlotsValue as u8 => {
+                Ok(Error::InvalidValidatorSlotsValue)
+            }
             _ => Err(TryFromU8ForError(())),
         }
     }

--- a/types/src/system_contract_errors/auction.rs
+++ b/types/src/system_contract_errors/auction.rs
@@ -96,6 +96,10 @@ pub enum Error {
     InvalidValidatorSlotsValue = 24,
 }
 
+/// Used for testing; this should be set to the maximum value of the [`Error`] enum.
+#[cfg(test)]
+const MAX_ERROR_VALUE: u8 = 24;
+
 impl CLTyped for Error {
     fn cl_type() -> CLType {
         CLType::U8
@@ -186,6 +190,28 @@ impl From<PurseLookupError> for Error {
         match error {
             PurseLookupError::KeyNotFound => Error::MissingKey,
             PurseLookupError::KeyUnexpectedType => Error::InvalidKeyVariant,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+
+    use super::{Error, MAX_ERROR_VALUE};
+
+    #[test]
+    fn error_round_trips() {
+        for i in 0..=u8::max_value() {
+            match Error::try_from(i) {
+                Ok(error) if i <= MAX_ERROR_VALUE => assert_eq!(error as u8, i),
+                Ok(error) => panic!(
+                    "value of variant {} ({}) exceeds MAX_ERROR_VALUE ({})",
+                    error, i, MAX_ERROR_VALUE
+                ),
+                Err(_) if i > MAX_ERROR_VALUE => (),
+                Err(_) => panic!("missing conversion from u8 to error value: {}", i),
+            }
         }
     }
 }

--- a/types/src/system_contract_errors/auction.rs
+++ b/types/src/system_contract_errors/auction.rs
@@ -201,7 +201,7 @@ impl From<PurseLookupError> for Error {
 mod tests {
     use std::convert::TryFrom;
 
-    use super::{Error, MAX_ERROR_VALUE};
+    use super::{Error, TryFromU8ForError, MAX_ERROR_VALUE};
 
     #[test]
     fn error_round_trips() {
@@ -212,8 +212,10 @@ mod tests {
                     "value of variant {} ({}) exceeds MAX_ERROR_VALUE ({})",
                     error, i, MAX_ERROR_VALUE
                 ),
-                Err(_) if i > MAX_ERROR_VALUE => (),
-                Err(_) => panic!("missing conversion from u8 to error value: {}", i),
+                Err(TryFromU8ForError(())) if i > MAX_ERROR_VALUE => (),
+                Err(TryFromU8ForError(())) => {
+                    panic!("missing conversion from u8 to error value: {}", i)
+                }
             }
         }
     }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1085

When doing some related work, I discovered that `Error::InvalidValidatorSlotsValue` was missing conversion code, so here I'm introducing a regression test and fixing it.