### PR TITLE
OP-1649 Reset next version of software to 0.2.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cargo-casper"
-version = "0.9.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "casper-client"
-version = "1.5.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "casper-contract"
-version = "0.6.0"
+version = "0.2.0"
 dependencies = [
  "casper-types",
  "hex_fmt",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-grpc-server"
-version = "0.20.0"
+version = "0.2.0"
 dependencies = [
  "casper-execution-engine",
  "casper-types",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-test-support"
-version = "0.8.0"
+version = "0.2.0"
 dependencies = [
  "casper-contract",
  "casper-engine-grpc-server",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "0.7.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.5.0"
+version = "0.2.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "Inflector",
  "indexmap",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "0.6.0"
+version = "0.2.0"
 dependencies = [
  "base16",
  "bincode",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-client"
-version = "1.5.0"
+version = "0.2.0"
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "A client for interacting with the Casper network"
@@ -22,9 +22,9 @@ doc = false
 
 [dependencies]
 base64 = "0.13.0"
-casper-execution-engine = { version = "0.7.0", path = "../execution_engine" }
-casper-node = { version = "1.5.0", path = "../node" }
-casper-types = { version = "0.6.0", path = "../types", features = ["std"] }
+casper-execution-engine = { version = "0.2.0", path = "../execution_engine" }
+casper-node = { version = "0.2.0", path = "../node" }
+casper-types = { version = "0.2.0", path = "../types", features = ["std"] }
 clap = "2.33.1"
 futures = "0.3.5"
 hex = { version = "0.4.2", features = ["serde"] }

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "0.7.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.2.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."
@@ -15,7 +15,7 @@ anyhow = "1.0.33"
 base16 = "0.2.1"
 bincode = "1.3.1"
 blake2 = "0.9.0"
-casper-types = { version = "0.6.0", path = "../types", features = ["std", "gens"] }
+casper-types = { version = "0.2.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 datasize = "0.2.0"
 csv = "1.1.3"

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/0.2.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/grpc/cargo_casper/Cargo.toml
+++ b/grpc/cargo_casper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-casper"
-version = "0.9.0"
+version = "0.2.0"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Command line tool for creating a Wasm smart contract and tests for use on the Casper network."

--- a/grpc/cargo_casper/src/common.rs
+++ b/grpc/cargo_casper/src/common.rs
@@ -13,8 +13,8 @@ use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
 
 lazy_static! {
     pub static ref CL_CONTRACT: Dependency =
-        Dependency::new("casper-contract", "0.6.0", "smart_contracts/contract");
-    pub static ref CL_TYPES: Dependency = Dependency::new("casper-types", "0.6.0", "types");
+        Dependency::new("casper-contract", "0.2.0", "smart_contracts/contract");
+    pub static ref CL_TYPES: Dependency = Dependency::new("casper-types", "0.2.0", "types");
 }
 
 pub fn print_error_and_exit(msg: &str) -> ! {

--- a/grpc/cargo_casper/src/tests_package.rs
+++ b/grpc/cargo_casper/src/tests_package.rs
@@ -115,7 +115,7 @@ lazy_static! {
         .join(PACKAGE_NAME)
         .join("src/integration_tests.rs");
     static ref ENGINE_TEST_SUPPORT: Dependency =
-        Dependency::new("casper-engine-test-support", "0.8.0", "grpc/test_support");
+        Dependency::new("casper-engine-test-support", "0.2.0", "grpc/test_support");
     static ref CARGO_TOML_ADDITIONAL_CONTENTS: String = format!(
         r#"
 [dev-dependencies]

--- a/grpc/server/Cargo.toml
+++ b/grpc/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-grpc-server"
-version = "0.20.0"
+version = "0.2.0"
 authors = ["Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Wasm execution engine for Casper smart contracts."
@@ -19,8 +19,8 @@ include = [
 ]
 
 [dependencies]
-casper-execution-engine = { version = "0.7.0", path = "../../execution_engine", features = ["gens"] }
-casper-types = { version = "0.6.0", path = "../../types", features = ["std", "gens"] }
+casper-execution-engine = { version = "0.2.0", path = "../../execution_engine", features = ["gens"] }
+casper-types = { version = "0.2.0", path = "../../types", features = ["std", "gens"] }
 clap = "2"
 ctrlc = "3"
 dirs = "3"

--- a/grpc/test_support/Cargo.toml
+++ b/grpc/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-test-support"
-version = "0.8.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.2.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the Casper network."
@@ -11,10 +11,10 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/grpc/test_su
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-contract = { version = "0.6.0", path = "../../smart_contracts/contract", features = ["std"] }
-casper-engine-grpc-server = { version = "0.20.0", path = "../server" }
-casper-execution-engine = { version = "0.7.0", path = "../../execution_engine" }
-casper-types = { version = "0.6.0", path = "../../types", features = ["std"] }
+casper-contract = { version = "0.2.0", path = "../../smart_contracts/contract", features = ["std"] }
+casper-engine-grpc-server = { version = "0.2.0", path = "../server" }
+casper-execution-engine = { version = "0.2.0", path = "../../execution_engine" }
+casper-types = { version = "0.2.0", path = "../../types", features = ["std"] }
 grpc = "0.6.1"
 lazy_static = "1"
 lmdb = "0.8.0"

--- a/grpc/test_support/src/lib.rs
+++ b/grpc/test_support/src/lib.rs
@@ -56,7 +56,7 @@
 //! assert_eq!(expected_value, returned_value);
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/0.8.0")]
+#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/0.2.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.5.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.2.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -19,9 +19,9 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1.3.1"
 blake2 = { version = "0.9.0", default-features = false }
-casper-execution-engine = { version = "0.7.0", path = "../execution_engine" }
-casper-node-macros = { version = "0.1.0", path = "../node_macros" }
-casper-types = { version = "0.6.0", path = "../types", features = ["std", "gens"] }
+casper-execution-engine = { version = "0.2.0", path = "../execution_engine" }
+casper-node-macros = { version = "0.2.0", path = "../node_macros" }
+casper-types = { version = "0.2.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 csv = "1.1.3"
 datasize = { version = "0.2.0", features = ["fake_clock-types", "futures-types", "smallvec-types", "tokio-types"] }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.5.0")]
+#![doc(html_root_url = "https://docs.rs/casper-node/0.2.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node_macros/Cargo.toml
+++ b/node_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node-macros"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Marc Brinkmann <marc@casperlabs.io>"]
 edition = "2018"
 description = "A macro to create reactor implementations for the casper-node."

--- a/node_macros/src/lib.rs
+++ b/node_macros/src/lib.rs
@@ -1,6 +1,6 @@
 //! Generates reactors with routing from concise definitions. See `README.md` for details.
 
-#![doc(html_root_url = "https://docs.rs/casper-node-macros/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/casper-node-macros/0.2.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-contract"
-version = "0.6.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.2.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Library for developing Casper smart contracts."
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contra
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-types = { version = "0.6.0", path = "../../types" }
+casper-types = { version = "0.2.0", path = "../../types" }
 hex_fmt = "0.3.0"
 thiserror = "1.0.18"
 wee_alloc = "0.4.5"

--- a/smart_contracts/contract/src/lib.rs
+++ b/smart_contracts/contract/src/lib.rs
@@ -53,7 +53,7 @@
     not(feature = "std"),
     feature(alloc_error_handler, core_intrinsics, lang_items)
 )]
-#![doc(html_root_url = "https://docs.rs/casper-contract/0.6.0")]
+#![doc(html_root_url = "https://docs.rs/casper-contract/0.2.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@casper/contract",
-  "version": "0.5.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casper/contract",
-  "version": "0.5.0",
+  "version": "0.2.0",
   "description": "Library for developing Casper smart contracts.",
   "main": "index.js",
   "ascMain": "assembly/index.ts",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-types"
-version = "0.6.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.2.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Types used to allow creation of Wasm contracts and tests for use on the Casper network."

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -10,7 +10,7 @@
     not(feature = "no-unstable-features"),
     feature(min_specialization, try_reserve)
 )]
-#![doc(html_root_url = "https://docs.rs/casper-types/0.6.0")]
+#![doc(html_root_url = "https://docs.rs/casper-types/0.2.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
Delta-1 source code (currently 1.6.0 for client and node) will be published on crates.io as 0.1.0.  
This is the post-release version bump so the next release is 0.2.0.