### PR TITLE
Post release version bump to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "casper-client"
-version = "1.5.0"
+version = "1.7.0"
 dependencies = [
  "base64 0.13.0",
  "casper-execution-engine",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.5.0"
+version = "1.7.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-client"
-version = "1.5.0"
+version = "1.7.0"
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "A client for interacting with the Casper network"
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 base64 = "0.13.0"
 casper-execution-engine = { version = "0.7.0", path = "../execution_engine" }
-casper-node = { version = "1.5.0", path = "../node" }
+casper-node = { version = "1.7.0", path = "../node" }
 casper-types = { version = "0.6.0", path = "../types", features = ["std"] }
 clap = "2.33.1"
 futures = "0.3.5"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.5.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.7.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.5.0")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.7.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -16,7 +16,7 @@ chainspec_config_path = '/etc/casper/chainspec.toml'
 [logging]
 
 # Output format.  Possible values are 'text' or 'json'.
-format = 'text'
+format = 'json'
 
 # Colored output.  Has no effect if format = 'json'.
 color = false
@@ -97,7 +97,7 @@ event_stream_buffer_length = 100
 # If the folder doesn't exist, it and any required parents will be created.
 #
 # If unset, the path must be supplied as an argument via the CLI.
-path = '/root/.local/share/casper-node'
+path = '/var/lib/casper/casper-node'
 
 # Optional maximum size of the database to use for the block store.
 #


### PR DESCRIPTION
Bumping master to 1.7.0 after cutting release 1.6.0.
We are jumping from 1.5.0 to 1.7.0 because I forgot to bump master to 1.6.0 after last release.