### PR TITLE
NDRS-556: add node ID enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
 dependencies = [
  "gimli",
 ]
@@ -58,10 +58,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.14"
+name = "aead"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "aes"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "block-cipher",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0301c9e9c443494d970a07885e8cf3e587bae8356a1d5abd0999068413f7205f"
+dependencies = [
+ "aead",
+ "aes",
+ "block-cipher",
+ "ghash",
+ "subtle 2.3.0",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
+dependencies = [
+ "block-cipher",
+ "byteorder",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aesni"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
+dependencies = [
+ "block-cipher",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "ahash"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -86,15 +146,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
-
-[[package]]
-name = "arc-swap"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
 name = "args-multi"
@@ -133,6 +187,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "asn1_der"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fce6b6a0ffdafebd82c87e79e3f40e8d2c523e5fea5566ff6b90509bf98d638"
+dependencies = [
+ "asn1_der_derive",
+]
+
+[[package]]
+name = "asn1_der_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +225,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695579f0f2520f3774bb40461e5adb066459d4e0af4d59d20175484fb8e9edf1"
 
 [[package]]
+name = "async-channel"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e"
+dependencies = [
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "libc",
+ "log 0.4.11",
+ "nb-connect",
+ "once_cell",
+ "parking",
+ "polling",
+ "vec-arena",
+ "waker-fn",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1"
+dependencies = [
+ "async-global-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "crossbeam-utils 0.8.0",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log 0.4.11",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab 0.4.2",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
+name = "async-trait"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
+dependencies = [
+ "autocfg 1.0.1",
+]
+
+[[package]]
 name = "atomic-shim"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +352,12 @@ checksum = "d20fdac7156779a1a30d970e838195558b4810dd06aa69e7c7461bdc518edf9b"
 dependencies = [
  "crossbeam",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -226,9 +425,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
+checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -309,7 +508,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.8.0",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -324,9 +523,20 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -339,7 +549,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
@@ -350,6 +560,16 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "block-padding 0.2.1",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-cipher"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
 dependencies = [
  "generic-array 0.14.4",
 ]
@@ -362,6 +582,32 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "bs58"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
 name = "bstr"
@@ -418,6 +664,12 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cargo-casper"
@@ -521,7 +773,7 @@ dependencies = [
  "grpc",
  "lazy_static",
  "log 0.4.11",
- "num-rational 0.3.0",
+ "num-rational 0.3.1",
  "num-traits",
  "rand 0.7.3",
  "serde_json",
@@ -547,7 +799,7 @@ dependencies = [
  "hex-buffer-serde",
  "hex_fmt",
  "hostname",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "libc",
  "linked-hash-map",
@@ -606,13 +858,15 @@ dependencies = [
  "http",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.9.0",
  "k256",
  "lazy_static",
  "libc",
+ "libp2p",
  "linked-hash-map",
  "lmdb",
  "log 0.4.11",
+ "multihash",
  "num",
  "num-derive",
  "num-traits",
@@ -686,7 +940,7 @@ dependencies = [
  "hex_fmt",
  "num-derive",
  "num-integer",
- "num-rational 0.3.0",
+ "num-rational 0.3.1",
  "num-traits",
  "proptest",
  "serde",
@@ -731,6 +985,29 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244fbce0d47e97e8ef2f63b81d5e05882cb518c68531eb33194990d7b7e85845"
+dependencies = [
+ "stream-cipher",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf18d374d66df0c05cdddd528a7db98f78c28e2519b120855c4f84c5027b1f5"
+dependencies = [
+ "aead",
+ "chacha20",
+ "poly1305",
+ "stream-cipher",
+ "zeroize",
+]
 
 [[package]]
 name = "chrono"
@@ -797,6 +1074,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,9 +1090,9 @@ checksum = "a2d9162b7289a46e86208d6af2c686ca5bfde445878c41a458a9fac706252d0b"
 
 [[package]]
 name = "const_fn"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
 name = "constant_time_eq"
@@ -824,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -834,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "counter-define"
@@ -851,6 +1137,15 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "create-accounts"
@@ -925,7 +1220,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -947,7 +1242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.9.0",
 ]
 
 [[package]]
@@ -1102,19 +1397,29 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+dependencies = [
+ "generic-array 0.12.3",
+ "subtle 1.0.0",
+]
+
+[[package]]
+name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
- "subtle",
+ "subtle 2.3.0",
 ]
 
 [[package]]
 name = "csv"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
 dependencies = [
  "bstr",
  "csv-core",
@@ -1153,6 +1458,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuckoofilter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,9 +1477,15 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "subtle",
+ "subtle 2.3.0",
  "zeroize",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "datasize"
@@ -1298,6 +1620,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-parser"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
+dependencies = [
+ "byteorder",
+ "quick-error",
+]
+
+[[package]]
 name = "do-nothing"
 version = "0.1.0"
 dependencies = [
@@ -1372,7 +1704,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.9.2",
  "zeroize",
 ]
 
@@ -1542,17 +1874,17 @@ dependencies = [
  "const-oid",
  "generic-array 0.14.4",
  "rand_core 0.5.1",
- "subtle",
+ "subtle 2.3.0",
  "zeroize",
 ]
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
+checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1606,6 +1938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
 name = "expensive-calculation"
 version = "0.1.0"
 dependencies = [
@@ -1647,6 +1985,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3006df2e7bf21592b4983931164020b02f54eefdc1e35b2f70147858cc1e20ad"
 
 [[package]]
+name = "fastrand"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "faucet"
 version = "0.1.0"
 dependencies = [
@@ -1661,6 +2008,24 @@ dependencies = [
  "casper-contract",
  "casper-types",
  "faucet",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "flate2"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1683,6 +2048,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -1762,6 +2137,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1769,6 +2145,21 @@ name = "futures-io"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
+
+[[package]]
+name = "futures-lite"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1798,6 +2189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +2212,18 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab 0.4.2",
+]
+
+[[package]]
+name = "futures_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
+dependencies = [
+ "bytes 0.5.6",
+ "futures 0.3.7",
+ "memchr",
+ "pin-project 0.4.27",
 ]
 
 [[package]]
@@ -1936,16 +2345,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.22.0"
+name = "ghash"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
+name = "gimli"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "groups"
@@ -2016,6 +2447,9 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "headers"
@@ -2084,6 +2518,27 @@ name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
+name = "hmac"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+dependencies = [
+ "crypto-mac 0.7.0",
+ "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
+dependencies = [
+ "digest 0.8.1",
+ "generic-array 0.12.3",
+ "hmac",
+]
 
 [[package]]
 name = "host-function-costs"
@@ -2176,9 +2631,9 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -2190,7 +2645,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 0.4.27",
+ "pin-project 1.0.1",
  "socket2",
  "tokio 0.2.22",
  "tower-service",
@@ -2220,6 +2675,27 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
+dependencies = [
+ "if-addrs-sys",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "if-addrs-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2276,6 +2752,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
@@ -2318,8 +2803,14 @@ dependencies = [
  "cfg-if 0.1.10",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.9.2",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kernel32-sys"
@@ -2340,6 +2831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log 0.4.11",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,6 +2856,348 @@ name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+
+[[package]]
+name = "libp2p"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021f703bfef6e3da78ef9828c8a244d639b8d57eedf58360922aca5ff69dfdcd"
+dependencies = [
+ "atomic",
+ "bytes 0.5.6",
+ "futures 0.3.7",
+ "lazy_static",
+ "libp2p-core",
+ "libp2p-core-derive",
+ "libp2p-deflate",
+ "libp2p-dns",
+ "libp2p-floodsub",
+ "libp2p-gossipsub",
+ "libp2p-identify",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-mplex",
+ "libp2p-noise",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-uds",
+ "libp2p-yamux",
+ "multihash",
+ "parity-multiaddr",
+ "parking_lot 0.11.0",
+ "pin-project 1.0.1",
+ "smallvec 1.4.2",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3960524389409633550567e8a9e0684d25a33f4f8408887ff897dd9fdfbdb771"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures 0.3.7",
+ "futures-timer",
+ "lazy_static",
+ "libsecp256k1",
+ "log 0.4.11",
+ "multihash",
+ "multistream-select",
+ "parity-multiaddr",
+ "parking_lot 0.11.0",
+ "pin-project 1.0.1",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2 0.9.2",
+ "smallvec 1.4.2",
+ "thiserror",
+ "unsigned-varint",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-core-derive"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "libp2p-deflate"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567962c5c5f8a1282979441300e1739ba939024010757c3dbfab4d462189df77"
+dependencies = [
+ "flate2",
+ "futures 0.3.7",
+ "libp2p-core",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436280f5fe21a58fcaff82c2606945579241f32bc0eaf2d39321aa4624a66e7f"
+dependencies = [
+ "futures 0.3.7",
+ "libp2p-core",
+ "log 0.4.11",
+]
+
+[[package]]
+name = "libp2p-floodsub"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc175613c5915332fd6458895407ec242ea055ae3b107a586626d5e3349350a"
+dependencies = [
+ "cuckoofilter",
+ "fnv",
+ "futures 0.3.7",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log 0.4.11",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "smallvec 1.4.2",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d500ad89ba14de4d18bebdff61a0ce3e769f1c5c5a95026c5da90187e5fff5c9"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "bytes 0.5.6",
+ "fnv",
+ "futures 0.3.7",
+ "futures_codec",
+ "hex_fmt",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log 0.4.11",
+ "lru_time_cache",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2 0.9.2",
+ "smallvec 1.4.2",
+ "unsigned-varint",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b90b350e37f398b73d778bd94422f4e6a3afa2c1582742ce2446b8a0dba787"
+dependencies = [
+ "futures 0.3.7",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log 0.4.11",
+ "prost",
+ "prost-build",
+ "smallvec 1.4.2",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb78341f114bf686d5fe50b33ff1a804d88fb326c0d39ee1c22db4346b21fc27"
+dependencies = [
+ "arrayvec",
+ "bytes 0.5.6",
+ "either",
+ "fnv",
+ "futures 0.3.7",
+ "futures_codec",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log 0.4.11",
+ "multihash",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2 0.9.2",
+ "smallvec 1.4.2",
+ "uint",
+ "unsigned-varint",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b575514fce0a3ccbd065d6aa377bd4d5102001b05c1a22a5eee49c450254ef0f"
+dependencies = [
+ "data-encoding",
+ "dns-parser",
+ "either",
+ "futures 0.3.7",
+ "lazy_static",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log 0.4.11",
+ "net2",
+ "rand 0.7.3",
+ "smallvec 1.4.2",
+ "tokio 0.2.22",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-mplex"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92b538238c80067c6417a58a07e41002b69d129355b60ec147d6337fdff0eb0"
+dependencies = [
+ "bytes 0.5.6",
+ "futures 0.3.7",
+ "futures_codec",
+ "libp2p-core",
+ "log 0.4.11",
+ "nohash-hasher",
+ "parking_lot 0.11.0",
+ "rand 0.7.3",
+ "smallvec 1.4.2",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c77142e3e5b18fefa7d267305c777c9cbe9b2232ec489979390100bebcc1e6"
+dependencies = [
+ "bytes 0.5.6",
+ "curve25519-dalek",
+ "futures 0.3.7",
+ "lazy_static",
+ "libp2p-core",
+ "log 0.4.11",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2 0.9.2",
+ "snow",
+ "static_assertions",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02ba1aa5727ccc118c09ba5111480873f2fe5608cb304e258fd12c173ecf27c9"
+dependencies = [
+ "async-trait",
+ "bytes 0.5.6",
+ "futures 0.3.7",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log 0.4.11",
+ "lru",
+ "minicbor",
+ "rand 0.7.3",
+ "smallvec 1.4.2",
+ "unsigned-varint",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa6fa33b16956b8a58afbfebe1406866011a1ab8960765bd36868952d7be6a1"
+dependencies = [
+ "either",
+ "futures 0.3.7",
+ "libp2p-core",
+ "log 0.4.11",
+ "rand 0.7.3",
+ "smallvec 1.4.2",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0b6f4ef48d9493607fae069deecce0579320a1f3de6cb056770b151018a9a5"
+dependencies = [
+ "futures 0.3.7",
+ "futures-timer",
+ "if-addrs",
+ "ipnet",
+ "libp2p-core",
+ "log 0.4.11",
+ "socket2",
+ "tokio 0.2.22",
+]
+
+[[package]]
+name = "libp2p-uds"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "945bed3c989a1b290b5a0d4e8fa6e44e01840efb9a5ab3f0d3d174f0e451ac0e"
+dependencies = [
+ "async-std",
+ "futures 0.3.7",
+ "libp2p-core",
+ "log 0.4.11",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c0c9b6ef7a168c2ae854170b0b6b77550599afe06cc3ac390eb45c5d9c7110"
+dependencies = [
+ "futures 0.3.7",
+ "libp2p-core",
+ "parking_lot 0.11.0",
+ "thiserror",
+ "yamux",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
+dependencies = [
+ "arrayref",
+ "crunchy",
+ "digest 0.8.1",
+ "hmac-drbg",
+ "rand 0.7.3",
+ "sha2 0.8.2",
+ "subtle 2.3.0",
+ "typenum",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -2502,6 +3344,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "lru_time_cache"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebac060fafad3adedd0c66a80741a92ff4bc8e94a273df2ba3770ab206f2e29a"
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,9 +3420,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -2605,6 +3462,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2ef6aa869726518c5d8206fa5d1337bda8a0442807611be617891c018fa781"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b3569c0dbfff1b8d5f1434c642b67f5bf81c0f354a3f5f8f180b549dba3c07c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,7 +3498,7 @@ dependencies = [
  "casper-contract",
  "casper-types",
  "mint-token",
- "num-rational 0.3.0",
+ "num-rational 0.3.1",
 ]
 
 [[package]]
@@ -2720,6 +3597,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "multihash"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567122ab6492f49b59def14ecc36e13e64dca4188196dd0cd41f9f3f979f3df6"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "digest 0.9.0",
+ "sha-1 0.9.2",
+ "sha2 0.9.2",
+ "sha3",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multimap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
+
+[[package]]
 name = "multipart"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +3633,20 @@ dependencies = [
  "safemem",
  "tempfile",
  "twoway",
+]
+
+[[package]]
+name = "multistream-select"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36a6aa6e32fbaf16795142335967214b8564a7a4661eb6dc846ef343a6e00ac1"
+dependencies = [
+ "bytes 0.5.6",
+ "futures 0.3.7",
+ "log 0.4.11",
+ "pin-project 1.0.1",
+ "smallvec 1.4.2",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2755,9 +3667,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+checksum = "1a1cda389c26d6b88f3d2dc38aa1b750fe87d298cc5d795ec9e975f402f00372"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2769,6 +3681,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nb-connect"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2795,15 +3717,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.3.0"
+name = "nohash-hasher"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3e176191bc4faad357e3122c4747aa098ac880e88b168f106386128736cf4a"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "num"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
  "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.3.0",
+ "num-rational 0.3.1",
  "num-traits",
 ]
 
@@ -2820,9 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -2831,18 +3759,18 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05ad05bd8977050b171b3f6b48175fea6e0565b7981059b486075e1026a9fb5"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-derive"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f09b9841adb6b5e1f89ef7087ea636e0fd94b2851f887c1e3eb5d5f8228fab3"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2851,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg 1.0.1",
  "num-traits",
@@ -2861,9 +3789,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -2884,21 +3812,21 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
+checksum = "e5fa6d5f418879385b213d905f7cf5bf4aa553d4c380f0152d1d4f2749186fa9"
 dependencies = [
  "autocfg 1.0.1",
- "num-bigint 0.3.0",
+ "num-bigint 0.3.1",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -2915,9 +3843,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"
@@ -2995,6 +3923,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-multiaddr"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7ad66970bbab360c97179b60906e2dc4aef1f7fca8ab4e5c5db8c97b16814a"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint",
+ "url",
+]
+
+[[package]]
 name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,6 +3951,12 @@ name = "parity-wasm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17797de36b94bc5f73edad736fd0a77ce5ab64dd622f809c1eead8c91fa6564"
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -3114,6 +4066,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -3276,6 +4238,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log 0.4.11",
+ "wepoll-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce46de8e53ee414ca4d02bfefac75d8c12fba948b76622a40b4be34dfce980"
+dependencies = [
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
+dependencies = [
+ "cfg-if 0.1.10",
+ "universal-hash",
+]
+
+[[package]]
 name = "pos"
 version = "0.1.0"
 dependencies = [
@@ -3320,9 +4314,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "predicates"
@@ -3376,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -3428,6 +4422,57 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
+]
+
+[[package]]
+name = "prost"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+dependencies = [
+ "bytes 0.5.6",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+dependencies = [
+ "bytes 0.5.6",
+ "heck",
+ "itertools 0.8.2",
+ "log 0.4.11",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+dependencies = [
+ "anyhow",
+ "itertools 0.8.2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+dependencies = [
+ "bytes 0.5.6",
+ "prost",
 ]
 
 [[package]]
@@ -3812,9 +4857,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3834,9 +4879,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove-associated-key"
@@ -3897,6 +4942,21 @@ version = "0.1.0"
 dependencies = [
  "casper-contract",
  "casper-types",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3972,6 +5032,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rw-stream-sink"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
+dependencies = [
+ "futures 0.3.7",
+ "pin-project 0.4.27",
+ "static_assertions",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4028,9 +5099,9 @@ checksum = "aef40838bbb143707f8309b1e92e6ba3225287592968ba6f6e3b6de4a9816486"
 
 [[package]]
 name = "security-framework"
-version = "0.4.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
@@ -4041,9 +5112,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4194,12 +5265,12 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -4207,14 +5278,38 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
  "opaque-debug 0.3.0",
 ]
 
@@ -4241,11 +5336,10 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
+checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
- "arc-swap",
  "libc",
 ]
 
@@ -4295,6 +5389,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
+name = "snow"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795dd7aeeee24468e5a32661f6d27f7b5cbed802031b2d7640c7b10f8fb2dd50"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "ring",
+ "rustc_version",
+ "sha2 0.9.2",
+ "subtle 2.3.0",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "socket2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4305,6 +5417,12 @@ dependencies = [
  "redox_syscall",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "standard-payment"
@@ -4343,6 +5461,16 @@ version = "0.1.0"
 dependencies = [
  "casper-contract",
  "casper-types",
+]
+
+[[package]]
+name = "stream-cipher"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
+dependencies = [
+ "block-cipher",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -4390,6 +5518,12 @@ dependencies = [
  "casper-contract",
  "casper-types",
 ]
+
+[[package]]
+name = "subtle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -4548,18 +5682,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5032,9 +6166,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2810660b9d5b18895d140caba6401765749a6a162e5d0736cfc44ea50db9d79d"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -5194,7 +6328,7 @@ dependencies = [
  "input_buffer",
  "log 0.4.11",
  "rand 0.7.3",
- "sha-1 0.9.1",
+ "sha-1 0.9.2",
  "url",
  "utf-8",
 ]
@@ -5292,6 +6426,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.3.0",
+]
+
+[[package]]
 name = "unix_socket"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5299,6 +6443,18 @@ checksum = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
+]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-io",
+ "futures-util",
+ "futures_codec",
 ]
 
 [[package]]
@@ -5317,10 +6473,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
@@ -5353,6 +6510,12 @@ name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+
+[[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
 
 [[package]]
 name = "vec_map"
@@ -5428,6 +6591,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -5577,6 +6746,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures 0.3.7",
+ "js-sys",
+ "parking_lot 0.11.0",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmi"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5622,10 +6806,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wepoll-sys"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "wheelbuf"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945bc99a6a121cb2759c7bfa7b779ddf0e69b68bb35a9b23ab72276cfdcd3c"
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "winapi"
@@ -5719,6 +6921,31 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
+name = "yamux"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
+dependencies = [
+ "futures 0.3.7",
+ "log 0.4.11",
+ "nohash-hasher",
+ "parking_lot 0.11.0",
+ "rand 0.7.3",
+ "static_assertions",
 ]
 
 [[package]]

--- a/client/lib/deploy.rs
+++ b/client/lib/deploy.rs
@@ -141,7 +141,7 @@ impl DeployExt for Deploy {
             chain_name,
             secret_key,
         } = params;
-        let mut rng = rand::thread_rng();
+        let mut rng = casper_node::new_rng();
         Deploy::new(
             timestamp,
             ttl,
@@ -196,7 +196,7 @@ impl DeployExt for Deploy {
         maybe_output_path: Option<&str>,
     ) -> Result<()> {
         let mut deploy = Deploy::read_deploy(input_path)?;
-        let mut rng = rand::thread_rng();
+        let mut rng = casper_node::new_rng();
         deploy.sign(&secret_key, &mut rng);
         deploy.write_deploy(maybe_output_path)?;
         Ok(())

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -44,6 +44,7 @@ itertools = "0.9.0"
 k256 = { version = "0.4.2", features = ["ecdsa", "zeroize"] }
 lazy_static = "1.4.0"
 libc = "0.2.66"
+libp2p = { version = "0.29.1", default-features = false, features = ["deflate", "dns", "floodsub", "gossipsub", "identify", "kad", "mdns-tokio", "mplex", "noise", "request-response", "tcp-tokio", "uds", "yamux"] }
 linked-hash-map = "0.5.3"
 lmdb = "0.8.0"
 log = { version = "0.4.8", features = ["std", "serde", "kv_unstable"] }
@@ -94,6 +95,7 @@ wheelbuf = "0.2.0"
 assert_matches = "1.3.0"
 fake_instant = "0.4.0"
 lazy_static = "1"
+multihash = "0.11.4"
 pnet = "0.26.0"
 rand_core = "0.5.1"
 rand_pcg = "0.2.1"

--- a/node/src/app/cli.rs
+++ b/node/src/app/cli.rs
@@ -7,8 +7,6 @@ pub mod arglang;
 use std::{env, fs, path::PathBuf, str::FromStr};
 
 use anyhow::{self, bail, Context};
-use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
 use regex::Regex;
 use structopt::StructOpt;
 use toml::{value::Table, Value};
@@ -145,7 +143,7 @@ impl Cli {
                 // eliminate any chance of runtime failures, regardless of how small (these
                 // exist with `OsRng`). Additionally, we want to limit the number of syscalls for
                 // performance reasons.
-                let mut rng = ChaCha20Rng::from_entropy();
+                let mut rng = casper_node::new_rng();
 
                 // The metrics are shared across all reactors.
                 let registry = Registry::new();

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -28,7 +28,7 @@ use semver::Version;
 
 use crate::{
     effect::{EffectBuilder, Effects},
-    types::CryptoRngCore,
+    NodeRng,
 };
 
 // TODO - confirm if we want to use the protocol version for this.
@@ -73,7 +73,7 @@ pub trait Component<REv> {
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event>;
 }

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -33,11 +33,11 @@ use crate::{
         },
         EffectBuilder, EffectExt, Effects,
     },
-    small_network::NodeId,
     types::{
-        json_compatibility::ExecutionResult, Block, BlockHash, CryptoRngCore, Deploy, DeployHash,
-        DeployHeader, FinalizedBlock,
+        json_compatibility::ExecutionResult, Block, BlockHash, Deploy, DeployHash, DeployHeader,
+        FinalizedBlock, NodeId,
     },
+    NodeRng,
 };
 pub(crate) use event::Event;
 
@@ -394,7 +394,7 @@ impl<REv: ReactorEventT> Component<REv> for BlockExecutor {
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -22,7 +22,8 @@ use crate::{
         requests::{BlockProposerRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects, Responder,
     },
-    types::{CryptoRngCore, DeployHash, DeployHeader, ProtoBlock, ProtoBlockHash, Timestamp},
+    types::{DeployHash, DeployHeader, ProtoBlock, ProtoBlockHash, Timestamp},
+    NodeRng,
 };
 
 const PRUNE_INTERVAL: Duration = Duration::from_secs(10);
@@ -405,7 +406,7 @@ where
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         self.metrics
@@ -554,7 +555,7 @@ mod tests {
 
         let no_blocks = HashSet::new();
         let (mut buffer, _effects) = create_test_buffer();
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let (hash1, deploy1) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
         let (hash2, deploy2) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
         let (hash3, deploy3) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
@@ -649,7 +650,7 @@ mod tests {
         let test_time = Timestamp::from(120);
         let ttl = TimeDiff::from(100);
 
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let (hash1, deploy1) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
         let (hash2, deploy2) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
         let (hash3, deploy3) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
@@ -705,7 +706,7 @@ mod tests {
         let ttl = TimeDiff::from(100);
         let block_time = Timestamp::from(120);
 
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let (hash1, deploy1) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
         // let deploy2 depend on deploy1
         let (hash2, deploy2) = generate_deploy(&mut rng, creation_time, ttl, vec![hash1]);

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -25,7 +25,8 @@ use crate::{
         requests::{BlockValidationRequest, FetcherRequest},
         EffectBuilder, EffectExt, EffectOptionExt, Effects, Responder,
     },
-    types::{BlockLike, CryptoRngCore, Deploy, DeployHash},
+    types::{BlockLike, Deploy, DeployHash},
+    NodeRng,
 };
 use keyed_counter::KeyedCounter;
 
@@ -96,7 +97,7 @@ where
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -29,7 +29,7 @@ use crate::{
         requests::{ChainspecLoaderRequest, ContractRuntimeRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects,
     },
-    types::CryptoRngCore,
+    NodeRng,
 };
 pub use chainspec::Chainspec;
 pub(crate) use chainspec::{DeployConfig, HighwayConfig};
@@ -152,7 +152,7 @@ where
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {

--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -530,7 +530,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::testing::{self, TestRng};
+    use crate::testing;
 
     fn check_spec(spec: Chainspec) {
         assert_eq!(spec.genesis.name, "test-chain");
@@ -658,7 +658,7 @@ mod tests {
 
     #[test]
     fn bincode_roundtrip() {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let chainspec = Chainspec::random(&mut rng);
         testing::bincode_roundtrip(&chainspec);
     }

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -34,7 +34,8 @@ use crate::{
         EffectBuilder, Effects,
     },
     protocol::Message,
-    types::{BlockHash, BlockHeader, CryptoRngCore, ProtoBlock, Timestamp},
+    types::{BlockHash, BlockHeader, ProtoBlock, Timestamp},
+    NodeRng,
 };
 
 pub use config::Config;
@@ -199,7 +200,7 @@ where
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        mut rng: &mut dyn CryptoRngCore,
+        mut rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         let mut handling_es = self.handling_wrapper(effect_builder, &mut rng);

--- a/node/src/components/consensus/cl_context.rs
+++ b/node/src/components/consensus/cl_context.rs
@@ -11,7 +11,7 @@ use crate::{
         asymmetric_key::{self, PublicKey, SecretKey, Signature},
         hash::{self, Digest},
     },
-    types::CryptoRngCore,
+    NodeRng,
 };
 
 pub(crate) struct Keypair {
@@ -32,7 +32,7 @@ impl ValidatorSecret for Keypair {
     type Hash = Digest;
     type Signature = Signature;
 
-    fn sign(&self, hash: &Digest, rng: &mut dyn CryptoRngCore) -> Signature {
+    fn sign(&self, hash: &Digest, rng: &mut NodeRng) -> Signature {
         asymmetric_key::sign(hash, self.secret_key.as_ref(), &self.public_key, rng)
     }
 }

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -4,10 +4,7 @@ use anyhow::Error;
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    components::consensus::traits::Context,
-    types::{CryptoRngCore, Timestamp},
-};
+use crate::{components::consensus::traits::Context, types::Timestamp, NodeRng};
 
 /// Information about the context in which a new block is created.
 #[derive(Clone, DataSize, Eq, PartialEq, Debug, Ord, PartialOrd)]
@@ -102,14 +99,14 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
         sender: I,
         msg: Vec<u8>,
         evidence_only: bool,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<ConsensusProtocolResult<I, C>>;
 
     /// Triggers consensus' timer.
     fn handle_timer(
         &mut self,
         timestamp: Timestamp,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<ConsensusProtocolResult<I, C>>;
 
     /// Proposes a new value for consensus.
@@ -117,7 +114,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
         &mut self,
         value: C::ConsensusValue,
         block_context: BlockContext,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<ConsensusProtocolResult<I, C>>;
 
     /// Marks the `value` as valid or invalid, based on validation requested via
@@ -126,7 +123,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
         &mut self,
         value: &C::ConsensusValue,
         valid: bool,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<ConsensusProtocolResult<I, C>>;
 
     /// Turns this instance into an active validator, that participates in the consensus protocol.

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -50,8 +50,9 @@ use crate::{
     },
     effect::{EffectBuilder, EffectExt, Effects, Responder},
     fatal,
-    types::{BlockHash, BlockHeader, CryptoRngCore, FinalizedBlock, ProtoBlock, Timestamp},
+    types::{BlockHash, BlockHeader, FinalizedBlock, ProtoBlock, Timestamp},
     utils::WithDir,
+    NodeRng,
 };
 
 pub use self::era::{Era, EraId};
@@ -116,7 +117,7 @@ where
         genesis_state_root_hash: Digest,
         registry: &Registry,
         new_consensus: Box<ConsensusConstructor<I>>,
-        mut rng: &mut dyn CryptoRngCore,
+        mut rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Event<I>>), Error> {
         let (root, config) = config.into_parts();
         let secret_signing_key = Rc::new(config.secret_key_path.load(root)?);
@@ -159,7 +160,7 @@ where
     pub(super) fn handling_wrapper<'a, REv: ReactorEventT<I>>(
         &'a mut self,
         effect_builder: EffectBuilder<REv>,
-        rng: &'a mut dyn CryptoRngCore,
+        rng: &'a mut NodeRng,
     ) -> EraSupervisorHandlingWrapper<'a, I, REv> {
         EraSupervisorHandlingWrapper {
             era_supervisor: self,
@@ -315,7 +316,7 @@ where
 pub(super) struct EraSupervisorHandlingWrapper<'a, I, REv: 'static> {
     pub(super) era_supervisor: &'a mut EraSupervisor<I>,
     pub(super) effect_builder: EffectBuilder<REv>,
-    pub(super) rng: &'a mut dyn CryptoRngCore,
+    pub(super) rng: &'a mut NodeRng,
 }
 
 impl<'a, I, REv> EraSupervisorHandlingWrapper<'a, I, REv>
@@ -328,7 +329,7 @@ where
     where
         F: FnOnce(
             &mut dyn ConsensusProtocol<I, ClContext>,
-            &mut dyn CryptoRngCore,
+            &mut NodeRng,
         ) -> Vec<ConsensusProtocolResult<I, ClContext>>,
     {
         match self.era_supervisor.active_eras.get_mut(&era_id) {

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -16,7 +16,8 @@ use crate::{
         highway_core::highway::SignedWireVote,
         traits::{Context, ValidatorSecret},
     },
-    types::{CryptoRngCore, TimeDiff, Timestamp},
+    types::{TimeDiff, Timestamp},
+    NodeRng,
 };
 
 /// An action taken by a validator.
@@ -103,7 +104,7 @@ impl<C: Context> ActiveValidator<C> {
         timestamp: Timestamp,
         state: &State<C>,
         instance_id: C::InstanceId,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<Effect<C>> {
         if self.is_faulty(state) {
             warn!("Creator knows it's faulty. Won't create a message.");
@@ -137,7 +138,7 @@ impl<C: Context> ActiveValidator<C> {
         now: Timestamp,
         state: &State<C>,
         instance_id: C::InstanceId,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<Effect<C>> {
         if let Some(evidence) = state.opt_evidence(self.vidx) {
             return vec![Effect::WeEquivocated(evidence.clone())];
@@ -165,7 +166,7 @@ impl<C: Context> ActiveValidator<C> {
         &mut self,
         evidence: &Evidence<C>,
         state: &State<C>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<Effect<C>> {
         let vidx = evidence.perpetrator();
         state
@@ -189,7 +190,7 @@ impl<C: Context> ActiveValidator<C> {
         state: &State<C>,
         instance_id: C::InstanceId,
         timestamp: Timestamp,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Option<Effect<C>> {
         if let Some((prop_time, _)) = self.next_proposal {
             warn!(
@@ -218,7 +219,7 @@ impl<C: Context> ActiveValidator<C> {
         block_context: BlockContext,
         state: &State<C>,
         instance_id: C::InstanceId,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<Effect<C>> {
         let timestamp = block_context.timestamp();
         if self.earliest_vote_time(state) > timestamp {
@@ -311,7 +312,7 @@ impl<C: Context> ActiveValidator<C> {
         value: Option<C::ConsensusValue>,
         state: &State<C>,
         instance_id: C::InstanceId,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> SignedWireVote<C> {
         if let Some((prop_time, _)) = self.next_proposal.take() {
             warn!(
@@ -425,7 +426,7 @@ impl<C: Context> ActiveValidator<C> {
     }
 
     /// Creates endorsement of the `vhash`.
-    fn endorse(&self, vhash: &C::Hash, rng: &mut dyn CryptoRngCore) -> Vertex<C> {
+    fn endorse(&self, vhash: &C::Hash, rng: &mut NodeRng) -> Vertex<C> {
         let endorsement = Endorsement::new(*vhash, self.vidx);
         let signature = self.secret.sign(&endorsement.hash(), rng);
         Vertex::Endorsements(Endorsements::new(vec![SignedEndorsement::new(
@@ -446,7 +447,6 @@ mod tests {
         },
         Vertex, *,
     };
-    use crate::testing::TestRng;
 
     type Eff = Effect<TestContext>;
 
@@ -473,7 +473,7 @@ mod tests {
     #[allow(clippy::unreadable_literal)] // 0xC0FFEE is more readable than 0x00C0_FFEE.
     fn active_validator() -> Result<(), AddVoteError<TestContext>> {
         let mut state = State::new_test(&[Weight(3), Weight(4)], 0);
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let mut fd = FinalityDetector::new(Weight(2));
         let instance_id = 1u64;
 

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -161,12 +161,11 @@ mod tests {
         super::state::{tests::*, State},
         *,
     };
-    use crate::testing::TestRng;
 
     #[test]
     fn finality_detector() -> Result<(), AddVoteError<TestContext>> {
         let mut state = State::new_test(&[Weight(5), Weight(4), Weight(1)], 0);
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         // Create blocks with scores as follows:
         //
@@ -206,7 +205,7 @@ mod tests {
     fn equivocators() -> Result<(), AddVoteError<TestContext>> {
         let mut state = State::new_test(&[Weight(5), Weight(4), Weight(1)], 0);
         let mut fd4 = FinalityDetector::new(Weight(4)); // Fault tolerance 4.
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         // Create blocks with scores as follows:
         //

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -142,19 +142,16 @@ fn round_participation<'a, C: Context>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        components::consensus::highway_core::{
-            highway_testing::TEST_BLOCK_REWARD,
-            state::{tests::*, Params},
-            validators::ValidatorMap,
-        },
-        testing::TestRng,
+    use crate::components::consensus::highway_core::{
+        highway_testing::TEST_BLOCK_REWARD,
+        state::{tests::*, Params},
+        validators::ValidatorMap,
     };
 
     #[test]
     fn round_participation_test() -> Result<(), AddVoteError<TestContext>> {
         let mut state = State::new_test(&[Weight(5)], 0); // Alice is the only validator.
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         // Round ID 0, length 32: Alice participates.
         let p0 = add_vote!(state, rng, ALICE, 0, 5u8, 0x1; N)?; // Proposal
@@ -207,7 +204,7 @@ mod tests {
         let weights = &[Weight(ALICE_W), Weight(BOB_W), Weight(CAROL_W)];
         let mut state = State::new(weights, params, vec![]);
         let total_weight = state.total_weight().0;
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         // Round 0: Alice has round length 16, Bob and Carol 8.
         // Bob and Alice cite each other, creating a summit with quorum 9.

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -12,7 +12,8 @@ use crate::{
         },
         traits::{Context, ValidatorSecret},
     },
-    types::{CryptoRngCore, Timestamp},
+    types::Timestamp,
+    NodeRng,
 };
 
 /// A dependency of a `Vertex` that can be satisfied by one or more other vertices.
@@ -95,7 +96,7 @@ impl<C: Context> SignedWireVote<C> {
     pub(crate) fn new(
         wire_vote: WireVote<C>,
         secret_key: &C::ValidatorSecret,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Self {
         let signature = secret_key.sign(&wire_vote.hash(), rng);
         SignedWireVote {

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -35,7 +35,8 @@ use crate::{
         traits::{Context, ValidatorSecret},
         BlockContext,
     },
-    types::{CryptoRngCore, Timestamp},
+    types::Timestamp,
+    NodeRng,
 };
 
 type ConsensusValue = Vec<u32>;
@@ -195,13 +196,7 @@ enum Distribution {
 
 impl Distribution {
     /// Returns vector of `count` elements of random values between `lower` and `uppwer`.
-    fn gen_range_vec(
-        &self,
-        rng: &mut dyn CryptoRngCore,
-        lower: u64,
-        upper: u64,
-        count: u8,
-    ) -> Vec<u64> {
+    fn gen_range_vec(&self, rng: &mut NodeRng, lower: u64, upper: u64, count: u8) -> Vec<u64> {
         match self {
             Distribution::Uniform => (0..count).map(|_| rng.gen_range(lower, upper)).collect(),
         }
@@ -211,7 +206,7 @@ impl Distribution {
 trait DeliveryStrategy {
     fn gen_delay(
         &mut self,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         message: &HighwayMessage,
         distributon: &Distribution,
         base_delivery_timestamp: Timestamp,
@@ -249,11 +244,7 @@ impl HighwayValidator {
         Ok(self.finality_detector.run(&self.highway)?.collect())
     }
 
-    fn post_hook(
-        &mut self,
-        rng: &mut dyn CryptoRngCore,
-        msg: HighwayMessage,
-    ) -> Vec<HighwayMessage> {
+    fn post_hook(&mut self, rng: &mut NodeRng, msg: HighwayMessage) -> Vec<HighwayMessage> {
         match self.fault.as_ref() {
             None => {
                 // Honest validator.
@@ -341,7 +332,7 @@ where
     /// Pops one message from the message queue (if there are any)
     /// and pass it to the recipient validator for execution.
     /// Messages returned from the execution are scheduled for later delivery.
-    pub(crate) fn crank(&mut self, rng: &mut dyn CryptoRngCore) -> TestResult<()> {
+    pub(crate) fn crank(&mut self, rng: &mut NodeRng) -> TestResult<()> {
         let QueueEntry {
             delivery_time,
             recipient,
@@ -402,12 +393,12 @@ where
 
     fn call_validator<F>(
         &mut self,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         validator_id: &ValidatorId,
         f: F,
     ) -> TestResult<Vec<HighwayMessage>>
     where
-        F: FnOnce(&mut HighwayValidator, &mut dyn CryptoRngCore) -> Vec<Effect<TestContext>>,
+        F: FnOnce(&mut HighwayValidator, &mut NodeRng) -> Vec<Effect<TestContext>>,
     {
         let validator_node = self.node_mut(validator_id)?;
         let res = f(validator_node.validator_mut(), rng);
@@ -427,7 +418,7 @@ where
     /// message.
     fn process_message(
         &mut self,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         validator_id: ValidatorId,
         message: Message<HighwayMessage>,
         delivery_time: Timestamp,
@@ -528,7 +519,7 @@ where
     // From the POV of the test system, synchronization is immediate.
     fn add_vertex(
         &mut self,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         recipient: ValidatorId,
         sender: ValidatorId,
         vertex: Vertex<TestContext>,
@@ -582,7 +573,7 @@ where
     /// it's returned and the original vertex mustn't be added to the state.
     fn synchronize_validator(
         &mut self,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         recipient: ValidatorId,
         sender: ValidatorId,
         pvv: PreValidatedVertex<TestContext>,
@@ -625,7 +616,7 @@ where
     #[allow(clippy::type_complexity)]
     fn synchronize_dependency(
         &mut self,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         missing_dependency: Dependency<TestContext>,
         recipient: ValidatorId,
         sender: ValidatorId,
@@ -655,7 +646,7 @@ where
 
 fn crank_until<F, DS: DeliveryStrategy>(
     htt: &mut HighwayTestHarness<DS>,
-    rng: &mut dyn CryptoRngCore,
+    rng: &mut NodeRng,
     f: F,
 ) -> TestResult<()>
 where
@@ -722,7 +713,7 @@ struct InstantDeliveryNoDropping;
 impl DeliveryStrategy for InstantDeliveryNoDropping {
     fn gen_delay(
         &mut self,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         message: &HighwayMessage,
         _distributon: &Distribution,
         base_delivery_timestamp: Timestamp,
@@ -791,7 +782,7 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
         self
     }
 
-    fn build(self, rng: &mut dyn CryptoRngCore) -> Result<HighwayTestHarness<DS>, BuilderError> {
+    fn build(self, rng: &mut NodeRng) -> Result<HighwayTestHarness<DS>, BuilderError> {
         let consensus_values = (0..self.consensus_values_count as u32)
             .map(|el| vec![el])
             .collect::<VecDeque<ConsensusValue>>();
@@ -1005,7 +996,7 @@ impl ValidatorSecret for TestSecret {
     type Hash = HashWrapper;
     type Signature = SignatureWrapper;
 
-    fn sign(&self, data: &Self::Hash, _rng: &mut dyn CryptoRngCore) -> Self::Signature {
+    fn sign(&self, data: &Self::Hash, _rng: &mut NodeRng) -> Self::Signature {
         SignatureWrapper(data.0 + self.0)
     }
 }
@@ -1044,13 +1035,12 @@ mod test_harness {
     use crate::{
         components::consensus::tests::consensus_des_testing::{Fault, ValidatorId},
         logging,
-        testing::TestRng,
     };
     use logging::{LoggingConfig, LoggingFormat};
 
     #[test]
     fn on_empty_queue_error() {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let mut highway_test_harness: HighwayTestHarness<InstantDeliveryNoDropping> =
             HighwayTestHarnessBuilder::new()
                 .consensus_values_count(1)
@@ -1080,7 +1070,7 @@ mod test_harness {
     fn liveness_test_no_faults() {
         let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true, true));
 
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let cv_count = 10;
 
         let mut highway_test_harness = HighwayTestHarnessBuilder::new()
@@ -1144,7 +1134,7 @@ mod test_harness {
     fn liveness_test_some_mute() {
         let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true, true));
 
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let cv_count = 10;
         let fault_perc = 30;
 
@@ -1185,7 +1175,7 @@ mod test_harness {
     fn liveness_test_some_equivocate() {
         let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true, true));
 
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let cv_count = 10;
         let fault_perc = 10;
 

--- a/node/src/components/consensus/highway_core/state/tallies.rs
+++ b/node/src/components/consensus/highway_core/state/tallies.rs
@@ -201,7 +201,6 @@ mod tests {
         super::{tests::*, State},
         *,
     };
-    use crate::testing::TestRng;
 
     impl<'a> Tallies<'a, TestContext> {
         /// Returns the number of tallies.
@@ -213,7 +212,7 @@ mod tests {
     #[test]
     fn tallies() -> Result<(), AddVoteError<TestContext>> {
         let mut state = State::new_test(WEIGHTS, 0);
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         // Create blocks with scores as follows:
         //

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -10,8 +10,7 @@ use crate::{
         highway_core::{highway::Dependency, highway_testing::TEST_BLOCK_REWARD},
         traits::ValidatorSecret,
     },
-    testing::TestRng,
-    types::CryptoRngCore,
+    NodeRng,
 };
 
 pub(crate) const WEIGHTS: &[Weight] = &[Weight(3), Weight(4), Weight(5)];
@@ -33,7 +32,7 @@ impl ValidatorSecret for TestSecret {
     type Hash = u64;
     type Signature = u64;
 
-    fn sign(&self, data: &Self::Hash, _rng: &mut dyn CryptoRngCore) -> Self::Signature {
+    fn sign(&self, data: &Self::Hash, _rng: &mut NodeRng) -> Self::Signature {
         data + u64::from(self.0)
     }
 }
@@ -134,7 +133,7 @@ impl State<TestContext> {
 #[test]
 fn add_vote() -> Result<(), AddVoteError<TestContext>> {
     let mut state = State::new_test(WEIGHTS, 0);
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
 
     // Create votes as follows; a0, b0 are blocks:
     //
@@ -213,7 +212,7 @@ fn add_vote() -> Result<(), AddVoteError<TestContext>> {
 
 #[test]
 fn ban_and_mark_faulty() -> Result<(), AddVoteError<TestContext>> {
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
     let params = Params::new(
         0,
         TEST_BLOCK_REWARD,
@@ -252,7 +251,7 @@ fn ban_and_mark_faulty() -> Result<(), AddVoteError<TestContext>> {
 #[test]
 fn find_in_swimlane() -> Result<(), AddVoteError<TestContext>> {
     let mut state = State::new_test(WEIGHTS, 0);
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
     let a0 = add_vote!(state, rng, ALICE, 0xA; N, N, N)?;
     let mut a = vec![a0];
     for i in 1..10 {
@@ -279,7 +278,7 @@ fn find_in_swimlane() -> Result<(), AddVoteError<TestContext>> {
 #[test]
 fn fork_choice() -> Result<(), AddVoteError<TestContext>> {
     let mut state = State::new_test(WEIGHTS, 0);
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
 
     // Create blocks with scores as follows:
     //
@@ -314,7 +313,7 @@ fn test_log2() {
 
 #[test]
 fn test_leader_prng() {
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
 
     // Repeat a few times to make it likely that the inner loop runs more than once.
     for _ in 0..10 {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -33,7 +33,8 @@ use crate::{
             traits::{Context, NodeIdT},
         },
     },
-    types::{CryptoRngCore, Timestamp},
+    types::Timestamp,
+    NodeRng,
 };
 
 #[derive(DataSize, Debug)]
@@ -207,7 +208,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     fn add_past_due_stored_vertices(
         &mut self,
         timestamp: Timestamp,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<CpResult<I, C>> {
         let mut results = vec![];
         let past_due_timestamps: Vec<Timestamp> = self
@@ -230,7 +231,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     fn add_vertices(
         &mut self,
         mut pvvs: Vec<(I, PreValidatedVertex<C>)>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<CpResult<I, C>> {
         // TODO: Is there a danger that this takes too much time, and starves other
         // components and events? Consider replacing the loop with a "callback" effect:
@@ -322,7 +323,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     fn add_valid_vertex(
         &mut self,
         vv: ValidVertex<C>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         now: Timestamp,
     ) -> Vec<CpResult<I, C>> {
         // Check whether we should change the round exponent.
@@ -381,7 +382,7 @@ where
         sender: I,
         msg: Vec<u8>,
         evidence_only: bool,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<CpResult<I, C>> {
         match bincode::deserialize(msg.as_slice()) {
             Err(err) => vec![ConsensusProtocolResult::InvalidIncomingMessage(
@@ -435,11 +436,7 @@ where
         }
     }
 
-    fn handle_timer(
-        &mut self,
-        timestamp: Timestamp,
-        rng: &mut dyn CryptoRngCore,
-    ) -> Vec<CpResult<I, C>> {
+    fn handle_timer(&mut self, timestamp: Timestamp, rng: &mut NodeRng) -> Vec<CpResult<I, C>> {
         let effects = self.highway.handle_timer(timestamp, rng);
         let mut results = self.process_av_effects(effects);
         results.extend(self.add_past_due_stored_vertices(timestamp, rng));
@@ -450,7 +447,7 @@ where
         &mut self,
         value: C::ConsensusValue,
         block_context: BlockContext,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<CpResult<I, C>> {
         let effects = self.highway.propose(value, block_context, rng);
         self.process_av_effects(effects)
@@ -460,7 +457,7 @@ where
         &mut self,
         value: &C::ConsensusValue,
         valid: bool,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Vec<CpResult<I, C>> {
         if valid {
             let mut results = self

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -3,9 +3,10 @@ use std::{
     hash::Hash,
 };
 
-use crate::types::CryptoRngCore;
 use datasize::DataSize;
 use serde::{de::DeserializeOwned, Serialize};
+
+use crate::NodeRng;
 
 pub trait NodeIdT: Clone + Display + Debug + Send + Eq + Hash + 'static {}
 impl<I> NodeIdT for I where I: Clone + Display + Debug + Send + Eq + Hash + 'static {}
@@ -37,7 +38,7 @@ pub(crate) trait ValidatorSecret {
 
     type Signature: Eq + PartialEq + Clone + Debug + Hash + Serialize + DeserializeOwned;
 
-    fn sign(&self, hash: &Self::Hash, rng: &mut dyn CryptoRngCore) -> Self::Signature;
+    fn sign(&self, hash: &Self::Hash, rng: &mut NodeRng) -> Self::Signature;
 }
 
 /// The collection of types the user can choose for cryptography, IDs, transactions, etc.

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -36,9 +36,8 @@ use crate::{
     components::Component,
     crypto::hash,
     effect::{requests::ContractRuntimeRequest, EffectBuilder, EffectExt, Effects},
-    types::CryptoRngCore,
     utils::WithDir,
-    Chainspec, StorageConfig,
+    Chainspec, NodeRng, StorageConfig,
 };
 
 /// The contract runtime components.
@@ -154,7 +153,7 @@ where
     fn handle_event(
         &mut self,
         _effect_builder: EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {

--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -12,9 +12,9 @@ use crate::{
         announcements::DeployAcceptorAnnouncement, requests::StorageRequest, EffectBuilder,
         EffectExt, Effects,
     },
-    small_network::NodeId,
-    types::{CryptoRngCore, Deploy},
+    types::{Deploy, NodeId},
     utils::Source,
+    NodeRng,
 };
 
 pub use event::Event;
@@ -155,7 +155,7 @@ impl<REv: ReactorEventT> Component<REv> for DeployAcceptor {
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         debug!(?event, "handling event");

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use semver::Version;
 
 use super::{DeployAcceptorConfig, Source};
-use crate::{small_network::NodeId, types::Deploy};
+use crate::types::{Deploy, NodeId};
 
 /// `DeployAcceptor` events.
 #[derive(Debug)]

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -33,7 +33,7 @@ use tokio::sync::mpsc::{self, UnboundedSender};
 use super::Component;
 use crate::{
     effect::{EffectBuilder, Effects},
-    types::CryptoRngCore,
+    NodeRng,
 };
 
 pub use config::Config;
@@ -82,7 +82,7 @@ where
     fn handle_event(
         &mut self,
         _effect_builder: EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {

--- a/node/src/components/fetcher/event.rs
+++ b/node/src/components/fetcher/event.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use super::Item;
 use crate::{
     effect::{requests::FetcherRequest, Responder},
-    small_network::NodeId,
+    types::NodeId,
     utils::Source,
 };
 use datasize::DataSize;

--- a/node/src/components/gossiper/event.rs
+++ b/node/src/components/gossiper/event.rs
@@ -5,7 +5,7 @@ use std::{
 
 use super::{Item, Message};
 use crate::{
-    components::small_network::NodeId,
+    types::NodeId,
     utils::{DisplayIter, Source},
 };
 

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -18,7 +18,7 @@ use crate::{
     components::{
         chainspec_loader::Chainspec,
         deploy_acceptor::{self, DeployAcceptor},
-        in_memory_network::{InMemoryNetwork, NetworkController, NodeId},
+        in_memory_network::{InMemoryNetwork, NetworkController},
         storage::{self, Storage, StorageType},
     },
     effect::announcements::{
@@ -31,8 +31,9 @@ use crate::{
         network::{Network, NetworkedReactor},
         ConditionCheckReactor, TestRng,
     },
-    types::{Deploy, Tag},
+    types::{Deploy, NodeId, Tag},
     utils::{Loadable, WithDir},
+    NodeRng,
 };
 use rand::Rng;
 
@@ -121,7 +122,7 @@ impl reactor::Reactor for Reactor {
         config: Self::Config,
         registry: &Registry,
         event_queue: EventQueueHandle<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
         let network = NetworkController::create_node(event_queue, rng);
 
@@ -152,7 +153,7 @@ impl reactor::Reactor for Reactor {
     fn dispatch_event(
         &mut self,
         effect_builder: EffectBuilder<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         event: Event,
     ) -> Effects<Self::Event> {
         match event {
@@ -330,7 +331,7 @@ async fn should_gossip() {
     const NETWORK_SIZES: [usize; 3] = [2, 5, 20];
     const DEPLOY_COUNTS: [usize; 3] = [1, 10, 30];
 
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
 
     for network_size in &NETWORK_SIZES {
         for deploy_count in &DEPLOY_COUNTS {
@@ -347,7 +348,7 @@ async fn should_get_from_alternate_source() {
 
     NetworkController::<NodeMessage>::create_active();
     let mut network = Network::<Reactor>::new();
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
 
     // Add `NETWORK_SIZE` nodes.
     let node_ids = network.add_nodes(&mut rng, NETWORK_SIZE).await;
@@ -377,7 +378,7 @@ async fn should_get_from_alternate_source() {
     debug!("removed node {}", &node_ids[0]);
 
     // Run node 2 until it receives and responds to the gossip request from node 0.
-    let node_id_0 = node_ids[0];
+    let node_id_0 = node_ids[0].clone();
     let sent_gossip_response = move |event: &Event| -> bool {
         match event {
             Event::NetworkRequest(NetworkRequest::SendMessage {
@@ -429,7 +430,7 @@ async fn should_timeout_gossip_response() {
 
     NetworkController::<NodeMessage>::create_active();
     let mut network = Network::<Reactor>::new();
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
 
     // The target number of peers to infect with a given piece of data.
     let infection_target = Config::default().infection_target();

--- a/node/src/components/in_memory_network.rs
+++ b/node/src/components/in_memory_network.rs
@@ -106,7 +106,7 @@
 //!
 //!     fn handle_event(&mut self,
 //!         effect_builder: EffectBuilder<REv>,
-//!         _rng: &mut dyn CryptoRngCore,
+//!         _rng: &mut NodeRng,
 //!         event: Self::Event
 //!     ) -> Effects<Self::Event> {
 //!         match event {
@@ -181,7 +181,7 @@
 //!            _cfg: Self::Config,
 //!            _registry: &Registry,
 //!            event_queue: EventQueueHandle<Self::Event>,
-//!            rng: &mut dyn CryptoRngCore,
+//!            rng: &mut NodeRng,
 //!     ) -> Result<(Self, Effects<Self::Event>), anyhow::Error> {
 //!         let effect_builder = EffectBuilder::new(event_queue);
 //!         let (shouter, shouter_effect) = Shouter::new(effect_builder);
@@ -194,7 +194,7 @@
 //!
 //!     fn dispatch_event<R: Rng + ?Sized>(&mut self,
 //!                       effect_builder: EffectBuilder<Event>,
-//!                       rng: &mut dyn CryptoRngCore,
+//!                       rng: &mut NodeRng,
 //!                       event: Event
 //!     ) -> Effects<Event> {
 //!          match event {
@@ -288,7 +288,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use rand::{seq::IteratorRandom, Rng};
+use rand::seq::IteratorRandom;
 use tokio::sync::mpsc::{self, error::SendError};
 use tracing::{debug, error, info, warn};
 
@@ -300,12 +300,10 @@ use crate::{
     },
     logging,
     reactor::{EventQueueHandle, QueueKind},
-    tls::KeyFingerprint,
-    types::CryptoRngCore,
+    testing::TestRng,
+    types::NodeId,
+    NodeRng,
 };
-
-/// The node ID type used by the in-memory network.
-pub type NodeId = KeyFingerprint;
 
 type Network<P> = Arc<RwLock<HashMap<NodeId, mpsc::UnboundedSender<(NodeId, P)>>>>;
 
@@ -373,7 +371,7 @@ where
     /// network is not of the correct message type.
     pub fn create_node<REv>(
         event_queue: EventQueueHandle<REv>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut TestRng,
     ) -> InMemoryNetwork<P>
     where
         REv: From<NetworkAnnouncement<NodeId, P>> + Send,
@@ -416,12 +414,12 @@ where
     pub(crate) fn create_node_local<REv>(
         &self,
         event_queue: EventQueueHandle<REv>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut TestRng,
     ) -> InMemoryNetwork<P>
     where
         REv: From<NetworkAnnouncement<NodeId, P>> + Send,
     {
-        InMemoryNetwork::new(event_queue, rng.gen(), self.nodes.clone())
+        InMemoryNetwork::new(event_queue, NodeId::random(rng), self.nodes.clone())
     }
 }
 
@@ -449,7 +447,7 @@ where
         {
             let mut nodes_write = nodes.write().expect("network lock poisoned");
             assert!(!nodes_write.contains_key(&node_id));
-            nodes_write.insert(node_id, sender);
+            nodes_write.insert(node_id.clone(), sender);
         }
 
         tokio::spawn(receiver_task(event_queue, receiver));
@@ -460,7 +458,7 @@ where
     /// Returns this node's ID.
     #[inline]
     pub fn node_id(&self) -> NodeId {
-        self.node_id
+        self.node_id.clone()
     }
 }
 
@@ -481,7 +479,7 @@ where
 
         match nodes.get(&dest) {
             Some(sender) => {
-                if let Err(SendError((_, msg))) = sender.send((self.node_id, payload)) {
+                if let Err(SendError((_, msg))) = sender.send((self.node_id.clone(), payload)) {
                     warn!(%dest, %msg, "could not send message (send error)");
 
                     // We do nothing else, the message is just dropped.
@@ -502,7 +500,7 @@ where
     fn handle_event(
         &mut self,
         _effect_builder: EffectBuilder<REv>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {
@@ -526,7 +524,7 @@ where
             NetworkRequest::Broadcast { payload, responder } => {
                 if let Ok(guard) = self.nodes.read() {
                     for dest in guard.keys().filter(|&node_id| node_id != &self.node_id) {
-                        self.send(&guard, *dest, payload.clone());
+                        self.send(&guard, dest.clone(), payload.clone());
                     }
                 } else {
                     error!("network lock has been poisoned")
@@ -549,8 +547,8 @@ where
                         .into_iter()
                         .collect();
                     // Not terribly efficient, but will always get us the maximum amount of nodes.
-                    for &dest in chosen.iter() {
-                        self.send(&guard, dest, payload.clone());
+                    for dest in chosen.iter() {
+                        self.send(&guard, dest.clone(), payload.clone());
                     }
                     responder.respond(chosen).ignore()
                 } else {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -19,10 +19,8 @@ use crate::{
         EffectExt, Effects, Responder,
     },
     protocol::Message,
-    types::{
-        json_compatibility::ExecutionResult, Block, BlockByHeight, BlockHash, CryptoRngCore,
-        DeployHash,
-    },
+    types::{json_compatibility::ExecutionResult, Block, BlockByHeight, BlockHash, DeployHash},
+    NodeRng,
 };
 
 #[derive(Debug, From)]
@@ -128,7 +126,7 @@ where
     fn handle_event(
         &mut self,
         effect_builder: crate::effect::EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -25,21 +25,23 @@
 
 mod event;
 
+use std::{convert::Infallible, fmt::Display, mem};
+
 use datasize::DataSize;
+use rand::{seq::SliceRandom, Rng};
+use tracing::{error, info, trace, warn};
 
 use super::{fetcher::FetchResult, storage::Storage, Component};
 use crate::{
-    effect::{self, EffectBuilder, EffectExt, EffectOptionExt, Effects},
-    types::{Block, BlockByHeight, BlockHash, BlockHeader, CryptoRngCore, FinalizedBlock},
-};
-use effect::requests::{
-    BlockExecutorRequest, BlockValidationRequest, FetcherRequest, StorageRequest,
+    effect::{
+        requests::{BlockExecutorRequest, BlockValidationRequest, FetcherRequest, StorageRequest},
+        EffectBuilder, EffectExt, EffectOptionExt, Effects,
+    },
+    types::{Block, BlockByHeight, BlockHash, BlockHeader, FinalizedBlock},
+    NodeRng,
 };
 use event::BlockByHeightResult;
 pub use event::Event;
-use rand::{seq::SliceRandom, Rng};
-use std::{convert::Infallible, fmt::Display, mem};
-use tracing::{error, info, trace, warn};
 
 pub trait ReactorEventT<I>:
     From<StorageRequest<Storage>>
@@ -216,12 +218,12 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
 
     fn block_downloaded<REv>(
         &mut self,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         effect_builder: EffectBuilder<REv>,
         block_header: &BlockHeader,
     ) -> Effects<Event<I>>
     where
-        I: Send + Copy + 'static,
+        I: Send + 'static,
         REv: ReactorEventT<I>,
     {
         self.reset_peers(rng);
@@ -257,12 +259,12 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
     /// Returns effects that are created as a response to that event.
     fn block_handled<REv>(
         &mut self,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         effect_builder: EffectBuilder<REv>,
         block_header: BlockHeader,
     ) -> Effects<Event<I>>
     where
-        I: Send + Copy + 'static,
+        I: Send + 'static,
         REv: ReactorEventT<I>,
     {
         let height = block_header.height();
@@ -320,7 +322,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         effect_builder: EffectBuilder<REv>,
     ) -> Effects<Event<I>>
     where
-        I: Send + Copy + 'static,
+        I: Send + 'static,
         REv: ReactorEventT<I>,
     {
         let peer = self.random_peer_unsafe();
@@ -369,11 +371,11 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
     fn fetch_next_block<REv>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         block_header: &BlockHeader,
     ) -> Effects<Event<I>>
     where
-        I: Send + Copy + 'static,
+        I: Send + 'static,
         REv: ReactorEventT<I>,
     {
         self.reset_peers(rng);
@@ -396,7 +398,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
 
 impl<I, REv> Component<REv> for LinearChainSync<I>
 where
-    I: Display + Clone + Copy + Send + PartialEq + 'static,
+    I: Display + Clone + Send + PartialEq + 'static,
     REv: ReactorEventT<I>,
 {
     type Event = Event<I>;
@@ -405,7 +407,7 @@ where
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {
@@ -488,8 +490,7 @@ where
                         );
                         // NOTE: Signal misbehaving validator to networking layer.
                         // NOTE: Cannot call `self.ban_peer` with `peer` value b/c it's fixed for
-                        // `KeyFingerprint` type and we're abstract in what
-                        // peer type is.
+                        // `KeyFingerprint` type and we're abstract in what peer type is.
                         return self.handle_event(
                             effect_builder,
                             rng,
@@ -527,10 +528,11 @@ where
                 let mut effects = Effects::new();
                 if self.peers.is_empty() {
                     // First peer connected, start downloading.
+                    let cloned_peer_id = peer_id.clone();
                     effects.extend(
                         effect_builder
                             .immediately()
-                            .event(move |_| Event::Start(peer_id)),
+                            .event(move |_| Event::Start(cloned_peer_id)),
                     );
                 }
                 self.peers.push(peer_id);
@@ -546,7 +548,7 @@ where
     }
 }
 
-fn fetch_block_deploys<I: Send + Copy + 'static, REv>(
+fn fetch_block_deploys<I: Send + 'static, REv>(
     effect_builder: EffectBuilder<REv>,
     peer: I,
     block_header: BlockHeader,
@@ -566,7 +568,7 @@ where
         })
 }
 
-fn fetch_block_by_hash<I: Send + Copy + 'static, REv>(
+fn fetch_block_by_hash<I: Send + 'static, REv>(
     effect_builder: EffectBuilder<REv>,
     peer: I,
     block_hash: BlockHash,
@@ -580,7 +582,7 @@ where
     )
 }
 
-fn fetch_block_at_height<I: Send + Copy + 'static, REv>(
+fn fetch_block_at_height<I: Send + Clone + 'static, REv>(
     effect_builder: EffectBuilder<REv>,
     peer: I,
     block_height: u64,
@@ -589,7 +591,7 @@ where
     REv: ReactorEventT<I>,
 {
     effect_builder
-        .fetch_block_by_height(block_height, peer)
+        .fetch_block_by_height(block_height, peer.clone())
         .option(
             move |fetch_result| match fetch_result {
                 FetchResult::FromPeer(result, _) => match *result {

--- a/node/src/components/metrics.rs
+++ b/node/src/components/metrics.rs
@@ -23,6 +23,8 @@
 //!    prevent any actual logic depending on them. If a counter is being increment as a metric and
 //!    also required for busines logic, a second counter should be kept in the component's state.
 
+use std::convert::Infallible;
+
 use datasize::DataSize;
 use prometheus::{Encoder, Registry, TextEncoder};
 use tracing::error;
@@ -30,9 +32,8 @@ use tracing::error;
 use crate::{
     components::Component,
     effect::{requests::MetricsRequest, EffectBuilder, EffectExt, Effects},
-    types::CryptoRngCore,
+    NodeRng,
 };
-use std::convert::Infallible;
 
 /// The metrics component.
 #[derive(DataSize, Debug)]
@@ -49,7 +50,7 @@ impl<REv> Component<REv> for Metrics {
     fn handle_event(
         &mut self,
         _effect_builder: EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         req: Self::Event,
     ) -> Effects<Self::Event> {
         match req {

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -38,8 +38,8 @@ use crate::{
         EffectBuilder, EffectExt, Effects,
     },
     reactor::Finalize,
-    small_network::NodeId,
-    types::{CryptoRngCore, StatusFeed},
+    types::{NodeId, StatusFeed},
+    NodeRng,
 };
 
 use crate::effect::requests::RestRequest;
@@ -105,7 +105,7 @@ where
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {

--- a/node/src/components/rest_server/event.rs
+++ b/node/src/components/rest_server/event.rs
@@ -3,8 +3,8 @@ use std::fmt::{self, Display, Formatter};
 use derive_more::From;
 
 use crate::{
-    components::small_network::NodeId,
     effect::{requests::RestRequest, Responder},
+    types::NodeId,
 };
 
 #[derive(Debug, From)]

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -46,8 +46,8 @@ use crate::{
         },
         EffectBuilder, EffectExt, Effects, Responder,
     },
-    small_network::NodeId,
-    types::{CryptoRngCore, StatusFeed},
+    types::{NodeId, StatusFeed},
+    NodeRng,
 };
 
 pub use config::Config;
@@ -172,7 +172,7 @@ where
     fn handle_event(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {

--- a/node/src/components/rpc_server/event.rs
+++ b/node/src/components/rpc_server/event.rs
@@ -13,10 +13,10 @@ use casper_execution_engine::{
 use casper_types::auction::EraValidators;
 
 use crate::{
-    components::{small_network::NodeId, storage::DeployMetadata},
+    components::storage::DeployMetadata,
     effect::{requests::RpcRequest, Responder},
     rpcs::chain::BlockIdentifier,
-    types::{Block, Deploy, DeployHash},
+    types::{Block, Deploy, DeployHash, NodeId},
 };
 
 #[derive(Debug, From)]

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -16,6 +16,7 @@ use prometheus::Registry;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
+use super::{Config, Event as SmallNetworkEvent, GossipedAddress, SmallNetwork};
 use crate::{
     components::{
         gossiper::{self, Gossiper},
@@ -29,21 +30,21 @@ use crate::{
     },
     protocol,
     reactor::{self, EventQueueHandle, Finalize, Reactor, Runner},
-    small_network::{self, Config, GossipedAddress, NodeId, SmallNetwork},
     testing::{
         self, init_logging,
         network::{Network, NetworkedReactor},
-        ConditionCheckReactor, TestRng,
+        ConditionCheckReactor,
     },
-    types::CryptoRngCore,
+    types::NodeId,
     utils::Source,
+    NodeRng,
 };
 
 /// Test-reactor event.
 #[derive(Debug, From)]
 enum Event {
     #[from]
-    SmallNet(small_network::Event<Message>),
+    SmallNet(SmallNetworkEvent<Message>),
     #[from]
     AddressGossiper(gossiper::Event<GossipedAddress>),
     #[from]
@@ -108,7 +109,7 @@ impl Reactor for TestReactor {
         cfg: Self::Config,
         registry: &Registry,
         event_queue: EventQueueHandle<Self::Event>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
         let (net, effects) = SmallNetwork::new(event_queue, cfg, false)?;
         let gossiper_config = gossiper::Config::default();
@@ -127,7 +128,7 @@ impl Reactor for TestReactor {
     fn dispatch_event(
         &mut self,
         effect_builder: EffectBuilder<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {
@@ -143,7 +144,7 @@ impl Reactor for TestReactor {
             Event::NetworkRequest(req) => self.dispatch_event(
                 effect_builder,
                 rng,
-                Event::SmallNet(small_network::Event::from(req)),
+                Event::SmallNet(SmallNetworkEvent::from(req)),
             ),
             Event::NetworkAnnouncement(NetworkAnnouncement::MessageReceived {
                 sender,
@@ -170,7 +171,7 @@ impl Reactor for TestReactor {
             Event::AddressGossiperAnnouncement(ann) => {
                 let GossiperAnnouncement::NewCompleteItem(gossiped_address) = ann;
                 let reactor_event =
-                    Event::SmallNet(small_network::Event::PeerAddressReceived(gossiped_address));
+                    Event::SmallNet(SmallNetworkEvent::PeerAddressReceived(gossiped_address));
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
         }
@@ -247,7 +248,7 @@ fn network_started(net: &Network<TestReactor>) -> bool {
 /// Ensures that network cleanup and basic networking works.
 #[tokio::test]
 async fn run_two_node_network_five_times() {
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
 
     // The networking port used by the tests for the root node.
     let first_node_port = testing::unused_port_on_localhost();
@@ -308,7 +309,7 @@ async fn run_two_node_network_five_times() {
 async fn network_with_unhealthy_nodes_settles_without_them() {
     init_logging();
 
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
     for (healthy, unhealthy) in &[(1u64, 1u64), (1, 2), (1, 4), (2, 2), (4, 4), (4, 1)] {
         let port = testing::unused_port_on_localhost();
 
@@ -359,7 +360,7 @@ async fn network_with_unhealthy_nodes_settles_without_them() {
 async fn bind_to_real_network_interface() {
     init_logging();
 
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
 
     let iface = datalink::interfaces()
         .into_iter()
@@ -399,7 +400,7 @@ async fn bind_to_real_network_interface() {
 async fn check_varying_size_network_connects() {
     init_logging();
 
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
 
     // Try with a few predefined sets of network sizes.
     for &number_of_nodes in &[2u16, 3, 5, 9, 15] {

--- a/node/src/components/storage/block_height_store.rs
+++ b/node/src/components/storage/block_height_store.rs
@@ -20,10 +20,9 @@ mod tests {
         super::{Config, InMemBlockHeightStore, LmdbBlockHeightStore},
         *,
     };
-    use crate::testing::TestRng;
 
     fn should_put_then_get<T: BlockHeightStore<String>>(block_height_store: &mut T) {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         let height = rng.gen();
 
@@ -49,7 +48,7 @@ mod tests {
     }
 
     fn should_fail_get<T: BlockHeightStore<String>>(block_height_store: &mut T) {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         let height = rng.gen();
 
@@ -76,7 +75,7 @@ mod tests {
 
     fn should_get_highest<T: BlockHeightStore<String>>(block_height_store: &mut T) {
         const BLOCK_COUNT: usize = 1000;
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         assert!(block_height_store.highest().unwrap().is_none());
 
@@ -112,7 +111,7 @@ mod tests {
         const BLOCK_COUNT: usize = 100;
 
         let (config, _tempdir) = Config::default_for_tests();
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         // Populate the DB then drop it.
         let max_height = {

--- a/node/src/components/storage/chainspec_store.rs
+++ b/node/src/components/storage/chainspec_store.rs
@@ -16,10 +16,8 @@ mod tests {
         *,
     };
 
-    use crate::testing::TestRng;
-
     fn should_put_then_get<T: ChainspecStore>(chainspec_store: &mut T) {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         let chainspec = Chainspec::random(&mut rng);
         let version = chainspec.genesis.protocol_version.clone();
@@ -46,7 +44,7 @@ mod tests {
     }
 
     fn should_fail_get<T: ChainspecStore>(chainspec_store: &mut T) {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         let chainspec = Chainspec::random(&mut rng);
         let mut version = chainspec.genesis.protocol_version.clone();

--- a/node/src/components/storage/event.rs
+++ b/node/src/components/storage/event.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use derive_more::From;
 
 use super::{StorageType, Value};
-use crate::{effect::requests::StorageRequest, small_network::NodeId};
+use crate::{effect::requests::StorageRequest, types::NodeId};
 
 /// `Storage` events.
 #[derive(Debug, From)]

--- a/node/src/components/storage/store.rs
+++ b/node/src/components/storage/store.rs
@@ -50,13 +50,10 @@ mod tests {
         super::{Config, DeployMetadata, InMemStore, LmdbStore},
         *,
     };
-    use crate::{
-        testing::TestRng,
-        types::{Block, Deploy},
-    };
+    use crate::types::{Block, Deploy};
 
     fn should_put_then_get<T: Store<Value = Deploy>>(store: &mut T) {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         let deploy = Deploy::random(&mut rng);
         let deploy_hash = *deploy.id();
@@ -90,7 +87,7 @@ mod tests {
     }
 
     fn second_put_should_return_false<T: Store<Value = Deploy>>(store: &mut T) {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let deploy = Deploy::random(&mut rng);
         assert!(store.put(deploy.clone()).unwrap());
         assert!(!store.put(deploy).unwrap());

--- a/node/src/crypto/asymmetric_key.rs
+++ b/node/src/crypto/asymmetric_key.rs
@@ -35,8 +35,8 @@ use super::{Error, Result};
 use crate::testing::TestRng;
 use crate::{
     crypto::hash::hash,
-    types::CryptoRngCore,
     utils::{read_file, write_file},
+    NodeRng,
 };
 use casper_types::account::AccountHash;
 
@@ -1178,7 +1178,7 @@ pub fn sign<T: AsRef<[u8]>>(
     message: T,
     secret_key: &SecretKey,
     public_key: &PublicKey,
-    rng: &mut dyn CryptoRngCore,
+    rng: &mut NodeRng,
 ) -> Signature {
     match (secret_key, public_key) {
         (SecretKey::Ed25519(secret_key), PublicKey::Ed25519(public_key)) => {
@@ -1427,7 +1427,7 @@ mod tests {
 
         #[test]
         fn secret_key_serialization_roundtrip() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_ed25519(&mut rng);
             super::secret_key_serialization_roundtrip(secret_key)
         }
@@ -1445,7 +1445,7 @@ mod tests {
 
         #[test]
         fn secret_key_to_and_from_der() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_ed25519(&mut rng);
             let der_encoded = secret_key.to_der().unwrap();
             secret_key_der_roundtrip(secret_key);
@@ -1456,7 +1456,7 @@ mod tests {
 
         #[test]
         fn secret_key_to_and_from_pem() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_ed25519(&mut rng);
             secret_key_pem_roundtrip(secret_key);
         }
@@ -1474,14 +1474,14 @@ MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC
 
         #[test]
         fn secret_key_to_and_from_file() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_ed25519(&mut rng);
             secret_key_file_roundtrip(secret_key);
         }
 
         #[test]
         fn public_key_serialization_roundtrip() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_ed25519(&mut rng);
             super::public_key_serialization_roundtrip(public_key);
         }
@@ -1490,7 +1490,7 @@ MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC
         fn public_key_from_bytes() {
             // Public key should be `PublicKey::ED25519_LENGTH` bytes.  Create vec with an extra
             // byte.
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_ed25519(&mut rng);
             let bytes: Vec<u8> = iter::once(rng.gen())
                 .chain(public_key.as_ref().iter().copied())
@@ -1505,14 +1505,14 @@ MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC
 
         #[test]
         fn public_key_to_and_from_der() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_ed25519(&mut rng);
             public_key_der_roundtrip(public_key);
         }
 
         #[test]
         fn public_key_to_and_from_pem() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_ed25519(&mut rng);
             public_key_pem_roundtrip(public_key);
         }
@@ -1530,21 +1530,21 @@ MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
 
         #[test]
         fn public_key_to_and_from_file() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_ed25519(&mut rng);
             public_key_file_roundtrip(public_key);
         }
 
         #[test]
         fn public_key_to_and_from_hex() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_ed25519(&mut rng);
             public_key_hex_roundtrip(public_key);
         }
 
         #[test]
         fn signature_serialization_roundtrip() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_ed25519(&mut rng);
             let public_key = PublicKey::from(&secret_key);
             let data = b"data";
@@ -1569,7 +1569,7 @@ MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
 
         #[test]
         fn signature_key_to_and_from_hex() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_ed25519(&mut rng);
             let public_key = PublicKey::from(&secret_key);
             let data = b"data";
@@ -1602,7 +1602,7 @@ MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
 
         #[test]
         fn sign_and_verify() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_ed25519(&mut rng);
 
             let public_key = PublicKey::from(&secret_key);
@@ -1620,7 +1620,7 @@ MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
 
         #[test]
         fn account_hash_generation_is_consistent() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_ed25519(&mut rng);
 
             let public_key_node = PublicKey::from(&secret_key);
@@ -1640,7 +1640,7 @@ MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
 
         #[test]
         fn secret_key_serialization_roundtrip() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_secp256k1(&mut rng);
             super::secret_key_serialization_roundtrip(secret_key)
         }
@@ -1658,14 +1658,14 @@ MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
 
         #[test]
         fn secret_key_to_and_from_der() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_secp256k1(&mut rng);
             secret_key_der_roundtrip(secret_key);
         }
 
         #[test]
         fn secret_key_to_and_from_pem() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_secp256k1(&mut rng);
             secret_key_pem_roundtrip(secret_key);
         }
@@ -1685,14 +1685,14 @@ Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
 
         #[test]
         fn secret_key_to_and_from_file() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_secp256k1(&mut rng);
             secret_key_file_roundtrip(secret_key);
         }
 
         #[test]
         fn public_key_serialization_roundtrip() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_secp256k1(&mut rng);
             super::public_key_serialization_roundtrip(public_key);
         }
@@ -1701,7 +1701,7 @@ Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
         fn public_key_from_bytes() {
             // Public key should be `PublicKey::SECP256K1_LENGTH` bytes.  Create vec with an extra
             // byte.
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_secp256k1(&mut rng);
             let bytes: Vec<u8> = iter::once(rng.gen())
                 .chain(public_key.as_ref().iter().copied())
@@ -1716,14 +1716,14 @@ Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
 
         #[test]
         fn public_key_to_and_from_der() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_secp256k1(&mut rng);
             public_key_der_roundtrip(public_key);
         }
 
         #[test]
         fn public_key_to_and_from_pem() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_secp256k1(&mut rng);
             public_key_pem_roundtrip(public_key);
         }
@@ -1742,21 +1742,21 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
 
         #[test]
         fn public_key_to_and_from_file() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_secp256k1(&mut rng);
             public_key_file_roundtrip(public_key);
         }
 
         #[test]
         fn public_key_to_and_from_hex() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_secp256k1(&mut rng);
             public_key_hex_roundtrip(public_key);
         }
 
         #[test]
         fn signature_serialization_roundtrip() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_secp256k1(&mut rng);
             let public_key = PublicKey::from(&secret_key);
             let data = b"data";
@@ -1777,7 +1777,7 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
 
         #[test]
         fn signature_key_to_and_from_hex() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_secp256k1(&mut rng);
             let public_key = PublicKey::from(&secret_key);
             let data = b"data";
@@ -1787,7 +1787,7 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
 
         #[test]
         fn public_key_traits() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key1 = PublicKey::random_secp256k1(&mut rng);
             let public_key2 = PublicKey::random_secp256k1(&mut rng);
             if public_key1.as_ref() < public_key2.as_ref() {
@@ -1799,7 +1799,7 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
 
         #[test]
         fn public_key_to_account_hash() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let public_key = PublicKey::random_secp256k1(&mut rng);
             assert_ne!(public_key.to_account_hash().as_ref(), public_key.as_ref());
         }
@@ -1813,7 +1813,7 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
 
         #[test]
         fn account_hash_generation_is_consistent() {
-            let mut rng = TestRng::new();
+            let mut rng = crate::new_rng();
             let secret_key = SecretKey::random_secp256k1(&mut rng);
 
             let public_key_node = PublicKey::from(&secret_key);
@@ -1827,7 +1827,7 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
 
     #[test]
     fn public_key_traits() {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let ed25519_public_key = PublicKey::random_ed25519(&mut rng);
         let secp256k1_public_key = PublicKey::random_secp256k1(&mut rng);
         check_ord_and_hash(ed25519_public_key, secp256k1_public_key);
@@ -1842,7 +1842,7 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
 
     #[test]
     fn sign_and_verify() {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let ed25519_secret_key = SecretKey::random_ed25519(&mut rng);
         let secp256k1_secret_key = SecretKey::random_secp256k1(&mut rng);
 
@@ -1876,7 +1876,7 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
 
     #[test]
     fn should_construct_secp256k1_from_uncompressed_bytes() {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
 
         // Construct a secp256k1 secret key and use that to construct an uncompressed public key.
         let secp256k1_secret_key = {

--- a/node/src/crypto/hash.rs
+++ b/node/src/crypto/hash.rs
@@ -246,7 +246,7 @@ mod test {
 
     #[test]
     fn bytesrepr_roundtrip() {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let hash = Digest::random(&mut rng);
         bytesrepr::test_serialization_roundtrip(&hash);
     }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -38,8 +38,9 @@ pub mod utils;
 
 use ansi_term::Color::Red;
 use lazy_static::lazy_static;
+#[cfg(not(test))]
+use rand::SeedableRng;
 
-pub(crate) use components::small_network;
 pub use components::{
     chainspec_loader::{Chainspec, Error as ChainspecError},
     consensus::Config as ConsensusConfig,
@@ -52,6 +53,7 @@ pub use components::{
     small_network::{Config as SmallNetworkConfig, Error as SmallNetworkError},
     storage::{Config as StorageConfig, Error as StorageError},
 };
+pub use types::NodeRng;
 pub use utils::OS_PAGE_SIZE;
 
 /// The maximum thread count which should be spawned by the tokio runtime.
@@ -89,4 +91,16 @@ lazy_static! {
 
     /// Version string for the compiled node. Filled in at build time, output allocated at runtime.
     pub static ref VERSION_STRING: String = version_string(false);
+}
+
+/// Constructs a new `NodeRng`.
+#[cfg(not(test))]
+pub fn new_rng() -> NodeRng {
+    NodeRng::from_entropy()
+}
+
+/// Constructs a new `NodeRng`.
+#[cfg(test)]
+pub fn new_rng() -> NodeRng {
+    NodeRng::new()
 }

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -49,8 +49,8 @@ use tracing_futures::Instrument;
 
 use crate::{
     effect::{Effect, EffectBuilder, Effects},
-    types::CryptoRngCore,
     utils::{self, WeightedRoundRobin},
+    NodeRng,
 };
 use quanta::Clock;
 pub use queue_kind::QueueKind;
@@ -147,7 +147,7 @@ pub trait Reactor: Sized {
     fn dispatch_event(
         &mut self,
         effect_builder: EffectBuilder<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event>;
 
@@ -161,7 +161,7 @@ pub trait Reactor: Sized {
         cfg: Self::Config,
         registry: &Registry,
         event_queue: EventQueueHandle<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Self::Event>), Self::Error>;
 
     /// Indicates that the reactor has completed all its work and should no longer dispatch events.
@@ -299,7 +299,7 @@ where
     ///
     /// Creates a metrics registry that is only going to be used in this runner.
     #[inline]
-    pub async fn new(cfg: R::Config, rng: &mut dyn CryptoRngCore) -> Result<Self, R::Error> {
+    pub async fn new(cfg: R::Config, rng: &mut NodeRng) -> Result<Self, R::Error> {
         // Instantiate a new registry for metrics for this reactor.
         let registry = Registry::new();
         Self::with_metrics(cfg, rng, &registry).await
@@ -309,7 +309,7 @@ where
     #[inline]
     pub async fn with_metrics(
         cfg: R::Config,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         registry: &Registry,
     ) -> Result<Self, R::Error> {
         let event_size = mem::size_of::<R::Event>();
@@ -366,7 +366,7 @@ where
 
     /// Processes a single event on the event queue.
     #[inline]
-    pub async fn crank(&mut self, rng: &mut dyn CryptoRngCore) {
+    pub async fn crank(&mut self, rng: &mut NodeRng) {
         // Create another span for tracing the processing of one event.
         let crank_span = debug_span!("crank", ev = self.event_count);
         let _inner_enter = crank_span.enter();
@@ -432,7 +432,7 @@ where
 
     /// Processes a single event if there is one, returns `None` otherwise.
     #[inline]
-    pub async fn try_crank(&mut self, rng: &mut dyn CryptoRngCore) -> Option<()> {
+    pub async fn try_crank(&mut self, rng: &mut NodeRng) -> Option<()> {
         if self.scheduler.item_count() == 0 {
             None
         } else {
@@ -443,7 +443,7 @@ where
 
     /// Runs the reactor until `is_stopped()` returns true.
     #[inline]
-    pub async fn run(&mut self, rng: &mut dyn CryptoRngCore) {
+    pub async fn run(&mut self, rng: &mut NodeRng) {
         while !self.reactor.is_stopped() {
             self.crank(rng).await;
         }

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -11,7 +11,6 @@ use crate::{
     components::{
         chainspec_loader::{self, ChainspecLoader},
         contract_runtime::{self, ContractRuntime},
-        small_network::NodeId,
         storage::{self, Storage, StorageType},
         Component,
     },
@@ -21,8 +20,9 @@ use crate::{
     },
     protocol::Message,
     reactor::{self, validator, EventQueueHandle},
-    types::CryptoRngCore,
+    types::NodeId,
     utils::WithDir,
+    NodeRng,
 };
 
 /// Top-level event for the reactor.
@@ -119,7 +119,7 @@ impl reactor::Reactor for Reactor {
         config: Self::Config,
         registry: &Registry,
         event_queue: EventQueueHandle<Self::Event>,
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Self::Event>), Error> {
         let chainspec = config
             .value()
@@ -157,7 +157,7 @@ impl reactor::Reactor for Reactor {
     fn dispatch_event(
         &mut self,
         effect_builder: EffectBuilder<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         event: Event,
     ) -> Effects<Self::Event> {
         match event {

--- a/node/src/reactor/initializer2.rs
+++ b/node/src/reactor/initializer2.rs
@@ -3,12 +3,10 @@
 use casper_node_macros::reactor;
 
 use crate::{
-    components::{
-        small_network::NodeId,
-        storage::{Storage, StorageType},
-    },
+    components::storage::{Storage, StorageType},
     protocol::Message,
     reactor::validator,
+    types::NodeId,
     utils::WithDir,
 };
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -27,9 +27,8 @@ use crate::{
         linear_chain,
         linear_chain_sync::{self, LinearChainSync},
         metrics::Metrics,
-        rest_server,
-        rest_server::RestServer,
-        small_network::{self, NodeId, SmallNetwork},
+        rest_server::{self, RestServer},
+        small_network::{self, SmallNetwork},
         storage::{self, Storage},
         Component,
     },
@@ -54,8 +53,9 @@ use crate::{
         validator::{self, Error, ValidatorInitConfig},
         EventQueueHandle, Finalize,
     },
-    types::{Block, BlockByHeight, BlockHeader, CryptoRngCore, Deploy, ProtoBlock, Tag, Timestamp},
+    types::{Block, BlockByHeight, BlockHeader, Deploy, NodeId, ProtoBlock, Tag, Timestamp},
     utils::{Source, WithDir},
+    NodeRng,
 };
 
 /// Top-level event for the reactor.
@@ -339,7 +339,7 @@ impl reactor::Reactor for Reactor {
         initializer: Self::Config,
         registry: &Registry,
         event_queue: EventQueueHandle<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
         let (root, initializer) = initializer.into_parts();
 
@@ -462,7 +462,7 @@ impl reactor::Reactor for Reactor {
     fn dispatch_event(
         &mut self,
         effect_builder: EffectBuilder<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -39,7 +39,7 @@ use crate::{
         metrics::Metrics,
         rest_server::{self, RestServer},
         rpc_server::{self, RpcServer},
-        small_network::{self, GossipedAddress, NodeId, SmallNetwork},
+        small_network::{self, GossipedAddress, SmallNetwork},
         storage::{self, Storage},
         Component,
     },
@@ -59,8 +59,9 @@ use crate::{
     },
     protocol::Message,
     reactor::{self, event_queue_metrics::EventQueueMetrics, EventQueueHandle},
-    types::{Block, CryptoRngCore, Deploy, ProtoBlock, Tag, TimeDiff, Timestamp},
+    types::{Block, Deploy, NodeId, ProtoBlock, Tag, TimeDiff, Timestamp},
     utils::Source,
+    NodeRng,
 };
 pub use config::Config;
 pub use error::Error;
@@ -339,7 +340,7 @@ impl reactor::Reactor for Reactor {
         event_queue: EventQueueHandle<Self::Event>,
         // We don't need `rng` b/c consensus component was the only one using it,
         // and now it's being passed on from the `joiner` reactor via `config`.
-        _rng: &mut dyn CryptoRngCore,
+        _rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Event>), Error> {
         let ValidatorInitConfig {
             config,
@@ -442,7 +443,7 @@ impl reactor::Reactor for Reactor {
     fn dispatch_event(
         &mut self,
         effect_builder: EffectBuilder<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         event: Event,
     ) -> Effects<Self::Event> {
         match event {
@@ -678,7 +679,7 @@ impl reactor::Reactor for Reactor {
 
                 let event = gossiper::Event::ItemReceived {
                     item_id: *deploy.id(),
-                    source,
+                    source: source.clone(),
                 };
                 effects.extend(self.dispatch_event(
                     effect_builder,

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -12,9 +12,9 @@ use crate::{
     crypto::asymmetric_key::{PublicKey, SecretKey},
     reactor::{initializer, joiner, validator, Runner},
     testing::{self, network::Network, ConditionCheckReactor, TestRng},
-    types::{CryptoRngCore, Timestamp},
+    types::Timestamp,
     utils::{External, Loadable, WithDir, RESOURCES_PATH},
-    Chainspec,
+    Chainspec, NodeRng,
 };
 
 struct TestChain {
@@ -89,7 +89,7 @@ impl TestChain {
 
     async fn create_initialized_network(
         &mut self,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> anyhow::Result<Network<validator::Reactor>> {
         let root = RESOURCES_PATH.join("local");
 
@@ -143,7 +143,7 @@ fn era_ids(runner: &Runner<ConditionCheckReactor<validator::Reactor>>) -> HashSe
 async fn run_validator_network() {
     testing::init_logging();
 
-    let mut rng = TestRng::new();
+    let mut rng = crate::new_rng();
 
     // Instantiate a new chain with a fixed size.
     const NETWORK_SIZE: usize = 5;

--- a/node/src/testing/condition_check_reactor.rs
+++ b/node/src/testing/condition_check_reactor.rs
@@ -7,7 +7,7 @@ use super::network::NetworkedReactor;
 use crate::{
     effect::{EffectBuilder, Effects},
     reactor::{EventQueueHandle, Finalize, Reactor},
-    types::CryptoRngCore,
+    NodeRng,
 };
 
 /// A reactor wrapping an inner reactor, and which has an optional hook into
@@ -58,7 +58,7 @@ impl<R: Reactor> Reactor for ConditionCheckReactor<R> {
         config: Self::Config,
         registry: &Registry,
         event_queue: EventQueueHandle<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
         let (reactor, effects) = R::new(config, registry, event_queue, rng)?;
         Ok((
@@ -74,7 +74,7 @@ impl<R: Reactor> Reactor for ConditionCheckReactor<R> {
     fn dispatch_event(
         &mut self,
         effect_builder: EffectBuilder<Self::Event>,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
         event: Self::Event,
     ) -> Effects<Self::Event> {
         self.condition_result = self

--- a/node/src/testing/network.rs
+++ b/node/src/testing/network.rs
@@ -17,7 +17,7 @@ use crate::{
     effect::{EffectBuilder, Effects},
     reactor::{Finalize, Reactor, Runner},
     testing::TestRng,
-    types::CryptoRngCore,
+    NodeRng,
 };
 
 /// Type alias for set of nodes inside a network.
@@ -99,7 +99,7 @@ where
     pub async fn add_node_with_config(
         &mut self,
         cfg: R::Config,
-        rng: &mut dyn CryptoRngCore,
+        rng: &mut NodeRng,
     ) -> Result<(R::NodeId, &mut Runner<ConditionCheckReactor<R>>), R::Error> {
         let runner: Runner<ConditionCheckReactor<R>> = Runner::new(cfg, rng).await?;
 

--- a/node/src/tls.rs
+++ b/node/src/tls.rs
@@ -143,15 +143,25 @@ impl Debug for CertFingerprint {
 #[derive(Copy, Clone, DataSize, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct KeyFingerprint(Sha512);
 
+impl KeyFingerprint {
+    /// Size of digest in bytes.
+    pub const LENGTH: usize = Sha512::SIZE;
+}
+
+impl AsRef<[u8]> for KeyFingerprint {
+    fn as_ref(&self) -> &[u8] {
+        self.0.bytes()
+    }
+}
+
 impl Debug for KeyFingerprint {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "KeyFingerprint({:10})", HexFmt(self.0.bytes()))
     }
 }
 
-#[cfg(test)]
-impl From<[u8; Sha512::SIZE]> for KeyFingerprint {
-    fn from(raw_bytes: [u8; Sha512::SIZE]) -> Self {
+impl From<[u8; KeyFingerprint::LENGTH]> for KeyFingerprint {
+    fn from(raw_bytes: [u8; KeyFingerprint::LENGTH]) -> Self {
         KeyFingerprint(Sha512(raw_bytes))
     }
 }

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -5,17 +5,21 @@ mod deploy;
 mod item;
 pub mod json_compatibility;
 mod node_config;
+mod node_id;
 mod peers_map;
 mod status_feed;
 mod timestamp;
 
 use rand::{CryptoRng, RngCore};
+#[cfg(not(test))]
+use rand_chacha::ChaCha20Rng;
 
 pub use block::{Block, BlockHash, BlockHeader, BlockValidationError};
 pub(crate) use block::{BlockByHeight, BlockLike, FinalizedBlock, ProtoBlock, ProtoBlockHash};
 pub use deploy::{Approval, Deploy, DeployHash, DeployHeader, Error as DeployError};
 pub use item::{Item, Tag};
 pub use node_config::NodeConfig;
+pub(crate) use node_id::NodeId;
 pub use peers_map::PeersMap;
 pub use status_feed::{GetStatusResult, StatusFeed};
 pub use timestamp::{TimeDiff, Timestamp};
@@ -24,3 +28,11 @@ pub use timestamp::{TimeDiff, Timestamp};
 pub trait CryptoRngCore: CryptoRng + RngCore {}
 
 impl<T> CryptoRngCore for T where T: CryptoRng + RngCore + ?Sized {}
+
+/// The cryptographically secure RNG used throughout the node.
+#[cfg(not(test))]
+pub type NodeRng = ChaCha20Rng;
+
+/// The RNG used throughout the node for testing.
+#[cfg(test)]
+pub type NodeRng = crate::testing::TestRng;

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -809,7 +809,7 @@ mod tests {
 
     #[test]
     fn json_block_roundtrip() {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let block = Block::random(&mut rng);
         let json_string = serde_json::to_string_pretty(&block).unwrap();
         let decoded = serde_json::from_str(&json_string).unwrap();
@@ -818,7 +818,7 @@ mod tests {
 
     #[test]
     fn json_finalized_block_roundtrip() {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let finalized_block = FinalizedBlock::random(&mut rng);
         let json_string = serde_json::to_string_pretty(&finalized_block).unwrap();
         let decoded = serde_json::from_str(&json_string).unwrap();

--- a/node/src/types/node_id.rs
+++ b/node/src/types/node_id.rs
@@ -1,0 +1,212 @@
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    str::FromStr,
+};
+
+use datasize::DataSize;
+use hex_fmt::HexFmt;
+use libp2p::PeerId;
+#[cfg(test)]
+use rand::{Rng, RngCore};
+use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
+
+#[cfg(test)]
+use crate::testing::TestRng;
+use crate::tls::KeyFingerprint;
+
+/// The network identifier for a node.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, DataSize)]
+pub enum NodeId {
+    Tls(KeyFingerprint),
+    #[data_size(skip)]
+    P2p(PeerId),
+}
+
+impl NodeId {
+    /// Generates a random instance using a `TestRng`.
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        if rng.gen() {
+            Self::random_tls(rng)
+        } else {
+            Self::random_p2p(rng)
+        }
+    }
+
+    /// Generates a random Tls instance using a `TestRng`.
+    #[cfg(test)]
+    pub(crate) fn random_tls(rng: &mut TestRng) -> Self {
+        NodeId::Tls(rng.gen())
+    }
+
+    /// Generates a random P2p instance using a `TestRng`.
+    #[cfg(test)]
+    pub(crate) fn random_p2p(rng: &mut TestRng) -> Self {
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes[..]);
+        let multihash = multihash::wrap(multihash::Code::Identity, &bytes);
+        let peer_id = PeerId::from_multihash(multihash).expect("should construct from multihash");
+        NodeId::P2p(peer_id)
+    }
+}
+
+/// Used to serialize and deserialize `NodeID` where the (de)serializer isn't a human-readable type.
+#[derive(Serialize, Deserialize)]
+enum NodeIdAsBytes<'a> {
+    Tls(KeyFingerprint),
+    P2p(&'a [u8]),
+}
+
+/// Used to serialize and deserialize `NodeID` where the (de)serializer is a human-readable type.
+#[derive(Serialize, Deserialize)]
+enum NodeIdAsString {
+    Tls(String),
+    P2p(String),
+}
+
+impl Serialize for NodeId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            let helper = match self {
+                NodeId::Tls(key_fingerprint) => {
+                    NodeIdAsString::Tls(hex::encode(key_fingerprint.as_ref()))
+                }
+                NodeId::P2p(peer_id) => NodeIdAsString::P2p(peer_id.to_base58()),
+            };
+            return helper.serialize(serializer);
+        }
+
+        let helper = match self {
+            NodeId::Tls(key_fingerprint) => NodeIdAsBytes::Tls(*key_fingerprint),
+            NodeId::P2p(peer_id) => NodeIdAsBytes::P2p(peer_id.as_ref()),
+        };
+        helper.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for NodeId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            let helper = NodeIdAsString::deserialize(deserializer)?;
+            match helper {
+                NodeIdAsString::Tls(hex_value) => {
+                    let bytes = hex::decode(hex_value).map_err(D::Error::custom)?;
+                    if bytes.len() != KeyFingerprint::LENGTH {
+                        return Err(SerdeError::custom("wrong length"));
+                    }
+                    let mut array = [0_u8; KeyFingerprint::LENGTH];
+                    array.copy_from_slice(bytes.as_slice());
+                    return Ok(NodeId::Tls(KeyFingerprint::from(array)));
+                }
+                NodeIdAsString::P2p(b58_value) => {
+                    let peer_id = PeerId::from_str(&b58_value).map_err(D::Error::custom)?;
+                    return Ok(NodeId::P2p(peer_id));
+                }
+            }
+        }
+
+        let helper = NodeIdAsBytes::deserialize(deserializer)?;
+        match helper {
+            NodeIdAsBytes::Tls(key_fingerprint) => Ok(NodeId::Tls(key_fingerprint)),
+            NodeIdAsBytes::P2p(bytes) => {
+                let peer_id = PeerId::from_bytes(bytes.to_vec())
+                    .map_err(|_| D::Error::custom("invalid PeerId"))?;
+                Ok(NodeId::P2p(peer_id))
+            }
+        }
+    }
+}
+
+impl Debug for NodeId {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            NodeId::Tls(key_fingerprint) => write!(
+                formatter,
+                "PeerId::Tls({})",
+                HexFmt(key_fingerprint.as_ref())
+            ),
+            NodeId::P2p(peer_id) => write!(formatter, "PeerId::P2p({})", peer_id.to_base58()),
+        }
+    }
+}
+
+impl Display for NodeId {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            NodeId::Tls(key_fingerprint) => write!(
+                formatter,
+                "PeerId::Tls({:10})",
+                HexFmt(key_fingerprint.as_ref())
+            ),
+            NodeId::P2p(peer_id) => {
+                let base58_peer_id = peer_id.to_base58();
+                write!(
+                    formatter,
+                    "PeerId::P2p({}..{})",
+                    &base58_peer_id[..4],
+                    &base58_peer_id[(base58_peer_id.len() - 4)..]
+                )
+            }
+        }
+    }
+}
+
+impl From<KeyFingerprint> for NodeId {
+    fn from(id: KeyFingerprint) -> Self {
+        NodeId::Tls(id)
+    }
+}
+
+impl From<PeerId> for NodeId {
+    fn from(id: PeerId) -> Self {
+        NodeId::P2p(id)
+    }
+}
+
+#[cfg(test)]
+impl From<[u8; KeyFingerprint::LENGTH]> for NodeId {
+    fn from(raw_bytes: [u8; KeyFingerprint::LENGTH]) -> Self {
+        NodeId::Tls(KeyFingerprint::from(raw_bytes))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn serde_roundtrip_tls() {
+        let mut rng = crate::new_rng();
+        let node_id = NodeId::random_tls(&mut rng);
+        let serialized = bincode::serialize(&node_id).unwrap();
+        let decoded = bincode::deserialize(&serialized).unwrap();
+        assert_eq!(node_id, decoded);
+    }
+
+    #[test]
+    fn serde_roundtrip_p2p() {
+        let mut rng = crate::new_rng();
+        let node_id = NodeId::random_p2p(&mut rng);
+        let serialized = bincode::serialize(&node_id).unwrap();
+        let decoded = bincode::deserialize(&serialized).unwrap();
+        assert_eq!(node_id, decoded);
+    }
+
+    #[test]
+    fn json_roundtrip_tls() {
+        let mut rng = crate::new_rng();
+        let node_id = NodeId::random_tls(&mut rng);
+        let json_string = serde_json::to_string_pretty(&node_id).unwrap();
+        let decoded = serde_json::from_str(&json_string).unwrap();
+        assert_eq!(node_id, decoded);
+    }
+
+    #[test]
+    fn json_roundtrip_p2p() {
+        let mut rng = crate::new_rng();
+        let node_id = NodeId::random_p2p(&mut rng);
+        let json_string = serde_json::to_string_pretty(&node_id).unwrap();
+        let decoded = serde_json::from_str(&json_string).unwrap();
+        assert_eq!(node_id, decoded);
+    }
+}

--- a/node/src/types/peers_map.rs
+++ b/node/src/types/peers_map.rs
@@ -5,7 +5,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::small_network::NodeId;
+use crate::types::NodeId;
 
 /// Map of peers.
 #[derive(Serialize, Deserialize, Debug, PartialOrd, PartialEq)]

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -5,8 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     components::{chainspec_loader::ChainspecInfo, consensus::EraId},
-    small_network::NodeId,
-    types::{Block, BlockHash, PeersMap, Timestamp},
+    types::{Block, BlockHash, NodeId, PeersMap, Timestamp},
 };
 
 /// Data feed for client "info_get_status" endpoint.

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -284,7 +284,6 @@ impl From<Duration> for TimeDiff {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::TestRng;
 
     #[test]
     fn timestamp_serialization_roundtrip() {
@@ -310,7 +309,7 @@ mod tests {
 
     #[test]
     fn timediff_serialization_roundtrip() {
-        let mut rng = TestRng::new();
+        let mut rng = crate::new_rng();
         let timediff = TimeDiff(rng.gen());
 
         let timediff_as_string = timediff.to_string();

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -189,7 +189,7 @@ impl<T> WithDir<T> {
 }
 
 /// The source of a piece of data.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub enum Source<I> {
     /// A peer with the wrapped ID.
     Peer(I),
@@ -197,11 +197,11 @@ pub enum Source<I> {
     Client,
 }
 
-impl<I: Copy> Source<I> {
+impl<I: Clone> Source<I> {
     /// If `self` represents a peer, returns its ID, otherwise returns `None`.
     pub(crate) fn node_id(&self) -> Option<I> {
         match self {
-            Source::Peer(node_id) => Some(*node_id),
+            Source::Peer(node_id) => Some(node_id.clone()),
             Source::Client => None,
         }
     }

--- a/node_macros/src/gen.rs
+++ b/node_macros/src/gen.rs
@@ -320,7 +320,7 @@ pub(crate) fn generate_reactor_impl(def: &ReactorDefinition) -> TokenStream {
             fn dispatch_event(
                 &mut self,
                 effect_builder: crate::reactor::EffectBuilder<Self::Event>,
-                rng: &mut dyn crate::types::CryptoRngCore,
+                rng: &mut crate::NodeRng,
                 event: Self::Event,
             ) -> crate::reactor::Effects<Self::Event> {
                 match event {
@@ -332,7 +332,7 @@ pub(crate) fn generate_reactor_impl(def: &ReactorDefinition) -> TokenStream {
                 cfg: Self::Config,
                 registry: &crate::reactor::Registry,
                 event_queue: crate::reactor::EventQueueHandle<Self::Event>,
-                rng: &mut dyn crate::types::CryptoRngCore,
+                rng: &mut crate::NodeRng,
             ) -> Result<(Self, crate::reactor::Effects<Self::Event>), Self::Error> {
                 let mut all_effects = crate::reactor::Effects::new();
 


### PR DESCRIPTION
This PR introduces libp2p's `PeerId` type into the system.  It has been added alongside the existing node identifier in the form of an enum, with the expectation that we'll be able to support connections of either type (libp2p or our current TLS ones) while we transition the small_network component to use libp2p fully.

Once the transition is complete, the `NodeId` enum introduced here can be changed to a simple newtype struct.

Rather than making `NodeId` able to be randomly generated by _any_ RNG, I strongly prefer to force the usage of our `TestRng` type, as was previously debated and agreed.  This caused a ripple effect whereby our `CryptoRngCore` trait has been removed in favour of a single, specific RNG type used throughout our crate.  In `test` configuration this is a `TestRng` and otherwise it is a `ChaCha20Rng`.

This still keeps things trivial should we wish to change from using that specific RNG.  It should only involve changing the alias in lib.rs.  As we designed the system to use not just a single RNG type, but a single RNG _instance_ throughout, I don't see any advantage at all to using `dyn CryptoRngCore` everywhere: there is no intent to use different concrete RNG types in these places.