### PR TITLE
NDRS-546: Pass consensus constructor into era supervisor.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -42,6 +42,7 @@ pub(crate) use consensus_protocol::{BlockContext, EraEnd};
 use derive_more::From;
 pub(crate) use era_supervisor::{EraId, EraSupervisor};
 use hex_fmt::HexFmt;
+pub(crate) use protocols::highway::HighwayProtocol;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 use traits::NodeIdT;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -66,13 +66,13 @@ mod era;
 const BONDED_ERAS: u64 = DEFAULT_UNBONDING_DELAY - AUCTION_DELAY;
 
 type ConsensusConstructor<I> = dyn Fn(
-    Digest,
-    Vec<(PublicKey, Motes)>,
-    &HashSet<PublicKey>,
-    &Chainspec,
-    Option<&dyn ConsensusProtocol<I, ClContext>>,
-    Timestamp,
-    u64,
+    Digest,                                       // the era's unique instance ID
+    Vec<(PublicKey, Motes)>,                      // validator stakes
+    &HashSet<PublicKey>,                          // slashed validators that are banned in this era
+    &Chainspec,                                   // the network's chainspec
+    Option<&dyn ConsensusProtocol<I, ClContext>>, // previous era's consensus instance
+    Timestamp,                                    // start time for this era
+    u64,                                          // random seed
 ) -> Box<dyn ConsensusProtocol<I, ClContext>>;
 
 #[derive(DataSize)]

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -107,14 +107,14 @@ pub struct Era<I> {
 }
 
 impl<I> Era<I> {
-    pub(crate) fn new<C: 'static + ConsensusProtocol<I, ClContext>>(
-        consensus: C,
+    pub(crate) fn new(
+        consensus: Box<dyn ConsensusProtocol<I, ClContext>>,
         start_height: u64,
         newly_slashed: Vec<PublicKey>,
         slashed: HashSet<PublicKey>,
     ) -> Self {
         Era {
-            consensus: Box::new(consensus),
+            consensus,
             start_height,
             candidates: Vec::new(),
             newly_slashed,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -17,7 +17,7 @@ use crate::{
         block_executor,
         block_validator::{self, BlockValidator},
         chainspec_loader::ChainspecLoader,
-        consensus::{self},
+        consensus::{self, HighwayProtocol},
         contract_runtime::{self, ContractRuntime},
         deploy_acceptor,
         fetcher::{self, Fetcher},
@@ -361,6 +361,7 @@ impl reactor::Reactor for Reactor {
                 .genesis_state_root_hash()
                 .expect("should have genesis post state hash"),
             registry,
+            Box::new(HighwayProtocol::new_boxed),
             rng,
         )?;
 


### PR DESCRIPTION
That way the era supervisor can be configured to work with different protocols.

https://casperlabs.atlassian.net/browse/NDRS-546