### PR TITLE
NDRS-484: Replace Serde with ToBytes/FromBytes implementation

### DIFF
--- a/client/lib/deploy.rs
+++ b/client/lib/deploy.rs
@@ -142,7 +142,7 @@ impl DeployExt for Deploy {
             secret_key,
         } = params;
         let mut rng = rand::thread_rng();
-        Deploy::new_signed(
+        Deploy::new(
             timestamp,
             ttl,
             gas_price,

--- a/client/lib/deploy.rs
+++ b/client/lib/deploy.rs
@@ -142,7 +142,7 @@ impl DeployExt for Deploy {
             secret_key,
         } = params;
         let mut rng = rand::thread_rng();
-        Deploy::new(
+        Deploy::new_signed(
             timestamp,
             ttl,
             gas_price,

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -9,7 +9,10 @@ use rand::{
 use serde::{Deserialize, Serialize};
 
 use casper_types::{
-    account::AccountHash, auction::EraId, bytesrepr, Key, ProtocolVersion, PublicKey, U512,
+    account::AccountHash,
+    auction::EraId,
+    bytesrepr::{self, FromBytes, ToBytes},
+    Key, ProtocolVersion, PublicKey, U512,
 };
 
 use super::SYSTEM_ACCOUNT_ADDR;
@@ -142,6 +145,40 @@ impl Distribution<GenesisAccount> for Standard {
         let bonded_amount = Motes::new(U512::from(u512_array));
 
         GenesisAccount::new(public_key, account_hash, balance, bonded_amount)
+    }
+}
+
+impl ToBytes for GenesisAccount {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.extend(self.public_key.to_bytes()?);
+        buffer.extend(self.account_hash.to_bytes()?);
+        buffer.extend(self.balance.value().to_bytes()?);
+        buffer.extend(self.bonded_amount.value().to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.public_key.serialized_length()
+            + self.account_hash.serialized_length()
+            + self.balance.value().serialized_length()
+            + self.bonded_amount.value().serialized_length()
+    }
+}
+
+impl FromBytes for GenesisAccount {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (public_key, remainder) = Option::<PublicKey>::from_bytes(bytes)?;
+        let (account_hash, remainder) = AccountHash::from_bytes(remainder)?;
+        let (balance_value, remainder) = U512::from_bytes(remainder)?;
+        let (bonded_amount_value, remainder) = U512::from_bytes(remainder)?;
+        let genesis_account = GenesisAccount {
+            public_key,
+            account_hash,
+            balance: Motes::new(balance_value),
+            bonded_amount: Motes::new(bonded_amount_value),
+        };
+        Ok((genesis_account, remainder))
     }
 }
 

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -512,7 +512,7 @@ mod tests {
             args: vec![],
         };
 
-        let deploy = Deploy::new_signed(
+        let deploy = Deploy::new(
             timestamp,
             ttl,
             gas_price,

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -512,7 +512,7 @@ mod tests {
             args: vec![],
         };
 
-        let deploy = Deploy::new(
+        let deploy = Deploy::new_signed(
             timestamp,
             ttl,
             gas_price,

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -3,6 +3,7 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
 };
 
+use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 use datasize::DataSize;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -60,6 +61,24 @@ impl Display for EraId {
 impl From<EraId> for u64 {
     fn from(era_id: EraId) -> Self {
         era_id.0
+    }
+}
+
+impl ToBytes for EraId {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
+    }
+}
+
+impl FromBytes for EraId {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (id_value, remainder) = u64::from_bytes(bytes)?;
+        let era_id = EraId(id_value);
+        Ok((era_id, remainder))
     }
 }
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -33,7 +33,6 @@ use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 #[cfg(test)]
 use crate::testing::TestRng;
 
-
 use crate::{
     components::{
         block_proposer::BlockProposerState, chainspec_loader::Chainspec, small_network::NodeId,
@@ -140,8 +139,6 @@ impl<B: Value> DeployMetadata<B> {
         let _ = execution_results.insert(block_hash, execution_result);
         DeployMetadata { execution_results }
     }
-
-
 }
 
 #[cfg(test)]
@@ -155,7 +152,6 @@ impl DeployMetadata<Block> {
         DeployMetadata { execution_results }
     }
 }
-
 
 impl<B: Value> Default for DeployMetadata<B> {
     fn default() -> Self {
@@ -843,7 +839,6 @@ where
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -854,6 +849,4 @@ mod tests {
         let deploy_metadata = DeployMetadata::random(&mut rng);
         bytesrepr::test_serialization_roundtrip(&deploy_metadata);
     }
-
-
 }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -145,7 +145,7 @@ impl<B: Value> DeployMetadata<B> {
 impl DeployMetadata<Block> {
     fn random(rng: &mut TestRng) -> Self {
         let block = Block::random(rng);
-        let id = super::storage::Value::id(&block);
+        let id = Value::id(&block);
         let mut execution_results = BTreeMap::new();
         let execution_result = ExecutionResult::random(rng);
         execution_results.insert(*id, execution_result);
@@ -160,16 +160,19 @@ impl<B: Value> Default for DeployMetadata<B> {
         }
     }
 }
+
 impl<B: Value> ToBytes for DeployMetadata<B> {
     fn to_bytes(&self) -> StdResult<Vec<u8>, bytesrepr::Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         buffer.extend(self.execution_results.to_bytes()?);
         Ok(buffer)
     }
+
     fn serialized_length(&self) -> usize {
         self.execution_results.serialized_length()
     }
 }
+
 impl<B: Value> FromBytes for DeployMetadata<B> {
     fn from_bytes(bytes: &[u8]) -> StdResult<(Self, &[u8]), bytesrepr::Error> {
         let (execution_results, remainder) = BTreeMap::<B::Id, ExecutionResult>::from_bytes(bytes)?;

--- a/node/src/components/storage/error.rs
+++ b/node/src/components/storage/error.rs
@@ -24,6 +24,14 @@ pub enum Error {
     #[error("deserialization: {0}")]
     Deserialization(#[source] bincode::ErrorKind),
 
+    /// Failed to Serialize using ToBytes.
+    #[error("Error in ToBytes serialization")]
+    CustomSerialization,
+
+    /// Failed to Deserialize using FromBytes.
+    #[error("Error in FromBytes deserialization")]
+    CustomDeserialization,
+
     /// Internal storage component error.
     #[error("internal: {0}")]
     Internal(Box<dyn StdError + Send + Sync>),

--- a/node/src/components/storage/lmdb_block_height_store.rs
+++ b/node/src/components/storage/lmdb_block_height_store.rs
@@ -4,11 +4,11 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 use lmdb::{
     self, Cursor, Database, DatabaseFlags, Environment, EnvironmentFlags, Transaction, WriteFlags,
 };
 
+use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 use tracing::info;
 
 use super::{BlockHeightStore, Error, Result};

--- a/node/src/crypto/asymmetric_key.rs
+++ b/node/src/crypto/asymmetric_key.rs
@@ -1440,12 +1440,11 @@ mod tests {
         assert_eq!(signature, deserialized);
         assert_eq!(signature.tag(), deserialized.tag());
 
-        // Try to/from using bytesrepr. 
+        // Try to/from using bytesrepr.
         let serialized = bytesrepr::serialize(signature).unwrap();
         let deserialized = bytesrepr::deserialize(serialized).unwrap();
         assert_eq!(signature, deserialized);
         assert_eq!(signature.tag(), deserialized.tag())
-
     }
 
     fn signature_hex_roundtrip(signature: Signature) {

--- a/node/src/crypto/asymmetric_key.rs
+++ b/node/src/crypto/asymmetric_key.rs
@@ -1439,6 +1439,13 @@ mod tests {
         let deserialized = serde_json::from_slice(&serialized).unwrap();
         assert_eq!(signature, deserialized);
         assert_eq!(signature.tag(), deserialized.tag());
+
+        // Try to/from using bytesrepr. 
+        let serialized = bytesrepr::serialize(signature).unwrap();
+        let deserialized = bytesrepr::deserialize(serialized).unwrap();
+        assert_eq!(signature, deserialized);
+        assert_eq!(signature.tag(), deserialized.tag())
+
     }
 
     fn signature_hex_roundtrip(signature: Signature) {
@@ -1688,7 +1695,7 @@ MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
         }
 
         #[test]
-        fn bytesrepr_roundtrip() {
+        fn bytesrepr_roundtrip_signature() {
             let mut rng = TestRng::new();
             let ed25519_secret_key = SecretKey::random_ed25519(&mut rng);
             let public_key = PublicKey::from(&ed25519_secret_key);
@@ -1831,7 +1838,7 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
         }
 
         #[test]
-        fn bytesrepr_roundtrip() {
+        fn bytesrepr_roundtrip_signature() {
             let mut rng = TestRng::new();
             let secret_key = SecretKey::random_secp256k1(&mut rng);
             let public_key = PublicKey::from(&secret_key);

--- a/node/src/crypto/asymmetric_key.rs
+++ b/node/src/crypto/asymmetric_key.rs
@@ -988,6 +988,62 @@ impl Display for Signature {
     }
 }
 
+impl ToBytes for Signature {
+    fn to_bytes(&self) -> StdResult<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        match self {
+            Signature::Ed25519(signature) => {
+                buffer.insert(0, ED25519_TAG);
+                buffer.extend(signature.to_bytes()?);
+            }
+            Signature::Secp256k1(signature) => {
+                buffer.insert(0, SECP256K1_TAG);
+                buffer.extend(signature.as_ref().to_vec().into_bytes()?);
+            }
+        }
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        TAG_LENGTH
+            + match self {
+                Signature::Ed25519(signature) => signature.serialized_length(),
+                Signature::Secp256k1(signature) => signature.as_ref().to_vec().serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for Signature {
+    fn from_bytes(bytes: &[u8]) -> StdResult<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            ED25519_TAG => {
+                let (ed25519_signature_bytes, remainder) =
+                    <[u8; ed25519::SIGNATURE_LENGTH]>::from_bytes(remainder)?;
+                let ed25519_signature =
+                    Self::new_ed25519(ed25519_signature_bytes).map_err(|error| {
+                        info!("failed to deserialize ed25519 signature:{}", error);
+                        bytesrepr::Error::Formatting
+                    })?;
+                Ok((ed25519_signature, remainder))
+            }
+            SECP256K1_TAG => {
+                let (secp256k1_signature_bytes, remainder) = Vec::<u8>::from_bytes(remainder)?;
+                let secp256k1_signature = Self::secp256k1_from_bytes(secp256k1_signature_bytes)
+                    .map_err(|error| {
+                        info!("failed to deserialize secp256k1 signature: {}", error);
+                        bytesrepr::Error::Formatting
+                    })?;
+                Ok((secp256k1_signature, remainder))
+            }
+            _ => {
+                info!("failed to deserialize to signature: invalid tag: {}", tag);
+                Err(bytesrepr::Error::Formatting)
+            }
+        }
+    }
+}
+
 impl Serialize for Signature {
     fn serialize<S: Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
         serialize(self, serializer)
@@ -1630,6 +1686,16 @@ MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
             let hash_types: AccountHash = public_key_types.into();
             assert_eq!(hash_types, hash_node)
         }
+
+        #[test]
+        fn bytesrepr_roundtrip() {
+            let mut rng = TestRng::new();
+            let ed25519_secret_key = SecretKey::random_ed25519(&mut rng);
+            let public_key = PublicKey::from(&ed25519_secret_key);
+            let data = b"data";
+            let signature = sign(data, &ed25519_secret_key, &public_key, &mut rng);
+            bytesrepr::test_serialization_roundtrip(&signature);
+        }
     }
 
     mod secp256k1 {
@@ -1762,6 +1828,16 @@ kv+kBR5u4ISEAkuc2TFWQHX0Yj9oTB9fx9+vvQdxJOhMtu46kGo0Uw==
             let data = b"data";
             let signature = sign(data, &secret_key, &public_key, &mut rng);
             super::signature_serialization_roundtrip(signature);
+        }
+
+        #[test]
+        fn bytesrepr_roundtrip() {
+            let mut rng = TestRng::new();
+            let secret_key = SecretKey::random_secp256k1(&mut rng);
+            let public_key = PublicKey::from(&secret_key);
+            let data = b"data";
+            let signature = sign(data, &secret_key, &public_key, &mut rng);
+            bytesrepr::test_serialization_roundtrip(&signature);
         }
 
         #[test]

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -11,7 +11,7 @@ use blake2::{
     digest::{Update, VariableOutput},
     VarBlake2b,
 };
-use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+
 use datasize::DataSize;
 use hex::FromHexError;
 use hex_fmt::{HexFmt, HexList};
@@ -23,6 +23,8 @@ use thiserror::Error;
 
 #[cfg(test)]
 use casper_types::auction::BLOCK_REWARD;
+
+use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 
 use super::{Item, Tag, Timestamp};
 use crate::{
@@ -818,10 +820,6 @@ impl Display for Block {
         Ok(())
     }
 }
-///        parent_hash: BlockHash,
-/// parent_seed: Digest,
-///  state_root_hash: Digest,
-/// finalized_block: FinalizedBlock,
 
 impl ToBytes for Block {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -983,9 +983,12 @@ mod tests {
     #[test]
     fn bytesrepr_roundtrip_era_end() {
         let mut rng = TestRng::new();
-        let finalized_block = FinalizedBlock::random(&mut rng);
-        if let Some(era_end) = finalized_block.era_end() {
-            bytesrepr::test_serialization_roundtrip(era_end);
+        let loop_iterations = 50;
+        for _ in 0..loop_iterations {
+            let finalized_block = FinalizedBlock::random(&mut rng);
+            if let Some(era_end) = finalized_block.era_end() {
+                bytesrepr::test_serialization_roundtrip(era_end);
+            }
         }
     }
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -2,6 +2,7 @@
 use std::iter;
 use std::{
     array::TryFromSliceError,
+    collections::BTreeMap,
     error::Error as StdError,
     fmt::{self, Debug, Display, Formatter},
     hash::Hash,
@@ -18,7 +19,6 @@ use hex_fmt::{HexFmt, HexList};
 #[cfg(test)]
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use thiserror::Error;
 
 #[cfg(test)]

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -983,6 +983,15 @@ mod tests {
     }
 
     #[test]
+    fn bytesrepr_roundtrip_era_end() {
+        let mut rng = TestRng::new();
+        let finalized_block = FinalizedBlock::random(&mut rng);
+        if let Some(era_end) = finalized_block.era_end() {
+            bytesrepr::test_serialization_roundtrip(era_end);
+        }
+    }
+
+    #[test]
     fn random_block_check() {
         let mut rng = TestRng::from_seed([1u8; 16]);
         let loop_iterations = 50;

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -319,7 +319,7 @@ pub struct Deploy {
 impl Deploy {
     /// Constructs a new signed `Deploy`.
     #[allow(clippy::too_many_arguments)]
-    pub fn new_signed(
+    pub fn new(
         timestamp: Timestamp,
         ttl: TimeDiff,
         gas_price: u64,
@@ -432,7 +432,7 @@ impl Deploy {
 
         let secret_key = SecretKey::random(rng);
 
-        Deploy::new_signed(
+        Deploy::new(
             timestamp,
             ttl,
             gas_price,
@@ -636,7 +636,7 @@ mod tests {
 
     #[test]
     fn is_not_valid() {
-        let mut deploy = Deploy::new_signed(
+        let mut deploy = Deploy::new(
             Timestamp::zero(),
             TimeDiff::from(Duration::default()),
             0,

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -317,9 +317,28 @@ pub struct Deploy {
 }
 
 impl Deploy {
-    /// Constructs a new `Deploy`.
+    /// Constructs a new unsigned `Deploy`
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        hash: DeployHash,
+        header: DeployHeader,
+        payment: ExecutableDeployItem,
+        session: ExecutableDeployItem,
+        approvals: Vec<Approval>,
+    ) -> Self {
+        Deploy {
+            hash,
+            header,
+            payment,
+            session,
+            approvals,
+            is_valid: None,
+        }
+    }
+
+    /// Constructs a new signed `Deploy`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_signed(
         timestamp: Timestamp,
         ttl: TimeDiff,
         gas_price: u64,
@@ -432,7 +451,7 @@ impl Deploy {
 
         let secret_key = SecretKey::random(rng);
 
-        Deploy::new(
+        Deploy::new_signed(
             timestamp,
             ttl,
             gas_price,
@@ -622,7 +641,6 @@ mod tests {
 
         let deploy = Deploy::random(&mut rng);
         bytesrepr::test_serialization_roundtrip(deploy.header());
-
         bytesrepr::test_serialization_roundtrip(&deploy);
     }
 
@@ -637,7 +655,7 @@ mod tests {
 
     #[test]
     fn is_not_valid() {
-        let mut deploy = Deploy::new(
+        let mut deploy = Deploy::new_signed(
             Timestamp::zero(),
             TimeDiff::from(Duration::default()),
             0,

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -594,21 +594,7 @@ impl FromBytes for Deploy {
             approvals,
             is_valid: None,
         };
-        if maybe_valid_deploy.is_valid() {
-            let is_valid = Some(true);
-            let valid_deploy = Deploy {
-                header: maybe_valid_deploy.header,
-                hash: maybe_valid_deploy.hash,
-                payment: maybe_valid_deploy.payment,
-                session: maybe_valid_deploy.session,
-                approvals: maybe_valid_deploy.approvals,
-                is_valid,
-            };
-            Ok((valid_deploy, remainder))
-        } else {
-            info!("deploy deserialization led to an invalid block");
-            Err(bytesrepr::Error::Formatting)
-        }
+        Ok((maybe_valid_deploy, remainder))
     }
 }
 

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -317,25 +317,6 @@ pub struct Deploy {
 }
 
 impl Deploy {
-    /// Constructs a new unsigned `Deploy`
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        hash: DeployHash,
-        header: DeployHeader,
-        payment: ExecutableDeployItem,
-        session: ExecutableDeployItem,
-        approvals: Vec<Approval>,
-    ) -> Self {
-        Deploy {
-            hash,
-            header,
-            payment,
-            session,
-            approvals,
-            is_valid: None,
-        }
-    }
-
     /// Constructs a new signed `Deploy`.
     #[allow(clippy::too_many_arguments)]
     pub fn new_signed(

--- a/node/src/types/json_compatibility/execution_result.rs
+++ b/node/src/types/json_compatibility/execution_result.rs
@@ -27,11 +27,30 @@ use casper_types::{
 #[cfg(test)]
 use crate::testing::TestRng;
 
-///Constants to track operation serialization
+/// Constants to track operation serialization.
 pub const OP_READ_TAG: u8 = 1;
 pub const OP_WRITE_TAG: u8 = 2;
 pub const OP_ADD_TAG: u8 = 3;
 pub const OP_NOOP_TAG: u8 = 4;
+
+/// Constants to track Transform serialization. 
+pub const IDENTITY: u8 = 0;
+pub const WRITE_CLVALUE: u8 = 1;
+pub const WRITE_ACCOUNT: u8 = 2;
+pub const WRITE_CONTRACT_WASM: u8 = 3;
+pub const WRITE_CONTRACT: u8 = 4;
+pub const WRITE_CONTRACT_PACKAGE: u8 = 5;
+pub const WRITE_DEPLOY_INFO: u8 = 6;
+pub const WRITE_TRANSFER: u8 = 7;
+pub const ADD_INT_I32: u8 = 8;
+pub const ADD_INT_U64: u8 = 9;
+pub const ADD_INT_U128: u8 = 10;
+pub const ADD_INT_U256: u8 = 11;
+pub const ADD_UINT_512: u8 = 12;
+pub const ADD_KEYS: u8 = 13;
+pub const FAILURE: u8 = 14;
+
+
 
 /// The result of executing a single deploy.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug, DataSize)]
@@ -320,22 +339,6 @@ impl From<&EngineTransform> for Transform {
     }
 }
 
-pub const IDENTITY: u8 = 0;
-pub const WRITE_CLVALUE: u8 = 1;
-pub const WRITE_ACCOUNT: u8 = 2;
-pub const WRITE_CONTRACT_WASM: u8 = 3;
-pub const WRITE_CONTRACT: u8 = 4;
-pub const WRITE_CONTRACT_PACKAGE: u8 = 5;
-pub const WRITE_DEPLOY_INFO: u8 = 6;
-pub const WRITE_TRANSFER: u8 = 7;
-pub const ADD_INT_I32: u8 = 8;
-pub const ADD_INT_U64: u8 = 9;
-pub const ADD_INT_U128: u8 = 10;
-pub const ADD_INT_U256: u8 = 11;
-pub const ADD_UINT_512: u8 = 12;
-pub const ADD_KEYS: u8 = 13;
-pub const FAILURE: u8 = 14;
-
 impl ToBytes for Transform {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
@@ -462,5 +465,39 @@ impl FromBytes for Transform {
                 Err(bytesrepr::Error::Formatting)
             }
         }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytesrepr_test_transform() {
+        let mut rng = TestRng::new();
+        let transform = Transform::random(&mut rng);
+        bytesrepr::test_serialization_roundtrip(&transform);
+    }
+
+    #[test]
+    fn bytesrepr_test_operation() {
+        let mut rng = TestRng::new();
+        let execution_result = ExecutionResult::random(&mut rng);
+        bytesrepr::test_serialization_roundtrip(&execution_result.effect.operations);
+    }
+
+    #[test]
+    fn bytesrepr_test_execution_effect() {
+        let mut rng = TestRng::new();
+        let execution_result = ExecutionResult::random(&mut rng);
+        bytesrepr::test_serialization_roundtrip(&execution_result.effect);
+    }
+
+    #[test]
+    fn bytesrepr_test_execution_result() {
+        let mut rng = TestRng::new();
+        let execution_result = ExecutionResult::random(&mut rng);
+        bytesrepr::test_serialization_roundtrip(&execution_result);
     }
 }

--- a/node/src/types/json_compatibility/execution_result.rs
+++ b/node/src/types/json_compatibility/execution_result.rs
@@ -33,7 +33,7 @@ pub const OP_WRITE_TAG: u8 = 2;
 pub const OP_ADD_TAG: u8 = 3;
 pub const OP_NOOP_TAG: u8 = 4;
 
-/// Constants to track Transform serialization. 
+/// Constants to track Transform serialization.
 pub const IDENTITY: u8 = 0;
 pub const WRITE_CLVALUE: u8 = 1;
 pub const WRITE_ACCOUNT: u8 = 2;
@@ -49,8 +49,6 @@ pub const ADD_INT_U256: u8 = 11;
 pub const ADD_UINT_512: u8 = 12;
 pub const ADD_KEYS: u8 = 13;
 pub const FAILURE: u8 = 14;
-
-
 
 /// The result of executing a single deploy.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug, DataSize)]
@@ -467,7 +465,6 @@ impl FromBytes for Transform {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/node/src/types/json_compatibility/execution_result.rs
+++ b/node/src/types/json_compatibility/execution_result.rs
@@ -28,10 +28,10 @@ use casper_types::{
 use crate::testing::TestRng;
 
 /// Constants to track operation serialization.
-const OP_READ_TAG: u8 = 1;
-const OP_WRITE_TAG: u8 = 2;
-const OP_ADD_TAG: u8 = 3;
-const OP_NOOP_TAG: u8 = 4;
+const OP_READ_TAG: u8 = 0;
+const OP_WRITE_TAG: u8 = 1;
+const OP_ADD_TAG: u8 = 2;
+const OP_NOOP_TAG: u8 = 3;
 
 /// Constants to track Transform serialization.
 const IDENTITY_TAG: u8 = 0;

--- a/node/src/types/json_compatibility/execution_result.rs
+++ b/node/src/types/json_compatibility/execution_result.rs
@@ -4,9 +4,10 @@
 //! It is stored as metadata related to a given deploy, and made available to clients via the
 //! JSON-RPC API.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use datasize::DataSize;
+use log::info;
 #[cfg(test)]
 use rand::{seq::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
@@ -18,10 +19,19 @@ use casper_execution_engine::{
     },
     shared::{stored_value::StoredValue, transform::Transform as EngineTransform},
 };
-use casper_types::{CLValue, U128, U256, U512};
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    CLValue, U128, U256, U512,
+};
 
 #[cfg(test)]
 use crate::testing::TestRng;
+
+///Constants to track operation serialization
+pub const OP_READ_TAG: u8 = 1;
+pub const OP_WRITE_TAG: u8 = 2;
+pub const OP_ADD_TAG: u8 = 3;
+pub const OP_NOOP_TAG: u8 = 4;
 
 /// The result of executing a single deploy.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug, DataSize)]
@@ -92,13 +102,43 @@ impl From<&EngineExecutionResult> for ExecutionResult {
     }
 }
 
+impl ToBytes for ExecutionResult {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.extend(self.effect.to_bytes()?);
+        buffer.extend(self.cost.to_bytes()?);
+        buffer.extend(self.error_message.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.effect.serialized_length()
+            + self.cost.serialized_length()
+            + self.error_message.serialized_length()
+    }
+}
+
+impl FromBytes for ExecutionResult {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (effect, remainder) = ExecutionEffect::from_bytes(bytes)?;
+        let (cost, remainder) = U512::from_bytes(remainder)?;
+        let (error_message, remainder) = Option::<String>::from_bytes(remainder)?;
+        let execution_result = ExecutionResult {
+            effect,
+            cost,
+            error_message,
+        };
+        Ok((execution_result, remainder))
+    }
+}
+
 /// The effect of executing a single deploy.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Default, Debug, DataSize)]
 struct ExecutionEffect {
     /// The resulting operations.  The map's key is the formatted string of the EE `Key`.
-    operations: HashMap<String, Operation>,
+    operations: BTreeMap<String, Operation>,
     /// The resulting operations.  The map's key is the formatted string of the EE `Key`.
-    transforms: HashMap<String, Transform>,
+    transforms: BTreeMap<String, Transform>,
 }
 
 impl From<&EngineExecutionEffect> for ExecutionEffect {
@@ -118,6 +158,31 @@ impl From<&EngineExecutionEffect> for ExecutionEffect {
     }
 }
 
+impl ToBytes for ExecutionEffect {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.extend(self.operations.to_bytes()?);
+        buffer.extend(self.transforms.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.operations.serialized_length() + self.transforms.serialized_length()
+    }
+}
+
+impl FromBytes for ExecutionEffect {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (operations, remainder) = BTreeMap::<String, Operation>::from_bytes(bytes)?;
+        let (transforms, remainder) = BTreeMap::<String, Transform>::from_bytes(remainder)?;
+        let execution_effect = ExecutionEffect {
+            operations,
+            transforms,
+        };
+        Ok((execution_effect, remainder))
+    }
+}
+
 #[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Debug, DataSize)]
 enum Operation {
     Read,
@@ -133,6 +198,47 @@ impl From<&Op> for Operation {
             Op::Write => Operation::Write,
             Op::Add => Operation::Add,
             Op::NoOp => Operation::NoOp,
+        }
+    }
+}
+
+impl ToBytes for Operation {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        match self {
+            Operation::Read => {
+                buffer.insert(0, OP_READ_TAG);
+            }
+            Operation::Write => {
+                buffer.insert(0, OP_WRITE_TAG);
+            }
+            Operation::Add => {
+                buffer.insert(0, OP_ADD_TAG);
+            }
+            Operation::NoOp => {
+                buffer.insert(0, OP_NOOP_TAG);
+            }
+        }
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        bytesrepr::U8_SERIALIZED_LENGTH
+    }
+}
+
+impl FromBytes for Operation {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            OP_READ_TAG => Ok((Operation::Read, remainder)),
+            OP_WRITE_TAG => Ok((Operation::Write, remainder)),
+            OP_ADD_TAG => Ok((Operation::Add, remainder)),
+            OP_NOOP_TAG => Ok((Operation::NoOp, remainder)),
+            _ => {
+                info!("Failed to deserialize Operation, invalid identifier found");
+                Err(bytesrepr::Error::Formatting)
+            }
         }
     }
 }
@@ -210,6 +316,151 @@ impl From<&EngineTransform> for Transform {
                 Transform::AddKeys(super::convert_named_keys(named_keys))
             }
             EngineTransform::Failure(error) => Transform::Failure(error.to_string()),
+        }
+    }
+}
+
+pub const IDENTITY: u8 = 0;
+pub const WRITE_CLVALUE: u8 = 1;
+pub const WRITE_ACCOUNT: u8 = 2;
+pub const WRITE_CONTRACT_WASM: u8 = 3;
+pub const WRITE_CONTRACT: u8 = 4;
+pub const WRITE_CONTRACT_PACKAGE: u8 = 5;
+pub const WRITE_DEPLOY_INFO: u8 = 6;
+pub const WRITE_TRANSFER: u8 = 7;
+pub const ADD_INT_I32: u8 = 8;
+pub const ADD_INT_U64: u8 = 9;
+pub const ADD_INT_U128: u8 = 10;
+pub const ADD_INT_U256: u8 = 11;
+pub const ADD_UINT_512: u8 = 12;
+pub const ADD_KEYS: u8 = 13;
+pub const FAILURE: u8 = 14;
+
+impl ToBytes for Transform {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        match self {
+            Transform::Identity => buffer.insert(0, IDENTITY),
+            Transform::WriteCLValue(value) => {
+                buffer.insert(0, WRITE_CLVALUE);
+                buffer.extend(value.to_bytes()?);
+            }
+            Transform::WriteAccount => buffer.insert(0, WRITE_ACCOUNT),
+            Transform::WriteContractWasm => buffer.insert(0, WRITE_CONTRACT_WASM),
+            Transform::WriteContract => buffer.insert(0, WRITE_CONTRACT),
+            Transform::WriteContractPackage => buffer.insert(0, WRITE_CONTRACT_PACKAGE),
+            Transform::WriteDeployInfo => buffer.insert(0, WRITE_DEPLOY_INFO),
+            Transform::WriteTransfer => buffer.insert(0, WRITE_TRANSFER),
+            Transform::AddInt32(value) => {
+                buffer.insert(0, ADD_INT_I32);
+                buffer.extend(value.to_bytes()?);
+            }
+            Transform::AddUInt64(value) => {
+                buffer.insert(0, ADD_INT_U64);
+                buffer.extend(value.to_bytes()?);
+            }
+            Transform::AddUInt128(value) => {
+                buffer.insert(0, ADD_INT_U128);
+                buffer.extend(value.to_bytes()?);
+            }
+            Transform::AddUInt256(value) => {
+                buffer.insert(0, ADD_INT_U256);
+                buffer.extend(value.to_bytes()?);
+            }
+            Transform::AddUInt512(value) => {
+                buffer.insert(0, ADD_UINT_512);
+                buffer.extend(value.to_bytes()?);
+            }
+            Transform::AddKeys(value) => {
+                buffer.insert(0, ADD_KEYS);
+                buffer.extend(value.to_bytes()?);
+            }
+            Transform::Failure(value) => {
+                buffer.insert(0, FAILURE);
+                buffer.extend(value.to_bytes()?);
+            }
+        }
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        match self {
+            Transform::WriteCLValue(value) => {
+                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
+            }
+            Transform::AddInt32(value) => {
+                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
+            }
+            Transform::AddUInt64(value) => {
+                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
+            }
+            Transform::AddUInt128(value) => {
+                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
+            }
+            Transform::AddUInt256(value) => {
+                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
+            }
+            Transform::AddUInt512(value) => {
+                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
+            }
+            Transform::AddKeys(value) => {
+                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
+            }
+            Transform::Failure(value) => {
+                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
+            }
+            _ => bytesrepr::U8_SERIALIZED_LENGTH,
+        }
+    }
+}
+
+impl FromBytes for Transform {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            IDENTITY => Ok((Transform::Identity, remainder)),
+            WRITE_CLVALUE => {
+                let (cl_value, remainder) = CLValue::from_bytes(remainder)?;
+                Ok((Transform::WriteCLValue(cl_value), remainder))
+            }
+            WRITE_ACCOUNT => Ok((Transform::WriteAccount, remainder)),
+            WRITE_CONTRACT_WASM => Ok((Transform::WriteContractWasm, remainder)),
+            WRITE_CONTRACT => Ok((Transform::WriteContract, remainder)),
+            WRITE_CONTRACT_PACKAGE => Ok((Transform::WriteContractPackage, remainder)),
+            WRITE_DEPLOY_INFO => Ok((Transform::WriteDeployInfo, remainder)),
+            WRITE_TRANSFER => Ok((Transform::WriteTransfer, remainder)),
+            ADD_INT_I32 => {
+                let (value_i32, remainder) = i32::from_bytes(remainder)?;
+                Ok((Transform::AddInt32(value_i32), remainder))
+            }
+            ADD_INT_U64 => {
+                let (value_u64, remainder) = u64::from_bytes(remainder)?;
+                Ok((Transform::AddUInt64(value_u64), remainder))
+            }
+            ADD_INT_U128 => {
+                let (value_u128, remainder) = U128::from_bytes(remainder)?;
+                Ok((Transform::AddUInt128(value_u128), remainder))
+            }
+            ADD_INT_U256 => {
+                let (value_u256, remainder) = U256::from_bytes(remainder)?;
+                Ok((Transform::AddUInt256(value_u256), remainder))
+            }
+            ADD_UINT_512 => {
+                let (value_u512, remainder) = U512::from_bytes(remainder)?;
+                Ok((Transform::AddUInt512(value_u512), remainder))
+            }
+            ADD_KEYS => {
+                let (value, remainder) = BTreeMap::<String, String>::from_bytes(remainder)?;
+                Ok((Transform::AddKeys(value), remainder))
+            }
+            FAILURE => {
+                let (value, remainder) = String::from_bytes(remainder)?;
+                Ok((Transform::Failure(value), remainder))
+            }
+            _ => {
+                info!("Failed to deserialize Transforms, invalid identifier found");
+                Err(bytesrepr::Error::Formatting)
+            }
         }
     }
 }

--- a/node/src/types/json_compatibility/execution_result.rs
+++ b/node/src/types/json_compatibility/execution_result.rs
@@ -20,7 +20,7 @@ use casper_execution_engine::{
     shared::{stored_value::StoredValue, transform::Transform as EngineTransform},
 };
 use casper_types::{
-    bytesrepr::{self, FromBytes, ToBytes},
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     CLValue, U128, U256, U512,
 };
 
@@ -28,27 +28,27 @@ use casper_types::{
 use crate::testing::TestRng;
 
 /// Constants to track operation serialization.
-pub const OP_READ_TAG: u8 = 1;
-pub const OP_WRITE_TAG: u8 = 2;
-pub const OP_ADD_TAG: u8 = 3;
-pub const OP_NOOP_TAG: u8 = 4;
+const OP_READ_TAG: u8 = 1;
+const OP_WRITE_TAG: u8 = 2;
+const OP_ADD_TAG: u8 = 3;
+const OP_NOOP_TAG: u8 = 4;
 
 /// Constants to track Transform serialization.
-pub const IDENTITY: u8 = 0;
-pub const WRITE_CLVALUE: u8 = 1;
-pub const WRITE_ACCOUNT: u8 = 2;
-pub const WRITE_CONTRACT_WASM: u8 = 3;
-pub const WRITE_CONTRACT: u8 = 4;
-pub const WRITE_CONTRACT_PACKAGE: u8 = 5;
-pub const WRITE_DEPLOY_INFO: u8 = 6;
-pub const WRITE_TRANSFER: u8 = 7;
-pub const ADD_INT_I32: u8 = 8;
-pub const ADD_INT_U64: u8 = 9;
-pub const ADD_INT_U128: u8 = 10;
-pub const ADD_INT_U256: u8 = 11;
-pub const ADD_UINT_512: u8 = 12;
-pub const ADD_KEYS: u8 = 13;
-pub const FAILURE: u8 = 14;
+const IDENTITY_TAG: u8 = 0;
+const WRITE_CLVALUE_TAG: u8 = 1;
+const WRITE_ACCOUNT_TAG: u8 = 2;
+const WRITE_CONTRACT_WASM_TAG: u8 = 3;
+const WRITE_CONTRACT_TAG: u8 = 4;
+const WRITE_CONTRACT_PACKAGE_TAG: u8 = 5;
+const WRITE_DEPLOY_INFO_TAG: u8 = 6;
+const WRITE_TRANSFER_TAG: u8 = 7;
+const ADD_INT32_TAG: u8 = 8;
+const ADD_UINT64_TAG: u8 = 9;
+const ADD_UINT128_TAG: u8 = 10;
+const ADD_UINT256_TAG: u8 = 11;
+const ADD_UINT512_TAG: u8 = 12;
+const ADD_KEYS_TAG: u8 = 13;
+const FAILURE_TAG: u8 = 14;
 
 /// The result of executing a single deploy.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug, DataSize)]
@@ -221,26 +221,16 @@ impl From<&Op> for Operation {
 
 impl ToBytes for Operation {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
         match self {
-            Operation::Read => {
-                buffer.insert(0, OP_READ_TAG);
-            }
-            Operation::Write => {
-                buffer.insert(0, OP_WRITE_TAG);
-            }
-            Operation::Add => {
-                buffer.insert(0, OP_ADD_TAG);
-            }
-            Operation::NoOp => {
-                buffer.insert(0, OP_NOOP_TAG);
-            }
+            Operation::Read => OP_READ_TAG.to_bytes(),
+            Operation::Write => OP_WRITE_TAG.to_bytes(),
+            Operation::Add => OP_ADD_TAG.to_bytes(),
+            Operation::NoOp => OP_NOOP_TAG.to_bytes(),
         }
-        Ok(buffer)
     }
 
     fn serialized_length(&self) -> usize {
-        bytesrepr::U8_SERIALIZED_LENGTH
+        U8_SERIALIZED_LENGTH
     }
 }
 
@@ -341,43 +331,43 @@ impl ToBytes for Transform {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         match self {
-            Transform::Identity => buffer.insert(0, IDENTITY),
+            Transform::Identity => buffer.insert(0, IDENTITY_TAG),
             Transform::WriteCLValue(value) => {
-                buffer.insert(0, WRITE_CLVALUE);
+                buffer.insert(0, WRITE_CLVALUE_TAG);
                 buffer.extend(value.to_bytes()?);
             }
-            Transform::WriteAccount => buffer.insert(0, WRITE_ACCOUNT),
-            Transform::WriteContractWasm => buffer.insert(0, WRITE_CONTRACT_WASM),
-            Transform::WriteContract => buffer.insert(0, WRITE_CONTRACT),
-            Transform::WriteContractPackage => buffer.insert(0, WRITE_CONTRACT_PACKAGE),
-            Transform::WriteDeployInfo => buffer.insert(0, WRITE_DEPLOY_INFO),
-            Transform::WriteTransfer => buffer.insert(0, WRITE_TRANSFER),
+            Transform::WriteAccount => buffer.insert(0, WRITE_ACCOUNT_TAG),
+            Transform::WriteContractWasm => buffer.insert(0, WRITE_CONTRACT_WASM_TAG),
+            Transform::WriteContract => buffer.insert(0, WRITE_CONTRACT_TAG),
+            Transform::WriteContractPackage => buffer.insert(0, WRITE_CONTRACT_PACKAGE_TAG),
+            Transform::WriteDeployInfo => buffer.insert(0, WRITE_DEPLOY_INFO_TAG),
+            Transform::WriteTransfer => buffer.insert(0, WRITE_TRANSFER_TAG),
             Transform::AddInt32(value) => {
-                buffer.insert(0, ADD_INT_I32);
+                buffer.insert(0, ADD_INT32_TAG);
                 buffer.extend(value.to_bytes()?);
             }
             Transform::AddUInt64(value) => {
-                buffer.insert(0, ADD_INT_U64);
+                buffer.insert(0, ADD_UINT64_TAG);
                 buffer.extend(value.to_bytes()?);
             }
             Transform::AddUInt128(value) => {
-                buffer.insert(0, ADD_INT_U128);
+                buffer.insert(0, ADD_UINT128_TAG);
                 buffer.extend(value.to_bytes()?);
             }
             Transform::AddUInt256(value) => {
-                buffer.insert(0, ADD_INT_U256);
+                buffer.insert(0, ADD_UINT256_TAG);
                 buffer.extend(value.to_bytes()?);
             }
             Transform::AddUInt512(value) => {
-                buffer.insert(0, ADD_UINT_512);
+                buffer.insert(0, ADD_UINT512_TAG);
                 buffer.extend(value.to_bytes()?);
             }
             Transform::AddKeys(value) => {
-                buffer.insert(0, ADD_KEYS);
+                buffer.insert(0, ADD_KEYS_TAG);
                 buffer.extend(value.to_bytes()?);
             }
             Transform::Failure(value) => {
-                buffer.insert(0, FAILURE);
+                buffer.insert(0, FAILURE_TAG);
                 buffer.extend(value.to_bytes()?);
             }
         }
@@ -386,31 +376,15 @@ impl ToBytes for Transform {
 
     fn serialized_length(&self) -> usize {
         match self {
-            Transform::WriteCLValue(value) => {
-                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
-            }
-            Transform::AddInt32(value) => {
-                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
-            }
-            Transform::AddUInt64(value) => {
-                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
-            }
-            Transform::AddUInt128(value) => {
-                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
-            }
-            Transform::AddUInt256(value) => {
-                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
-            }
-            Transform::AddUInt512(value) => {
-                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
-            }
-            Transform::AddKeys(value) => {
-                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
-            }
-            Transform::Failure(value) => {
-                value.serialized_length() + bytesrepr::U8_SERIALIZED_LENGTH
-            }
-            _ => bytesrepr::U8_SERIALIZED_LENGTH,
+            Transform::WriteCLValue(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
+            Transform::AddInt32(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
+            Transform::AddUInt64(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
+            Transform::AddUInt128(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
+            Transform::AddUInt256(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
+            Transform::AddUInt512(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
+            Transform::AddKeys(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
+            Transform::Failure(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
+            _ => U8_SERIALIZED_LENGTH,
         }
     }
 }
@@ -419,47 +393,47 @@ impl FromBytes for Transform {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (tag, remainder) = u8::from_bytes(bytes)?;
         match tag {
-            IDENTITY => Ok((Transform::Identity, remainder)),
-            WRITE_CLVALUE => {
+            IDENTITY_TAG => Ok((Transform::Identity, remainder)),
+            WRITE_CLVALUE_TAG => {
                 let (cl_value, remainder) = CLValue::from_bytes(remainder)?;
                 Ok((Transform::WriteCLValue(cl_value), remainder))
             }
-            WRITE_ACCOUNT => Ok((Transform::WriteAccount, remainder)),
-            WRITE_CONTRACT_WASM => Ok((Transform::WriteContractWasm, remainder)),
-            WRITE_CONTRACT => Ok((Transform::WriteContract, remainder)),
-            WRITE_CONTRACT_PACKAGE => Ok((Transform::WriteContractPackage, remainder)),
-            WRITE_DEPLOY_INFO => Ok((Transform::WriteDeployInfo, remainder)),
-            WRITE_TRANSFER => Ok((Transform::WriteTransfer, remainder)),
-            ADD_INT_I32 => {
+            WRITE_ACCOUNT_TAG => Ok((Transform::WriteAccount, remainder)),
+            WRITE_CONTRACT_WASM_TAG => Ok((Transform::WriteContractWasm, remainder)),
+            WRITE_CONTRACT_TAG => Ok((Transform::WriteContract, remainder)),
+            WRITE_CONTRACT_PACKAGE_TAG => Ok((Transform::WriteContractPackage, remainder)),
+            WRITE_DEPLOY_INFO_TAG => Ok((Transform::WriteDeployInfo, remainder)),
+            WRITE_TRANSFER_TAG => Ok((Transform::WriteTransfer, remainder)),
+            ADD_INT32_TAG => {
                 let (value_i32, remainder) = i32::from_bytes(remainder)?;
                 Ok((Transform::AddInt32(value_i32), remainder))
             }
-            ADD_INT_U64 => {
+            ADD_UINT64_TAG => {
                 let (value_u64, remainder) = u64::from_bytes(remainder)?;
                 Ok((Transform::AddUInt64(value_u64), remainder))
             }
-            ADD_INT_U128 => {
+            ADD_UINT128_TAG => {
                 let (value_u128, remainder) = U128::from_bytes(remainder)?;
                 Ok((Transform::AddUInt128(value_u128), remainder))
             }
-            ADD_INT_U256 => {
+            ADD_UINT256_TAG => {
                 let (value_u256, remainder) = U256::from_bytes(remainder)?;
                 Ok((Transform::AddUInt256(value_u256), remainder))
             }
-            ADD_UINT_512 => {
+            ADD_UINT512_TAG => {
                 let (value_u512, remainder) = U512::from_bytes(remainder)?;
                 Ok((Transform::AddUInt512(value_u512), remainder))
             }
-            ADD_KEYS => {
+            ADD_KEYS_TAG => {
                 let (value, remainder) = BTreeMap::<String, String>::from_bytes(remainder)?;
                 Ok((Transform::AddKeys(value), remainder))
             }
-            FAILURE => {
+            FAILURE_TAG => {
                 let (value, remainder) = String::from_bytes(remainder)?;
                 Ok((Transform::Failure(value), remainder))
             }
             _ => {
-                info!("Failed to deserialize Transforms, invalid identifier found");
+                info!("Failed to deserialize Transform, invalid identifier found");
                 Err(bytesrepr::Error::Formatting)
             }
         }


### PR DESCRIPTION
Replaced usage of `serde` with our custom serialization implementation for data structures interacting with the storage component. 

REF: https://casperlabs.atlassian.net/browse/NDRS-484