### PR TITLE
NO-TICKET: Make ConsensusMessage debug string a bit less verbose.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -56,23 +56,6 @@ pub enum ConsensusMessage {
     EvidenceRequest { era_id: EraId, pub_key: PublicKey },
 }
 
-impl Debug for ConsensusMessage {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ConsensusMessage::Protocol { era_id, payload } => f
-                .debug_struct("Protocol")
-                .field("era_id.0", &era_id.0)
-                .field("payload", &HexFmt(payload))
-                .finish(),
-            ConsensusMessage::EvidenceRequest { era_id, pub_key } => f
-                .debug_struct("EvidenceRequest")
-                .field("era_id.0", &era_id.0)
-                .field("pub_key", pub_key)
-                .finish(),
-        }
-    }
-}
-
 /// Consensus component event.
 #[derive(DataSize, Debug, From)]
 pub enum Event<I> {
@@ -108,6 +91,21 @@ pub enum Event<I> {
     },
     /// An event instructing us to shutdown if the latest era received no votes
     Shutdown,
+}
+
+impl Debug for ConsensusMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConsensusMessage::Protocol { era_id, payload: _ } => {
+                write!(f, "Protocol {{ era_id.0: {}, .. }}", era_id.0)
+            }
+            ConsensusMessage::EvidenceRequest { era_id, pub_key } => f
+                .debug_struct("EvidenceRequest")
+                .field("era_id.0", &era_id.0)
+                .field("pub_key", pub_key)
+                .finish(),
+        }
+    }
 }
 
 impl Display for ConsensusMessage {

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -18,6 +18,10 @@ use std::{
 };
 
 use datasize::DataSize;
+use derive_more::From;
+use hex_fmt::HexFmt;
+use serde::{Deserialize, Serialize};
+use tracing::error;
 
 use casper_execution_engine::core::engine_state::era_validators::GetEraValidatorsError;
 use casper_types::auction::ValidatorWeights;
@@ -39,21 +43,34 @@ use crate::{
 
 pub use config::Config;
 pub(crate) use consensus_protocol::{BlockContext, EraEnd};
-use derive_more::From;
 pub(crate) use era_supervisor::{EraId, EraSupervisor};
-use hex_fmt::HexFmt;
 pub(crate) use protocols::highway::HighwayProtocol;
-use serde::{Deserialize, Serialize};
-use tracing::error;
 use traits::NodeIdT;
 
-#[derive(Debug, DataSize, Clone, Serialize, Deserialize)]
+#[derive(DataSize, Clone, Serialize, Deserialize)]
 pub enum ConsensusMessage {
     /// A protocol message, to be handled by the instance in the specified era.
     Protocol { era_id: EraId, payload: Vec<u8> },
     /// A request for evidence against the specified validator, from any era that is still bonded
     /// in `era_id`.
     EvidenceRequest { era_id: EraId, pub_key: PublicKey },
+}
+
+impl Debug for ConsensusMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConsensusMessage::Protocol { era_id, payload } => f
+                .debug_struct("Protocol")
+                .field("era_id.0", &era_id.0)
+                .field("payload", &HexFmt(payload))
+                .finish(),
+            ConsensusMessage::EvidenceRequest { era_id, pub_key } => f
+                .debug_struct("EvidenceRequest")
+                .field("era_id.0", &era_id.0)
+                .field("pub_key", pub_key)
+                .finish(),
+        }
+    }
 }
 
 /// Consensus component event.


### PR DESCRIPTION
The [two log statements](https://github.com/CasperLabs/casper-node/blob/d044ad02f6dce60db322005e5a34f650a6a78880/node/src/reactor.rs#L400) for events now look like:

`Nov 09 16:00:05.590 DEBUG crank{ev=497}:dispatch events{ev=497}: [casper_node::reactor reactor.rs:400] event=network: msg from 3bf5..5908: payload: Consensus::protocol message 0000..b709 in era 0; q=NetworkIncoming`
`Nov 09 16:00:05.590 TRACE crank{ev=497}:dispatch events{ev=497}: [casper_node::reactor reactor.rs:401] event=Network(IncomingMessage { peer_id: KeyFingerprint(3bf5..5908), msg: Message(Consensus(Protocol { era_id.0: 0, .. })) }); q=NetworkIncoming`

Before, they looked like this:

`Nov 09 14:59:44.724 DEBUG crank{ev=7403}:dispatch events{ev=7403}: [casper_node::reactor reactor.rs:400] event=network announcement: received from 9a5a..3604: Consensus::protocol message 0000..f907 in era 0; q=NetworkIncoming`
`Nov 09 14:59:44.724 TRACE crank{ev=7403}:dispatch events{ev=7403}: [casper_node::reactor reactor.rs:401] event=NetworkAnnouncement(MessageReceived { sender: KeyFingerprint(9a5a..3604), payload: Consensus(Protocol { era_id: EraId(0), payload: [0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 203, 81, 7, 153, 82, 161, 169, 188, 30, 22, 231, 228, 148, 134, 138, 14, 78, 133, 224, 198, 48, 215, 80, 246, 60, 155, 69, 222, 38, 20, 208, 153, 1, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 149, 237, 39, 85, 97, 41, 84, 81, 148, 49, 30, 66, 20, 212, 160, 213, 159, 248, 244, 241, 233, 177, 210, 56, 185, 227, 124, 155, 198, 17, 5, 40, 1, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 37, 161, 15, 213, 209, 230, 213, 190, 85, 78, 38, 17, 194, 28, 71, 31, 181, 101, 95, 85, 184, 155, 33, 50, 135, 247, 234, 180, 90, 77, 231, 67, 1, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 146, 253, 89, 232, 12, 231, 79, 108, 151, 229, 213, 237, 190, 202, 90, 73, 92, 8, 237, 240, 174, 201, 93, 167, 207, 204, 134, 59, 65, 253, 152, 104, 1, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 87, 34, 37, 84, 66, 58, 202, 102, 221, 129, 8, 185, 92, 0, 116, 162, 76, 238, 241, 160, 119, 189, 45, 26, 25, 25, 107, 216, 63, 13, 43, 169, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 120, 72, 247, 198, 131, 140, 14, 228, 142, 167, 71, 220, 170, 63, 28, 180, 215, 237, 78, 129, 113, 58, 173, 18, 90, 4, 13, 38, 31, 88, 12, 202, 1, 32, 0, 0, 0, 0, 0, 0, 0, 81, 135, 183, 168, 2, 27, 244, 242, 192, 4, 234, 58, 84, 207, 236, 225, 117, 79, 17, 199, 98, 77, 35, 99, 199, 244, 207, 79, 221, 209, 68, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 48, 78, 173, 117, 1, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 93, 161, 42, 84, 18, 37, 240, 243, 160, 35, 6, 173, 169, 221, 33, 134, 224, 166, 127, 254, 99, 142, 35, 22, 74, 178, 246, 235, 239, 41, 180, 59, 137, 206, 105, 87, 31, 23, 122, 117, 209, 117, 215, 212, 40, 206, 53, 94, 45, 87, 157, 187, 102, 50, 116, 246, 62, 0, 16, 76, 114, 50, 249, 7] }) }); q=NetworkIncoming`