### PR TITLE
EE-1098: privatize fields on auction::Bid

### DIFF
--- a/node/src/types/json_compatibility/auction_state.rs
+++ b/node/src/types/json_compatibility/auction_state.rs
@@ -27,16 +27,16 @@ pub struct Bid {
     ///
     /// `Some` indicates locked funds for a specific era and an autowin status, and `None` case
     /// means that funds are unlocked and autowin status is removed.
-    pub funds_locked: Option<u64>,
+    pub release_era: Option<u64>,
 }
 
 impl From<AuctionBid> for Bid {
     fn from(bid: AuctionBid) -> Self {
         Bid {
-            bonding_purse: bid.bonding_purse.to_formatted_string(),
-            staked_amount: bid.staked_amount,
-            delegation_rate: bid.delegation_rate,
-            funds_locked: bid.funds_locked,
+            bonding_purse: bid.bonding_purse().to_formatted_string(),
+            staked_amount: *bid.staked_amount(),
+            delegation_rate: *bid.delegation_rate(),
+            release_era: bid.release_era(),
         }
     }
 }

--- a/smart_contracts/contracts/system/auction-install/src/main.rs
+++ b/smart_contracts/contracts/system/auction-install/src/main.rs
@@ -60,7 +60,7 @@ pub extern "C" fn install() {
 
         for (validator_public_key, amount) in genesis_validators {
             let bonding_purse = create_purse(mint_package_hash, amount);
-            let founding_validator = Bid::new_locked(bonding_purse, amount, locked_funds_period);
+            let founding_validator = Bid::locked(bonding_purse, amount, locked_funds_period);
             validators.insert(validator_public_key, founding_validator);
             initial_validator_weights.insert(validator_public_key, amount);
             bid_purses.insert(validator_public_key, bonding_purse);

--- a/types/src/auction/bid.rs
+++ b/types/src/auction/bid.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     auction::{types::DelegationRate, EraId},
     bytesrepr::{self, FromBytes, ToBytes},
+    system_contract_errors::auction::Error,
     CLType, CLTyped, URef, U512,
 };
 
@@ -12,37 +13,114 @@ use crate::{
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 pub struct Bid {
     /// The purse that was used for bonding.
-    pub bonding_purse: URef,
+    bonding_purse: URef,
     /// The total amount of staked tokens.
-    pub staked_amount: U512,
+    staked_amount: U512,
     /// Delegation rate
-    pub delegation_rate: DelegationRate,
+    delegation_rate: DelegationRate,
     /// A flag that represents a winning entry.
     ///
     /// `Some` indicates locked funds for a specific era and an autowin status, and `None` case
     /// means that funds are unlocked and autowin status is removed.
-    pub funds_locked: Option<EraId>,
+    release_era: Option<EraId>,
 }
 
 impl Bid {
     /// Creates new instance of a bid with locked funds.
-    pub fn new_locked(bonding_purse: URef, staked_amount: U512, funds_locked: EraId) -> Self {
+    pub fn locked(bonding_purse: URef, staked_amount: U512, release_era: EraId) -> Self {
         Self {
             bonding_purse,
             staked_amount,
             delegation_rate: 0,
-            funds_locked: Some(funds_locked),
+            release_era: Some(release_era),
         }
     }
 
-    /// Checks if a given founding validator can release its funds.
-    pub fn can_release_funds(&self) -> bool {
-        self.funds_locked.is_some()
+    /// Creates new instance of a bid with unlocked funds.
+    pub fn unlocked(
+        bonding_purse: URef,
+        staked_amount: U512,
+        delegation_rate: DelegationRate,
+    ) -> Self {
+        Self {
+            bonding_purse,
+            staked_amount,
+            delegation_rate,
+            release_era: None,
+        }
     }
 
-    /// Checks if a given founding validator can withdraw its funds.
-    pub fn can_withdraw_funds(&self) -> bool {
-        self.funds_locked.is_none()
+    /// Gets the bonding purse of the provided bid
+    pub fn bonding_purse(&self) -> &URef {
+        &self.bonding_purse
+    }
+
+    /// Gets the staked amount of the provided bid
+    pub fn staked_amount(&self) -> &U512 {
+        &self.staked_amount
+    }
+
+    /// Gets the delegation rate of the provided bid
+    pub fn delegation_rate(&self) -> &DelegationRate {
+        &self.delegation_rate
+    }
+
+    /// Returns `true` if the provided bid is locked.
+    pub fn is_locked(&self) -> bool {
+        self.release_era.is_some()
+    }
+
+    /// Returns the release era of the provided bid, if it is locked.
+    pub fn release_era(&self) -> Option<EraId> {
+        self.release_era
+    }
+
+    /// Decreases the stake of the provided bid
+    pub fn decrease_stake(&mut self, amount: U512) -> Result<U512, Error> {
+        if self.is_locked() {
+            return Err(Error::ValidatorFundsLocked);
+        }
+
+        let updated_staked_amount = self
+            .staked_amount
+            .checked_sub(amount)
+            .ok_or(Error::InvalidAmount)?;
+
+        self.staked_amount = updated_staked_amount;
+
+        Ok(updated_staked_amount)
+    }
+
+    /// Increases the stake of the provided bid
+    pub fn increase_stake(&mut self, amount: U512) -> Result<U512, Error> {
+        let updated_staked_amount = self
+            .staked_amount
+            .checked_add(amount)
+            .ok_or(Error::InvalidAmount)?;
+
+        self.staked_amount = updated_staked_amount;
+
+        Ok(updated_staked_amount)
+    }
+
+    /// Updates the delegation rate of the provided bid
+    pub fn with_delegation_rate(&mut self, delegation_rate: DelegationRate) -> &mut Self {
+        self.delegation_rate = delegation_rate;
+        self
+    }
+
+    /// Unlocks the provided bid if the provided era is greater than the bid's release era.  
+    ///
+    /// Returns `true` if the provided bid was unlocked.
+    pub fn unlock(&mut self, era: EraId) -> bool {
+        match self.release_era {
+            Some(release_era) if era >= release_era => {
+                self.release_era = None;
+                true
+            }
+            Some(_) => false,
+            None => false,
+        }
     }
 }
 
@@ -58,7 +136,7 @@ impl ToBytes for Bid {
         result.extend(self.bonding_purse.to_bytes()?);
         result.extend(self.staked_amount.to_bytes()?);
         result.extend(self.delegation_rate.to_bytes()?);
-        result.extend(self.funds_locked.to_bytes()?);
+        result.extend(self.release_era.to_bytes()?);
         Ok(result)
     }
 
@@ -66,7 +144,7 @@ impl ToBytes for Bid {
         self.bonding_purse.serialized_length()
             + self.staked_amount.serialized_length()
             + self.delegation_rate.serialized_length()
-            + self.funds_locked.serialized_length()
+            + self.release_era.serialized_length()
     }
 }
 
@@ -75,13 +153,13 @@ impl FromBytes for Bid {
         let (bonding_purse, bytes) = FromBytes::from_bytes(bytes)?;
         let (staked_amount, bytes) = FromBytes::from_bytes(bytes)?;
         let (delegation_rate, bytes) = FromBytes::from_bytes(bytes)?;
-        let (funds_locked, bytes) = FromBytes::from_bytes(bytes)?;
+        let (release_era, bytes) = FromBytes::from_bytes(bytes)?;
         Ok((
             Bid {
                 bonding_purse,
                 staked_amount,
                 delegation_rate,
-                funds_locked,
+                release_era,
             },
             bytes,
         ))
@@ -101,7 +179,7 @@ mod tests {
             bonding_purse: URef::new([42; 32], AccessRights::READ_ADD_WRITE),
             staked_amount: U512::one(),
             delegation_rate: DelegationRate::max_value(),
-            funds_locked: Some(EraId::max_value() - 1),
+            release_era: Some(EraId::max_value() - 1),
         };
         bytesrepr::test_serialization_roundtrip(&founding_validator);
     }

--- a/types/src/auction/seigniorage_recipient.rs
+++ b/types/src/auction/seigniorage_recipient.rs
@@ -71,8 +71,8 @@ impl FromBytes for SeigniorageRecipient {
 impl From<&Bid> for SeigniorageRecipient {
     fn from(founding_validator: &Bid) -> Self {
         Self {
-            stake: founding_validator.staked_amount,
-            delegation_rate: founding_validator.delegation_rate,
+            stake: *founding_validator.staked_amount(),
+            delegation_rate: *founding_validator.delegation_rate(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1098

> This will improve the auction by disentangling the bid modification logic from the surrounding auction code.