### PR TITLE
NDRS-549: include casper-node-macros in the casper-updater tool

### DIFF
--- a/ci/casper_updater/src/main.rs
+++ b/ci/casper_updater/src/main.rs
@@ -171,6 +171,9 @@ fn main() {
     );
     execution_engine.update();
 
+    let node_macros = Package::cargo("node_macros", &*regex_data::node_macros::DEPENDENT_FILES);
+    node_macros.update();
+
     let node = Package::cargo("node", &*regex_data::node::DEPENDENT_FILES);
     node.update();
 

--- a/ci/casper_updater/src/regex_data.rs
+++ b/ci/casper_updater/src/regex_data.rs
@@ -127,6 +127,35 @@ pub mod execution_engine {
     }
 }
 
+pub mod node_macros {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
+            vec![
+                DependentFile::new(
+                    "node/Cargo.toml",
+                    Regex::new(r#"(?m)(^casper-node-macros = \{[^\}]*version = )"(?:[^"]+)"#).unwrap(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "node_macros/Cargo.toml",
+                    MANIFEST_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "node_macros/src/lib.rs",
+                    Regex::new(
+                        r#"(?m)(#!\[doc\(html_root_url = "https://docs.rs/casper-node-macros)/(?:[^"]+)"#,
+                    )
+                    .unwrap(),
+                    replacement_with_slash,
+                ),
+            ]
+        };
+    }
+}
+
 pub mod node {
     use super::*;
 

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -76,9 +76,9 @@ check_python_has_toml
 
 # These are the subdirs of casper-node which contain packages for publishing.  They should remain ordered from
 # least-dependent to most.
-publish node_macros
 publish types
 publish execution_engine
+publish node_macros
 publish node
 publish grpc/server
 publish client

--- a/node_macros/Cargo.toml
+++ b/node_macros/Cargo.toml
@@ -3,6 +3,12 @@ name = "casper-node-macros"
 version = "0.1.0"
 authors = ["Marc Brinkmann <marc@casperlabs.io>"]
 edition = "2018"
+description = "A macro to create reactor implementations for the casper-node."
+readme = "README.md"
+documentation = "https://docs.rs/casper-node-macros"
+homepage = "https://casperlabs.io"
+repository = "https://github.com/CasperLabs/casper-node/tree/master/node_macros"
+license-file = "../LICENSE"
 
 [dependencies]
 indexmap = "1.6.0"

--- a/node_macros/README.md
+++ b/node_macros/README.md
@@ -1,4 +1,4 @@
-# Cosy macros
+# casper-node-macros
 
 The `casper-node-macros` crate offers an easy-to-use macro to create reactor implementations for the component system. It enforces a set of convention and allows generating a large amount of otherwise boilerplate heavy setup code comfortably.
 

--- a/node_macros/src/lib.rs
+++ b/node_macros/src/lib.rs
@@ -1,6 +1,12 @@
-//! Cosy reactor proc macro.
-//!
 //! Generates reactors with routing from concise definitions. See `README.md` for details.
+
+#![doc(html_root_url = "https://docs.rs/casper-node-macros/0.1.0")]
+#![doc(
+    html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
+    html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",
+    test(attr(forbid(warnings)))
+)]
+#![warn(missing_docs, trivial_casts, trivial_numeric_casts)]
 
 mod gen;
 mod parse;

--- a/node_macros/src/parse.rs
+++ b/node_macros/src/parse.rs
@@ -1,4 +1,4 @@
-//! Parser for cosy macro.
+//! Parser for reactor macro.
 //!
 //! Contains the `Parse` implementations for the intermediate representation of the macro, which is
 //! `ReactorDefinition`. Many functions required by the code generator are also included here as


### PR DESCRIPTION
This PR updates the `casper-updater` tool to also update files affected by version changes in the new `casper-node-macros` crate.