### PR TITLE
NDRS-544: Don't handle consensus messages in the joiner.

### DIFF
--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -491,13 +491,6 @@ impl reactor::Reactor for Reactor {
                     });
                     self.dispatch_event(effect_builder, rng, event)
                 }
-                // needed so that consensus can notify us of the eras it knows of
-                // TODO: remove when proper syncing is implemented
-                Message::Consensus(msg) => self.dispatch_event(
-                    effect_builder,
-                    rng,
-                    Event::Consensus(consensus::Event::MessageReceived { sender, msg }),
-                ),
                 Message::AddressGossiper(message) => {
                     let event = Event::AddressGossiper(gossiper::Event::MessageReceived {
                         sender,


### PR DESCRIPTION
Related to https://casperlabs.atlassian.net/browse/NDRS-544

This fixes the panic that happens after the joiner drops proto block validation requests, which drops the responder, breaks the channel and triggers a panic in `make_request`.

If the joiner handles consensus messages, it can receive proposals from validators, and consensus will try to validate proto blocks it receives as proposals, triggering the issue. However, consensus messages are not required for proper functioning of the joiner and can be ignored, which is what this PR does.