### PR TITLE
NDRS-546: Further disentangle Highway from EraSupervisor.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -129,6 +129,14 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
         rng: &mut dyn CryptoRngCore,
     ) -> Vec<ConsensusProtocolResult<I, C>>;
 
+    /// Turns this instance into an active validator, that participates in the consensus protocol.
+    fn activate_validator(
+        &mut self,
+        our_id: C::ValidatorId,
+        secret: C::ValidatorSecret,
+        timestamp: Timestamp,
+    ) -> Vec<ConsensusProtocolResult<I, C>>;
+
     /// Turns this instance into a passive observer, that does not create any new vertices.
     fn deactivate_validator(&mut self);
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -19,7 +19,6 @@ use blake2::{
 };
 use datasize::DataSize;
 use itertools::Itertools;
-use num_traits::AsPrimitive;
 use prometheus::Registry;
 use rand::Rng;
 use tracing::{error, info, trace, warn};
@@ -28,8 +27,8 @@ use casper_execution_engine::{
     core::engine_state::era_validators::GetEraValidatorsRequest, shared::motes::Motes,
 };
 use casper_types::{
-    auction::{ValidatorWeights, AUCTION_DELAY, BLOCK_REWARD, DEFAULT_UNBONDING_DELAY},
-    ProtocolVersion, U512,
+    auction::{ValidatorWeights, AUCTION_DELAY, DEFAULT_UNBONDING_DELAY},
+    ProtocolVersion,
 };
 
 use crate::{
@@ -42,7 +41,6 @@ use crate::{
                 BlockContext, ConsensusProtocol, ConsensusProtocolResult, EraEnd,
                 FinalizedBlock as CpFinalizedBlock,
             },
-            highway_core::{highway::Params, validators::Validators},
             metrics::ConsensusMetrics,
             protocols::highway::HighwayProtocol,
             traits::NodeIdT,
@@ -156,8 +154,8 @@ where
         }
     }
 
-    fn highway_config(&self) -> HighwayConfig {
-        self.chainspec.genesis.highway_config
+    fn highway_config(&self) -> &HighwayConfig {
+        &self.chainspec.genesis.highway_config
     }
 
     fn booking_block_height(&self, era_id: EraId) -> u64 {
@@ -209,41 +207,14 @@ where
         }
         self.current_era = era_id;
 
-        let sum_stakes: Motes = validator_stakes.iter().map(|(_, stake)| *stake).sum();
-        assert!(
-            !sum_stakes.value().is_zero(),
-            "cannot start era with total weight 0"
-        );
-
-        let init_round_exp = era_id
-            .checked_sub(1)
-            .and_then(|last_era_id| self.active_eras.get(&last_era_id))
-            .and_then(|era| {
-                era.consensus
-                    .as_any()
-                    .downcast_ref::<HighwayProtocol<I, ClContext>>()
-            })
-            .and_then(|highway_proto| highway_proto.median_round_exp())
-            .unwrap_or(self.highway_config().minimum_round_exponent);
-
         info!(
             ?validator_stakes,
             %start_time,
             %timestamp,
             %start_height,
             era = era_id.0,
-            %init_round_exp,
             "starting era",
         );
-
-        // For Highway, we need u64 weights. Scale down by  sum / u64::MAX,  rounded up.
-        // If we round up the divisor, the resulting sum is guaranteed to be  <= u64::MAX.
-        let scaling_factor = (sum_stakes.value() + U512::from(u64::MAX) - 1) / U512::from(u64::MAX);
-        let scale_stake = |(key, stake): (PublicKey, Motes)| {
-            (key, AsPrimitive::<u64>::as_(stake.value() / scaling_factor))
-        };
-        let mut validators: Validators<PublicKey> =
-            validator_stakes.into_iter().map(scale_stake).collect();
 
         let slashed = era_id
             .iter_other_bonded()
@@ -252,45 +223,16 @@ where
             .cloned()
             .collect();
 
-        for pub_key in &slashed {
-            validators.ban(pub_key);
-        }
-
-        let total_weight = u128::from(validators.total_weight());
-        let ftt_percent = u128::from(self.highway_config().finality_threshold_percent);
-        let ftt = ((total_weight * ftt_percent / 100) as u64).into();
-
-        // TODO: The initial round length should be the observed median of the switch block.
-        let params = Params::new(
-            seed,
-            BLOCK_REWARD,
-            BLOCK_REWARD / 5, // TODO: Make reduced block reward configurable?
-            self.highway_config().minimum_round_exponent,
-            init_round_exp,
-            self.highway_config().minimum_era_height,
-            start_time,
-            start_time + self.highway_config().era_duration,
-        );
-
         // Activate the era if this node was already running when the era began, it is still
         // ongoing based on its minimum duration, and we are one of the validators.
         let our_id = self.public_signing_key;
-        let era_rounds_len = params.min_round_len() * params.end_height();
-        let min_end_time = start_time + self.highway_config().era_duration.max(era_rounds_len);
         let should_activate = if self.node_start_time >= start_time {
             info!(
                 era = era_id.0,
                 %self.node_start_time, "not voting; node was not started before the era began",
             );
             false
-        } else if min_end_time < timestamp {
-            info!(
-                era = era_id.0,
-                %min_end_time,
-                "not voting; era started too long ago",
-            );
-            false
-        } else if !validators.iter().any(|v| *v.id() == our_id) {
+        } else if !validator_stakes.iter().any(|(v, _)| *v == our_id) {
             info!(era = era_id.0, %our_id, "not voting; not a validator");
             false
         } else {
@@ -298,11 +240,18 @@ where
             true
         };
 
+        let prev_era = era_id
+            .checked_sub(1)
+            .and_then(|last_era_id| self.active_eras.get(&last_era_id));
+
         let mut highway = HighwayProtocol::<I, ClContext>::new(
             instance_id(&self.chainspec, state_root_hash, start_height),
-            validators,
-            params,
-            ftt,
+            validator_stakes,
+            &slashed,
+            self.highway_config(),
+            prev_era.map(|era| &*era.consensus),
+            start_time,
+            seed,
         );
 
         let results = if should_activate {

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -307,7 +307,7 @@ where
 
         let results = if should_activate {
             let secret = Keypair::new(Rc::clone(&self.secret_signing_key), our_id);
-            highway.activate_validator(our_id, secret, params, timestamp)
+            highway.activate_validator(our_id, secret, timestamp)
         } else {
             Vec::new()
         };

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -150,7 +150,6 @@ impl<C: Context> Highway<C> {
         &mut self,
         id: C::ValidatorId,
         secret: C::ValidatorSecret,
-        params: Params,
         current_time: Timestamp,
     ) -> Vec<Effect<C>> {
         assert!(
@@ -161,7 +160,7 @@ impl<C: Context> Highway<C> {
             .validators
             .get_index(&id)
             .expect("missing own validator ID");
-        let start_time = current_time.max(params.start_timestamp());
+        let start_time = current_time.max(self.state.params().start_timestamp());
         let (av, effects) = ActiveValidator::new(idx, secret, start_time, &self.state);
         self.active_validator = Some(av);
         effects

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -879,7 +879,7 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
                     Timestamp::zero(), // Length depends only on block number.
                 );
                 let mut highway = Highway::new(instance_id, validators.clone(), params);
-                let effects = highway.activate_validator(vid, v_sec, params, start_time);
+                let effects = highway.activate_validator(vid, v_sec, start_time);
 
                 let finality_detector = FinalityDetector::new(Weight(ftt));
 

--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -1,4 +1,4 @@
-use super::{TimeDiff, Timestamp};
+use super::Timestamp;
 
 /// Protocol parameters for Highway.
 #[derive(Debug, Clone, Copy)]
@@ -82,11 +82,6 @@ impl Params {
     /// Returns the initial round exponent.
     pub(crate) fn init_round_exp(&self) -> u8 {
         self.init_round_exp
-    }
-
-    /// Returns the minimum round length, i.e. `1 << self.min_round_exp()` milliseconds.
-    pub(crate) fn min_round_len(&self) -> TimeDiff {
-        super::round_len(self.min_round_exp)
     }
 
     /// Returns the minimum height of the last block.

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -72,12 +72,9 @@ impl<I: NodeIdT, C: Context> HighwayProtocol<I, C> {
         &mut self,
         our_id: C::ValidatorId,
         secret: C::ValidatorSecret,
-        params: Params,
         timestamp: Timestamp,
     ) -> Vec<CpResult<I, C>> {
-        let av_effects = self
-            .highway
-            .activate_validator(our_id, secret, params, timestamp);
+        let av_effects = self.highway.activate_validator(our_id, secret, timestamp);
         self.process_av_effects(av_effects)
     }
 

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -96,7 +96,6 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             "initializing Highway instance",
         );
 
-        // TODO: The initial round length should be the observed median of the switch block.
         let params = Params::new(
             seed,
             BLOCK_REWARD,

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -2,30 +2,36 @@ mod round_success_meter;
 
 use std::{
     any::Any,
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
 };
 
+use casper_execution_engine::shared::motes::Motes;
 use datasize::DataSize;
 use itertools::Itertools;
+use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
 use tracing::{info, trace};
 
 use self::round_success_meter::RoundSuccessMeter;
+use casper_types::{auction::BLOCK_REWARD, U512};
 
 use crate::{
-    components::consensus::{
-        consensus_protocol::{BlockContext, ConsensusProtocol, ConsensusProtocolResult},
-        highway_core::{
-            active_validator::Effect as AvEffect,
-            finality_detector::FinalityDetector,
-            highway::{
-                Dependency, GetDepOutcome, Highway, Params, PreValidatedVertex, ValidVertex, Vertex,
+    components::{
+        chainspec_loader::HighwayConfig,
+        consensus::{
+            consensus_protocol::{BlockContext, ConsensusProtocol, ConsensusProtocolResult},
+            highway_core::{
+                active_validator::Effect as AvEffect,
+                finality_detector::FinalityDetector,
+                highway::{
+                    Dependency, GetDepOutcome, Highway, Params, PreValidatedVertex, ValidVertex,
+                    Vertex,
+                },
+                validators::Validators,
             },
-            validators::Validators,
-            Weight,
+            traits::{Context, NodeIdT},
         },
-        traits::{Context, NodeIdT},
     },
     types::{CryptoRngCore, Timestamp},
 };
@@ -48,13 +54,60 @@ where
     round_success_meter: RoundSuccessMeter<C>,
 }
 
-impl<I: NodeIdT, C: Context> HighwayProtocol<I, C> {
+impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     pub(crate) fn new(
         instance_id: C::InstanceId,
-        validators: Validators<C::ValidatorId>,
-        params: Params,
-        ftt: Weight,
+        validator_stakes: Vec<(C::ValidatorId, Motes)>,
+        slashed: &HashSet<C::ValidatorId>,
+        highway_config: &HighwayConfig,
+        prev_cp: Option<&dyn ConsensusProtocol<I, C>>,
+        start_time: Timestamp,
+        seed: u64,
     ) -> Self {
+        let sum_stakes: Motes = validator_stakes.iter().map(|(_, stake)| *stake).sum();
+        assert!(
+            !sum_stakes.value().is_zero(),
+            "cannot start era with total weight 0"
+        );
+        // For Highway, we need u64 weights. Scale down by  sum / u64::MAX,  rounded up.
+        // If we round up the divisor, the resulting sum is guaranteed to be  <= u64::MAX.
+        let scaling_factor = (sum_stakes.value() + U512::from(u64::MAX) - 1) / U512::from(u64::MAX);
+        let scale_stake = |(key, stake): (C::ValidatorId, Motes)| {
+            (key, AsPrimitive::<u64>::as_(stake.value() / scaling_factor))
+        };
+        let mut validators: Validators<C::ValidatorId> =
+            validator_stakes.into_iter().map(scale_stake).collect();
+
+        for vid in slashed {
+            validators.ban(vid);
+        }
+
+        let total_weight = u128::from(validators.total_weight());
+        let ftt_percent = u128::from(highway_config.finality_threshold_percent);
+        let ftt = ((total_weight * ftt_percent / 100) as u64).into();
+
+        let init_round_exp = prev_cp
+            .and_then(|cp| cp.as_any().downcast_ref::<HighwayProtocol<I, C>>())
+            .and_then(|highway_proto| highway_proto.median_round_exp())
+            .unwrap_or(highway_config.minimum_round_exponent);
+
+        info!(
+            %init_round_exp,
+            "initializing Highway instance",
+        );
+
+        // TODO: The initial round length should be the observed median of the switch block.
+        let params = Params::new(
+            seed,
+            BLOCK_REWARD,
+            BLOCK_REWARD / 5, // TODO: Make reduced block reward configurable?
+            highway_config.minimum_round_exponent,
+            init_round_exp,
+            highway_config.minimum_era_height,
+            start_time,
+            start_time + highway_config.era_duration,
+        );
+
         let min_round_exp = params.min_round_exp();
         let round_exp = params.init_round_exp();
         let start_timestamp = params.start_timestamp();

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -68,16 +68,6 @@ impl<I: NodeIdT, C: Context> HighwayProtocol<I, C> {
         }
     }
 
-    pub(crate) fn activate_validator(
-        &mut self,
-        our_id: C::ValidatorId,
-        secret: C::ValidatorSecret,
-        timestamp: Timestamp,
-    ) -> Vec<CpResult<I, C>> {
-        let av_effects = self.highway.activate_validator(our_id, secret, timestamp);
-        self.process_av_effects(av_effects)
-    }
-
     fn process_av_effects<E>(&mut self, av_effects: E) -> Vec<CpResult<I, C>>
     where
         E: IntoIterator<Item = AvEffect<C>>,
@@ -430,6 +420,16 @@ where
             // TODO: Disconnect from senders.
             vec![]
         }
+    }
+
+    fn activate_validator(
+        &mut self,
+        our_id: C::ValidatorId,
+        secret: C::ValidatorSecret,
+        timestamp: Timestamp,
+    ) -> Vec<CpResult<I, C>> {
+        let av_effects = self.highway.activate_validator(our_id, secret, timestamp);
+        self.process_av_effects(av_effects)
     }
 
     fn deactivate_validator(&mut self) {


### PR DESCRIPTION
Continuing https://github.com/CasperLabs/casper-node/pull/454, this moves `active_validator` into the `ConsensusProtocol` trait and moves some Highway-specific logic from the era supervisor into the `HighwayProtocol` implementation.

https://casperlabs.atlassian.net/browse/NDRS-546