### PR TITLE
EE-{1101,1103}: add auction::Delegator, fix bid scores

### DIFF
--- a/grpc/tests/src/test/regression/ee_1103.rs
+++ b/grpc/tests/src/test/regression/ee_1103.rs
@@ -1,0 +1,324 @@
+use lazy_static::lazy_static;
+
+use casper_engine_test_support::{
+    internal::{utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS},
+    MINIMUM_ACCOUNT_CREATION_BALANCE,
+};
+use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
+use casper_types::{
+    account::AccountHash,
+    auction::{ARG_DELEGATOR, ARG_VALIDATOR},
+    runtime_args, PublicKey, RuntimeArgs, U512,
+};
+
+const ARG_TARGET: &str = "target";
+const ARG_AMOUNT: &str = "amount";
+
+const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
+const CONTRACT_DELEGATE: &str = "delegate.wasm";
+const TRANSFER_AMOUNT: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
+const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
+
+const FAUCET: PublicKey = PublicKey::Ed25519([1; 32]);
+const VALIDATOR_1: PublicKey = PublicKey::Ed25519([3; 32]);
+const VALIDATOR_2: PublicKey = PublicKey::Ed25519([5; 32]);
+const VALIDATOR_3: PublicKey = PublicKey::Ed25519([7; 32]);
+const DELEGATOR_1: PublicKey = PublicKey::Ed25519([204; 32]);
+const DELEGATOR_2: PublicKey = PublicKey::Ed25519([206; 32]);
+const DELEGATOR_3: PublicKey = PublicKey::Ed25519([208; 32]);
+
+lazy_static! {
+    static ref FAUCET_ADDR: AccountHash = FAUCET.into();
+    static ref VALIDATOR_1_ADDR: AccountHash = VALIDATOR_1.into();
+    static ref VALIDATOR_2_ADDR: AccountHash = VALIDATOR_2.into();
+    static ref VALIDATOR_3_ADDR: AccountHash = VALIDATOR_3.into();
+    static ref FAUCET_BALANCE: U512 = U512::from(100_000_000_000_000_000u64);
+    static ref VALIDATOR_1_BALANCE: U512 = U512::from(1_000_000_000_000_000u64);
+    static ref VALIDATOR_2_BALANCE: U512 = U512::from(1_000_000_000_000_000u64);
+    static ref VALIDATOR_3_BALANCE: U512 = U512::from(1_000_000_000_000_000u64);
+    static ref VALIDATOR_1_STAKE: U512 = U512::from(500_000_000_000_000u64);
+    static ref VALIDATOR_2_STAKE: U512 = U512::from(400_000_000_000_000u64);
+    static ref VALIDATOR_3_STAKE: U512 = U512::from(300_000_000_000_000u64);
+    static ref DELEGATOR_1_ADDR: AccountHash = DELEGATOR_1.into();
+    static ref DELEGATOR_2_ADDR: AccountHash = DELEGATOR_2.into();
+    static ref DELEGATOR_3_ADDR: AccountHash = DELEGATOR_3.into();
+    static ref DELEGATOR_1_BALANCE: U512 = U512::from(1_000_000_000_000_000u64);
+    static ref DELEGATOR_2_BALANCE: U512 = U512::from(1_000_000_000_000_000u64);
+    static ref DELEGATOR_3_BALANCE: U512 = U512::from(1_000_000_000_000_000u64);
+    static ref DELEGATOR_1_STAKE: U512 = U512::from(500_000_000_000_000u64);
+    static ref DELEGATOR_2_STAKE: U512 = U512::from(400_000_000_000_000u64);
+    static ref DELEGATOR_3_STAKE: U512 = U512::from(300_000_000_000_000u64);
+}
+
+#[ignore]
+#[test]
+fn validator_scores_should_reflect_delegates() {
+    let accounts = {
+        let faucet = GenesisAccount::new(
+            FAUCET,
+            *FAUCET_ADDR,
+            Motes::new(*FAUCET_BALANCE),
+            Motes::new(U512::zero()),
+        );
+        let validator_1 = GenesisAccount::new(
+            VALIDATOR_1,
+            *VALIDATOR_1_ADDR,
+            Motes::new(*VALIDATOR_1_BALANCE),
+            Motes::new(*VALIDATOR_1_STAKE),
+        );
+        let validator_2 = GenesisAccount::new(
+            VALIDATOR_2,
+            *VALIDATOR_2_ADDR,
+            Motes::new(*VALIDATOR_2_BALANCE),
+            Motes::new(*VALIDATOR_2_STAKE),
+        );
+        let validator_3 = GenesisAccount::new(
+            VALIDATOR_3,
+            *VALIDATOR_3_ADDR,
+            Motes::new(*VALIDATOR_3_BALANCE),
+            Motes::new(*VALIDATOR_3_STAKE),
+        );
+        let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
+        tmp.push(faucet);
+        tmp.push(validator_1);
+        tmp.push(validator_2);
+        tmp.push(validator_3);
+        tmp
+    };
+
+    let system_fund_request = ExecuteRequestBuilder::standard(
+        *FAUCET_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => SYSTEM_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let delegator_1_fund_request = ExecuteRequestBuilder::standard(
+        *FAUCET_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *DELEGATOR_1_ADDR,
+            ARG_AMOUNT => *DELEGATOR_1_BALANCE
+        },
+    )
+    .build();
+
+    let delegator_2_fund_request = ExecuteRequestBuilder::standard(
+        *FAUCET_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *DELEGATOR_2_ADDR,
+            ARG_AMOUNT => *DELEGATOR_2_BALANCE
+        },
+    )
+    .build();
+
+    let delegator_3_fund_request = ExecuteRequestBuilder::standard(
+        *FAUCET_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *DELEGATOR_3_ADDR,
+            ARG_AMOUNT => *DELEGATOR_3_BALANCE
+        },
+    )
+    .build();
+
+    let post_genesis_requests = vec![
+        system_fund_request,
+        delegator_1_fund_request,
+        delegator_2_fund_request,
+        delegator_3_fund_request,
+    ];
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    let run_genesis_request = utils::create_run_genesis_request(accounts);
+    builder.run_genesis(&run_genesis_request);
+
+    for request in post_genesis_requests {
+        builder.exec(request).commit().expect_success();
+    }
+
+    let mut era = builder.get_era();
+    let auction_delay = builder.get_auction_delay();
+
+    // Check initial weights
+    {
+        let era_weights = builder
+            .get_validator_weights(era)
+            .expect("should get validator weights");
+
+        assert_eq!(era_weights.get(&VALIDATOR_1), Some(&*VALIDATOR_1_STAKE));
+        assert_eq!(era_weights.get(&VALIDATOR_2), Some(&*VALIDATOR_2_STAKE));
+        assert_eq!(era_weights.get(&VALIDATOR_3), Some(&*VALIDATOR_3_STAKE));
+    }
+
+    // Check weights after auction_delay eras
+    {
+        for _ in 0..=auction_delay {
+            builder.run_auction();
+        }
+
+        era = builder.get_era();
+        assert_eq!(builder.get_auction_delay(), auction_delay);
+
+        let era_weights = builder
+            .get_validator_weights(era + auction_delay)
+            .expect("should get validator weights");
+
+        assert_eq!(era_weights.get(&VALIDATOR_1), Some(&*VALIDATOR_1_STAKE));
+        assert_eq!(era_weights.get(&VALIDATOR_2), Some(&*VALIDATOR_2_STAKE));
+        assert_eq!(era_weights.get(&VALIDATOR_3), Some(&*VALIDATOR_3_STAKE));
+    }
+
+    // Check weights after Delegator 1 delegates to Validator 1 (and auction_delay)
+    {
+        let delegator_1_delegate_request = ExecuteRequestBuilder::standard(
+            *DELEGATOR_1_ADDR,
+            CONTRACT_DELEGATE,
+            runtime_args! {
+                ARG_AMOUNT => *DELEGATOR_1_STAKE,
+                ARG_VALIDATOR => VALIDATOR_1,
+                ARG_DELEGATOR => DELEGATOR_1,
+            },
+        )
+        .build();
+
+        builder
+            .exec(delegator_1_delegate_request)
+            .commit()
+            .expect_success();
+
+        for _ in 0..=auction_delay {
+            builder.run_auction();
+        }
+
+        era = builder.get_era();
+        assert_eq!(builder.get_auction_delay(), auction_delay);
+
+        let era_weights = builder
+            .get_validator_weights(era)
+            .expect("should get validator weights");
+
+        let validator_1_expected_stake = *VALIDATOR_1_STAKE + *DELEGATOR_1_STAKE;
+
+        let validator_2_expected_stake = *VALIDATOR_2_STAKE;
+
+        let validator_3_expected_stake = *VALIDATOR_3_STAKE;
+
+        assert_eq!(
+            era_weights.get(&VALIDATOR_1),
+            Some(&validator_1_expected_stake)
+        );
+        assert_eq!(
+            era_weights.get(&VALIDATOR_2),
+            Some(&validator_2_expected_stake)
+        );
+        assert_eq!(
+            era_weights.get(&VALIDATOR_3),
+            Some(&validator_3_expected_stake)
+        );
+    }
+
+    // Check weights after Delegator 2 delegates to Validator 1 (and auction_delay)
+    {
+        let delegator_2_delegate_request = ExecuteRequestBuilder::standard(
+            *DELEGATOR_2_ADDR,
+            CONTRACT_DELEGATE,
+            runtime_args! {
+                ARG_AMOUNT => *DELEGATOR_2_STAKE,
+                ARG_VALIDATOR => VALIDATOR_1,
+                ARG_DELEGATOR => DELEGATOR_2,
+            },
+        )
+        .build();
+
+        builder
+            .exec(delegator_2_delegate_request)
+            .commit()
+            .expect_success();
+
+        for _ in 0..=auction_delay {
+            builder.run_auction();
+        }
+
+        era = builder.get_era();
+        assert_eq!(builder.get_auction_delay(), auction_delay);
+
+        let era_weights = builder
+            .get_validator_weights(era)
+            .expect("should get validator weights");
+
+        let validator_1_expected_stake =
+            *VALIDATOR_1_STAKE + *DELEGATOR_1_STAKE + *DELEGATOR_2_STAKE;
+
+        let validator_2_expected_stake = *VALIDATOR_2_STAKE;
+
+        let validator_3_expected_stake = *VALIDATOR_3_STAKE;
+
+        assert_eq!(
+            era_weights.get(&VALIDATOR_1),
+            Some(&validator_1_expected_stake)
+        );
+        assert_eq!(
+            era_weights.get(&VALIDATOR_2),
+            Some(&validator_2_expected_stake)
+        );
+        assert_eq!(
+            era_weights.get(&VALIDATOR_3),
+            Some(&validator_3_expected_stake)
+        );
+    }
+
+    // Check weights after Delegator 3 delegates to Validator 2 (and auction_delay)
+    {
+        let delegator_3_delegate_request = ExecuteRequestBuilder::standard(
+            *DELEGATOR_3_ADDR,
+            CONTRACT_DELEGATE,
+            runtime_args! {
+                ARG_AMOUNT => *DELEGATOR_3_STAKE,
+                ARG_VALIDATOR => VALIDATOR_2,
+                ARG_DELEGATOR => DELEGATOR_3,
+            },
+        )
+        .build();
+
+        builder
+            .exec(delegator_3_delegate_request)
+            .commit()
+            .expect_success();
+
+        for _ in 0..=auction_delay {
+            builder.run_auction();
+        }
+        era = builder.get_era();
+        assert_eq!(builder.get_auction_delay(), auction_delay);
+
+        let era_weights = builder
+            .get_validator_weights(era)
+            .expect("should get validator weights");
+
+        let validator_1_expected_stake =
+            *VALIDATOR_1_STAKE + *DELEGATOR_1_STAKE + *DELEGATOR_2_STAKE;
+
+        let validator_2_expected_stake = *VALIDATOR_2_STAKE + *DELEGATOR_3_STAKE;
+
+        let validator_3_expected_stake = *VALIDATOR_3_STAKE;
+
+        assert_eq!(
+            era_weights.get(&VALIDATOR_1),
+            Some(&validator_1_expected_stake)
+        );
+        assert_eq!(
+            era_weights.get(&VALIDATOR_2),
+            Some(&validator_2_expected_stake)
+        );
+        assert_eq!(
+            era_weights.get(&VALIDATOR_3),
+            Some(&validator_3_expected_stake)
+        );
+    }
+}

--- a/grpc/tests/src/test/regression/ee_1103.rs
+++ b/grpc/tests/src/test/regression/ee_1103.rs
@@ -27,6 +27,8 @@ const DELEGATOR_1: PublicKey = PublicKey::Ed25519([204; 32]);
 const DELEGATOR_2: PublicKey = PublicKey::Ed25519([206; 32]);
 const DELEGATOR_3: PublicKey = PublicKey::Ed25519([208; 32]);
 
+// These values were chosen to correspond to the values in accounts.csv
+// at the time of their introduction.
 lazy_static! {
     static ref FAUCET_ADDR: AccountHash = FAUCET.into();
     static ref VALIDATOR_1_ADDR: AccountHash = VALIDATOR_1.into();

--- a/grpc/tests/src/test/regression/mod.rs
+++ b/grpc/tests/src/test/regression/mod.rs
@@ -1,4 +1,5 @@
 mod ee_1045;
+mod ee_1103;
 mod ee_221;
 mod ee_401;
 mod ee_441;

--- a/types/src/auction/bid.rs
+++ b/types/src/auction/bid.rs
@@ -1,12 +1,12 @@
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, vec::Vec};
 
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    auction::{types::DelegationRate, EraId},
+    auction::{types::DelegationRate, Delegator, EraId},
     bytesrepr::{self, FromBytes, ToBytes},
     system_contract_errors::auction::Error,
-    CLType, CLTyped, URef, U512,
+    CLType, CLTyped, PublicKey, URef, U512,
 };
 
 /// An entry in a founding validator map.
@@ -23,16 +23,22 @@ pub struct Bid {
     /// `Some` indicates locked funds for a specific era and an autowin status, and `None` case
     /// means that funds are unlocked and autowin status is removed.
     release_era: Option<EraId>,
+    /// Delegators
+    delegators: BTreeMap<PublicKey, Delegator>,
 }
 
 impl Bid {
     /// Creates new instance of a bid with locked funds.
     pub fn locked(bonding_purse: URef, staked_amount: U512, release_era: EraId) -> Self {
+        let delegation_rate = 0;
+        let release_era = Some(release_era);
+        let delegators = BTreeMap::new();
         Self {
             bonding_purse,
             staked_amount,
-            delegation_rate: 0,
-            release_era: Some(release_era),
+            delegation_rate,
+            release_era,
+            delegators,
         }
     }
 
@@ -42,11 +48,14 @@ impl Bid {
         staked_amount: U512,
         delegation_rate: DelegationRate,
     ) -> Self {
+        let release_era = None;
+        let delegators = BTreeMap::new();
         Self {
             bonding_purse,
             staked_amount,
             delegation_rate,
-            release_era: None,
+            release_era,
+            delegators,
         }
     }
 
@@ -73,6 +82,11 @@ impl Bid {
     /// Returns the release era of the provided bid, if it is locked.
     pub fn release_era(&self) -> Option<EraId> {
         self.release_era
+    }
+
+    /// Returns a mutable reference to the delegators of the provided bid
+    pub fn delegators_mut(&mut self) -> &mut BTreeMap<PublicKey, Delegator> {
+        &mut self.delegators
     }
 
     /// Decreases the stake of the provided bid
@@ -137,6 +151,7 @@ impl ToBytes for Bid {
         result.extend(self.staked_amount.to_bytes()?);
         result.extend(self.delegation_rate.to_bytes()?);
         result.extend(self.release_era.to_bytes()?);
+        result.extend(self.delegators.to_bytes()?);
         Ok(result)
     }
 
@@ -145,6 +160,7 @@ impl ToBytes for Bid {
             + self.staked_amount.serialized_length()
             + self.delegation_rate.serialized_length()
             + self.release_era.serialized_length()
+            + self.delegators.serialized_length()
     }
 }
 
@@ -154,12 +170,14 @@ impl FromBytes for Bid {
         let (staked_amount, bytes) = FromBytes::from_bytes(bytes)?;
         let (delegation_rate, bytes) = FromBytes::from_bytes(bytes)?;
         let (release_era, bytes) = FromBytes::from_bytes(bytes)?;
+        let (delegators, bytes) = FromBytes::from_bytes(bytes)?;
         Ok((
             Bid {
                 bonding_purse,
                 staked_amount,
                 delegation_rate,
                 release_era,
+                delegators,
             },
             bytes,
         ))
@@ -168,6 +186,8 @@ impl FromBytes for Bid {
 
 #[cfg(test)]
 mod tests {
+    use alloc::collections::BTreeMap;
+
     use crate::{
         auction::{Bid, DelegationRate, EraId},
         bytesrepr, AccessRights, URef, U512,
@@ -180,6 +200,7 @@ mod tests {
             staked_amount: U512::one(),
             delegation_rate: DelegationRate::max_value(),
             release_era: Some(EraId::max_value() - 1),
+            delegators: BTreeMap::default(),
         };
         bytesrepr::test_serialization_roundtrip(&founding_validator);
     }

--- a/types/src/auction/bid.rs
+++ b/types/src/auction/bid.rs
@@ -23,7 +23,7 @@ pub struct Bid {
     /// `Some` indicates locked funds for a specific era and an autowin status, and `None` case
     /// means that funds are unlocked and autowin status is removed.
     release_era: Option<EraId>,
-    /// Delegators
+    /// This validator's delegators, indexed by their public keys
     delegators: BTreeMap<PublicKey, Delegator>,
 }
 

--- a/types/src/auction/delegator.rs
+++ b/types/src/auction/delegator.rs
@@ -1,0 +1,90 @@
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    system_contract_errors::auction::Error,
+    CLType, CLTyped, PublicKey, URef, U512,
+};
+
+/// Represents a party delegating their stake to a validator (or "delegatee")
+#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Delegator {
+    staked_amount: U512,
+    rewards_purse: URef,
+    delegatee: PublicKey,
+}
+
+impl Delegator {
+    /// Creates a new [`Delegator`]
+    pub fn new(staked_amount: U512, rewards_purse: URef, delegatee: PublicKey) -> Self {
+        Delegator {
+            staked_amount,
+            rewards_purse,
+            delegatee,
+        }
+    }
+
+    /// Decreases the stake of the provided bid
+    pub fn decrease_stake(&mut self, amount: U512) -> Result<U512, Error> {
+        let updated_staked_amount = self
+            .staked_amount
+            .checked_sub(amount)
+            .ok_or(Error::InvalidAmount)?;
+
+        self.staked_amount = updated_staked_amount;
+
+        Ok(updated_staked_amount)
+    }
+
+    /// Increases the stake of the provided bid
+    pub fn increase_stake(&mut self, amount: U512) -> Result<U512, Error> {
+        let updated_staked_amount = self
+            .staked_amount
+            .checked_add(amount)
+            .ok_or(Error::InvalidAmount)?;
+
+        self.staked_amount = updated_staked_amount;
+
+        Ok(updated_staked_amount)
+    }
+}
+
+impl CLTyped for Delegator {
+    fn cl_type() -> CLType {
+        CLType::Any
+    }
+}
+
+impl ToBytes for Delegator {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.extend(self.staked_amount.to_bytes()?);
+        buffer.extend(self.rewards_purse.to_bytes()?);
+        buffer.extend(self.delegatee.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.staked_amount.serialized_length()
+            + self.rewards_purse.serialized_length()
+            + self.delegatee.serialized_length()
+    }
+}
+
+impl FromBytes for Delegator {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (staked_amount, bytes) = U512::from_bytes(bytes)?;
+        let (rewards_purse, bytes) = URef::from_bytes(bytes)?;
+        let (delegatee, bytes) = PublicKey::from_bytes(bytes)?;
+        Ok((
+            Delegator {
+                staked_amount,
+                rewards_purse,
+                delegatee,
+            },
+            bytes,
+        ))
+    }
+}

--- a/types/src/auction/delegator.rs
+++ b/types/src/auction/delegator.rs
@@ -12,16 +12,16 @@ use crate::{
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Delegator {
     staked_amount: U512,
-    rewards_purse: URef,
+    bonding_purse: URef,
     delegatee: PublicKey,
 }
 
 impl Delegator {
     /// Creates a new [`Delegator`]
-    pub fn new(staked_amount: U512, rewards_purse: URef, delegatee: PublicKey) -> Self {
+    pub fn new(staked_amount: U512, bonding_purse: URef, delegatee: PublicKey) -> Self {
         Delegator {
             staked_amount,
-            rewards_purse,
+            bonding_purse,
             delegatee,
         }
     }
@@ -66,14 +66,14 @@ impl ToBytes for Delegator {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         buffer.extend(self.staked_amount.to_bytes()?);
-        buffer.extend(self.rewards_purse.to_bytes()?);
+        buffer.extend(self.bonding_purse.to_bytes()?);
         buffer.extend(self.delegatee.to_bytes()?);
         Ok(buffer)
     }
 
     fn serialized_length(&self) -> usize {
         self.staked_amount.serialized_length()
-            + self.rewards_purse.serialized_length()
+            + self.bonding_purse.serialized_length()
             + self.delegatee.serialized_length()
     }
 }
@@ -81,12 +81,12 @@ impl ToBytes for Delegator {
 impl FromBytes for Delegator {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (staked_amount, bytes) = U512::from_bytes(bytes)?;
-        let (rewards_purse, bytes) = URef::from_bytes(bytes)?;
+        let (bonding_purse, bytes) = URef::from_bytes(bytes)?;
         let (delegatee, bytes) = PublicKey::from_bytes(bytes)?;
         Ok((
             Delegator {
                 staked_amount,
-                rewards_purse,
+                bonding_purse,
                 delegatee,
             },
             bytes,

--- a/types/src/auction/delegator.rs
+++ b/types/src/auction/delegator.rs
@@ -26,6 +26,11 @@ impl Delegator {
         }
     }
 
+    /// Returns the staked amount
+    pub fn staked_amount(&self) -> &U512 {
+        &self.staked_amount
+    }
+
     /// Decreases the stake of the provided bid
     pub fn decrease_stake(&mut self, amount: U512) -> Result<U512, Error> {
         let updated_staked_amount = self


### PR DESCRIPTION
Refs:
https://casperlabs.atlassian.net/browse/EE-1101
https://casperlabs.atlassian.net/browse/EE-1103

This PR:
- introduces a `Delegator` struct to track a given delegator's stake and bonding purse.
- adds a `delegators` field to the `Bid` type to track the delegators attached to a particular validator.
- uses the `delegators` and `staked_amount` fields on `Bid` to synthesize a given validator's total stake when calculating bid "scores" or "weights" (fixing [EE-1103](https://casperlabs.atlassian.net/browse/EE-1103)).

**IMPORTANT**:
I'm presenting `Delegator` and and the `delegators` field on `Bid` _not_ as the minimal fix for the bug, but as part of a larger tranche of work to reduce some of the complexity in the auction.  Rather than saving all of the changes for a later PR, I wanted to open this PR to address the bug and reduce the surface area of future PRs.  Upcoming PRs will expand on these changes. 