### PR TITLE
NDRS-546: Use Context trait in ConsensusProtocol.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -1,6 +1,7 @@
 //! The consensus component. Provides distributed consensus among the nodes in the network.
 
 mod candidate_block;
+mod cl_context;
 mod config;
 mod consensus_protocol;
 mod era_supervisor;

--- a/node/src/components/consensus/cl_context.rs
+++ b/node/src/components/consensus/cl_context.rs
@@ -14,12 +14,12 @@ use crate::{
     types::CryptoRngCore,
 };
 
-pub(crate) struct ClSecret {
+pub(crate) struct Keypair {
     secret_key: Rc<SecretKey>,
     public_key: PublicKey,
 }
 
-impl ClSecret {
+impl Keypair {
     pub(crate) fn new(secret_key: Rc<SecretKey>, public_key: PublicKey) -> Self {
         Self {
             secret_key,
@@ -28,7 +28,7 @@ impl ClSecret {
     }
 }
 
-impl ValidatorSecret for ClSecret {
+impl ValidatorSecret for Keypair {
     type Hash = Digest;
     type Signature = Signature;
 
@@ -44,7 +44,7 @@ pub(crate) struct ClContext;
 impl Context for ClContext {
     type ConsensusValue = CandidateBlock;
     type ValidatorId = PublicKey;
-    type ValidatorSecret = ClSecret;
+    type ValidatorSecret = Keypair;
     type Signature = Signature;
     type Hash = Digest;
     type InstanceId = Digest;

--- a/node/src/components/consensus/cl_context.rs
+++ b/node/src/components/consensus/cl_context.rs
@@ -1,0 +1,63 @@
+use std::rc::Rc;
+
+use tracing::info;
+
+use crate::{
+    components::consensus::{
+        candidate_block::CandidateBlock,
+        traits::{Context, ValidatorSecret},
+    },
+    crypto::{
+        asymmetric_key::{self, PublicKey, SecretKey, Signature},
+        hash::{self, Digest},
+    },
+    types::CryptoRngCore,
+};
+
+pub(crate) struct ClSecret {
+    secret_key: Rc<SecretKey>,
+    public_key: PublicKey,
+}
+
+impl ClSecret {
+    pub(crate) fn new(secret_key: Rc<SecretKey>, public_key: PublicKey) -> Self {
+        Self {
+            secret_key,
+            public_key,
+        }
+    }
+}
+
+impl ValidatorSecret for ClSecret {
+    type Hash = Digest;
+    type Signature = Signature;
+
+    fn sign(&self, hash: &Digest, rng: &mut dyn CryptoRngCore) -> Signature {
+        asymmetric_key::sign(hash, self.secret_key.as_ref(), &self.public_key, rng)
+    }
+}
+
+/// The collection of types used for cryptography, IDs and blocks in the CasperLabs node.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ClContext;
+
+impl Context for ClContext {
+    type ConsensusValue = CandidateBlock;
+    type ValidatorId = PublicKey;
+    type ValidatorSecret = ClSecret;
+    type Signature = Signature;
+    type Hash = Digest;
+    type InstanceId = Digest;
+
+    fn hash(data: &[u8]) -> Digest {
+        hash::hash(data)
+    }
+
+    fn verify_signature(hash: &Digest, public_key: &PublicKey, signature: &Signature) -> bool {
+        if let Err(error) = asymmetric_key::verify(hash, signature, public_key) {
+            info!(%error, %signature, %public_key, %hash, "failed to validate signature");
+            return false;
+        }
+        true
+    }
+}

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -5,7 +5,7 @@ use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    components::consensus::traits::{ConsensusValueT, Context},
+    components::consensus::traits::Context,
     types::{CryptoRngCore, Timestamp},
 };
 
@@ -48,19 +48,19 @@ pub struct EraEnd<VID> {
 /// about all the information contained in this type, as long as the total weight of faulty
 /// validators remains below the threshold.
 #[derive(Debug, Eq, PartialEq)]
-pub(crate) struct FinalizedBlock<C: ConsensusValueT, VID> {
+pub(crate) struct FinalizedBlock<C: Context> {
     /// The finalized value.
-    pub(crate) value: C,
+    pub(crate) value: C::ConsensusValue,
     /// The timestamp at which this value was proposed.
     pub(crate) timestamp: Timestamp,
     /// The relative height in this instance of the protocol.
     pub(crate) height: u64,
     /// If this is a terminal block, i.e. the last one to be finalized, this includes rewards.
-    pub(crate) rewards: Option<BTreeMap<VID, u64>>,
+    pub(crate) rewards: Option<BTreeMap<C::ValidatorId, u64>>,
     /// The validators known to be faulty as seen by this block.
-    pub(crate) equivocators: Vec<VID>,
+    pub(crate) equivocators: Vec<C::ValidatorId>,
     /// Proposer of this value
-    pub(crate) proposer: VID,
+    pub(crate) proposer: C::ValidatorId,
 }
 
 #[derive(Debug)]
@@ -75,7 +75,7 @@ pub(crate) enum ConsensusProtocolResult<I, C: Context> {
         block_context: BlockContext,
     },
     /// A block was finalized.
-    FinalizedBlock(FinalizedBlock<C::ConsensusValue, C::ValidatorId>),
+    FinalizedBlock(FinalizedBlock<C>),
     /// Request validation of the consensus value, contained in a message received from the given
     /// node.
     ///

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -5,7 +5,7 @@ use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    components::consensus::traits::ConsensusValueT,
+    components::consensus::traits::{ConsensusValueT, Context},
     types::{CryptoRngCore, Timestamp},
 };
 
@@ -64,7 +64,7 @@ pub(crate) struct FinalizedBlock<C: ConsensusValueT, VID> {
 }
 
 #[derive(Debug)]
-pub(crate) enum ConsensusProtocolResult<I, C: ConsensusValueT, VID> {
+pub(crate) enum ConsensusProtocolResult<I, C: Context> {
     CreatedGossipMessage(Vec<u8>),
     CreatedTargetedMessage(Vec<u8>, I),
     InvalidIncomingMessage(Vec<u8>, I, Error),
@@ -75,22 +75,22 @@ pub(crate) enum ConsensusProtocolResult<I, C: ConsensusValueT, VID> {
         block_context: BlockContext,
     },
     /// A block was finalized.
-    FinalizedBlock(FinalizedBlock<C, VID>),
+    FinalizedBlock(FinalizedBlock<C::ConsensusValue, C::ValidatorId>),
     /// Request validation of the consensus value, contained in a message received from the given
     /// node.
     ///
     /// The domain logic should verify any intrinsic validity conditions of consensus values, e.g.
     /// that it has the expected structure, or that deploys that are mentioned by hash actually
     /// exist, and then call `ConsensusProtocol::resolve_validity`.
-    ValidateConsensusValue(I, C),
+    ValidateConsensusValue(I, C::ConsensusValue),
     /// New direct evidence was added against the given validator.
-    NewEvidence(VID),
+    NewEvidence(C::ValidatorId),
     /// Send evidence about the validator from an earlier era to the peer.
-    SendEvidence(I, VID),
+    SendEvidence(I, C::ValidatorId),
 }
 
 /// An API for a single instance of the consensus.
-pub(crate) trait ConsensusProtocol<I, C: ConsensusValueT, VID> {
+pub(crate) trait ConsensusProtocol<I, C: Context> {
     /// Upcasts consensus protocol into `dyn Any`.
     ///
     /// Typically called on a boxed trait object for downcasting afterwards.
@@ -103,44 +103,48 @@ pub(crate) trait ConsensusProtocol<I, C: ConsensusValueT, VID> {
         msg: Vec<u8>,
         evidence_only: bool,
         rng: &mut dyn CryptoRngCore,
-    ) -> Vec<ConsensusProtocolResult<I, C, VID>>;
+    ) -> Vec<ConsensusProtocolResult<I, C>>;
 
     /// Triggers consensus' timer.
     fn handle_timer(
         &mut self,
         timestamp: Timestamp,
         rng: &mut dyn CryptoRngCore,
-    ) -> Vec<ConsensusProtocolResult<I, C, VID>>;
+    ) -> Vec<ConsensusProtocolResult<I, C>>;
 
     /// Proposes a new value for consensus.
     fn propose(
         &mut self,
-        value: C,
+        value: C::ConsensusValue,
         block_context: BlockContext,
         rng: &mut dyn CryptoRngCore,
-    ) -> Vec<ConsensusProtocolResult<I, C, VID>>;
+    ) -> Vec<ConsensusProtocolResult<I, C>>;
 
     /// Marks the `value` as valid or invalid, based on validation requested via
     /// `ConsensusProtocolResult::ValidateConsensusvalue`.
     fn resolve_validity(
         &mut self,
-        value: &C,
+        value: &C::ConsensusValue,
         valid: bool,
         rng: &mut dyn CryptoRngCore,
-    ) -> Vec<ConsensusProtocolResult<I, C, VID>>;
+    ) -> Vec<ConsensusProtocolResult<I, C>>;
 
     /// Turns this instance into a passive observer, that does not create any new vertices.
     fn deactivate_validator(&mut self);
 
     /// Returns whether the validator `vid` is known to be faulty.
-    fn has_evidence(&self, vid: &VID) -> bool;
+    fn has_evidence(&self, vid: &C::ValidatorId) -> bool;
 
     /// Marks the validator `vid` as faulty, based on evidence from a different instance.
-    fn mark_faulty(&mut self, vid: &VID);
+    fn mark_faulty(&mut self, vid: &C::ValidatorId);
 
     /// Sends evidence for a faulty of validator `vid` to the `sender` of the request.
-    fn request_evidence(&self, sender: I, vid: &VID) -> Vec<ConsensusProtocolResult<I, C, VID>>;
+    fn request_evidence(
+        &self,
+        sender: I,
+        vid: &C::ValidatorId,
+    ) -> Vec<ConsensusProtocolResult<I, C>>;
 
     /// Returns the list of all validators that were observed as faulty in this consensus instance.
-    fn validators_with_evidence(&self) -> Vec<&VID>;
+    fn validators_with_evidence(&self) -> Vec<&C::ValidatorId>;
 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -37,7 +37,7 @@ use crate::{
         chainspec_loader::{Chainspec, HighwayConfig},
         consensus::{
             candidate_block::CandidateBlock,
-            cl_context::{ClContext, ClSecret},
+            cl_context::{ClContext, Keypair},
             consensus_protocol::{
                 BlockContext, ConsensusProtocol, ConsensusProtocolResult, EraEnd,
                 FinalizedBlock as CpFinalizedBlock,
@@ -306,7 +306,7 @@ where
         );
 
         let results = if should_activate {
-            let secret = ClSecret::new(Rc::clone(&self.secret_signing_key), our_id);
+            let secret = Keypair::new(Rc::clone(&self.secret_signing_key), our_id);
             highway.activate_validator(our_id, secret, params, timestamp)
         } else {
             Vec::new()

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -203,7 +203,7 @@ where
         start_time: Timestamp,
         start_height: u64,
         state_root_hash: hash::Digest,
-    ) -> Vec<ConsensusProtocolResult<I, CandidateBlock, PublicKey>> {
+    ) -> Vec<ConsensusProtocolResult<I, ClContext>> {
         if self.active_eras.contains_key(&era_id) {
             panic!("{} already exists", era_id);
         }
@@ -364,9 +364,9 @@ where
     fn delegate_to_era<F>(&mut self, era_id: EraId, f: F) -> Effects<Event<I>>
     where
         F: FnOnce(
-            &mut dyn ConsensusProtocol<I, CandidateBlock, PublicKey>,
+            &mut dyn ConsensusProtocol<I, ClContext>,
             &mut dyn CryptoRngCore,
-        ) -> Vec<ConsensusProtocolResult<I, CandidateBlock, PublicKey>>,
+        ) -> Vec<ConsensusProtocolResult<I, ClContext>>,
     {
         match self.era_supervisor.active_eras.get_mut(&era_id) {
             None => {
@@ -586,7 +586,7 @@ where
 
     fn handle_consensus_results<T>(&mut self, era_id: EraId, results: T) -> Effects<Event<I>>
     where
-        T: IntoIterator<Item = ConsensusProtocolResult<I, CandidateBlock, PublicKey>>,
+        T: IntoIterator<Item = ConsensusProtocolResult<I, ClContext>>,
     {
         results
             .into_iter()
@@ -615,7 +615,7 @@ where
     fn handle_consensus_result(
         &mut self,
         era_id: EraId,
-        consensus_result: ConsensusProtocolResult<I, CandidateBlock, PublicKey>,
+        consensus_result: ConsensusProtocolResult<I, ClContext>,
     ) -> Effects<Event<I>> {
         match consensus_result {
             ConsensusProtocolResult::InvalidIncomingMessage(_, sender, error) => {

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -84,7 +84,7 @@ impl PendingCandidate {
 
 pub struct Era<I> {
     /// The consensus protocol instance.
-    pub(crate) consensus: Box<dyn ConsensusProtocol<I, CandidateBlock, PublicKey>>,
+    pub(crate) consensus: Box<dyn ConsensusProtocol<I, ClContext>>,
     /// The height of this era's first block.
     pub(crate) start_height: u64,
     /// Pending candidate blocks, waiting for validation. The boolean is `true` if the proto block
@@ -101,7 +101,7 @@ pub struct Era<I> {
 }
 
 impl<I> Era<I> {
-    pub(crate) fn new<C: 'static + ConsensusProtocol<I, CandidateBlock, PublicKey>>(
+    pub(crate) fn new<C: 'static + ConsensusProtocol<I, ClContext>>(
         consensus: C,
         start_height: u64,
         newly_slashed: Vec<PublicKey>,

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -10,11 +10,9 @@ use tracing::warn;
 
 use crate::{
     components::consensus::{
-        candidate_block::CandidateBlock,
-        consensus_protocol::ConsensusProtocol,
-        era_supervisor::BONDED_ERAS,
-        protocols::highway::{HighwayContext, HighwayProtocol},
-        ConsensusMessage,
+        candidate_block::CandidateBlock, cl_context::ClContext,
+        consensus_protocol::ConsensusProtocol, era_supervisor::BONDED_ERAS,
+        protocols::highway::HighwayProtocol, ConsensusMessage,
     },
     crypto::asymmetric_key::PublicKey,
     types::ProtoBlock,
@@ -227,12 +225,12 @@ where
         let consensus_heap_size = {
             let any_ref = consensus.as_any();
 
-            if let Some(highway) = any_ref.downcast_ref::<HighwayProtocol<I, HighwayContext>>() {
+            if let Some(highway) = any_ref.downcast_ref::<HighwayProtocol<I, ClContext>>() {
                 highway.estimate_heap_size()
             } else {
                 warn!(
                     "could not downcast consensus protocol to \
-                    HighwayProtocol<I, HighwayContext> to determine heap allocation size"
+                    HighwayProtocol<I, ClContext> to determine heap allocation size"
                 );
                 0
             }

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -49,10 +49,7 @@ impl<C: Context> FinalityDetector<C> {
     pub(crate) fn run<'a>(
         &'a mut self,
         highway: &'a Highway<C>,
-    ) -> Result<
-        impl Iterator<Item = FinalizedBlock<C::ConsensusValue, C::ValidatorId>> + 'a,
-        FttExceeded,
-    > {
+    ) -> Result<impl Iterator<Item = FinalizedBlock<C>> + 'a, FttExceeded> {
         let state = highway.state();
         let fault_w = state.faulty_weight();
         if fault_w >= self.ftt || fault_w > (state.total_weight() - Weight(1)) / 2 {

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -231,9 +231,7 @@ impl HighwayValidator {
         &self.highway
     }
 
-    fn run_finality(
-        &mut self,
-    ) -> Result<Vec<FinalizedBlock<ConsensusValue, ValidatorId>>, FttExceeded> {
+    fn run_finality(&mut self) -> Result<Vec<FinalizedBlock<TestContext>>, FttExceeded> {
         Ok(self.finality_detector.run(&self.highway)?.collect())
     }
 

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -319,10 +319,9 @@ enum HighwayMessage<C: Context> {
     RequestDependency(Dependency<C>),
 }
 
-type CpResult<I, C> =
-    ConsensusProtocolResult<I, <C as Context>::ConsensusValue, <C as Context>::ValidatorId>;
+type CpResult<I, C> = ConsensusProtocolResult<I, C>;
 
-impl<I, C> ConsensusProtocol<I, C::ConsensusValue, C::ValidatorId> for HighwayProtocol<I, C>
+impl<I, C> ConsensusProtocol<I, C> for HighwayProtocol<I, C>
 where
     I: NodeIdT,
     C: Context + 'static,


### PR DESCRIPTION
This cleanup is a preparation for making the era supervisor easier to test ([NDRS-546](https://casperlabs.atlassian.net/browse/NDRS-546)). To do that, I'd like to implement a mock consensus protocol that can be used instead of `HighwayProtocol`, so that tests can be written independently of Highway-specific details. However, that abstraction is currently broken, and we've leaked a lot of Highway logic into the era supervisor. E.g. `activate_validator` is not part of the trait. To put it there, the trait needs `C::ValidatorSecret` (and we'll need to move the instantiation of the Highway `Params` inside of its implementation).

https://casperlabs.atlassian.net/browse/NDRS-546