### PR TITLE
NO-TICKET: Rename ConsensusProtocolResult to ProtocolOutcome.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -61,7 +61,7 @@ pub(crate) struct FinalizedBlock<C: Context> {
 }
 
 #[derive(Debug)]
-pub(crate) enum ConsensusProtocolResult<I, C: Context> {
+pub(crate) enum ProtocolOutcome<I, C: Context> {
     CreatedGossipMessage(Vec<u8>),
     CreatedTargetedMessage(Vec<u8>, I),
     InvalidIncomingMessage(Vec<u8>, I, Error),
@@ -100,14 +100,14 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
         msg: Vec<u8>,
         evidence_only: bool,
         rng: &mut NodeRng,
-    ) -> Vec<ConsensusProtocolResult<I, C>>;
+    ) -> Vec<ProtocolOutcome<I, C>>;
 
     /// Triggers consensus' timer.
     fn handle_timer(
         &mut self,
         timestamp: Timestamp,
         rng: &mut NodeRng,
-    ) -> Vec<ConsensusProtocolResult<I, C>>;
+    ) -> Vec<ProtocolOutcome<I, C>>;
 
     /// Proposes a new value for consensus.
     fn propose(
@@ -115,16 +115,16 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
         value: C::ConsensusValue,
         block_context: BlockContext,
         rng: &mut NodeRng,
-    ) -> Vec<ConsensusProtocolResult<I, C>>;
+    ) -> Vec<ProtocolOutcome<I, C>>;
 
     /// Marks the `value` as valid or invalid, based on validation requested via
-    /// `ConsensusProtocolResult::ValidateConsensusvalue`.
+    /// `ProtocolOutcome::ValidateConsensusvalue`.
     fn resolve_validity(
         &mut self,
         value: &C::ConsensusValue,
         valid: bool,
         rng: &mut NodeRng,
-    ) -> Vec<ConsensusProtocolResult<I, C>>;
+    ) -> Vec<ProtocolOutcome<I, C>>;
 
     /// Turns this instance into an active validator, that participates in the consensus protocol.
     fn activate_validator(
@@ -132,7 +132,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
         our_id: C::ValidatorId,
         secret: C::ValidatorSecret,
         timestamp: Timestamp,
-    ) -> Vec<ConsensusProtocolResult<I, C>>;
+    ) -> Vec<ProtocolOutcome<I, C>>;
 
     /// Turns this instance into a passive observer, that does not create any new vertices.
     fn deactivate_validator(&mut self);
@@ -144,11 +144,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
     fn mark_faulty(&mut self, vid: &C::ValidatorId);
 
     /// Sends evidence for a faulty of validator `vid` to the `sender` of the request.
-    fn request_evidence(
-        &self,
-        sender: I,
-        vid: &C::ValidatorId,
-    ) -> Vec<ConsensusProtocolResult<I, C>>;
+    fn request_evidence(&self, sender: I, vid: &C::ValidatorId) -> Vec<ProtocolOutcome<I, C>>;
 
     /// Returns the list of all validators that were observed as faulty in this consensus instance.
     fn validators_with_evidence(&self) -> Vec<&C::ValidatorId>;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -36,8 +36,8 @@ use crate::{
             candidate_block::CandidateBlock,
             cl_context::{ClContext, Keypair},
             consensus_protocol::{
-                BlockContext, ConsensusProtocol, ConsensusProtocolResult, EraEnd,
-                FinalizedBlock as CpFinalizedBlock,
+                BlockContext, ConsensusProtocol, EraEnd, FinalizedBlock as CpFinalizedBlock,
+                ProtocolOutcome,
             },
             metrics::ConsensusMetrics,
             traits::NodeIdT,
@@ -218,7 +218,7 @@ where
         start_time: Timestamp,
         start_height: u64,
         state_root_hash: Digest,
-    ) -> Vec<ConsensusProtocolResult<I, ClContext>> {
+    ) -> Vec<ProtocolOutcome<I, ClContext>> {
         if self.active_eras.contains_key(&era_id) {
             panic!("{} already exists", era_id);
         }
@@ -332,7 +332,7 @@ where
         F: FnOnce(
             &mut dyn ConsensusProtocol<I, ClContext>,
             &mut NodeRng,
-        ) -> Vec<ConsensusProtocolResult<I, ClContext>>,
+        ) -> Vec<ProtocolOutcome<I, ClContext>>,
     {
         match self.era_supervisor.active_eras.get_mut(&era_id) {
             None => {
@@ -552,7 +552,7 @@ where
 
     fn handle_consensus_results<T>(&mut self, era_id: EraId, results: T) -> Effects<Event<I>>
     where
-        T: IntoIterator<Item = ConsensusProtocolResult<I, ClContext>>,
+        T: IntoIterator<Item = ProtocolOutcome<I, ClContext>>,
     {
         results
             .into_iter()
@@ -581,10 +581,10 @@ where
     fn handle_consensus_result(
         &mut self,
         era_id: EraId,
-        consensus_result: ConsensusProtocolResult<I, ClContext>,
+        consensus_result: ProtocolOutcome<I, ClContext>,
     ) -> Effects<Event<I>> {
         match consensus_result {
-            ConsensusProtocolResult::InvalidIncomingMessage(_, sender, error) => {
+            ProtocolOutcome::InvalidIncomingMessage(_, sender, error) => {
                 // TODO: we will probably want to disconnect from the sender here
                 error!(
                     %sender,
@@ -593,23 +593,23 @@ where
                 );
                 Default::default()
             }
-            ConsensusProtocolResult::CreatedGossipMessage(out_msg) => {
+            ProtocolOutcome::CreatedGossipMessage(out_msg) => {
                 // TODO: we'll want to gossip instead of broadcast here
                 self.effect_builder
                     .broadcast_message(era_id.message(out_msg).into())
                     .ignore()
             }
-            ConsensusProtocolResult::CreatedTargetedMessage(out_msg, to) => self
+            ProtocolOutcome::CreatedTargetedMessage(out_msg, to) => self
                 .effect_builder
                 .send_message(to, era_id.message(out_msg).into())
                 .ignore(),
-            ConsensusProtocolResult::ScheduleTimer(timestamp) => {
+            ProtocolOutcome::ScheduleTimer(timestamp) => {
                 let timediff = timestamp.saturating_sub(Timestamp::now());
                 self.effect_builder
                     .set_timeout(timediff.into())
                     .event(move |_| Event::Timer { era_id, timestamp })
             }
-            ConsensusProtocolResult::CreateNewBlock { block_context } => self
+            ProtocolOutcome::CreateNewBlock { block_context } => self
                 .effect_builder
                 .request_proto_block(block_context, self.rng.gen())
                 .event(move |(proto_block, block_context)| Event::NewProtoBlock {
@@ -617,7 +617,7 @@ where
                     proto_block,
                     block_context,
                 }),
-            ConsensusProtocolResult::FinalizedBlock(CpFinalizedBlock {
+            ProtocolOutcome::FinalizedBlock(CpFinalizedBlock {
                 value,
                 timestamp,
                 height,
@@ -653,7 +653,7 @@ where
                 effects.extend(self.effect_builder.execute_block(finalized_block).ignore());
                 effects
             }
-            ConsensusProtocolResult::ValidateConsensusValue(sender, candidate_block, timestamp) => {
+            ProtocolOutcome::ValidateConsensusValue(sender, candidate_block, timestamp) => {
                 if !self.era_supervisor.is_bonded(era_id) {
                     return Effects::new();
                 }
@@ -687,7 +687,7 @@ where
                 );
                 effects
             }
-            ConsensusProtocolResult::NewEvidence(pub_key) => {
+            ProtocolOutcome::NewEvidence(pub_key) => {
                 info!(%pub_key, era = era_id.0, "validator equivocated");
                 let mut effects = Effects::new();
                 for e_id in (era_id.0..=(era_id.0 + self.era_supervisor.bonded_eras)).map(EraId) {
@@ -705,7 +705,7 @@ where
                 }
                 effects
             }
-            ConsensusProtocolResult::SendEvidence(sender, pub_key) => era_id
+            ProtocolOutcome::SendEvidence(sender, pub_key) => era_id
                 .iter_other(self.era_supervisor.bonded_eras)
                 .flat_map(|e_id| {
                     self.delegate_to_era(e_id, |consensus, _| {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -20,7 +20,7 @@ use crate::{
     components::{
         chainspec_loader::Chainspec,
         consensus::{
-            consensus_protocol::{BlockContext, ConsensusProtocol, ConsensusProtocolResult},
+            consensus_protocol::{BlockContext, ConsensusProtocol, ProtocolOutcome},
             highway_core::{
                 active_validator::Effect as AvEffect,
                 finality_detector::FinalityDetector,
@@ -132,7 +132,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         })
     }
 
-    fn process_av_effects<E>(&mut self, av_effects: E) -> Vec<CpResult<I, C>>
+    fn process_av_effects<E>(&mut self, av_effects: E) -> Vec<ProtocolOutcome<I, C>>
     where
         E: IntoIterator<Item = AvEffect<C>>,
     {
@@ -142,17 +142,15 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             .collect()
     }
 
-    fn process_av_effect(&mut self, effect: AvEffect<C>) -> Vec<CpResult<I, C>> {
+    fn process_av_effect(&mut self, effect: AvEffect<C>) -> Vec<ProtocolOutcome<I, C>> {
         match effect {
             AvEffect::NewVertex(vv) => {
                 self.calculate_round_exponent(&vv);
                 self.process_new_vertex(vv.into())
             }
-            AvEffect::ScheduleTimer(timestamp) => {
-                vec![ConsensusProtocolResult::ScheduleTimer(timestamp)]
-            }
+            AvEffect::ScheduleTimer(timestamp) => vec![ProtocolOutcome::ScheduleTimer(timestamp)],
             AvEffect::RequestNewBlock(block_context) => {
-                vec![ConsensusProtocolResult::CreateNewBlock { block_context }]
+                vec![ProtocolOutcome::CreateNewBlock { block_context }]
             }
             AvEffect::WeEquivocated(evidence) => {
                 panic!("this validator equivocated: {:?}", evidence);
@@ -160,7 +158,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         }
     }
 
-    fn process_new_vertex(&mut self, v: Vertex<C>) -> Vec<CpResult<I, C>> {
+    fn process_new_vertex(&mut self, v: Vertex<C>) -> Vec<ProtocolOutcome<I, C>> {
         let mut results = Vec::new();
         if let Vertex::Evidence(ev) = &v {
             let v_id = self
@@ -169,21 +167,21 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                 .id(ev.perpetrator())
                 .expect("validator not found")
                 .clone();
-            results.push(ConsensusProtocolResult::NewEvidence(v_id));
+            results.push(ProtocolOutcome::NewEvidence(v_id));
         }
         let msg = HighwayMessage::NewVertex(v);
-        results.push(ConsensusProtocolResult::CreatedGossipMessage(
+        results.push(ProtocolOutcome::CreatedGossipMessage(
             bincode::serialize(&msg).expect("should serialize message"),
         ));
         results.extend(self.detect_finality());
         results
     }
 
-    fn detect_finality(&mut self) -> impl Iterator<Item = CpResult<I, C>> + '_ {
+    fn detect_finality(&mut self) -> impl Iterator<Item = ProtocolOutcome<I, C>> + '_ {
         self.finality_detector
             .run(&self.highway)
             .expect("too many faulty validators")
-            .map(ConsensusProtocolResult::FinalizedBlock)
+            .map(ProtocolOutcome::FinalizedBlock)
     }
 
     /// Store a (pre-validated) vertex which will be added later.  This creates a timer to be sent
@@ -193,12 +191,12 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         future_timestamp: Timestamp,
         sender: I,
         pvv: PreValidatedVertex<C>,
-    ) -> Vec<CpResult<I, C>> {
+    ) -> Vec<ProtocolOutcome<I, C>> {
         self.vertices_to_be_added_later
             .entry(future_timestamp)
             .or_insert_with(Vec::new)
             .push((sender, pvv));
-        vec![ConsensusProtocolResult::ScheduleTimer(future_timestamp)]
+        vec![ProtocolOutcome::ScheduleTimer(future_timestamp)]
     }
 
     /// Call `Self::add_vertices` on any vertices in `vertices_to_be_added_later` which are
@@ -209,7 +207,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         &mut self,
         timestamp: Timestamp,
         rng: &mut NodeRng,
-    ) -> Vec<CpResult<I, C>> {
+    ) -> Vec<ProtocolOutcome<I, C>> {
         let mut results = vec![];
         let past_due_timestamps: Vec<Timestamp> = self
             .vertices_to_be_added_later
@@ -232,7 +230,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         &mut self,
         mut pvvs: Vec<(I, PreValidatedVertex<C>)>,
         rng: &mut NodeRng,
-    ) -> Vec<CpResult<I, C>> {
+    ) -> Vec<ProtocolOutcome<I, C>> {
         // TODO: Is there a danger that this takes too much time, and starves other
         // components and events? Consider replacing the loop with a "callback" effect:
         // Instead of handling `HighwayMessage::NewVertex(v)` directly, return a
@@ -253,7 +251,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                         .or_default()
                         .push((sender.clone(), pvv));
                     let msg = HighwayMessage::RequestDependency(dep);
-                    results.push(ConsensusProtocolResult::CreatedTargetedMessage(
+                    results.push(ProtocolOutcome::CreatedTargetedMessage(
                         bincode::serialize(&msg).expect("should serialize message"),
                         sender,
                     ));
@@ -269,7 +267,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                                     .entry(value.clone())
                                     .or_default()
                                     .push(vv);
-                                results.push(ConsensusProtocolResult::ValidateConsensusValue(
+                                results.push(ProtocolOutcome::ValidateConsensusValue(
                                     sender, value, timestamp,
                                 ));
                             } else {
@@ -325,7 +323,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         vv: ValidVertex<C>,
         rng: &mut NodeRng,
         now: Timestamp,
-    ) -> Vec<CpResult<I, C>> {
+    ) -> Vec<ProtocolOutcome<I, C>> {
         // Check whether we should change the round exponent.
         // It's important to do it before the vertex is added to the state - this way if the last
         // round has finished, we now have all the vertices from that round in the state, and no
@@ -334,7 +332,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         let av_effects = self.highway.add_valid_vertex(vv.clone(), rng, now);
         let mut results = self.process_av_effects(av_effects);
         let msg = HighwayMessage::NewVertex(vv.into());
-        results.push(ConsensusProtocolResult::CreatedGossipMessage(
+        results.push(ProtocolOutcome::CreatedGossipMessage(
             bincode::serialize(&msg).expect("should serialize message"),
         ));
         results
@@ -369,7 +367,6 @@ enum HighwayMessage<C: Context> {
     NewVertex(Vertex<C>),
     RequestDependency(Dependency<C>),
 }
-type CpResult<I, C> = ConsensusProtocolResult<I, C>;
 
 impl<I, C> ConsensusProtocol<I, C> for HighwayProtocol<I, C>
 where
@@ -382,9 +379,9 @@ where
         msg: Vec<u8>,
         evidence_only: bool,
         rng: &mut NodeRng,
-    ) -> Vec<CpResult<I, C>> {
+    ) -> Vec<ProtocolOutcome<I, C>> {
         match bincode::deserialize(msg.as_slice()) {
-            Err(err) => vec![ConsensusProtocolResult::InvalidIncomingMessage(
+            Err(err) => vec![ProtocolOutcome::InvalidIncomingMessage(
                 msg,
                 sender,
                 err.into(),
@@ -399,7 +396,7 @@ where
                     Ok(pvv) => pvv,
                     Err((_, err)) => {
                         // TODO: Disconnect from senders.
-                        return vec![ConsensusProtocolResult::InvalidIncomingMessage(
+                        return vec![ProtocolOutcome::InvalidIncomingMessage(
                             msg,
                             sender,
                             err.into(),
@@ -418,15 +415,13 @@ where
                     info!(?dep, ?sender, "requested dependency doesn't exist");
                     vec![]
                 }
-                GetDepOutcome::Evidence(vid) => {
-                    vec![ConsensusProtocolResult::SendEvidence(sender, vid)]
-                }
+                GetDepOutcome::Evidence(vid) => vec![ProtocolOutcome::SendEvidence(sender, vid)],
                 GetDepOutcome::Vertex(vv) => {
                     let msg = HighwayMessage::NewVertex(vv.into());
                     let serialized_msg =
                         bincode::serialize(&msg).expect("should serialize message");
                     // TODO: Should this be done via a gossip service?
-                    vec![ConsensusProtocolResult::CreatedTargetedMessage(
+                    vec![ProtocolOutcome::CreatedTargetedMessage(
                         serialized_msg,
                         sender,
                     )]
@@ -435,7 +430,11 @@ where
         }
     }
 
-    fn handle_timer(&mut self, timestamp: Timestamp, rng: &mut NodeRng) -> Vec<CpResult<I, C>> {
+    fn handle_timer(
+        &mut self,
+        timestamp: Timestamp,
+        rng: &mut NodeRng,
+    ) -> Vec<ProtocolOutcome<I, C>> {
         let effects = self.highway.handle_timer(timestamp, rng);
         let mut results = self.process_av_effects(effects);
         results.extend(self.add_past_due_stored_vertices(timestamp, rng));
@@ -447,7 +446,7 @@ where
         value: C::ConsensusValue,
         block_context: BlockContext,
         rng: &mut NodeRng,
-    ) -> Vec<CpResult<I, C>> {
+    ) -> Vec<ProtocolOutcome<I, C>> {
         let effects = self.highway.propose(value, block_context, rng);
         self.process_av_effects(effects)
     }
@@ -457,7 +456,7 @@ where
         value: &C::ConsensusValue,
         valid: bool,
         rng: &mut NodeRng,
-    ) -> Vec<CpResult<I, C>> {
+    ) -> Vec<ProtocolOutcome<I, C>> {
         if valid {
             let mut results = self
                 .pending_values
@@ -486,7 +485,7 @@ where
         our_id: C::ValidatorId,
         secret: C::ValidatorSecret,
         timestamp: Timestamp,
-    ) -> Vec<CpResult<I, C>> {
+    ) -> Vec<ProtocolOutcome<I, C>> {
         let av_effects = self.highway.activate_validator(our_id, secret, timestamp);
         self.process_av_effects(av_effects)
     }
@@ -503,7 +502,7 @@ where
         self.highway.mark_faulty(vid);
     }
 
-    fn request_evidence(&self, sender: I, vid: &C::ValidatorId) -> Vec<CpResult<I, C>> {
+    fn request_evidence(&self, sender: I, vid: &C::ValidatorId) -> Vec<ProtocolOutcome<I, C>> {
         self.highway
             .validators()
             .get_index(vid)
@@ -514,7 +513,7 @@ where
                         let msg = HighwayMessage::NewVertex(vv.into());
                         let serialized_msg =
                             bincode::serialize(&msg).expect("should serialize message");
-                        Some(ConsensusProtocolResult::CreatedTargetedMessage(
+                        Some(ProtocolOutcome::CreatedTargetedMessage(
                             serialized_msg,
                             sender,
                         ))


### PR DESCRIPTION
It's not a `Result<_, _>` (and doesn't implement `Try`), and the name was a bit long. We already use `HighwayProtocol` where we want to say "Highway Consensus Protocol", so it seems legitimate to omit the `Consensus` part here, too. It's only used within the consensus component anyway.