### PR TITLE
NO_TICKET: Several client nitpicks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5472,9 +5472,9 @@ dependencies = [
 
 [[package]]
 name = "warp-json-rpc"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f47179c6df70470fb9f77d6624a825943539d792ab123f63d0dadfa0f1864c"
+checksum = "c902fcb1a0754ea4f78a2231f9e54d2b8e641274ae7967bff9bbf2c564d6c193"
 dependencies = [
  "anyhow",
  "erased-serde",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,6 +17,7 @@ path = "lib/lib.rs"
 [[bin]]
 name = "casper-client"
 path = "src/main.rs"
+doc = false
 
 [dependencies]
 base64 = "0.13.0"

--- a/client/README.md
+++ b/client/README.md
@@ -5,7 +5,7 @@ A client for interacting with the Casper network.
 
 ## Running the client
 
-The client runs in one of several modes, each mode performing a single action.  To see all available commands:
+The client runs in one of several modes, each mode performing a single action. To see all available commands:
 
 ```
 cd client
@@ -83,7 +83,7 @@ ARGS:
 
 ### Generate asymmetric signing keys
 
-Some commands require the use of a secret key for signing data.  To generate a secret and public key pair:
+Some commands require the use of a secret key for signing data. To generate a secret and public key pair:
 
 ```
 cargo run --release -- keygen $HOME/.client_keys
@@ -92,10 +92,10 @@ cargo run --release -- keygen $HOME/.client_keys
 
 ## Interacting with a local node
 
-Many client commands require to send HTTP requests and receive responses.  To do this with a local node running on the
+Many client commands require to send HTTP requests and receive responses. To do this with a local node running on the
 same machine, follow the instructions in [the `nctl` README](../utils/nctl/README.md) to set up a local test network.
 
-Ensure the network has fully started before running client commands.  This can be determined by running
+Ensure the network has fully started before running client commands. This can be determined by running
 `nctl-view-node-peers` and checking each node has connections to all others.
 
 For client commands requiring a node address (specified via the `--node-address` or `-n` arg), the default value is
@@ -105,18 +105,18 @@ can usually be omitted.
 
 ### Transfer funds between purses
 
-The testnet will be set up so that the nodes each have an initial balance of tokens in their main purses.  Let's say we
-want to create a new purse under the public key we just created (in the "Generate asymmetric signing keys" section).  We
-can do this by creating a new deploy which will transfer funds between two purses once executed.  The simplest way to
+The testnet will be set up so that the nodes each have an initial balance of tokens in their main purses. Let's say we
+want to create a new purse under the public key we just created (in the "Generate asymmetric signing keys" section). We
+can do this by creating a new deploy which will transfer funds between two purses once executed. The simplest way to
 achieve this is via the `transfer` subcommand.
 
-First, set the contents of the `public_key_hex` file to a variable.  We'll use this as the target account:
+First, set the contents of the `public_key_hex` file to a variable. We'll use this as the target account:
 
 ```
 PUBLIC_KEY=$(cat $HOME/.client_keys/public_key_hex)
 ```
 
-Then execute the `transfer` subcommand.  We'll specify that we want to transfer 1,234,567 tokens from the main purse of
+Then execute the `transfer` subcommand. We'll specify that we want to transfer 1,234,567 tokens from the main purse of
 node 3, and that we'll pay a maximum of 10,000 tokens to execute this deploy: 
 
 ```
@@ -252,13 +252,13 @@ cargo run --release -- get-deploy c42210759368a07a1b1ff4f019f7e77e7c9eaf2961b8c9
 </details>
 
 The `block_hash` in the response's `execution_results` is worth noting, as it can be used to identify the block in which
-the deploy is included.  If the deploy was successfully received and parsed by the node, but failed to execute, the
+the deploy is included. If the deploy was successfully received and parsed by the node, but failed to execute, the
 `error_message` in `execution_results` may provide useful information.
 
 
 ### Get details of a `Block`
 
-To see information about a `Block` created by the network, you can use `get-block`.  For example:
+To see information about a `Block` created by the network, you can use `get-block`. For example:
 
 ```
 cargo run --release -- get-block --block-hash=80a09df67f45bfb290c8f36021daf2fb898587a48fa0e4f7c506202ae8f791b8
@@ -305,7 +305,7 @@ for the purposes of querying the global state.
 
 ### Query the global state
 
-To view data stored to global state after executing a deploy, you can use `query-state`.  For example, to see the value
+To view data stored to global state after executing a deploy, you can use `query-state`. For example, to see the value
 stored under our new account's public key:
 
 ```
@@ -349,7 +349,7 @@ This yields details of the newly-created account object, including the `URef` of
 
 ### Get the balance of a purse
 
-This can be done via `get-balance`.  For example, to get the balance of the main purse of our newly-created account:
+This can be done via `get-balance`. For example, to get the balance of the main purse of our newly-created account:
 
 ```
 cargo run --release -- get-balance \
@@ -371,6 +371,6 @@ cargo run --release -- get-balance \
 ```
 </details>
 
-Note that the system mint contract is required to retrieve the balance of any given purse.  If you execute a
+Note that the system mint contract is required to retrieve the balance of any given purse. If you execute a
 `query-state` specifying a purse `URef` as the `--key` argument, you'll find that the actual value stored there is a unit
-value `()`.  This makes the `get-balance` subcommand particularly useful. 
+value `()`. This makes the `get-balance` subcommand particularly useful. 

--- a/client/README.md
+++ b/client/README.md
@@ -15,37 +15,35 @@ cargo run --release -- help
 <details><summary>example output</summary>
 
 ```commandline
-Casper client 0.1.0
+Casper client 1.5.0
 A client for interacting with the Casper network
 
 USAGE:
     casper-client [SUBCOMMAND]
 
 FLAGS:
-    -h, --help
-            Prints help information
-
-    -V, --version
-            Prints version information
-
+    -h, --help       Prints help information
+    -V, --version    Prints version information
 
 SUBCOMMANDS:
-    put-deploy               Creates a new deploy and sends it to the network for execution
-    make-deploy              Constructs a deploy and outputs it to a file or stdout. As a file, the deploy can
-                             subsequently be signed by other parties and sent to a node, or signed with the sign-
-                             deploy subcommand
-    sign-deploy              Cryptographically signs a deploy and appends signature to existing approvals
-    send-deploy              Sends a deploy to the network for execution
-    transfer                 Transfers funds between purses
-    get-deploy               Retrieves a stored deploy
-    get-block                Retrieves a block
-    list-deploys             Gets the list of all deploy hashes from a given block
-    get-balance              Retrieves a stored balance
-    get-global-state-hash    Retrieves a global state hash
-    query-state              Retrieves a stored value from global state
-    keygen                   Generates account key files in the given directory
-    generate-completion      Generates a shell completion script
-    help                     Prints this message or the help of the given subcommand(s)
+    put-deploy             Creates a deploy and sends it to the network for execution
+    make-deploy            Creates a deploy and outputs it to a file or stdout. As a file, the deploy can
+                           subsequently be signed by other parties using the 'sign-deploy' subcommand and then sent
+                           to the network for execution using the 'send-deploy' subcommand
+    sign-deploy            Reads a previously-saved deploy from a file, cryptographically signs it, and outputs it
+                           to a file or stdout
+    send-deploy            Reads a previously-saved deploy from a file and sends it to the network for execution
+    transfer               Transfers funds between purses
+    get-deploy             Retrieves a deploy from the network
+    get-block              Retrieves a block from the network
+    list-deploys           Retrieves the list of all deploy hashes in a given block
+    get-state-root-hash    Retrieves a state root hash at a given block
+    query-state            Retrieves a stored value from the network
+    get-balance            Retrieves a purse's balance from the network
+    get-auction-info       Retrieves the bids and validators as of the most recently added block
+    keygen                 Generates account key files in the given directory
+    generate-completion    Generates a shell completion script
+    help                   Prints this message or the help of the given subcommand(s)
 ```
 </details>
 
@@ -58,8 +56,8 @@ cargo run --release -- help keygen
 <details><summary>example output</summary>
 
 ```commandline
-casper-client-keygen
-Generates account key files in the given directory. Creates ["public_key_hex", "secret_key.pem", "public_key.pem"].
+casper-client-keygen 
+Generates account key files in the given directory. Creates ["secret_key.pem", "public_key.pem", "public_key_hex"].
 "public_key_hex" contains the hex-encoded key's bytes with the hex-encoded algorithm tag prefixed
 
 USAGE:
@@ -282,7 +280,7 @@ cargo run --release -- get-block --block-hash=80a09df67f45bfb290c8f36021daf2fb89
         ],
         "era_end": null,
         "era_id": 89,
-        "global_state_hash": "c79f4c9a017532fe265593d86d3917581479fd1601093e16d17ec90aeaa63b83",
+        "state_root_hash": "c79f4c9a017532fe265593d86d3917581479fd1601093e16d17ec90aeaa63b83",
         "height": 987,
         "parent_hash": "ffb95eac42eae1112d37797a1ecc67860e88a9364c44845cb7a96eb426dca502",
         "proposer": "015b7723f1d9499fa02bd17dfe4e1315cfe1660a071e27ab1f29d6ceb6e2abcd73",
@@ -299,7 +297,7 @@ cargo run --release -- get-block --block-hash=80a09df67f45bfb290c8f36021daf2fb89
 ```
 </details>
 
-The `global_state_hash` in the response's `header` is worth noting, as it can be used to identify the state root hash
+The `state_root_hash` in the response's `header` is worth noting, as it can be used to identify the state root hash
 for the purposes of querying the global state.
 
 
@@ -310,7 +308,7 @@ stored under our new account's public key:
 
 ```
 cargo run --release -- query-state \
-    --global-state-hash=242666f5959e6a51b7a75c23264f3cb326eecd6bec6dbab147f5801ec23daed6 \
+    --state-root-hash=242666f5959e6a51b7a75c23264f3cb326eecd6bec6dbab147f5801ec23daed6 \
     --key=$PUBLIC_KEY
 ```
 
@@ -353,7 +351,7 @@ This can be done via `get-balance`. For example, to get the balance of the main 
 
 ```
 cargo run --release -- get-balance \
-    --global-state-hash=242666f5959e6a51b7a75c23264f3cb326eecd6bec6dbab147f5801ec23daed6 \
+    --state-root-hash=242666f5959e6a51b7a75c23264f3cb326eecd6bec6dbab147f5801ec23daed6 \
     --purse-uref=uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007
 ```
 
@@ -372,5 +370,5 @@ cargo run --release -- get-balance \
 </details>
 
 Note that the system mint contract is required to retrieve the balance of any given purse. If you execute a
-`query-state` specifying a purse `URef` as the `--key` argument, you'll find that the actual value stored there is a unit
-value `()`. This makes the `get-balance` subcommand particularly useful. 
+`query-state` specifying a purse `URef` as the `--key` argument, you'll find that the actual value stored there is a
+unit value `()`. This makes the `get-balance` subcommand particularly useful. 

--- a/client/lib/cl_type.rs
+++ b/client/lib/cl_type.rs
@@ -11,7 +11,7 @@ use casper_types::{
 use crate::error::{Error, Result};
 
 /// Parse a `CLType` from `&str`.
-pub fn parse(strval: &str) -> StdResult<CLType, ()> {
+pub(crate) fn parse(strval: &str) -> StdResult<CLType, ()> {
     let supported_types = supported_cl_types();
     let cl_type = match strval.to_lowercase() {
         t if t == supported_types[0].0 => supported_types[0].1.clone(),
@@ -90,17 +90,77 @@ pub(crate) fn supported_cl_types() -> Vec<(&'static str, CLType)> {
     ]
 }
 
-/// Returns a list of `CLTypes` supported by casper_client.
-pub fn supported_cl_type_list() -> String {
-    let mut msg = String::new();
-    let supported_types = supported_cl_types();
-    for (index, item) in supported_types.iter().map(|(name, _)| name).enumerate() {
-        msg.push_str(item);
-        if index < supported_types.len() - 1 {
-            msg.push_str(", ")
+/// Functions for use in help commands.
+pub mod help {
+    use std::convert::TryFrom;
+
+    use casper_node::crypto::asymmetric_key::PublicKey as NodePublicKey;
+    use casper_types::{account::AccountHash, AccessRights, Key, URef};
+
+    /// Returns a list of `CLType`s able to be passed as a string for use as payment code or session
+    /// code args.
+    pub fn supported_cl_type_list() -> String {
+        let mut msg = String::new();
+        let supported_types = super::supported_cl_types();
+        for (index, item) in supported_types.iter().map(|(name, _)| name).enumerate() {
+            msg.push_str(item);
+            if index < supported_types.len() - 1 {
+                msg.push_str(", ")
+            }
         }
+        msg
     }
-    msg
+
+    /// Returns a string listing examples of the format required when passing in payment code or
+    /// session code args.
+    pub fn supported_cl_type_examples() -> String {
+        let bytes = (1..33).collect::<Vec<_>>();
+        let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
+
+        format!(
+            r#"name_01:bool='false'
+name_02:i32='-1'
+name_03:i64='-2'
+name_04:u8='3'
+name_05:u32='4'
+name_06:u64='5'
+name_07:u128='6'
+name_08:u256='7'
+name_09:u512='8'
+name_10:unit=''
+name_11:string='a value'
+key_account_name:key='{}'
+key_hash_name:key='{}'
+key_uref_name:key='{}'
+account_hash_name:account_hash='{}'
+uref_name:uref='{}'
+public_key_name:public_key='{}'
+
+Optional values of all of these types can also be specified.
+Prefix the type with "opt_" and use the term "null" without quotes to specify a None value:
+name_01:opt_bool='true'       # Some(true)
+name_02:opt_bool='false'      # Some(false)
+name_03:opt_bool=null         # None
+name_04:opt_i32='-1'          # Some(-1)
+name_05:opt_i32=null          # None
+name_06:opt_unit=''           # Some(())
+name_07:opt_unit=null         # None
+name_08:opt_string='a value'  # Some("a value".to_string())
+name_09:opt_string='null'     # Some("null".to_string())
+name_10:opt_string=null       # None
+"#,
+            Key::Account(AccountHash::new(array)).to_formatted_string(),
+            Key::Hash(array).to_formatted_string(),
+            Key::URef(URef::new(array, AccessRights::NONE)).to_formatted_string(),
+            AccountHash::new(array).to_formatted_string(),
+            URef::new(array, AccessRights::READ_ADD_WRITE).to_formatted_string(),
+            NodePublicKey::from_hex(
+                "0119bf44096984cdfe8541bac167dc3b96c85086aa30b6b6cb0c5c38ad703166e1"
+            )
+            .unwrap()
+            .to_hex(),
+        )
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -161,7 +221,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue> {
                 "true" | "t" => Ok(true),
                 "false" | "f" => Ok(false),
                 invalid => Err(Error::InvalidCLValue(format!(
-                    "can't parse {} as a bool.  Should be 'true' or 'false'",
+                    "can't parse {} as a bool. Should be 'true' or 'false'",
                     invalid
                 ))),
             };
@@ -253,7 +313,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue> {
             let parse = || {
                 if !trimmed_value.is_empty() {
                     return Err(Error::InvalidCLValue(format!(
-                        "can't parse {} as unit.  Should be ''",
+                        "can't parse {} as unit. Should be ''",
                         trimmed_value
                     )));
                 }

--- a/client/lib/cl_type.rs
+++ b/client/lib/cl_type.rs
@@ -118,36 +118,36 @@ pub mod help {
         let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
 
         format!(
-            r#"name_01:bool='false'
-name_02:i32='-1'
-name_03:i64='-2'
-name_04:u8='3'
-name_05:u32='4'
-name_06:u64='5'
-name_07:u128='6'
-name_08:u256='7'
-name_09:u512='8'
-name_10:unit=''
-name_11:string='a value'
-key_account_name:key='{}'
-key_hash_name:key='{}'
-key_uref_name:key='{}'
-account_hash_name:account_hash='{}'
-uref_name:uref='{}'
-public_key_name:public_key='{}'
+            r#""name_01:bool='false'"
+"name_02:i32='-1'"
+"name_03:i64='-2'"
+"name_04:u8='3'"
+"name_05:u32='4'"
+"name_06:u64='5'"
+"name_07:u128='6'"
+"name_08:u256='7'"
+"name_09:u512='8'"
+"name_10:unit=''"
+"name_11:string='a value'"
+"key_account_name:key='{}'"
+"key_hash_name:key='{}'"
+"key_uref_name:key='{}'"
+"account_hash_name:account_hash='{}'"
+"uref_name:uref='{}'"
+"public_key_name:public_key='{}'"
 
 Optional values of all of these types can also be specified.
 Prefix the type with "opt_" and use the term "null" without quotes to specify a None value:
-name_01:opt_bool='true'       # Some(true)
-name_02:opt_bool='false'      # Some(false)
-name_03:opt_bool=null         # None
-name_04:opt_i32='-1'          # Some(-1)
-name_05:opt_i32=null          # None
-name_06:opt_unit=''           # Some(())
-name_07:opt_unit=null         # None
-name_08:opt_string='a value'  # Some("a value".to_string())
-name_09:opt_string='null'     # Some("null".to_string())
-name_10:opt_string=null       # None
+"name_01:opt_bool='true'"       # Some(true)
+"name_02:opt_bool='false'"      # Some(false)
+"name_03:opt_bool=null"         # None
+"name_04:opt_i32='-1'"          # Some(-1)
+"name_05:opt_i32=null"          # None
+"name_06:opt_unit=''"           # Some(())
+"name_07:opt_unit=null"         # None
+"name_08:opt_string='a value'"  # Some("a value".to_string())
+"name_09:opt_string='null'"     # Some("null".to_string())
+"name_10:opt_string=null"       # None
 "#,
             Key::Account(AccountHash::new(array)).to_formatted_string(),
             Key::Hash(array).to_formatted_string(),

--- a/client/lib/error.rs
+++ b/client/lib/error.rs
@@ -15,7 +15,9 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 /// Error that can be returned by `casper-client`.
 #[derive(Error, Debug)]
 pub enum Error {
-    /// Failed to parse a `Key` from a formatted string.
+    /// Failed to parse a
+    /// [`Key`](https://docs.rs/casper-types/latest/casper-types/enum.PublicKey.html) from a
+    /// formatted string.
     #[error("failed to parse as a key")]
     FailedToParseKey,
 

--- a/client/lib/keygen.rs
+++ b/client/lib/keygen.rs
@@ -6,15 +6,15 @@ use casper_node::crypto::asymmetric_key::{PublicKey, SecretKey};
 
 use crate::error::{Error, Result};
 
-/// Default filename for the hex-encoded public key file.
-pub const PUBLIC_KEY_HEX: &str = "public_key_hex";
 /// Default filename for the PEM-encoded secret key file.
 pub const SECRET_KEY_PEM: &str = "secret_key.pem";
+/// Default filename for the hex-encoded public key file.
+pub const PUBLIC_KEY_HEX: &str = "public_key_hex";
 /// Default filename for the PEM-encoded public key file.
 pub const PUBLIC_KEY_PEM: &str = "public_key.pem";
 
-/// List of keygen related filenames.
-pub const FILES: [&str; 3] = [PUBLIC_KEY_HEX, SECRET_KEY_PEM, PUBLIC_KEY_PEM];
+/// List of keygen related filenames: "secret_key.pem", "public_key.pem" and "public_key_hex".
+pub const FILES: [&str; 3] = [SECRET_KEY_PEM, PUBLIC_KEY_PEM, PUBLIC_KEY_HEX];
 
 /// Name of Ed25519 algorithm.
 pub const ED25519: &str = "Ed25519";
@@ -25,11 +25,12 @@ pub const SECP256K1: &str = "secp256k1";
 /// the specified directory.
 ///
 /// The secret key is written to "secret_key.pem", and the public key is written to "public_key.pem"
-/// and also in hex format to "public_key_hex".  For the hex format, the algorithm's tag is
+/// and also in hex format to "public_key_hex". For the hex format, the algorithm's tag is
 /// prepended, e.g. `01` for Ed25519, `02` for secp256k1.
 ///
-/// If `force` is true, existing files will be overwritten.  If `force` is false and any of the
-/// files exist, `Error::FileAlreadyExists(path)` is returned and no files are written.
+/// If `force` is true, existing files will be overwritten. If `force` is false and any of the
+/// files exist, [`Error::FileAlreadyExists`](../enum.Error.html#variant.FileAlreadyExists) is
+/// returned and no files are written.
 pub fn generate_files(output_dir: &str, algorithm: &str, force: bool) -> Result<()> {
     let _ = fs::create_dir_all(output_dir).map_err(|error| Error::IoError {
         context: format!("unable to create directory at '{}'", output_dir),

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -41,8 +41,8 @@ use rpc::{RpcCall, TransferTarget};
 /// Creates a `Deploy` and sends it to the network for execution.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
-///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
-///   be assigned.
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
 /// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
@@ -75,8 +75,8 @@ pub fn put_deploy(
 /// using [`send_deploy_file()`](fn.send_deploy_file.html).
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
-///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
-///   be assigned.
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
 /// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`. If the
@@ -117,8 +117,8 @@ pub fn sign_deploy_file(input_path: &str, secret_key: &str, maybe_output_path: &
 /// Reads a previously-saved `Deploy` from a file and sends it to the network for execution.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
-///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
-///   be assigned.
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
 /// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
@@ -135,8 +135,8 @@ pub fn send_deploy_file(
 /// Transfers funds between purses.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
-///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
-///   be assigned.
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
 /// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
@@ -187,8 +187,8 @@ pub fn transfer(
 /// Retrieves a `Deploy` from the network.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
-///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
-///   be assigned.
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
 /// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
@@ -205,8 +205,8 @@ pub fn get_deploy(
 /// Retrieves a `Block` from the network.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
-///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
-///   be assigned.
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
 /// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
@@ -224,8 +224,8 @@ pub fn get_block(
 /// Retrieves a state root hash at a given `Block`.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
-///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
-///   be assigned.
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
 /// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
@@ -243,8 +243,8 @@ pub fn get_state_root_hash(
 /// Retrieves a stored value from the network.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
-///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
-///   be assigned.
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
 /// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
@@ -275,8 +275,8 @@ pub fn get_item(
 /// Retrieves a purse's balance from the network.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
-///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
-///   be assigned.
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
 /// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
@@ -298,8 +298,8 @@ pub fn get_balance(
 /// Retrieves the bids and validators as of the most recently added `Block`.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
-///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
-///   be assigned.
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
 /// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -12,17 +12,14 @@
     unused_qualifications
 )]
 
+mod cl_type;
 mod deploy;
 mod error;
 mod executable_deploy_item_ext;
+pub mod keygen;
 mod parsing;
 mod rpc;
 mod validation;
-
-pub mod cl_type;
-pub mod keygen;
-pub use deploy::ListDeploysResult;
-pub use error::Error;
 
 use std::convert::TryInto;
 
@@ -32,161 +29,29 @@ use casper_execution_engine::core::engine_state::ExecutableDeployItem;
 use casper_node::types::Deploy;
 use casper_types::{UIntParseError, U512};
 
+pub use cl_type::help;
+pub use deploy::ListDeploysResult;
 use deploy::{DeployExt, DeployParams};
+pub use error::Error;
 use error::Result;
 use executable_deploy_item_ext::ExecutableDeployItemExt;
 use parsing::none_if_empty;
 use rpc::{RpcCall, TransferTarget};
 
-/// Gets a `Deploy` from the node.
+/// Creates a `Deploy` and sends it to the network for execution.
 ///
-/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
-///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
-///   empty.  If empty, a random ID will be assigned.
-/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
-///   `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the request will be printed to `stdout`.
-/// * `deploy_hash` must be a hex-encoded, 32-byte hash digest.
-pub fn get_deploy(
-    maybe_rpc_id: &str,
-    node_address: &str,
-    verbose: bool,
-    deploy_hash: &str,
-) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_deploy(deploy_hash)
-}
-
-/// Queries the node for an item at the given state root hash, under the given key and path.
-///
-/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
-///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
-///   empty.  If empty, a random ID will be assigned.
-/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
-///   `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the request will be printed to `stdout`.
-/// * `state_root_hash` must be a hex-encoded, 32-byte hash digest.
-/// * `key` must be a formatted [`PublicKey`](casper_node::crypto::asymmetric_key::PublicKey) or
-///   [`Key`](casper_types::Key).  This will take the form of e.g.
-///       * `01c9e33693951aaac23c49bee44ad6f863eedcd38c084a3a8f11237716a3df9c2c` or
-///       * `account-hash-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20` or
-///       * `hash-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20` or
-///       * `uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007`
-/// * `path` is comprised of components starting from the `key`, separated by `/`s.
-pub fn get_item(
-    maybe_rpc_id: &str,
-    node_address: &str,
-    verbose: bool,
-    state_root_hash: &str,
-    key: &str,
-    path: &str,
-) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_item(state_root_hash, key, path)
-}
-
-/// Queries the node for a state root hash at a given `Block`.
-///
-/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
-///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
-///   empty.  If empty, a random ID will be assigned.
-/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
-///   `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the request will be printed to `stdout`.
-/// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the block
-///   height or empty.  If empty, the latest block will be used.
-pub fn get_state_root_hash(
-    maybe_rpc_id: &str,
-    node_address: &str,
-    verbose: bool,
-    maybe_block_id: &str,
-) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_state_root_hash(maybe_block_id)
-}
-
-/// Gets the balance from a purse.
-///
-/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
-///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
-///   empty.  If empty, a random ID will be assigned.
-/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
-///   `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the request will be printed to `stdout`.
-/// * `state_root_hash` must be a hex-encoded, 32-byte hash digest.
-/// * `purse_uref` must be a formatted URef as obtained with `get_item`.  This will take the form of
-///   e.g. `uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007`
-pub fn get_balance(
-    maybe_rpc_id: &str,
-    node_address: &str,
-    verbose: bool,
-    state_root_hash: &str,
-    purse_uref: &str,
-) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_balance(state_root_hash, purse_uref)
-}
-
-/// Gets the bids and validators as of the most recently added block.
-///
-/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
-///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
-///   empty.  If empty, a random ID will be assigned.
-/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
-///   `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the request will be printed to `stdout`.
-/// * `state_root_hash` must be a hex-encoded, 32-byte hash digest.
-pub fn get_auction_info(maybe_rpc_id: &str, node_address: &str, verbose: bool) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_auction_info()
-}
-
-/// Reads a previously-saved `Deploy` from file, and sends that to the node.
-///
-/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
-///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
-///   empty.  If empty, a random ID will be assigned.
-/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
-///   `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the request will be printed to `stdout`.
-/// * `input_path` is the path to the file to read.
-pub fn send_deploy_file(
-    maybe_rpc_id: &str,
-    node_address: &str,
-    verbose: bool,
-    input_path: &str,
-) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose)?.send_deploy_file(input_path)
-}
-
-/// Gets a `Block` from the node.
-///
-/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
-///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
-///   empty.  If empty, a random ID will be assigned.
-/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
-///   `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the request will be printed to `stdout`.
-/// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the block
-///   height or empty.  If empty, the latest block will be retrieved.
-pub fn get_block(
-    maybe_rpc_id: &str,
-    node_address: &str,
-    verbose: bool,
-    maybe_block_id: &str,
-) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_block(maybe_block_id)
-}
-
-/// Puts a `Deploy` on a node.
-///
-/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
-///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
-///   empty.  If empty, a random ID will be assigned.
-/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
-///   `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the request will be printed to `stdout`.
-/// * `deploy` contains deploy-related options for this deploy. See `DeployStrParams` for more
-///   details.
-/// * `session` contains session-related options for this deploy. See `SessionStrParams` for more
-///   details.
-/// * `payment` contains payment-related options for this deploy. See `PaymentStrParams` for more
-///   details.
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
+///   be assigned.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * `deploy` contains deploy-related options for this `Deploy`. See
+///   [`DeployStrParams`](struct.DeployStrParams.html) for more details.
+/// * `session` contains session-related options for this `Deploy`. See
+///   [`SessionStrParams`](struct.SessionStrParams.html) for more details.
+/// * `payment` contains payment-related options for this `Deploy`. See
+///   [`PaymentStrParams`](struct.PaymentStrParams.html) for more details.
 pub fn put_deploy(
     maybe_rpc_id: &str,
     node_address: &str,
@@ -203,20 +68,25 @@ pub fn put_deploy(
     RpcCall::new(maybe_rpc_id, node_address, verbose)?.put_deploy(deploy)
 }
 
-/// Make a deploy and output to file or stdout.
+/// Creates a `Deploy` and outputs it to a file or stdout.
 ///
-/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
-///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
-///   empty.  If empty, a random ID will be assigned.
-/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
-///   `"http://127.0.0.1:7777"`.
-/// * `maybe_output_path` specifies the output file, or if left empty, will log it to `stdout`.
-/// * `deploy` contains deploy-related options for this deploy. See `DeployStrParams` for more
-///   details.
-/// * `session` contains session-related options for this deploy. See `SessionStrParams` for more
-///   details.
-/// * `payment` contains payment-related options for this deploy. See `PaymentStrParams` for more
-///   details.
+/// As a file, the `Deploy` can subsequently be signed by other parties using
+/// [`sign_deploy_file()`](fn.sign_deploy_file.html) and then sent to the network for execution
+/// using [`send_deploy_file()`](fn.send_deploy_file.html).
+///
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
+///   be assigned.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`. If the
+///   file already exists, it will be overwritten.
+/// * `deploy` contains deploy-related options for this `Deploy`. See
+///   [`DeployStrParams`](struct.DeployStrParams.html) for more details.
+/// * `session` contains session-related options for this `Deploy`. See
+///   [`SessionStrParams`](struct.SessionStrParams.html) for more details.
+/// * `payment` contains payment-related options for this `Deploy`. See
+///   [`PaymentStrParams`](struct.PaymentStrParams.html) for more details.
 pub fn make_deploy(
     maybe_output_path: &str,
     deploy: DeployStrParams<'_>,
@@ -231,25 +101,61 @@ pub fn make_deploy(
     )
 }
 
-/// Transfers an amount between purses.
+/// Reads a previously-saved `Deploy` from a file, cryptographically signs it, and outputs it to a
+/// file or stdout.
 ///
-/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
-///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
-///   empty.  If empty, a random ID will be assigned.
-/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
-///   `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `input_path` specifies the path to the previously-saved `Deploy` file.
+/// * `secret_key` specifies the path to the secret key with which to sign the `Deploy`.
+/// * `maybe_output_path` specifies the output file, or if empty, will print it to `stdout`. If the
+///   file already exists, it will be overwritten.
+pub fn sign_deploy_file(input_path: &str, secret_key: &str, maybe_output_path: &str) -> Result<()> {
+    let secret_key = parsing::secret_key(secret_key)?;
+    let maybe_output = parsing::output(maybe_output_path);
+    Deploy::sign_deploy_file(&input_path, secret_key, maybe_output)
+}
+
+/// Reads a previously-saved `Deploy` from a file and sends it to the network for execution.
+///
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
+///   be assigned.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * `input_path` specifies the path to the previously-saved `Deploy` file.
+pub fn send_deploy_file(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    input_path: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.send_deploy_file(input_path)
+}
+
+/// Transfers funds between purses.
+///
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
+///   be assigned.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
 /// * `amount` specifies the amount to be transferred.
-/// * `maybe_source_purse` is the source purse in the sender's account that this amount will be
-///   drawn from, if it is `""`, it will default to the account's main purse.
-/// * `maybe_target_purse` is the target purse in the sender's account that this amount will be
-///   transferred to. It is incompatible with `maybe_target_account`.
-/// * `maybe_target_account` is the target account that this amount will be transferred to. It is
-///   incompatible with `maybe_target_purse`.
-/// * `deploy` contains deploy-related options for this deploy. See `DeployStrParams` for more
-///   details.
-/// * `payment` contains payment-related options for this deploy. See `PaymentStrParams` for more
-///   details.
+/// * `maybe_source_purse` is the purse `URef` from which the funds will be transferred, formatted
+///   as e.g. `uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007`. If it is
+///   an empty string, the network will use the main purse from the sender's account.
+/// * `maybe_target_purse` is the purse `URef` into which the funds will be transferred, formatted
+///   as e.g. `uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007`. If it is
+///   an empty string, `maybe_target_account` must be specified instead. These options are
+///   incompatible: exactly one must be empty and the other valid.
+/// * `maybe_target_account` is the account `PublicKey` into which the funds will be transferred,
+///   formatted as a hex-encoded string. The account's main purse will receive the funds. If it is
+///   an empty string, `maybe_target_purse` must be specified instead. These options are
+///   incompatible: exactly one must be empty and the other valid.
+/// * `deploy` contains deploy-related options for this `Deploy`. See
+///   [`DeployStrParams`](struct.DeployStrParams.html) for more details.
+/// * `payment` contains payment-related options for this `Deploy`. See
+///   [`PaymentStrParams`](struct.PaymentStrParams.html) for more details.
 #[allow(clippy::too_many_arguments)]
 pub fn transfer(
     maybe_rpc_id: &str,
@@ -278,35 +184,157 @@ pub fn transfer(
     )
 }
 
-/// Signs a `Deploy` file.
+/// Retrieves a `Deploy` from the network.
 ///
-/// * `input_path` specifies the path to the deploy file.
-/// * `secret_key` specifies the key with which to sign the deploy.
-/// * `maybe_output_path` specifies the output file, or if left empty, will log it to `stdout`.
-pub fn sign_deploy_file(input_path: &str, secret_key: &str, maybe_output_path: &str) -> Result<()> {
-    let secret_key = parsing::secret_key(secret_key)?;
-    let maybe_output = parsing::output(maybe_output_path);
-    Deploy::sign_deploy_file(&input_path, secret_key, maybe_output)
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
+///   be assigned.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * `deploy_hash` must be a hex-encoded, 32-byte hash digest.
+pub fn get_deploy(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    deploy_hash: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_deploy(deploy_hash)
+}
+
+/// Retrieves a `Block` from the network.
+///
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
+///   be assigned.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the
+///   `Block` height or empty. If empty, the latest `Block` will be retrieved.
+pub fn get_block(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    maybe_block_id: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_block(maybe_block_id)
+}
+
+/// Retrieves a state root hash at a given `Block`.
+///
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
+///   be assigned.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the
+///   `Block` height or empty. If empty, the latest `Block` will be used.
+pub fn get_state_root_hash(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    maybe_block_id: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_state_root_hash(maybe_block_id)
+}
+
+/// Retrieves a stored value from the network.
+///
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
+///   be assigned.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * `state_root_hash` must be a hex-encoded, 32-byte hash digest.
+/// * `key` must be a formatted [`PublicKey`](https://docs.rs/casper-node/latest/casper-node/crypto/asymmetric_key/enum.PublicKey.html)
+///   or [`Key`](https://docs.rs/casper-types/latest/casper-types/enum.PublicKey.html). This will
+///   take one of the following forms:
+/// ```text
+/// 01c9e33693951aaac23c49bee44ad6f863eedcd38c084a3a8f11237716a3df9c2c           # PublicKey
+/// account-hash-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20  # Key::Account
+/// hash-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20        # Key::Hash
+/// uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007    # Key::URef
+/// transfer-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20    # Key::Transfer
+/// deploy-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20      # Key::DeployInfo
+/// ```
+/// * `path` is comprised of components starting from the `key`, separated by `/`s.
+pub fn get_item(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    state_root_hash: &str,
+    key: &str,
+    path: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_item(state_root_hash, key, path)
+}
+
+/// Retrieves a purse's balance from the network.
+///
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
+///   be assigned.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * `state_root_hash` must be a hex-encoded, 32-byte hash digest.
+/// * `purse` is a URef, formatted as e.g.
+/// ```text
+/// uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007
+/// ```
+pub fn get_balance(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    state_root_hash: &str,
+    purse: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_balance(state_root_hash, purse)
+}
+
+/// Retrieves the bids and validators as of the most recently added `Block`.
+///
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. It must either be able to be parsed as a `u32` or empty. If empty, a random ID will
+///   be assigned.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+pub fn get_auction_info(maybe_rpc_id: &str, node_address: &str, verbose: bool) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_auction_info()
 }
 
 /// Container for `Deploy` construction options.
 pub struct DeployStrParams<'a> {
-    /// Path to secret key file
+    /// Path to secret key file.
     pub secret_key: &'a str,
-    /// RFC3339-like formatted timestamp. e.g. `2018-02-16T00:31:37Z`. If not provided, the current
-    /// time will be used. See https://docs.rs/humantime/latest/humantime/fn.parse_rfc3339_weak.html for more information.
+    /// RFC3339-like formatted timestamp. e.g. `2018-02-16T00:31:37Z`.
+    ///
+    /// If `timestamp` is empty, the current time will be used. Note that timestamp is UTC, not
+    /// local.
+    ///
+    /// See
+    /// [the `humantime` docs](https://docs.rs/humantime/latest/humantime/fn.parse_rfc3339_weak.html)
+    /// for more information.
     pub timestamp: &'a str,
-    /// Time that the deploy will remain valid for. A deploy can only be included in a block
-    /// between `timestamp` and `timestamp + ttl`. Input examples: '1hr 12min', '30min 50sec',
-    /// '1day'. For all options, see https://docs.rs/humantime/latest/humantime/fn.parse_duration.html [default: 1hour]
+    /// Time that the `Deploy` will remain valid for.
+    ///
+    /// A `Deploy` can only be included in a `Block` between `timestamp` and `timestamp + ttl`.
+    /// Input examples: '1hr 12min', '30min 50sec', '1day'.
+    ///
+    /// See
+    /// [the `humantime` docs](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html)
+    /// for more information.
     pub ttl: &'a str,
-    /// A hex-encoded deploy hash of a deploy which must be executed before this deploy
-    pub dependencies: &'a [&'a str],
-    /// Conversion rate between the cost of Wasm opcodes and the motes sent by the payment code
-    /// [default: 10]
+    /// Conversion rate between the cost of Wasm opcodes and the motes sent by the payment code.
     pub gas_price: &'a str,
-    /// Name of the chain, to avoid the deploy from being accidentally or maliciously included in a
-    /// different chain
+    /// Hex-encoded `Deploy` hashes of deploys which must be executed before this one.
+    pub dependencies: &'a [&'a str],
+    /// Name of the chain, to avoid the `Deploy` from being accidentally or maliciously included in
+    /// a different chain.
     pub chain_name: &'a str,
 }
 
@@ -333,7 +361,68 @@ impl<'a> TryInto<DeployParams> for DeployStrParams<'a> {
     }
 }
 
-/// Container for payment related arguments.
+/// Container for payment-related arguments used while constructing a `Deploy`.
+///
+/// ## `payment_args_simple`
+///
+/// For methods taking `payment_args_simple`, this parameter is the payment contract arguments, in
+/// the form `<NAME:TYPE='VALUE'>` or `<NAME:TYPE=null>`.
+///
+/// It can only be used with the following simple `CLType`s: bool, i32, i64, u8, u32, u64, u128,
+/// u256, u512, unit, string, key, account_hash, uref, public_key and `Option` of each of these.
+///
+/// Example inputs are:
+///
+/// ```text
+/// name_01:bool='false'
+/// name_02:i32='-1'
+/// name_03:i64='-2'
+/// name_04:u8='3'
+/// name_05:u32='4'
+/// name_06:u64='5'
+/// name_07:u128='6'
+/// name_08:u256='7'
+/// name_09:u512='8'
+/// name_10:unit=''
+/// name_11:string='a value'
+/// key_account_name:key='account-hash-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20'
+/// key_hash_name:key='hash-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20'
+/// key_uref_name:key='uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-000'
+/// account_hash_name:account_hash='account-hash-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20'
+/// uref_name:uref='uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007'
+/// public_key_name:public_key='0119bf44096984cdfe8541bac167dc3b96c85086aa30b6b6cb0c5c38ad703166e1'
+/// ```
+///
+/// For optional values of any these types, prefix the type with "opt_" and use the term "null"
+/// without quotes to specify a None value:
+///
+/// ```text
+/// name_01:opt_bool='true'       # Some(true)
+/// name_02:opt_bool='false'      # Some(false)
+/// name_03:opt_bool=null         # None
+/// name_04:opt_i32='-1'          # Some(-1)
+/// name_05:opt_i32=null          # None
+/// name_06:opt_unit=''           # Some(())
+/// name_07:opt_unit=null         # None
+/// name_08:opt_string='a value'  # Some("a value".to_string())
+/// name_09:opt_string='null'     # Some("null".to_string())
+/// name_10:opt_string=null       # None
+/// ```
+///
+/// To get a list of supported types, call
+/// [`supported_cl_type_list()`](help/fn.supported_cl_type_list.html). To get this list of examples
+/// for supported types, call
+/// [`supported_cl_type_examples()`](help/fn.supported_cl_type_examples.html).
+///
+/// ## `payment_args_complex`
+///
+/// For methods taking `payment_args_complex`, this parameter is the payment contract arguments, in
+/// the form of a `ToBytes`-encoded file.
+///
+/// ---
+///
+/// **Note** while multiple payment args can be specified for a single payment code instance, only
+/// one of `payment_args_simple` and `payment_args_complex` may be used.
 #[derive(Default)]
 pub struct PaymentStrParams<'a> {
     payment_amount: &'a str,
@@ -381,11 +470,11 @@ impl<'a> TryInto<ExecutableDeployItem> for PaymentStrParams<'a> {
 }
 
 impl<'a> PaymentStrParams<'a> {
-    /// Construct PaymentStrParams from a file.
+    /// Constructs a `PaymentStrParams` using a payment smart contract file.
     ///
     /// * `payment_path` is the path to the compiled Wasm payment code.
-    /// * See `Self::with_name` for a description of `payment_args_simple` and
-    ///   `payment_args_complex`.
+    /// * See the struct docs for a description of [`payment_args_simple`](#payment_args_simple) and
+    ///   [`payment_args_complex`](#payment_args_complex).
     pub fn with_path(
         payment_path: &'a str,
         payment_args_simple: Vec<&'a str>,
@@ -399,7 +488,7 @@ impl<'a> PaymentStrParams<'a> {
         }
     }
 
-    /// Construct a PaymentStrParams from an amount.
+    /// Constructs a `PaymentStrParams` using a payment amount.
     ///
     /// `payment_amount` uses the standard-payment system contract rather than custom payment Wasm.
     /// The value is the 'amount' arg of the standard-payment contract.
@@ -410,21 +499,14 @@ impl<'a> PaymentStrParams<'a> {
         }
     }
 
-    /// Construct PaymentStrParams with a name.
+    /// Constructs a `PaymentStrParams` using a stored contract's name.
     ///
     /// * `payment_name` is the name of the stored contract (associated with the executing account)
-    /// to be called as the payment.
+    ///   to be called as the payment.
     /// * `payment_entry_point` is the name of the method that will be used when calling the payment
     ///   contract.
-    /// * `payment_args_simple` is payment contract arguments, of the form `<NAME:TYPE='VALUE'>...`
-    /// For simple CLTypes, a named and typed arg which is passed to the Wasm code. To see an
-    /// example for each type, run 'casper-client --show-arg-examples'. This arg can be
-    /// repeated to pass multiple named, typed args, but can only be used for the following
-    /// types: `bool, i32, i64, u8, u32, u64, u128, u256, u512, unit, string, key, account_hash,
-    /// uref, public_key`.
-    /// * `payment_args_complex` is the path to file containing named and typed args for passing to
-    /// the Wasm code.
-    /// Note that only one of `payment_args_simple` and `payment_args_complex` should be used.
+    /// * See the struct docs for a description of [`payment_args_simple`](#payment_args_simple) and
+    ///   [`payment_args_complex`](#payment_args_complex).
     pub fn with_name(
         payment_name: &'a str,
         payment_entry_point: &'a str,
@@ -440,14 +522,13 @@ impl<'a> PaymentStrParams<'a> {
         }
     }
 
-    /// Construct PaymentStrParams with a hex-encoded hash.
+    /// Constructs a `PaymentStrParams` using a stored contract's hex-encoded hash.
     ///
-    /// * `payment_hash` is the hex-encoded hash of the stored contract to be called as the
-    /// payment.
+    /// * `payment_hash` is the hex-encoded hash of the stored contract to be called as the payment.
     /// * `payment_entry_point` is the name of the method that will be used when calling the payment
     ///   contract.
-    /// * See `Self::with_name` for a description of `payment_args_simple` and
-    ///   `payment_args_complex`.
+    /// * See the struct docs for a description of [`payment_args_simple`](#payment_args_simple) and
+    ///   [`payment_args_complex`](#payment_args_complex).
     pub fn with_hash(
         payment_hash: &'a str,
         payment_entry_point: &'a str,
@@ -463,15 +544,15 @@ impl<'a> PaymentStrParams<'a> {
         }
     }
 
-    /// Construct PaymentStrParams with a package name.
+    /// Constructs a `PaymentStrParams` using a stored contract's package name.
     ///
     /// * `payment_package_name` is the name of the stored package to be called as the payment.
-    /// * `payment_version` is the version of the called payment contract. Latest will be used by
-    ///   default.
+    /// * `payment_version` is the version of the called payment contract. The latest will be used
+    ///   if `payment_version` is empty.
     /// * `payment_entry_point` is the name of the method that will be used when calling the payment
     ///   contract.
-    /// * See `Self::with_name` for a description of `payment_args_simple` and
-    ///   `payment_args_complex`.
+    /// * See the struct docs for a description of [`payment_args_simple`](#payment_args_simple) and
+    ///   [`payment_args_complex`](#payment_args_complex).
     pub fn with_package_name(
         payment_package_name: &'a str,
         payment_version: &'a str,
@@ -489,16 +570,16 @@ impl<'a> PaymentStrParams<'a> {
         }
     }
 
-    /// Construct PaymentStrParams with a package hash.
+    /// Constructs a `PaymentStrParams` using a stored contract's package hash.
     ///
     /// * `payment_package_hash` is the hex-encoded hash of the stored package to be called as the
     ///   payment.
-    /// * `payment_version` is the version of the called payment contract. Latest will be used by
-    ///   default.
+    /// * `payment_version` is the version of the called payment contract. The latest will be used
+    ///   if `payment_version` is empty.
     /// * `payment_entry_point` is the name of the method that will be used when calling the payment
     ///   contract.
-    /// * See `Self::with_name` for a description of `payment_args_simple` and
-    ///   `payment_args_complex`.
+    /// * See the struct docs for a description of [`payment_args_simple`](#payment_args_simple) and
+    ///   [`payment_args_complex`](#payment_args_complex).
     pub fn with_package_hash(
         payment_package_hash: &'a str,
         payment_version: &'a str,
@@ -547,7 +628,26 @@ impl<'a> TryInto<ExecutableDeployItem> for SessionStrParams<'a> {
     }
 }
 
-/// Container for session related arguments.
+/// Container for session-related arguments used while constructing a `Deploy`.
+///
+/// ## `session_args_simple`
+///
+/// For methods taking `session_args_simple`, this parameter is the session contract arguments, in
+/// the form `<NAME:TYPE='VALUE'>` or `<NAME:TYPE=null>`.
+///
+/// There are further details in
+/// [the docs for the equivalent
+/// `payment_args_simple`](struct.PaymentStrParams.html#payment_args_simple).
+///
+/// ## `session_args_complex`
+///
+/// For methods taking `session_args_complex`, this parameter is the session contract arguments, in
+/// the form of a `ToBytes`-encoded file.
+///
+/// ---
+///
+/// **Note** while multiple payment args can be specified for a single session code instance, only
+/// one of `session_args_simple` and `session_args_complex` may be used.
 #[derive(Default)]
 pub struct SessionStrParams<'a> {
     session_hash: &'a str,
@@ -562,11 +662,11 @@ pub struct SessionStrParams<'a> {
 }
 
 impl<'a> SessionStrParams<'a> {
-    /// Construct a SessionStrParams from a file.
+    /// Constructs a `SessionStrParams` using a session smart contract file.
     ///
     /// * `session_path` is the path to the compiled Wasm session code.
-    /// * See `Self::with_name` for a description of `session_args_simple` and
-    ///   `session_args_complex`.
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    ///   [`session_args_complex`](#session_args_complex).
     pub fn with_path(
         session_path: &'a str,
         session_args_simple: Vec<&'a str>,
@@ -580,21 +680,14 @@ impl<'a> SessionStrParams<'a> {
         }
     }
 
-    /// Construct `SessionStrParams` with a name.
+    /// Constructs a `SessionStrParams` using a stored contract's name.
     ///
     /// * `session_name` is the name of the stored contract (associated with the executing account)
-    /// to be called as the session.
+    ///   to be called as the session.
     /// * `session_entry_point` is the name of the method that will be used when calling the session
     ///   contract.
-    /// * `session_args_simple` is session contract arguments, of the form `<NAME:TYPE='VALUE'>...`
-    /// For simple CLTypes, a named and typed arg which is passed to the Wasm code. To see an
-    /// example for each type, run 'casper-client --show-arg-examples'. This arg can be
-    /// repeated to pass multiple named, typed args, but can only be used for the following
-    /// types: `bool, i32, i64, u8, u32, u64, u128, u256, u512, unit, string, key, account_hash,
-    /// uref, public_key`.
-    /// * `session_args_complex` is the path to file containing named and typed args for passing to
-    /// the Wasm code.
-    /// Note that only one of `session_args_simple` and `session_args_complex` should be used.
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    ///   [`session_args_complex`](#session_args_complex).
     pub fn with_name(
         session_name: &'a str,
         session_entry_point: &'a str,
@@ -610,14 +703,13 @@ impl<'a> SessionStrParams<'a> {
         }
     }
 
-    /// Construct `SessionStrParams` with a hex-encoded hash.
+    /// Constructs a `SessionStrParams` using a stored contract's hex-encoded hash.
     ///
-    /// * `session_hash` is the hex-encoded hash of the stored contract to be called as the
-    /// session.
+    /// * `session_hash` is the hex-encoded hash of the stored contract to be called as the session.
     /// * `session_entry_point` is the name of the method that will be used when calling the session
     ///   contract.
-    /// * See `Self::with_name` for a description of `session_args_simple` and
-    ///   `session_args_complex`.
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    ///   [`session_args_complex`](#session_args_complex).
     pub fn with_hash(
         session_hash: &'a str,
         session_entry_point: &'a str,
@@ -633,15 +725,15 @@ impl<'a> SessionStrParams<'a> {
         }
     }
 
-    /// Construct `SessionStrParams` with a package name.
+    /// Constructs a `SessionStrParams` using a stored contract's package name.
     ///
     /// * `session_package_name` is the name of the stored package to be called as the session.
-    /// * `session_version` is the version of the called session contract. Latest will be used by
-    ///   default.
+    /// * `session_version` is the version of the called session contract. The latest will be used
+    ///   if `session_version` is empty.
     /// * `session_entry_point` is the name of the method that will be used when calling the session
     ///   contract.
-    /// * See `Self::with_name` for a description of `session_args_simple` and
-    ///   `session_args_complex`.
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    ///   [`session_args_complex`](#session_args_complex).
     pub fn with_package_name(
         session_package_name: &'a str,
         session_version: &'a str,
@@ -659,16 +751,16 @@ impl<'a> SessionStrParams<'a> {
         }
     }
 
-    /// Construct SessionStrParams with a package hash.
+    /// Constructs a `SessionStrParams` using a stored contract's package hash.
     ///
     /// * `session_package_hash` is the hex-encoded hash of the stored package to be called as the
     ///   session.
-    /// * `session_version` is the version of the called session contract. Latest will be used by
-    ///   default.
+    /// * `session_version` is the version of the called session contract. The latest will be used
+    ///   if `session_version` is empty.
     /// * `session_entry_point` is the name of the method that will be used when calling the session
     ///   contract.
-    /// * See `Self::with_name` for a description of `session_args_simple` and
-    ///   `session_args_complex`.
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    ///   [`session_args_complex`](#session_args_complex).
     pub fn with_package_hash(
         session_package_hash: &'a str,
         session_version: &'a str,

--- a/client/lib/parsing.rs
+++ b/client/lib/parsing.rs
@@ -60,7 +60,7 @@ fn dependencies(values: &[&str]) -> Result<Vec<DeployHash>> {
 mod arg_simple {
     use super::*;
 
-    const ARG_VALUE_NAME: &str = "NAME:TYPE='VALUE'";
+    const ARG_VALUE_NAME: &str = r#""NAME:TYPE='VALUE'" OR "NAME:TYPE=null""#;
 
     pub(crate) mod session {
         use super::*;

--- a/client/lib/parsing.rs
+++ b/client/lib/parsing.rs
@@ -22,7 +22,7 @@ use crate::{
     cl_type,
     deploy::DeployParams,
     error::{Error, Result},
-    ExecutableDeployItemExt, TransferTarget,
+    help, ExecutableDeployItemExt, TransferTarget,
 };
 
 pub(super) fn none_if_empty(value: &'_ str) -> Option<&'_ str> {
@@ -108,7 +108,7 @@ mod arg_simple {
             Error::InvalidCLValue(format!(
                 "unknown variant {}, expected one of {}",
                 parts[1],
-                cl_type::supported_cl_type_list()
+                help::supported_cl_type_list()
             ))
         })?;
         Ok((parts[0], cl_type, parts[2]))
@@ -126,7 +126,7 @@ mod arg_simple {
     }
 }
 
-/// Handles providing the arg for and retrieval of complex session and payment args.  These are read
+/// Handles providing the arg for and retrieval of complex session and payment args. These are read
 /// in from a file.
 mod args_complex {
     use super::*;

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -1,5 +1,5 @@
 use futures::executor;
-use jsonrpc_lite::{JsonRpc, Params};
+use jsonrpc_lite::{Id, JsonRpc, Params};
 use rand::Rng;
 use reqwest::Client;
 use serde::Serialize;
@@ -36,11 +36,9 @@ pub(crate) enum TransferTarget {
 }
 
 /// Struct representing a single JSON-RPC call to the casper node.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct RpcCall {
-    // TODO - If/when https://github.com/AtsukiTak/warp-json-rpc/pull/1 is merged and published,
-    //        change `rpc_id` to a `jsonrpc_lite::Id`.
-    rpc_id: u32,
+    rpc_id: Id,
     node_address: String,
     verbose: bool,
 }
@@ -58,9 +56,11 @@ impl RpcCall {
     /// When `verbose` is `true`, the request will be printed to `stdout`.
     pub(crate) fn new(maybe_rpc_id: &str, node_address: &str, verbose: bool) -> Result<Self> {
         let rpc_id = if maybe_rpc_id.is_empty() {
-            rand::thread_rng().gen()
+            Id::from(rand::thread_rng().gen::<i64>())
+        } else if let Ok(i64_id) = maybe_rpc_id.parse::<i64>() {
+            Id::from(i64_id)
         } else {
-            maybe_rpc_id.parse()?
+            Id::from(maybe_rpc_id.to_string())
         };
 
         Ok(Self {
@@ -209,7 +209,7 @@ impl RpcCall {
 
     async fn request(self, method: &str, params: Params) -> Result<JsonRpc> {
         let url = format!("{}/{}", self.node_address, RPC_API_PATH);
-        let rpc_req = JsonRpc::request_with_params(self.rpc_id as i64, method, params);
+        let rpc_req = JsonRpc::request_with_params(self.rpc_id, method, params);
 
         if self.verbose {
             println!(

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -65,7 +65,7 @@ impl RpcCall {
 
         Ok(Self {
             rpc_id,
-            node_address: node_address.to_string(),
+            node_address: node_address.trim_end_matches('/').to_string(),
             verbose,
         })
     }

--- a/client/lib/validation.rs
+++ b/client/lib/validation.rs
@@ -187,7 +187,12 @@ pub(crate) fn validate_get_block_response(
     let block_value = maybe_result
         .and_then(|value| value.get("block"))
         .ok_or_else(|| ValidateResponseError::NoBlockInResponse)?;
-    let block: Block = serde_json::from_value(block_value.to_owned())?;
+    let maybe_block: Option<Block> = serde_json::from_value(block_value.to_owned())?;
+    let block = if let Some(block) = maybe_block {
+        block
+    } else {
+        return Ok(());
+    };
     block.verify()?;
     match maybe_block_identifier {
         Some(BlockIdentifier::Hash(block_hash)) => {

--- a/client/lib/validation.rs
+++ b/client/lib/validation.rs
@@ -201,7 +201,7 @@ pub(crate) fn validate_get_block_response(
                 return Err(ValidateResponseError::UnexpectedBlockHeight);
             }
         }
-        // More is necessary here to mitigate a MITM attack.  In this case we would want to validate
+        // More is necessary here to mitigate a MITM attack. In this case we would want to validate
         // `block.proofs()` to make sure that 1/3 of the validator weight signed the block, and we
         // would have to know the latest validators through some trustworthy means
         None => (),

--- a/client/src/block/get.rs
+++ b/client/src/block/get.rs
@@ -16,7 +16,7 @@ enum DisplayOrder {
 
 impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
     const NAME: &'static str = "get-block";
-    const ABOUT: &'static str = "Retrieves a block";
+    const ABOUT: &'static str = "Retrieves a block from the network";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         SubCommand::with_name(Self::NAME)

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -141,7 +141,7 @@ pub mod state_root_hash {
     use super::*;
 
     const ARG_NAME: &str = "state-root-hash";
-    const ARG_SHORT: &str = "g";
+    const ARG_SHORT: &str = "s";
     const ARG_VALUE_NAME: &str = super::ARG_HEX_STRING;
     const ARG_HELP: &str = "Hex-encoded hash of the state root";
 

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -11,7 +11,7 @@ pub mod verbose {
 
     pub const ARG_NAME: &str = "verbose";
     const ARG_NAME_SHORT: &str = "v";
-    const ARG_HELP: &str = "Generates verbose output";
+    const ARG_HELP: &str = "Generates verbose output, e.g. prints the RPC request";
 
     pub fn arg(order: usize) -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)
@@ -63,7 +63,7 @@ pub mod rpc_id {
     //       update this to "STRING OR INTEGER".
     const ARG_VALUE_NAME: &str = "INTEGER";
     const ARG_HELP: &str =
-        "JSON-RPC identifier, applied to the request and returned in the response.  If not \
+        "JSON-RPC identifier, applied to the request and returned in the response. If not \
         provided, a random one will be assigned";
 
     pub fn arg(order: usize) -> Arg<'static, 'static> {
@@ -168,9 +168,9 @@ pub mod block_identifier {
 
     const ARG_NAME: &str = "block-identifier";
     const ARG_SHORT: &str = "b";
-    const ARG_VALUE_NAME: &str = super::ARG_HEX_STRING;
+    const ARG_VALUE_NAME: &str = "HEX STRING OR INTEGER";
     const ARG_HELP: &str =
-        "Hex-encoded block hash or height of the block.  If not given, the last block added to the \
+        "Hex-encoded block hash or height of the block. If not given, the last block added to the \
         chain as known at the given node will be used";
 
     pub(crate) fn arg(order: usize) -> Arg<'static, 'static> {

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -59,12 +59,10 @@ pub mod rpc_id {
     use super::*;
 
     const ARG_NAME: &str = "id";
-    // TODO: If/when https://github.com/AtsukiTak/warp-json-rpc/pull/1 is merged and published,
-    //       update this to "STRING OR INTEGER".
-    const ARG_VALUE_NAME: &str = "INTEGER";
+    const ARG_VALUE_NAME: &str = "STRING OR INTEGER";
     const ARG_HELP: &str =
         "JSON-RPC identifier, applied to the request and returned in the response. If not \
-        provided, a random one will be assigned";
+        provided, a random integer will be assigned";
 
     pub fn arg(order: usize) -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)

--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -1,14 +1,12 @@
 //! This module contains structs and helpers which are used by multiple subcommands related to
 //! creating deploys.
 
-use std::{convert::TryFrom, process};
+use std::process;
 
 use clap::{App, AppSettings, Arg, ArgGroup, ArgMatches};
 use lazy_static::lazy_static;
 
-use casper_client::{cl_type, PaymentStrParams, SessionStrParams};
-use casper_node::crypto::asymmetric_key::PublicKey as NodePublicKey;
-use casper_types::{account::AccountHash, AccessRights, Key, URef};
+use casper_client::{help, PaymentStrParams, SessionStrParams};
 
 use crate::common;
 
@@ -75,63 +73,8 @@ pub(super) mod show_arg_examples {
             return false;
         }
 
-        let bytes = (1..33).collect::<Vec<_>>();
-        let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
-
         println!("Examples for passing values via --session-arg or --payment-arg:");
-        println!("name_01:bool='false'");
-        println!("name_02:i32='-1'");
-        println!("name_03:i64='-2'");
-        println!("name_04:u8='3'");
-        println!("name_05:u32='4'");
-        println!("name_06:u64='5'");
-        println!("name_07:u128='6'");
-        println!("name_08:u256='7'");
-        println!("name_09:u512='8'");
-        println!("name_10:unit=''");
-        println!("name_11:string='a value'");
-        println!(
-            "key_account_name:key='{}'",
-            Key::Account(AccountHash::new(array)).to_formatted_string()
-        );
-        println!(
-            "key_hash_name:key='{}'",
-            Key::Hash(array).to_formatted_string()
-        );
-        println!(
-            "key_uref_name:key='{}'",
-            Key::URef(URef::new(array, AccessRights::NONE)).to_formatted_string()
-        );
-        println!(
-            "account_hash_name:account_hash='{}'",
-            AccountHash::new(array).to_formatted_string()
-        );
-        println!(
-            "uref_name:uref='{}'",
-            URef::new(array, AccessRights::READ_ADD_WRITE).to_formatted_string()
-        );
-        println!(
-            "public_key_name:public_key='{}'",
-            NodePublicKey::from_hex(
-                "0119bf44096984cdfe8541bac167dc3b96c85086aa30b6b6cb0c5c38ad703166e1"
-            )
-            .unwrap()
-            .to_hex()
-        );
-        println!("\nOptional values of each of these types can also be specified.");
-        println!(
-            r#"Prefix the type with "opt_" and use the term "null" without quotes to specify a None value:"#
-        );
-        println!("name_01:opt_bool='true'       # Some(true)");
-        println!("name_02:opt_bool='false'      # Some(false)");
-        println!("name_03:opt_bool=null         # None");
-        println!("name_04:opt_i32='-1'          # Some(-1)");
-        println!("name_05:opt_i32=null          # None");
-        println!("name_06:opt_unit=''           # Some(())");
-        println!("name_07:opt_unit=null         # None");
-        println!("name_08:opt_string='a value'  # Some(\"a value\".to_string())");
-        println!("name_09:opt_string='null'     # Some(\"null\".to_string())");
-        println!("name_10:opt_string=null       # None");
+        println!("{}", help::supported_cl_type_examples());
 
         true
     }
@@ -409,7 +352,7 @@ pub(super) mod arg_simple {
             an example for each type, run '--{}'. This arg can be repeated to pass multiple named, \
             typed args, but can only be used for the following types: {}",
             super::show_arg_examples::ARG_NAME,
-            cl_type::supported_cl_type_list()
+            help::supported_cl_type_list()
         );
     }
 
@@ -466,14 +409,15 @@ pub(super) mod arg_simple {
     }
 }
 
-/// Handles providing the arg for and retrieval of complex session and payment args.  These are read
+/// Handles providing the arg for and retrieval of complex session and payment args. These are read
 /// in from a file.
 pub(super) mod args_complex {
     use super::*;
 
     const ARG_VALUE_NAME: &str = common::ARG_PATH;
     const ARG_HELP: &str =
-        "Path to file containing named and typed args for passing to the Wasm code";
+        "Path to file containing 'ToBytes'-encoded named and typed args for passing to the Wasm \
+        code";
 
     pub(in crate::deploy) mod session {
         use super::*;

--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -344,7 +344,7 @@ pub(super) mod session_path {
 pub(super) mod arg_simple {
     use super::*;
 
-    const ARG_VALUE_NAME: &str = "NAME:TYPE='VALUE' OR NAME:TYPE=null";
+    const ARG_VALUE_NAME: &str = r#""NAME:TYPE='VALUE'" OR "NAME:TYPE=null""#;
 
     lazy_static! {
         static ref ARG_HELP: String = format!(

--- a/client/src/deploy/get.rs
+++ b/client/src/deploy/get.rs
@@ -39,7 +39,7 @@ mod deploy_hash {
 
 impl<'a, 'b> ClientCommand<'a, 'b> for GetDeploy {
     const NAME: &'static str = "get-deploy";
-    const ABOUT: &'static str = "Retrieves a stored deploy";
+    const ABOUT: &'static str = "Retrieves a deploy from the network";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         SubCommand::with_name(Self::NAME)

--- a/client/src/deploy/list.rs
+++ b/client/src/deploy/list.rs
@@ -19,7 +19,7 @@ pub struct ListDeploys;
 
 impl<'a, 'b> ClientCommand<'a, 'b> for ListDeploys {
     const NAME: &'static str = "list-deploys";
-    const ABOUT: &'static str = "Gets the list of all deploy hashes from a given block";
+    const ABOUT: &'static str = "Retrieves the list of all deploy hashes in a given block";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         SubCommand::with_name(Self::NAME)

--- a/client/src/deploy/make.rs
+++ b/client/src/deploy/make.rs
@@ -9,9 +9,10 @@ pub struct MakeDeploy;
 
 impl<'a, 'b> ClientCommand<'a, 'b> for MakeDeploy {
     const NAME: &'static str = "make-deploy";
-    const ABOUT: &'static str = "Constructs a deploy and outputs it to a file \
-    or stdout. As a file, the deploy can subsequently be signed by other \
-    parties and sent to a node, or signed with the sign-deploy subcommand";
+    const ABOUT: &'static str =
+        "Creates a deploy and outputs it to a file or stdout. As a file, the deploy can \
+        subsequently be signed by other parties using the 'sign-deploy' subcommand and then sent \
+        to the network for execution using the 'send-deploy' subcommand";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         let subcommand = SubCommand::with_name(Self::NAME)

--- a/client/src/deploy/put.rs
+++ b/client/src/deploy/put.rs
@@ -8,7 +8,7 @@ use crate::{command::ClientCommand, common};
 
 impl<'a, 'b> ClientCommand<'a, 'b> for PutDeploy {
     const NAME: &'static str = "put-deploy";
-    const ABOUT: &'static str = "Creates a new deploy and sends it to the network for execution";
+    const ABOUT: &'static str = "Creates a deploy and sends it to the network for execution";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         let subcommand = SubCommand::with_name(Self::NAME)

--- a/client/src/deploy/send.rs
+++ b/client/src/deploy/send.rs
@@ -7,7 +7,8 @@ pub struct SendDeploy;
 
 impl<'a, 'b> ClientCommand<'a, 'b> for SendDeploy {
     const NAME: &'static str = "send-deploy";
-    const ABOUT: &'static str = "Sends a deploy to the network for execution";
+    const ABOUT: &'static str =
+        "Reads a previously-saved deploy from a file and sends it to the network for execution";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         SubCommand::with_name(Self::NAME)

--- a/client/src/deploy/sign.rs
+++ b/client/src/deploy/sign.rs
@@ -8,7 +8,8 @@ pub struct SignDeploy;
 impl<'a, 'b> ClientCommand<'a, 'b> for SignDeploy {
     const NAME: &'static str = "sign-deploy";
     const ABOUT: &'static str =
-        "Cryptographically signs a deploy and appends signature to existing approvals";
+        "Reads a previously-saved deploy from a file, cryptographically signs it, and outputs it \
+        to a file or stdout";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         SubCommand::with_name(Self::NAME)

--- a/client/src/deploy/transfer.rs
+++ b/client/src/deploy/transfer.rs
@@ -36,10 +36,10 @@ mod source_purse {
     use super::*;
 
     pub(super) const ARG_NAME: &str = "source-purse";
-    const ARG_VALUE_NAME: &str = "HEX STRING";
+    const ARG_VALUE_NAME: &str = "UREF";
     const ARG_HELP: &str =
-        "Hex-encoded URef of the source purse. If this is omitted, the main purse of the account \
-        creating this transfer will be used as the source purse";
+        "URef of the source purse. If this is omitted, the main purse of the account creating this \
+        transfer will be used as the source purse";
 
     pub(super) fn arg() -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)
@@ -66,7 +66,7 @@ pub(super) mod target_account {
         "Hex-encoded public key of the account from which the main purse will be used as the \
         target.";
 
-    // Conflicts with --target-purse, but that's handled via an `ArgGroup` in the subcommand.  Don't
+    // Conflicts with --target-purse, but that's handled via an `ArgGroup` in the subcommand. Don't
     // add a `conflicts_with()` to the arg or the `ArgGroup` fails to work correctly.
     pub(super) fn arg() -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)
@@ -88,8 +88,8 @@ pub(super) mod target_purse {
     use super::*;
 
     pub(super) const ARG_NAME: &str = "target-purse";
-    const ARG_VALUE_NAME: &str = "HEX STRING";
-    const ARG_HELP: &str = "Hex-encoded URef of the target purse";
+    const ARG_VALUE_NAME: &str = "UREF";
+    const ARG_HELP: &str = "URef of the target purse";
 
     // Conflicts with --target-account, but that's handled via an `ArgGroup` in the subcommand.
     // Don't add a `conflicts_with()` to the arg or the `ArgGroup` fails to work correctly.

--- a/client/src/get_balance.rs
+++ b/client/src/get_balance.rs
@@ -23,7 +23,7 @@ mod purse_uref {
     const ARG_SHORT: &str = "p";
     const ARG_VALUE_NAME: &str = "FORMATTED STRING";
     const ARG_HELP: &str =
-        "The URef under which the purse is stored.  This must be a properly formatted URef \
+        "The URef under which the purse is stored. This must be a properly formatted URef \
         \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
 
     pub(super) fn arg() -> Arg<'static, 'static> {
@@ -45,7 +45,7 @@ mod purse_uref {
 
 impl<'a, 'b> ClientCommand<'a, 'b> for GetBalance {
     const NAME: &'static str = "get-balance";
-    const ABOUT: &'static str = "Retrieves a stored balance";
+    const ABOUT: &'static str = "Retrieves a purse's balance from the network";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         SubCommand::with_name(Self::NAME)

--- a/client/src/get_state_hash.rs
+++ b/client/src/get_state_hash.rs
@@ -16,7 +16,7 @@ enum DisplayOrder {
 
 impl<'a, 'b> ClientCommand<'a, 'b> for GetStateRootHash {
     const NAME: &'static str = "get-state-root-hash";
-    const ABOUT: &'static str = "Retrieves a hash of the state root";
+    const ABOUT: &'static str = "Retrieves a state root hash at a given block";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         SubCommand::with_name(Self::NAME)

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,10 +1,10 @@
-mod balance;
 mod block;
 mod command;
 mod common;
 mod deploy;
 mod generate_completion;
 mod get_auction_info;
+mod get_balance;
 mod get_state_hash;
 mod keygen;
 mod query_state;
@@ -37,9 +37,9 @@ enum DisplayOrder {
     GetDeploy,
     GetBlock,
     ListDeploys,
-    GetBalance,
     GetStateRootHash,
     QueryState,
+    GetBalance,
     GetAuctionInfo,
     Keygen,
     GenerateCompletion,

--- a/client/src/query_state.rs
+++ b/client/src/query_state.rs
@@ -24,13 +24,13 @@ mod key {
     const ARG_SHORT: &str = "k";
     const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
     const ARG_HELP: &str =
-        "The base key for the query.  This must be a properly formatted public key, account hash, \
-        contract address hash or URef.  The format for each respectively is \"<HEX STRING>\", \
-        \"account-hash-<HEX STRING>\", \"hash-<HEX STRING>\" and \
-        \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\".  The public key may instead be read in from a \
-        file, in which case enter the path to the file as the --key argument.  The file should be \
-        one of the two public key files generated via the `keygen` subcommand; \"public_key_hex\" \
-        or \"public_key.pem\"";
+        "The base key for the query. This must be a properly formatted public key, account hash, \
+        contract address hash, URef, transfer hash or deploy-info hash. The format for each \
+        respectively is \"<HEX STRING>\", \"account-hash-<HEX STRING>\", \"hash-<HEX STRING>\", \
+        \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\", \"transfer-<HEX-STRING>\" and \
+        \"deploy-<HEX-STRING>\". The public key may instead be read in from a file, in which case \
+        enter the path to the file as the --key argument. The file should be one of the two public \
+        key files generated via the `keygen` subcommand; \"public_key_hex\" or \"public_key.pem\"";
 
     pub(super) fn arg() -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)
@@ -76,8 +76,8 @@ mod path {
 
     const ARG_NAME: &str = "query-path";
     const ARG_SHORT: &str = "q";
-    const ARG_VALUE_NAME: &str = "PATH/FROM/BASE/KEY";
-    const ARG_HELP: &str = "The path from the base key for the query";
+    const ARG_VALUE_NAME: &str = "PATH/FROM/KEY";
+    const ARG_HELP: &str = "The path from the key of the query";
 
     pub(super) fn arg() -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)
@@ -96,7 +96,7 @@ mod path {
 
 impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
     const NAME: &'static str = "query-state";
-    const ABOUT: &'static str = "Retrieves a stored value from global state";
+    const ABOUT: &'static str = "Retrieves a stored value from the network";
 
     fn build(display_order: usize) -> App<'a, 'b> {
         SubCommand::with_name(Self::NAME)

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -86,7 +86,7 @@ untrusted = "0.7.1"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 wabt = "0.10.0"
 warp = "0.2.4"
-warp-json-rpc = "0.1.6"
+warp-json-rpc = "0.2.0"
 wasmi = "0.6.2"
 wheelbuf = "0.2.0"
 


### PR DESCRIPTION
This PR covers several points:
* The rustdocs for the library and help strings for the binary were all reviewed and consistent terminology used throughout
* The README was fixed (it hadn't been updated after the renaming of `global_state_hash`)
* Since [the PR to warp-json-rpc](https://github.com/AtsukiTak/warp-json-rpc/pull/1) has been merged and published, the node can now handle strings as the RPC IDs, making it compliant with the JSON-RPC spec.  The client has been updated to take advantage of this.
* Simple session args and payment args need to be wrapped in double quotes to be parsed correctly; the help strings were updated to cover this
* The `node_address` arg now has trailing `/`s removed, meaning values like `http://localhost:7777/` now succeed