### PR TITLE
NO-TICK: Do not accept endorsements created by equivocators.

### DIFF
--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -362,6 +362,16 @@ impl<C: Context> State<C> {
         info!(?evidence, "marking validator #{} as faulty", idx.0);
         self.faults.insert(idx, Fault::Direct(evidence));
         self.panorama[idx] = Observation::Faulty;
+        // Remove endorsements for vote created by known equivocator.
+        let equivocator_vote = self
+            .endorsements
+            .keys()
+            .find(|v| {
+                let vidx = self.votes.get(v).expect("vote exists").creator;
+                vidx == idx
+            })
+            .cloned();
+        equivocator_vote.map(|v| self.endorsements.remove(&v));
     }
 
     /// Add set of endorsements to the state.


### PR DESCRIPTION
1. Remove an entry from `complete_endorsements` when we detect that its creator has equivocated. We should never endorse votes created by known equivocators.
2. Do not accept endorsements created by faulty validators.