### PR TITLE
NDRS-573: Rename vote to unit.

### DIFF
--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -92,7 +92,7 @@ pub(crate) struct HighwayConfig {
     pub(crate) booking_duration: TimeDiff,
     pub(crate) entropy_duration: TimeDiff,
     // TODO: Do we need this? When we see the switch block finalized it should suffice to keep
-    // gossiping, without producing new votes. Everyone else will eventually see the same finality.
+    // gossiping, without producing new units. Everyone else will eventually see the same finality.
     pub(crate) voting_period_duration: TimeDiff,
     pub(crate) finality_threshold_percent: u8,
     pub(crate) minimum_round_exponent: u8,

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -93,7 +93,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
     /// Typically called on a boxed trait object for downcasting afterwards.
     fn as_any(&self) -> &dyn Any;
 
-    /// Handles an incoming message (like NewVote, RequestDependency).
+    /// Handles an incoming message (like NewUnit, RequestDependency).
     fn handle_message(
         &mut self,
         sender: I,

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -5,15 +5,15 @@ use tracing::{error, trace, warn};
 use super::{
     endorsement::{Endorsement, SignedEndorsement},
     evidence::Evidence,
-    highway::{Endorsements, ValidVertex, Vertex, WireVote},
-    state::{self, Observation, Panorama, State, Vote},
+    highway::{Endorsements, ValidVertex, Vertex, WireUnit},
+    state::{self, Observation, Panorama, State, Unit},
     validators::ValidatorIndex,
 };
 
 use crate::{
     components::consensus::{
         consensus_protocol::BlockContext,
-        highway_core::highway::SignedWireVote,
+        highway_core::highway::SignedWireUnit,
         traits::{Context, ValidatorSecret},
     },
     types::{TimeDiff, Timestamp},
@@ -40,16 +40,16 @@ pub(crate) enum Effect<C: Context> {
 ///
 /// It implements the Highway schedule. The protocol proceeds in rounds, and in each round one
 /// validator is the _leader_.
-/// * In the beginning of the round, the leader sends a _proposal_ vote, containing a consensus
+/// * In the beginning of the round, the leader sends a _proposal_ unit, containing a consensus
 ///   value (i.e. a block).
-/// * Upon receiving the proposal, all the other validators send a _confirmation_ vote, citing only
+/// * Upon receiving the proposal, all the other validators send a _confirmation_ unit, citing only
 ///   the proposal, their own previous message, and resulting transitive justifications.
-/// * At a fixed point in time later in the round, everyone unconditionally sends a _witness_ vote,
-///   citing every vote they have received so far.
+/// * At a fixed point in time later in the round, everyone unconditionally sends a _witness_ unit,
+///   citing every unit they have received so far.
 ///
 /// If the rounds are long enough (i.e. message delivery is fast enough) and there are enough
 /// honest validators, there will be a lot of confirmations for the proposal, and enough witness
-/// votes citing all those confirmations, to create a summit and finalize the proposal.
+/// units citing all those confirmations, to create a summit and finalize the proposal.
 pub(crate) struct ActiveValidator<C: Context> {
     /// Our own validator index.
     vidx: ValidatorIndex,
@@ -111,7 +111,7 @@ impl<C: Context> ActiveValidator<C> {
             return vec![];
         }
         let mut effects = self.schedule_timer(timestamp, state);
-        if self.earliest_vote_time(state) > timestamp {
+        if self.earliest_unit_time(state) > timestamp {
             warn!(%timestamp, "skipping outdated timer event");
             return effects;
         }
@@ -123,16 +123,16 @@ impl<C: Context> ActiveValidator<C> {
         } else if timestamp == r_id + self.witness_offset(r_len) {
             let panorama = state.panorama().cutoff(state, timestamp);
             if panorama.has_correct() {
-                let witness_vote =
-                    self.new_vote(panorama, timestamp, None, state, instance_id, rng);
-                effects.push(Effect::NewVertex(ValidVertex(Vertex::Vote(witness_vote))))
+                let witness_unit =
+                    self.new_unit(panorama, timestamp, None, state, instance_id, rng);
+                effects.push(Effect::NewVertex(ValidVertex(Vertex::Unit(witness_unit))))
             }
         }
         effects
     }
 
-    /// Returns actions a validator needs to take upon receiving a new vote.
-    pub(crate) fn on_new_vote(
+    /// Returns actions a validator needs to take upon receiving a new unit.
+    pub(crate) fn on_new_unit(
         &mut self,
         vhash: &C::Hash,
         now: Timestamp,
@@ -147,8 +147,8 @@ impl<C: Context> ActiveValidator<C> {
         if self.should_send_confirmation(vhash, now, state) {
             let panorama = self.confirmation_panorama(vhash, state);
             if panorama.has_correct() {
-                let confirmation_vote = self.new_vote(panorama, now, None, state, instance_id, rng);
-                let vv = ValidVertex(Vertex::Vote(confirmation_vote));
+                let confirmation_unit = self.new_unit(panorama, now, None, state, instance_id, rng);
+                let vv = ValidVertex(Vertex::Unit(confirmation_unit));
                 effects.extend(vec![Effect::NewVertex(vv)])
             }
         };
@@ -160,7 +160,7 @@ impl<C: Context> ActiveValidator<C> {
     }
 
     /// Returns actions validator needs to take upon receiving a new evidence.
-    /// Endorses all latest votes by honest validators that do not mark new perpetrator as faulty
+    /// Endorses all latest units by honest validators that do not mark new perpetrator as faulty
     /// and cite some new message by that validator.
     pub(crate) fn on_new_evidence(
         &mut self,
@@ -172,8 +172,8 @@ impl<C: Context> ActiveValidator<C> {
         state
             .iter_correct_hashes()
             .filter(|&v| {
-                let vote = state.vote(v);
-                vote.new_hash_obs(state, vidx)
+                let unit = state.unit(v);
+                unit.new_hash_obs(state, vidx)
             })
             .map(|v| self.endorse(v, rng))
             .map(|endorsement| Effect::NewVertex(ValidVertex(endorsement)))
@@ -202,8 +202,8 @@ impl<C: Context> ActiveValidator<C> {
         let panorama = state.panorama().cutoff(state, timestamp);
         let opt_parent_hash = state.fork_choice(&panorama);
         if opt_parent_hash.map_or(false, |hash| state.is_terminal_block(hash)) {
-            let proposal_vote = self.new_vote(panorama, timestamp, None, state, instance_id, rng);
-            return Some(Effect::NewVertex(ValidVertex(Vertex::Vote(proposal_vote))));
+            let proposal_unit = self.new_unit(panorama, timestamp, None, state, instance_id, rng);
+            return Some(Effect::NewVertex(ValidVertex(Vertex::Unit(proposal_unit))));
         }
         let opt_parent = opt_parent_hash.map(|bh| state.block(bh));
         let height = opt_parent.map_or(0, |block| block.height);
@@ -222,7 +222,7 @@ impl<C: Context> ActiveValidator<C> {
         rng: &mut NodeRng,
     ) -> Vec<Effect<C>> {
         let timestamp = block_context.timestamp();
-        if self.earliest_vote_time(state) > timestamp {
+        if self.earliest_unit_time(state) > timestamp {
             warn!(?block_context, "skipping outdated proposal");
             return vec![];
         }
@@ -243,9 +243,9 @@ impl<C: Context> ActiveValidator<C> {
             warn!("unexpected proposal value");
             return vec![];
         };
-        let proposal_vote =
-            self.new_vote(panorama, timestamp, Some(value), state, instance_id, rng);
-        vec![Effect::NewVertex(ValidVertex(Vertex::Vote(proposal_vote)))]
+        let proposal_unit =
+            self.new_unit(panorama, timestamp, Some(value), state, instance_id, rng);
+        vec![Effect::NewVertex(ValidVertex(Vertex::Unit(proposal_unit)))]
     }
 
     /// Returns whether the incoming message is a proposal that we need to send a confirmation for.
@@ -255,36 +255,36 @@ impl<C: Context> ActiveValidator<C> {
         timestamp: Timestamp,
         state: &State<C>,
     ) -> bool {
-        let earliest_vote_time = self.earliest_vote_time(state);
-        if timestamp < earliest_vote_time {
+        let earliest_unit_time = self.earliest_unit_time(state);
+        if timestamp < earliest_unit_time {
             warn!(
-                %earliest_vote_time, %timestamp,
-                "earliest_vote_time is greater than current time stamp"
+                %earliest_unit_time, %timestamp,
+                "earliest_unit_time is greater than current time stamp"
             );
             return false;
         }
-        let vote = state.vote(vhash);
-        if vote.timestamp > timestamp {
+        let unit = state.unit(vhash);
+        if unit.timestamp > timestamp {
             error!(
-                %vote.timestamp, %timestamp,
-                "added a vote with a future timestamp, should never happen"
+                %unit.timestamp, %timestamp,
+                "added a unit with a future timestamp, should never happen"
             );
             return false;
         }
         // If it's not a proposal, the sender is faulty, or we are, don't send a confirmation.
-        if vote.creator == self.vidx || self.is_faulty(state) || !state.is_correct_proposal(vote) {
+        if unit.creator == self.vidx || self.is_faulty(state) || !state.is_correct_proposal(unit) {
             return false;
         }
-        if let Some(vote) = self.latest_vote(state) {
-            if vote.panorama.sees_correct(state, vhash) {
-                error!(%vhash, "called on_new_vote with already confirmed proposal");
+        if let Some(unit) = self.latest_unit(state) {
+            if unit.panorama.sees_correct(state, vhash) {
+                error!(%vhash, "called on_new_unit with already confirmed proposal");
                 return false; // We already sent a confirmation.
             }
         }
         let r_id = state::round_id(timestamp, self.round_exp(state, timestamp));
-        if vote.timestamp != r_id {
+        if unit.timestamp != r_id {
             trace!(
-                %vote.timestamp, %r_id,
+                %unit.timestamp, %r_id,
                 "not confirming proposal: wrong round",
             );
             return false;
@@ -292,26 +292,26 @@ impl<C: Context> ActiveValidator<C> {
         true
     }
 
-    /// Returns the panorama of the confirmation for the leader vote `vhash`.
+    /// Returns the panorama of the confirmation for the leader unit `vhash`.
     fn confirmation_panorama(&self, vhash: &C::Hash, state: &State<C>) -> Panorama<C> {
-        let vote = state.vote(vhash);
+        let unit = state.unit(vhash);
         let mut panorama;
         if let Some(prev_hash) = state.panorama().get(self.vidx).correct().cloned() {
-            let own_vote = state.vote(&prev_hash);
-            panorama = vote.panorama.merge(state, &own_vote.panorama);
+            let own_unit = state.unit(&prev_hash);
+            panorama = unit.panorama.merge(state, &own_unit.panorama);
             panorama[self.vidx] = Observation::Correct(prev_hash);
         } else {
-            panorama = vote.panorama.clone();
+            panorama = unit.panorama.clone();
         }
-        panorama[vote.creator] = Observation::Correct(*vhash);
+        panorama[unit.creator] = Observation::Correct(*vhash);
         for faulty_v in state.faulty_validators() {
             panorama[faulty_v] = Observation::Faulty;
         }
         panorama
     }
 
-    /// Returns a new vote with the given data, and the correct sequence number.
-    fn new_vote(
+    /// Returns a new unit with the given data, and the correct sequence number.
+    fn new_unit(
         &mut self,
         mut panorama: Panorama<C>,
         timestamp: Timestamp,
@@ -319,21 +319,21 @@ impl<C: Context> ActiveValidator<C> {
         state: &State<C>,
         instance_id: C::InstanceId,
         rng: &mut NodeRng,
-    ) -> SignedWireVote<C> {
+    ) -> SignedWireUnit<C> {
         if let Some((prop_time, _)) = self.next_proposal.take() {
             warn!(
                 ?timestamp,
-                "canceling proposal for {} due to vote", prop_time
+                "canceling proposal for {} due to unit", prop_time
             );
         }
         if panorama[self.vidx] != state.panorama()[self.vidx] {
-            error!("replacing vote panorama to avoid equivocation");
+            error!("replacing unit panorama to avoid equivocation");
             panorama = state.panorama().clone();
         }
         let seq_number = panorama.next_seq_num(state, self.vidx);
         // TODO: After LNC we won't always need all known endorsements.
         let endorsed = state.endorsements().collect();
-        let wvote = WireVote {
+        let wunit = WireUnit {
             panorama,
             creator: self.vidx,
             instance_id,
@@ -343,14 +343,14 @@ impl<C: Context> ActiveValidator<C> {
             round_exp: self.round_exp(state, timestamp),
             endorsed,
         };
-        SignedWireVote::new(wvote, &self.secret, rng)
+        SignedWireUnit::new(wunit, &self.secret, rng)
     }
 
     /// Returns a `ScheduleTimer` effect for the next time we need to be called.
     ///
-    /// If the time is before the current round's witness vote, schedule the witness vote.
-    /// Otherwise, if we are the next round's leader, schedule the proposal vote.
-    /// Otherwise schedule the next round's witness vote.
+    /// If the time is before the current round's witness unit, schedule the witness unit.
+    /// Otherwise, if we are the next round's leader, schedule the proposal unit.
+    /// Otherwise schedule the next round's witness unit.
     fn schedule_timer(&mut self, timestamp: Timestamp, state: &State<C>) -> Vec<Effect<C>> {
         if self.next_timer > timestamp {
             return Vec::new(); // We already scheduled the next call; nothing to do.
@@ -372,25 +372,25 @@ impl<C: Context> ActiveValidator<C> {
         vec![Effect::ScheduleTimer(self.next_timer)]
     }
 
-    /// Returns the earliest timestamp where we can cast our next vote: It can't be earlier than
-    /// our previous vote, and it can't be the third vote in a single round.
-    fn earliest_vote_time(&self, state: &State<C>) -> Timestamp {
-        self.latest_vote(state)
-            .map_or_else(Timestamp::zero, |vote| {
-                vote.previous().map_or(vote.timestamp, |vh2| {
-                    let vote2 = state.vote(vh2);
-                    vote.timestamp.max(vote2.round_id() + vote2.round_len())
+    /// Returns the earliest timestamp where we can cast our next unit: It can't be earlier than
+    /// our previous unit, and it can't be the third unit in a single round.
+    fn earliest_unit_time(&self, state: &State<C>) -> Timestamp {
+        self.latest_unit(state)
+            .map_or_else(Timestamp::zero, |unit| {
+                unit.previous().map_or(unit.timestamp, |vh2| {
+                    let unit2 = state.unit(vh2);
+                    unit.timestamp.max(unit2.round_id() + unit2.round_len())
                 })
             })
     }
 
-    /// Returns the most recent vote by this validator.
-    fn latest_vote<'a>(&self, state: &'a State<C>) -> Option<&'a Vote<C>> {
+    /// Returns the most recent unit by this validator.
+    fn latest_unit<'a>(&self, state: &'a State<C>) -> Option<&'a Unit<C>> {
         state
             .panorama()
             .get(self.vidx)
             .correct()
-            .map(|vh| state.vote(vh))
+            .map(|vh| state.unit(vh))
     }
 
     /// Checks if validator knows it's faulty.
@@ -398,37 +398,37 @@ impl<C: Context> ActiveValidator<C> {
         state.panorama().get(self.vidx).is_faulty()
     }
 
-    /// Returns the duration after the beginning of a round when the witness votes are sent.
+    /// Returns the duration after the beginning of a round when the witness units are sent.
     fn witness_offset(&self, round_len: TimeDiff) -> TimeDiff {
         round_len * 2 / 3
     }
 
     /// The round exponent of the round containing `timestamp`.
     ///
-    /// This returns `self.next_round_exp`, if that is a valid round exponent for a vote cast at
-    /// `timestamp`. Otherwise it returns the round exponent of our latest vote.
+    /// This returns `self.next_round_exp`, if that is a valid round exponent for a unit cast at
+    /// `timestamp`. Otherwise it returns the round exponent of our latest unit.
     fn round_exp(&self, state: &State<C>, timestamp: Timestamp) -> u8 {
-        self.latest_vote(state).map_or(self.next_round_exp, |vote| {
-            let max_re = self.next_round_exp.max(vote.round_exp);
-            if vote.timestamp < state::round_id(timestamp, max_re) {
+        self.latest_unit(state).map_or(self.next_round_exp, |unit| {
+            let max_re = self.next_round_exp.max(unit.round_exp);
+            if unit.timestamp < state::round_id(timestamp, max_re) {
                 self.next_round_exp
             } else {
-                vote.round_exp
+                unit.round_exp
             }
         })
     }
 
     /// Returns whether we should endorse the `vhash`.
     ///
-    /// We should endorse vote from honest validator that cites _an_ equivocator
+    /// We should endorse unit from honest validator that cites _an_ equivocator
     /// as honest and it cites some new message by that validator.
     fn should_endorse(&self, vhash: &C::Hash, state: &State<C>) -> bool {
-        let vote = state.vote(vhash);
-        !state.is_faulty(vote.creator)
-            && vote
+        let unit = state.unit(vhash);
+        !state.is_faulty(unit.creator)
+            && unit
                 .panorama
                 .enumerate()
-                .any(|(vidx, _)| state.is_faulty(vidx) && vote.new_hash_obs(state, vidx))
+                .any(|(vidx, _)| state.is_faulty(vidx) && unit.new_hash_obs(state, vidx))
     }
 
     /// Creates endorsement of the `vhash`.
@@ -457,9 +457,9 @@ mod tests {
     type Eff = Effect<TestContext>;
 
     impl Eff {
-        fn unwrap_vote(self) -> SignedWireVote<TestContext> {
-            if let Eff::NewVertex(ValidVertex(Vertex::Vote(swvote))) = self {
-                swvote
+        fn unwrap_unit(self) -> SignedWireUnit<TestContext> {
+            if let Eff::NewVertex(ValidVertex(Vertex::Unit(swunit))) = self {
+                swunit
             } else {
                 panic!("Unexpected effect: {:?}", self);
             }
@@ -477,7 +477,7 @@ mod tests {
 
     #[test]
     #[allow(clippy::unreadable_literal)] // 0xC0FFEE is more readable than 0x00C0_FFEE.
-    fn active_validator() -> Result<(), AddVoteError<TestContext>> {
+    fn active_validator() -> Result<(), AddUnitError<TestContext>> {
         let mut state = State::new_test(&[Weight(3), Weight(4)], 0);
         let mut rng = crate::new_rng();
         let mut fd = FinalityDetector::new(Weight(2));
@@ -497,7 +497,7 @@ mod tests {
             .handle_timer(415.into(), &state, instance_id, &mut rng)
             .is_empty()); // Too early: No new effects.
 
-        // Alice wants to propose a block, and also make her witness vote at 426.
+        // Alice wants to propose a block, and also make her witness unit at 426.
         let bctx = match &*alice_av.handle_timer(416.into(), &state, instance_id, &mut rng) {
             [Eff::ScheduleTimer(timestamp), Eff::RequestNewBlock(bctx)]
                 if *timestamp == 426.into() =>
@@ -510,34 +510,34 @@ mod tests {
 
         // She has a pending deploy from Colin who wants to pay for a hot beverage.
         let effects = alice_av.propose(0xC0FFEE, bctx, &state, instance_id, &mut rng);
-        let proposal_wvote = unwrap_single(effects).unwrap_vote();
-        let prop_hash = proposal_wvote.hash();
-        state.add_vote(proposal_wvote)?;
+        let proposal_wunit = unwrap_single(effects).unwrap_unit();
+        let prop_hash = proposal_wunit.hash();
+        state.add_unit(proposal_wunit)?;
         assert!(alice_av
-            .on_new_vote(&prop_hash, 417.into(), &state, instance_id, &mut rng)
+            .on_new_unit(&prop_hash, 417.into(), &state, instance_id, &mut rng)
             .is_empty());
 
-        // Bob creates a confirmation vote for Alice's proposal.
-        let effects = bob_av.on_new_vote(&prop_hash, 419.into(), &state, instance_id, &mut rng);
-        state.add_vote(unwrap_single(effects).unwrap_vote())?;
+        // Bob creates a confirmation unit for Alice's proposal.
+        let effects = bob_av.on_new_unit(&prop_hash, 419.into(), &state, instance_id, &mut rng);
+        state.add_unit(unwrap_single(effects).unwrap_unit())?;
 
         // Bob creates his witness message 2/3 through the round.
         let mut effects = bob_av
             .handle_timer(426.into(), &state, instance_id, &mut rng)
             .into_iter();
         assert_eq!(Some(Eff::ScheduleTimer(432.into())), effects.next()); // Bob is the next leader.
-        state.add_vote(effects.next().unwrap().unwrap_vote())?;
+        state.add_unit(effects.next().unwrap().unwrap_unit())?;
         assert_eq!(None, effects.next());
 
-        // Alice has not witnessed Bob's vote yet.
+        // Alice has not witnessed Bob's unit yet.
         assert_eq!(None, fd.next_finalized(&state));
 
         // Alice also sends her own witness message, completing the summit for her proposal.
         let mut effects = alice_av
             .handle_timer(426.into(), &state, instance_id, &mut rng)
             .into_iter();
-        assert_eq!(Some(Eff::ScheduleTimer(442.into())), effects.next()); // Timer for witness vote.
-        state.add_vote(effects.next().unwrap().unwrap_vote())?;
+        assert_eq!(Some(Eff::ScheduleTimer(442.into())), effects.next()); // Timer for witness unit.
+        state.add_unit(effects.next().unwrap().unwrap_unit())?;
         assert_eq!(None, effects.next());
 
         // Payment finalized! "One Pumpkin Spice Mochaccino for Corbyn!"

--- a/node/src/components/consensus/highway_core/endorsement.rs
+++ b/node/src/components/consensus/highway_core/endorsement.rs
@@ -13,12 +13,12 @@ pub(crate) enum EndorsementError {
     Signature,
 }
 
-/// Testimony that creator of `vote` was seen honest
+/// Testimony that creator of `unit` was seen honest
 /// by `endorser` at the moment of creating this endorsement.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Endorsement<C: Context> {
-    /// Vote being endorsed.
-    vote: C::Hash,
+    /// Unit being endorsed.
+    unit: C::Hash,
     /// The validator who created and sent this endorsement.
     creator: ValidatorIndex,
 }
@@ -26,19 +26,19 @@ pub(crate) struct Endorsement<C: Context> {
 impl<C: Context> Endorsement<C> {
     pub(crate) fn new(vhash: C::Hash, creator: ValidatorIndex) -> Self {
         Endorsement {
-            vote: vhash,
+            unit: vhash,
             creator,
         }
     }
 
     pub(crate) fn hash(&self) -> C::Hash {
         <C as Context>::hash(
-            &bincode::serialize(&(self.vote, self.creator)).expect("serialize endorsement"),
+            &bincode::serialize(&(self.unit, self.creator)).expect("serialize endorsement"),
         )
     }
 }
 
-/// Testimony that creator of `vote` was seen honest
+/// Testimony that creator of `unit` was seen honest
 /// by `endorser` at the moment of creating this endorsement.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct SignedEndorsement<C: Context> {
@@ -56,8 +56,8 @@ impl<C: Context> SignedEndorsement<C> {
         }
     }
 
-    pub(crate) fn vote(&self) -> &C::Hash {
-        &self.endorsement.vote
+    pub(crate) fn unit(&self) -> &C::Hash {
+        &self.endorsement.unit
     }
 
     pub(crate) fn validator_idx(&self) -> ValidatorIndex {

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -1,7 +1,7 @@
 mod vertex;
 
 pub(crate) use crate::components::consensus::highway_core::state::Params;
-pub(crate) use vertex::{Dependency, Endorsements, SignedWireVote, Vertex, WireVote};
+pub(crate) use vertex::{Dependency, Endorsements, SignedWireUnit, Vertex, WireUnit};
 
 use thiserror::Error;
 use tracing::{debug, error, info};
@@ -12,7 +12,7 @@ use crate::{
         highway_core::{
             active_validator::{ActiveValidator, Effect},
             evidence::EvidenceError,
-            state::{Fault, State, VoteError},
+            state::{Fault, State, UnitError},
             validators::{Validator, Validators},
         },
         traits::Context,
@@ -29,8 +29,8 @@ use super::{
 /// An error due to an invalid vertex.
 #[derive(Debug, Error, PartialEq)]
 pub(crate) enum VertexError {
-    #[error("The vertex contains an invalid vote: `{0}`")]
-    Vote(#[from] VoteError),
+    #[error("The vertex contains an invalid unit: `{0}`")]
+    Unit(#[from] UnitError),
     #[error("The vertex contains invalid evidence.")]
     Evidence(#[from] EvidenceError),
     #[error("The endorsements contains invalid entry.")]
@@ -98,7 +98,7 @@ impl<C: Context> ValidVertex<C> {
     pub(crate) fn endorsements(&self) -> Option<&Endorsements<C>> {
         match &self.0 {
             Vertex::Endorsements(endorsements) => Some(endorsements),
-            Vertex::Evidence(_) | Vertex::Vote(_) => None,
+            Vertex::Evidence(_) | Vertex::Unit(_) => None,
         }
     }
 }
@@ -211,20 +211,20 @@ impl<C: Context> Highway<C> {
         match pvv.inner() {
             Vertex::Evidence(_) => None,
             Vertex::Endorsements(endorsements) => {
-                let vote = *endorsements.vote();
-                if !self.state.has_vote(&vote) {
-                    Some(Dependency::Vote(vote))
+                let unit = *endorsements.unit();
+                if !self.state.has_unit(&unit) {
+                    Some(Dependency::Unit(unit))
                 } else {
                     None
                 }
             }
-            Vertex::Vote(vote) => vote
-                .wire_vote
+            Vertex::Unit(unit) => unit
+                .wire_unit
                 .panorama
                 .missing_dependency(&self.state)
                 .or_else(|| {
                     self.state
-                        .needs_endorsements(vote)
+                        .needs_endorsements(unit)
                         .map(Dependency::Endorsement)
                 }),
         }
@@ -256,7 +256,7 @@ impl<C: Context> Highway<C> {
     ) -> Vec<Effect<C>> {
         if !self.has_vertex(&vertex) {
             match vertex {
-                Vertex::Vote(vote) => self.add_valid_vote(vote, now, rng),
+                Vertex::Unit(unit) => self.add_valid_unit(unit, now, rng),
                 Vertex::Evidence(evidence) => self.add_evidence(evidence, rng),
                 Vertex::Endorsements(endorsements) => {
                     self.state.add_endorsements(endorsements);
@@ -271,14 +271,14 @@ impl<C: Context> Highway<C> {
     /// Returns whether the vertex is already part of this protocol state.
     pub(crate) fn has_vertex(&self, vertex: &Vertex<C>) -> bool {
         match vertex {
-            Vertex::Vote(vote) => self.state.has_vote(&vote.hash()),
+            Vertex::Unit(unit) => self.state.has_unit(&unit.hash()),
             Vertex::Evidence(evidence) => self.state.has_evidence(evidence.perpetrator()),
             Vertex::Endorsements(endorsements) => {
-                let vote = endorsements.vote();
-                self.state.is_endorsed(vote)
+                let unit = endorsements.unit();
+                self.state.is_endorsed(unit)
                     || self
                         .state
-                        .has_all_endorsements(vote, endorsements.validator_ids())
+                        .has_all_endorsements(unit, endorsements.validator_ids())
             }
         }
     }
@@ -300,7 +300,7 @@ impl<C: Context> Highway<C> {
     /// Returns whether we have a vertex that satisfies the dependency.
     pub(crate) fn has_dependency(&self, dependency: &Dependency<C>) -> bool {
         match dependency {
-            Dependency::Vote(hash) => self.state.has_vote(hash),
+            Dependency::Unit(hash) => self.state.has_unit(hash),
             Dependency::Evidence(idx) => self.state.is_faulty(*idx),
             Dependency::Endorsement(hash) => self.state.is_endorsed(hash),
         }
@@ -312,9 +312,9 @@ impl<C: Context> Highway<C> {
     /// case, `get_dependency` will never return `None`, unless the peer is faulty.
     pub(crate) fn get_dependency(&self, dependency: &Dependency<C>) -> GetDepOutcome<C> {
         match dependency {
-            Dependency::Vote(hash) => match self.state.wire_vote(hash, self.instance_id) {
+            Dependency::Unit(hash) => match self.state.wire_unit(hash, self.instance_id) {
                 None => GetDepOutcome::None,
-                Some(vote) => GetDepOutcome::Vertex(ValidVertex(Vertex::Vote(vote))),
+                Some(unit) => GetDepOutcome::Vertex(ValidVertex(Vertex::Unit(unit))),
             },
             Dependency::Evidence(idx) => match self.state.opt_fault(*idx) {
                 None | Some(Fault::Banned) => GetDepOutcome::None,
@@ -344,7 +344,7 @@ impl<C: Context> Highway<C> {
 
         // Here we just use the timer's timestamp, and assume it's ~ Timestamp::now()
         //
-        // This is because proposal votes, i.e. new blocks, are
+        // This is because proposal units, i.e. new blocks, are
         // supposed to thave the exact timestamp that matches the
         // beginning of the round (which we use as the "round ID").
         //
@@ -416,7 +416,7 @@ impl<C: Context> Highway<C> {
         &self.state
     }
 
-    fn on_new_vote(
+    fn on_new_unit(
         &mut self,
         vhash: &C::Hash,
         timestamp: Timestamp,
@@ -424,7 +424,7 @@ impl<C: Context> Highway<C> {
     ) -> Vec<Effect<C>> {
         let instance_id = self.instance_id;
         self.map_active_validator(
-            |av, state, rng| av.on_new_vote(vhash, timestamp, state, instance_id, rng),
+            |av, state, rng| av.on_new_unit(vhash, timestamp, state, instance_id, rng),
             timestamp,
             rng,
         )
@@ -486,16 +486,16 @@ impl<C: Context> Highway<C> {
     /// `PreValidatedVertex` and `validate_vertex`.)
     fn do_pre_validate_vertex(&self, vertex: &Vertex<C>) -> Result<(), VertexError> {
         match vertex {
-            Vertex::Vote(vote) => {
-                let creator = vote.wire_vote.creator;
-                let v_id = self.validators.id(creator).ok_or(VoteError::Creator)?;
-                if vote.wire_vote.instance_id != self.instance_id {
-                    return Err(VoteError::InstanceId.into());
+            Vertex::Unit(unit) => {
+                let creator = unit.wire_unit.creator;
+                let v_id = self.validators.id(creator).ok_or(UnitError::Creator)?;
+                if unit.wire_unit.instance_id != self.instance_id {
+                    return Err(UnitError::InstanceId.into());
                 }
-                if !C::verify_signature(&vote.hash(), v_id, &vote.signature) {
-                    return Err(VoteError::Signature.into());
+                if !C::verify_signature(&unit.hash(), v_id, &unit.signature) {
+                    return Err(UnitError::Signature.into());
                 }
-                Ok(self.state.pre_validate_vote(vote)?)
+                Ok(self.state.pre_validate_unit(unit)?)
             }
             Vertex::Evidence(evidence) => {
                 let v_id = self
@@ -505,10 +505,10 @@ impl<C: Context> Highway<C> {
                 Ok(evidence.validate(v_id, &self.instance_id)?)
             }
             Vertex::Endorsements(endorsements) => {
-                let vote = *endorsements.vote();
+                let unit = *endorsements.unit();
                 for (v_id, signature) in endorsements.endorsers.iter() {
                     let validator = self.validators.id(*v_id).ok_or(EndorsementError::Creator)?;
-                    let endorsement: Endorsement<C> = Endorsement::new(vote, *v_id);
+                    let endorsement: Endorsement<C> = Endorsement::new(unit, *v_id);
                     if !C::verify_signature(&endorsement.hash(), validator, &signature) {
                         return Err(EndorsementError::Signature.into());
                     }
@@ -522,7 +522,7 @@ impl<C: Context> Highway<C> {
     /// This requires all dependencies to be present.
     fn do_validate_vertex(&self, vertex: &Vertex<C>) -> Result<(), VertexError> {
         match vertex {
-            Vertex::Vote(vote) => Ok(self.state.validate_vote(vote)?),
+            Vertex::Unit(unit) => Ok(self.state.validate_unit(unit)?),
             Vertex::Evidence(_evidence) => Ok(()),
             Vertex::Endorsements(_endorsements) => {
                 // TODO: Validate against equivocations in endorsements.
@@ -541,20 +541,20 @@ impl<C: Context> Highway<C> {
         }
     }
 
-    /// Adds a valid vote to the protocol state.
+    /// Adds a valid unit to the protocol state.
     ///
-    /// Validity must be checked before calling this! Adding an invalid vote will result in a panic
+    /// Validity must be checked before calling this! Adding an invalid unit will result in a panic
     /// or an inconsistent state.
-    fn add_valid_vote(
+    fn add_valid_unit(
         &mut self,
-        swvote: SignedWireVote<C>,
+        swunit: SignedWireUnit<C>,
         now: Timestamp,
         rng: &mut NodeRng,
     ) -> Vec<Effect<C>> {
-        let vote_hash = swvote.hash();
-        let creator = swvote.wire_vote.creator;
+        let unit_hash = swunit.hash();
+        let creator = swunit.wire_unit.creator;
         let was_honest = !self.state.is_faulty(creator);
-        self.state.add_valid_vote(swvote);
+        self.state.add_valid_unit(swunit);
         let mut evidence_effects = self
             .state
             .opt_evidence(creator)
@@ -567,7 +567,7 @@ impl<C: Context> Highway<C> {
                 }
             })
             .unwrap_or_default();
-        evidence_effects.extend(self.on_new_vote(&vote_hash, now, rng));
+        evidence_effects.extend(self.on_new_unit(&unit_hash, now, rng));
         evidence_effects
     }
 }
@@ -580,7 +580,7 @@ pub(crate) mod tests {
         components::consensus::{
             highway_core::{
                 evidence::{Evidence, EvidenceError},
-                highway::{Highway, SignedWireVote, Vertex, VertexError, VoteError, WireVote},
+                highway::{Highway, SignedWireUnit, Vertex, VertexError, UnitError, WireUnit},
                 state::{
                     tests::{
                         TestContext, TestSecret, ALICE, ALICE_SEC, BOB, BOB_SEC, CAROL, CAROL_SEC,
@@ -619,7 +619,7 @@ pub(crate) mod tests {
             state,
             active_validator: None,
         };
-        let wvote = WireVote {
+        let wunit = WireUnit {
             panorama: Panorama::new(WEIGHTS.len()),
             creator: CAROL,
             instance_id: highway.instance_id,
@@ -630,23 +630,23 @@ pub(crate) mod tests {
             endorsed: vec![],
         };
         let invalid_signature = 1u64;
-        let invalid_signature_vote = SignedWireVote {
-            wire_vote: wvote.clone(),
+        let invalid_signature_unit = SignedWireUnit {
+            wire_unit: wunit.clone(),
             signature: invalid_signature,
         };
-        let invalid_vertex = Vertex::Vote(invalid_signature_vote);
-        let err = VertexError::Vote(VoteError::Signature);
+        let invalid_vertex = Vertex::Unit(invalid_signature_unit);
+        let err = VertexError::Unit(UnitError::Signature);
         let expected = (invalid_vertex.clone(), err);
         assert_eq!(Err(expected), highway.pre_validate_vertex(invalid_vertex));
 
         // TODO: Also test the `missing_dependency` and `validate_vertex` steps.
 
-        let valid_signature = CAROL_SEC.sign(&wvote.hash(), &mut rng);
-        let correct_signature_vote = SignedWireVote {
-            wire_vote: wvote,
+        let valid_signature = CAROL_SEC.sign(&wunit.hash(), &mut rng);
+        let correct_signature_unit = SignedWireUnit {
+            wire_unit: wunit,
             signature: valid_signature,
         };
-        let valid_vertex = Vertex::Vote(correct_signature_vote);
+        let valid_vertex = Vertex::Unit(correct_signature_unit);
         let pvv = highway.pre_validate_vertex(valid_vertex).unwrap();
         assert_eq!(None, highway.missing_dependency(&pvv));
         let vv = highway.validate_vertex(pvv).unwrap();
@@ -665,13 +665,13 @@ pub(crate) mod tests {
             active_validator: None,
         };
 
-        let mut validate = |wvote0: &WireVote<TestContext>,
+        let mut validate = |wunit0: &WireUnit<TestContext>,
                             signer0: &TestSecret,
-                            wvote1: &WireVote<TestContext>,
+                            wunit1: &WireUnit<TestContext>,
                             signer1: &TestSecret| {
-            let swvote0 = SignedWireVote::new(wvote0.clone(), signer0, &mut rng);
-            let swvote1 = SignedWireVote::new(wvote1.clone(), signer1, &mut rng);
-            let evidence = Evidence::Equivocation(swvote0, swvote1);
+            let swunit0 = SignedWireUnit::new(wunit0.clone(), signer0, &mut rng);
+            let swunit1 = SignedWireUnit::new(wunit1.clone(), signer1, &mut rng);
+            let evidence = Evidence::Equivocation(swunit0, swunit1);
             let vertex = Vertex::Evidence(evidence);
             highway
                 .pre_validate_vertex(vertex.clone())
@@ -681,8 +681,8 @@ pub(crate) mod tests {
                 })
         };
 
-        // Two votes with different values and the same sequence number. Carol equivocated!
-        let mut wvote0 = WireVote {
+        // Two units with different values and the same sequence number. Carol equivocated!
+        let mut wunit0 = WireUnit {
             panorama: Panorama::new(WEIGHTS.len()),
             creator: CAROL,
             instance_id: highway.instance_id,
@@ -692,7 +692,7 @@ pub(crate) mod tests {
             round_exp: 4,
             endorsed: vec![],
         };
-        let wvote1 = WireVote {
+        let wunit1 = WireUnit {
             panorama: Panorama::new(WEIGHTS.len()),
             creator: CAROL,
             instance_id: highway.instance_id,
@@ -703,49 +703,49 @@ pub(crate) mod tests {
             endorsed: vec![],
         };
 
-        assert!(validate(&wvote0, &CAROL_SEC, &wvote1, &CAROL_SEC,).is_ok());
+        assert!(validate(&wunit0, &CAROL_SEC, &wunit1, &CAROL_SEC,).is_ok());
 
-        // It's only an equivocation if the two votes are different.
+        // It's only an equivocation if the two units are different.
         assert_eq!(
-            Err(VertexError::Evidence(EvidenceError::EquivocationSameVote)),
-            validate(&wvote0, &CAROL_SEC, &wvote0, &CAROL_SEC)
+            Err(VertexError::Evidence(EvidenceError::EquivocationSameUnit)),
+            validate(&wunit0, &CAROL_SEC, &wunit0, &CAROL_SEC)
         );
 
-        // Both votes have Carol as their creator; Bob's signature would be invalid.
-        assert_eq!(
-            Err(VertexError::Evidence(EvidenceError::Signature)),
-            validate(&wvote0, &CAROL_SEC, &wvote1, &BOB_SEC)
-        );
+        // Both units have Carol as their creator; Bob's signature would be invalid.
         assert_eq!(
             Err(VertexError::Evidence(EvidenceError::Signature)),
-            validate(&wvote0, &BOB_SEC, &wvote1, &CAROL_SEC)
+            validate(&wunit0, &CAROL_SEC, &wunit1, &BOB_SEC)
+        );
+        assert_eq!(
+            Err(VertexError::Evidence(EvidenceError::Signature)),
+            validate(&wunit0, &BOB_SEC, &wunit1, &CAROL_SEC)
         );
 
-        // If the first vote was actually Bob's and the second Carol's, nobody equivocated.
-        wvote0.creator = BOB;
+        // If the first unit was actually Bob's and the second Carol's, nobody equivocated.
+        wunit0.creator = BOB;
         assert_eq!(
             Err(VertexError::Evidence(
                 EvidenceError::EquivocationDifferentCreators
             )),
-            validate(&wvote0, &BOB_SEC, &wvote1, &CAROL_SEC)
+            validate(&wunit0, &BOB_SEC, &wunit1, &CAROL_SEC)
         );
-        wvote0.creator = CAROL;
+        wunit0.creator = CAROL;
 
-        // If the votes have different sequence numbers they might belong to the same fork.
-        wvote0.seq_number = 1;
+        // If the units have different sequence numbers they might belong to the same fork.
+        wunit0.seq_number = 1;
         assert_eq!(
             Err(VertexError::Evidence(
                 EvidenceError::EquivocationDifferentSeqNumbers
             )),
-            validate(&wvote0, &CAROL_SEC, &wvote1, &CAROL_SEC)
+            validate(&wunit0, &CAROL_SEC, &wunit1, &CAROL_SEC)
         );
-        wvote0.seq_number = 0;
+        wunit0.seq_number = 0;
 
-        // If the votes are from a different network or era we don't accept the evidence.
-        wvote0.instance_id = 2;
+        // If the units are from a different network or era we don't accept the evidence.
+        wunit0.instance_id = 2;
         assert_eq!(
             Err(VertexError::Evidence(EvidenceError::EquivocationInstanceId)),
-            validate(&wvote0, &CAROL_SEC, &wvote1, &CAROL_SEC)
+            validate(&wunit0, &CAROL_SEC, &wunit1, &CAROL_SEC)
         );
     }
 }

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -580,7 +580,7 @@ pub(crate) mod tests {
         components::consensus::{
             highway_core::{
                 evidence::{Evidence, EvidenceError},
-                highway::{Highway, SignedWireUnit, Vertex, VertexError, UnitError, WireUnit},
+                highway::{Highway, SignedWireUnit, UnitError, Vertex, VertexError, WireUnit},
                 state::{
                     tests::{
                         TestContext, TestSecret, ALICE, ALICE_SEC, BOB, BOB_SEC, CAROL, CAROL_SEC,

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -23,7 +23,7 @@ use crate::{
     deserialize = "C::Hash: Deserialize<'de>",
 ))]
 pub(crate) enum Dependency<C: Context> {
-    Vote(C::Hash),
+    Unit(C::Hash),
     Evidence(ValidatorIndex),
     Endorsement(C::Hash),
 }
@@ -37,7 +37,7 @@ pub(crate) enum Dependency<C: Context> {
     deserialize = "C::Hash: Deserialize<'de>",
 ))]
 pub(crate) enum Vertex<C: Context> {
-    Vote(SignedWireVote<C>),
+    Unit(SignedWireUnit<C>),
     Evidence(Evidence<C>),
     Endorsements(Endorsements<C>),
 }
@@ -51,15 +51,15 @@ impl<C: Context> Vertex<C> {
     /// obtained _and_ validated. Only after that, the vertex can be considered valid.
     pub(crate) fn value(&self) -> Option<&C::ConsensusValue> {
         match self {
-            Vertex::Vote(swvote) => swvote.wire_vote.value.as_ref(),
+            Vertex::Unit(swunit) => swunit.wire_unit.value.as_ref(),
             Vertex::Evidence(_) | Vertex::Endorsements(_) => None,
         }
     }
 
-    /// Returns the vote hash of this vertex (if it is a vote).
-    pub(crate) fn vote_hash(&self) -> Option<C::Hash> {
+    /// Returns the unit hash of this vertex (if it is a unit).
+    pub(crate) fn unit_hash(&self) -> Option<C::Hash> {
         match self {
-            Vertex::Vote(swvote) => Some(swvote.hash()),
+            Vertex::Unit(swunit) => Some(swunit.hash()),
             Vertex::Evidence(_) | Vertex::Endorsements(_) => None,
         }
     }
@@ -67,15 +67,15 @@ impl<C: Context> Vertex<C> {
     /// Returns whether this is evidence, as opposed to other types of vertices.
     pub(crate) fn is_evidence(&self) -> bool {
         match self {
-            Vertex::Vote(_) | Vertex::Endorsements(_) => false,
+            Vertex::Unit(_) | Vertex::Endorsements(_) => false,
             Vertex::Evidence(_) => true,
         }
     }
 
-    /// Returns a `Timestamp` provided the vertex is a `Vertex::Vote`
+    /// Returns a `Timestamp` provided the vertex is a `Vertex::Unit`
     pub(crate) fn timestamp(&self) -> Option<Timestamp> {
         match self {
-            Vertex::Vote(signed_wire_vote) => Some(signed_wire_vote.wire_vote.timestamp),
+            Vertex::Unit(signed_wire_unit) => Some(signed_wire_unit.wire_unit.timestamp),
             Vertex::Evidence(_) => None,
             Vertex::Endorsements(_) => None,
         }
@@ -87,36 +87,36 @@ impl<C: Context> Vertex<C> {
     serialize = "C::Hash: Serialize",
     deserialize = "C::Hash: Deserialize<'de>",
 ))]
-pub(crate) struct SignedWireVote<C: Context> {
-    pub(crate) wire_vote: WireVote<C>,
+pub(crate) struct SignedWireUnit<C: Context> {
+    pub(crate) wire_unit: WireUnit<C>,
     pub(crate) signature: C::Signature,
 }
 
-impl<C: Context> SignedWireVote<C> {
+impl<C: Context> SignedWireUnit<C> {
     pub(crate) fn new(
-        wire_vote: WireVote<C>,
+        wire_unit: WireUnit<C>,
         secret_key: &C::ValidatorSecret,
         rng: &mut NodeRng,
     ) -> Self {
-        let signature = secret_key.sign(&wire_vote.hash(), rng);
-        SignedWireVote {
-            wire_vote,
+        let signature = secret_key.sign(&wire_unit.hash(), rng);
+        SignedWireUnit {
+            wire_unit,
             signature,
         }
     }
 
     pub(crate) fn hash(&self) -> C::Hash {
-        self.wire_vote.hash()
+        self.wire_unit.hash()
     }
 }
 
-/// A vote as it is sent over the wire, possibly containing a new block.
+/// A unit as it is sent over the wire, possibly containing a new block.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(
     serialize = "C::Hash: Serialize",
     deserialize = "C::Hash: Deserialize<'de>",
 ))]
-pub(crate) struct WireVote<C: Context> {
+pub(crate) struct WireUnit<C: Context> {
     pub(crate) panorama: Panorama<C>,
     pub(crate) creator: ValidatorIndex,
     pub(crate) instance_id: C::InstanceId,
@@ -127,7 +127,7 @@ pub(crate) struct WireVote<C: Context> {
     pub(crate) endorsed: Vec<C::Hash>,
 }
 
-impl<C: Context> Debug for WireVote<C> {
+impl<C: Context> Debug for WireUnit<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         /// A type whose debug implementation prints ".." (without the quotes).
         struct Ellipsis;
@@ -138,7 +138,7 @@ impl<C: Context> Debug for WireVote<C> {
             }
         }
 
-        f.debug_struct("WireVote")
+        f.debug_struct("WireUnit")
             .field("hash()", &self.hash())
             .field("value", &self.value.as_ref().map(|_| Ellipsis))
             .field("creator.0", &self.creator.0)
@@ -153,15 +153,15 @@ impl<C: Context> Debug for WireVote<C> {
     }
 }
 
-impl<C: Context> WireVote<C> {
-    /// Returns the vote's hash, which is used as a vote identifier.
+impl<C: Context> WireUnit<C> {
+    /// Returns the unit's hash, which is used as a unit identifier.
     // TODO: This involves serializing and hashing. Memoize?
     pub(crate) fn hash(&self) -> C::Hash {
         // TODO: Use serialize_into to avoid allocation?
-        <C as Context>::hash(&bincode::serialize(self).expect("serialize WireVote"))
+        <C as Context>::hash(&bincode::serialize(self).expect("serialize WireUnit"))
     }
 
-    /// Returns the time at which the round containing this vote began.
+    /// Returns the time at which the round containing this unit began.
     pub(crate) fn round_id(&self) -> Timestamp {
         state::round_id(self.timestamp, self.round_exp)
     }
@@ -173,29 +173,29 @@ impl<C: Context> WireVote<C> {
     deserialize = "C::Hash: Deserialize<'de>",
 ))]
 pub(crate) struct Endorsements<C: Context> {
-    pub(crate) vote: C::Hash,
+    pub(crate) unit: C::Hash,
     pub(crate) endorsers: Vec<(ValidatorIndex, C::Signature)>,
 }
 
 impl<C: Context> Endorsements<C> {
     pub fn new<I: IntoIterator<Item = SignedEndorsement<C>>>(endorsements: I) -> Self {
         let mut iter = endorsements.into_iter().peekable();
-        let vote = *iter.peek().expect("non-empty iter").vote();
+        let unit = *iter.peek().expect("non-empty iter").unit();
         let endorsers = iter
             .map(|e| {
-                assert_eq!(e.vote(), &vote, "endorsements for different votes.");
+                assert_eq!(e.unit(), &unit, "endorsements for different units.");
                 (e.validator_idx(), *e.signature())
             })
             .collect();
-        Endorsements { vote, endorsers }
+        Endorsements { unit, endorsers }
     }
 
     /// Returns hash of the endorsed vode.
-    pub fn vote(&self) -> &C::Hash {
-        &self.vote
+    pub fn unit(&self) -> &C::Hash {
+        &self.unit
     }
 
-    /// Returns an iterator over validator indexes that endorsed the `vote`.
+    /// Returns an iterator over validator indexes that endorsed the `unit`.
     pub fn validator_ids(&self) -> impl Iterator<Item = &ValidatorIndex> {
         self.endorsers.iter().map(|(v, _)| v)
     }

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -2,7 +2,7 @@ mod block;
 mod panorama;
 mod params;
 mod tallies;
-mod vote;
+mod unit;
 mod weight;
 
 #[cfg(test)]
@@ -13,7 +13,7 @@ use quanta::Clock;
 pub(crate) use weight::Weight;
 
 pub(super) use panorama::{Observation, Panorama};
-pub(super) use vote::Vote;
+pub(super) use unit::Unit;
 
 use std::{borrow::Borrow, cmp::Ordering, collections::HashMap, convert::identity, iter};
 
@@ -28,7 +28,7 @@ use crate::{
         highway_core::{
             endorsement::{Endorsement, SignedEndorsement},
             evidence::Evidence,
-            highway::{Endorsements, SignedWireVote, WireVote},
+            highway::{Endorsements, SignedWireUnit, WireUnit},
             validators::{ValidatorIndex, ValidatorMap},
         },
         traits::Context,
@@ -40,24 +40,24 @@ use block::Block;
 use tallies::Tallies;
 
 #[derive(Debug, Error, PartialEq)]
-pub(crate) enum VoteError {
-    #[error("The vote is a ballot but doesn't cite any block.")]
+pub(crate) enum UnitError {
+    #[error("The unit is a ballot but doesn't cite any block.")]
     MissingBlock,
     #[error("The panorama's length {} doesn't match the number of validators.", _0)]
     PanoramaLength(usize),
-    #[error("The vote accuses its own creator as faulty.")]
+    #[error("The unit accuses its own creator as faulty.")]
     FaultyCreator,
-    #[error("The panorama has a vote from {:?} in the slot for {:?}.", _0, _1)]
+    #[error("The panorama has a unit from {:?} in the slot for {:?}.", _0, _1)]
     PanoramaIndex(ValidatorIndex, ValidatorIndex),
-    #[error("The panorama is missing votes indirectly cited via {:?}.", _0)]
+    #[error("The panorama is missing units indirectly cited via {:?}.", _0)]
     InconsistentPanorama(ValidatorIndex),
-    #[error("The vote contains the wrong sequence number.")]
+    #[error("The unit contains the wrong sequence number.")]
     SequenceNumber,
-    #[error("The vote's timestamp is older than a justification's.")]
+    #[error("The unit's timestamp is older than a justification's.")]
     Timestamps,
     #[error("The creator is not a validator.")]
     Creator,
-    #[error("The vote was created for a wrong instance ID.")]
+    #[error("The unit was created for a wrong instance ID.")]
     InstanceId,
     #[error("The signature is invalid.")]
     Signature,
@@ -67,16 +67,16 @@ pub(crate) enum VoteError {
     RoundLengthExpLessThanMinimum,
     #[error("The round length exponent is greater than the maximum allowed by the chain-spec.")]
     RoundLengthExpGreaterThanMaximum,
-    #[error("This would be the third vote in that round. Only two are allowed.")]
-    ThreeVotesInRound,
+    #[error("This would be the third unit in that round. Only two are allowed.")]
+    ThreeUnitsInRound,
     #[error(
-        "A block must be the leader's ({:?}) first vote, at the beginning of the round.",
+        "A block must be the leader's ({:?}) first unit, at the beginning of the round.",
         _0
     )]
     NonLeaderBlock(ValidatorIndex),
-    #[error("The vote is a block, but its parent is already a terminal block.")]
+    #[error("The unit is a block, but its parent is already a terminal block.")]
     ValueAfterTerminalBlock,
-    #[error("The vote's creator is banned.")]
+    #[error("The unit's creator is banned.")]
     Banned,
 }
 
@@ -119,18 +119,18 @@ pub(crate) struct State<C: Context> {
     /// Cumulative validator weights: Entry `i` contains the sum of the weights of validators `0`
     /// through `i`.
     cumulative_w: ValidatorMap<Weight>,
-    /// All votes imported so far, by hash.
+    /// All units imported so far, by hash.
     // TODO: HashMaps prevent deterministic tests.
-    votes: HashMap<C::Hash, Vote<C>>,
+    units: HashMap<C::Hash, Unit<C>>,
     /// All blocks, by hash.
     blocks: HashMap<C::Hash, Block<C>>,
     /// List of faulty validators and their type of fault.
     faults: HashMap<ValidatorIndex, Fault<C>>,
     /// The full panorama, corresponding to the complete protocol state.
     panorama: Panorama<C>,
-    /// All currently endorsed votes, by hash.
+    /// All currently endorsed units, by hash.
     endorsements: HashMap<C::Hash, Vec<SignedEndorsement<C>>>,
-    /// Votes that don't yet have 2/3 of stake endorsing them.
+    /// Units that don't yet have 2/3 of stake endorsing them.
     incomplete_endorsements: HashMap<C::Hash, Vec<SignedEndorsement<C>>>,
     /// Clock to track fork choice
     clock: Clock,
@@ -168,7 +168,7 @@ impl<C: Context> State<C> {
             params,
             weights,
             cumulative_w,
-            votes: HashMap::new(),
+            units: HashMap::new(),
             blocks: HashMap::new(),
             faults,
             panorama,
@@ -198,7 +198,7 @@ impl<C: Context> State<C> {
         &self.weights
     }
 
-    /// Returns hashes of endorsed votes.
+    /// Returns hashes of endorsed units.
     pub(crate) fn endorsements<'a>(&'a self) -> impl Iterator<Item = C::Hash> + 'a {
         self.endorsements.keys().cloned()
     }
@@ -232,9 +232,9 @@ impl<C: Context> State<C> {
         self.opt_fault(idx).and_then(Fault::evidence)
     }
 
-    /// Returns endorsements for `vote`, if any.
-    pub(crate) fn opt_endorsements(&self, vote: &C::Hash) -> Option<Vec<SignedEndorsement<C>>> {
-        self.endorsements.get(vote).cloned()
+    /// Returns endorsements for `unit`, if any.
+    pub(crate) fn opt_endorsements(&self, unit: &C::Hash) -> Option<Vec<SignedEndorsement<C>>> {
+        self.endorsements.get(unit).cloned()
     }
 
     /// Returns whether evidence against validator nr. `idx` is known.
@@ -242,14 +242,14 @@ impl<C: Context> State<C> {
         self.opt_evidence(idx).is_some()
     }
 
-    /// Returns whether we have all endorsements for `vote`.
+    /// Returns whether we have all endorsements for `unit`.
     pub(crate) fn has_all_endorsements<'a, I: IntoIterator<Item = &'a ValidatorIndex>>(
         &self,
-        vote: &C::Hash,
+        unit: &C::Hash,
         v_ids: I,
     ) -> bool {
         self.incomplete_endorsements
-            .get(vote)
+            .get(unit)
             .map(|v| {
                 v_ids
                     .into_iter()
@@ -258,16 +258,16 @@ impl<C: Context> State<C> {
             .unwrap_or(false)
     }
 
-    /// Returns whether we have seen enough endorsements for the vote.
-    /// Vote is endorsed when it, or its descendant, has more than ≥ ⅔ of votes (by weight).
+    /// Returns whether we have seen enough endorsements for the unit.
+    /// Unit is endorsed when it, or its descendant, has more than ≥ ⅔ of units (by weight).
     pub(crate) fn is_endorsed(&self, hash: &C::Hash) -> bool {
         self.endorsements.contains_key(hash)
         // TODO: check if any descendant (from the same creator) of `hash` is endorsed.
     }
 
-    /// Returns hash of vote that needs to be endorsed.
-    pub(crate) fn needs_endorsements(&self, vote: &SignedWireVote<C>) -> Option<C::Hash> {
-        vote.wire_vote
+    /// Returns hash of unit that needs to be endorsed.
+    pub(crate) fn needs_endorsements(&self, unit: &SignedWireUnit<C>) -> Option<C::Hash> {
+        unit.wire_unit
             .endorsed
             .iter()
             .find(|hash| !self.endorsements.contains_key(&hash))
@@ -295,32 +295,32 @@ impl<C: Context> State<C> {
         self.faults.keys().cloned()
     }
 
-    /// Returns an iterator over latest vote hashes from honest validators.
+    /// Returns an iterator over latest unit hashes from honest validators.
     pub(crate) fn iter_correct_hashes(&self) -> impl Iterator<Item = &C::Hash> {
         self.panorama.iter_correct_hashes()
     }
 
-    /// Returns the vote with the given hash, if present.
-    pub(crate) fn opt_vote(&self, hash: &C::Hash) -> Option<&Vote<C>> {
-        self.votes.get(hash)
+    /// Returns the unit with the given hash, if present.
+    pub(crate) fn opt_unit(&self, hash: &C::Hash) -> Option<&Unit<C>> {
+        self.units.get(hash)
     }
 
-    /// Returns whether the vote with the given hash is known.
-    pub(crate) fn has_vote(&self, hash: &C::Hash) -> bool {
-        self.votes.contains_key(hash)
+    /// Returns whether the unit with the given hash is known.
+    pub(crate) fn has_unit(&self, hash: &C::Hash) -> bool {
+        self.units.contains_key(hash)
     }
 
-    /// Returns the vote with the given hash. Panics if not found.
-    pub(crate) fn vote(&self, hash: &C::Hash) -> &Vote<C> {
-        self.opt_vote(hash).expect("vote hash must exist")
+    /// Returns the unit with the given hash. Panics if not found.
+    pub(crate) fn unit(&self, hash: &C::Hash) -> &Unit<C> {
+        self.opt_unit(hash).expect("unit hash must exist")
     }
 
-    /// Returns the block contained in the vote with the given hash, if present.
+    /// Returns the block contained in the unit with the given hash, if present.
     pub(crate) fn opt_block(&self, hash: &C::Hash) -> Option<&Block<C>> {
         self.blocks.get(hash)
     }
 
-    /// Returns the block contained in the vote with the given hash. Panics if not found.
+    /// Returns the block contained in the unit with the given hash. Panics if not found.
     pub(crate) fn block(&self, hash: &C::Hash) -> &Block<C> {
         self.opt_block(hash).expect("block hash must exist")
     }
@@ -342,20 +342,20 @@ impl<C: Context> State<C> {
         self.cumulative_w.binary_search(&r).unwrap_or_else(identity)
     }
 
-    /// Adds the vote to the protocol state.
+    /// Adds the unit to the protocol state.
     ///
-    /// The vote must be valid, and its dependencies satisfied.
-    pub(crate) fn add_valid_vote(&mut self, swvote: SignedWireVote<C>) {
-        let wvote = &swvote.wire_vote;
-        self.update_panorama(&swvote);
-        let hash = wvote.hash();
-        let fork_choice = self.fork_choice(&wvote.panorama).cloned();
-        let (vote, opt_value) = Vote::new(swvote, fork_choice.as_ref(), self);
+    /// The unit must be valid, and its dependencies satisfied.
+    pub(crate) fn add_valid_unit(&mut self, swunit: SignedWireUnit<C>) {
+        let wunit = &swunit.wire_unit;
+        self.update_panorama(&swunit);
+        let hash = wunit.hash();
+        let fork_choice = self.fork_choice(&wunit.panorama).cloned();
+        let (unit, opt_value) = Unit::new(swunit, fork_choice.as_ref(), self);
         if let Some(value) = opt_value {
             let block = Block::new(fork_choice, value, self);
             self.blocks.insert(hash, block);
         }
-        self.votes.insert(hash, vote);
+        self.units.insert(hash, unit);
     }
 
     /// Adds direct evidence proving a validator to be faulty, unless that validators is already
@@ -374,31 +374,31 @@ impl<C: Context> State<C> {
     }
 
     /// Add set of endorsements to the state.
-    /// If, after adding, we have collected enough endorsements to consider vote _endorsed_,
+    /// If, after adding, we have collected enough endorsements to consider unit _endorsed_,
     /// it will be *upgraded* to fully endorsed.
     pub(crate) fn add_endorsements(&mut self, endorsements: Endorsements<C>) {
-        let vote = *endorsements.vote();
+        let unit = *endorsements.unit();
         let validator_count = self.validator_count();
-        info!("Received endorsements of {:?}", vote);
+        info!("Received endorsements of {:?}", unit);
         {
             let entry = self
                 .incomplete_endorsements
-                .entry(vote)
+                .entry(unit)
                 .or_insert_with(|| Vec::with_capacity(validator_count));
             for (vid, signature) in endorsements.endorsers {
                 // Add endorsements from validators we haven't seen endorsement yet.
                 if !entry.iter().any(|e| e.validator_idx() == vid) {
                     let endorsement =
-                        SignedEndorsement::new(Endorsement::new(vote, vid), signature);
+                        SignedEndorsement::new(Endorsement::new(unit, vid), signature);
                     entry.push(endorsement)
                 }
             }
         }
-        // Stake required to consider vote to be endorsed.
+        // Stake required to consider unit to be endorsed.
         let threshold = self.total_weight() / 3 * 2;
         let endorsed: Weight = self
             .incomplete_endorsements
-            .get(&vote)
+            .get(&unit)
             .unwrap()
             .iter()
             .map(|e| {
@@ -407,41 +407,41 @@ impl<C: Context> State<C> {
             })
             .sum();
         if endorsed >= threshold {
-            info!(%vote, "Vote endorsed by at least 2/3 of validators.");
-            let fully_endorsed = self.incomplete_endorsements.remove(&vote).unwrap();
-            self.endorsements.insert(vote, fully_endorsed);
+            info!(%unit, "Unit endorsed by at least 2/3 of validators.");
+            let fully_endorsed = self.incomplete_endorsements.remove(&unit).unwrap();
+            self.endorsements.insert(unit, fully_endorsed);
         }
     }
 
-    pub(crate) fn wire_vote(
+    pub(crate) fn wire_unit(
         &self,
         hash: &C::Hash,
         instance_id: C::InstanceId,
-    ) -> Option<SignedWireVote<C>> {
-        let vote = self.opt_vote(hash)?.clone();
+    ) -> Option<SignedWireUnit<C>> {
+        let unit = self.opt_unit(hash)?.clone();
         let opt_block = self.opt_block(hash);
         let value = opt_block.map(|block| block.value.clone());
         // TODO: After LNC we won't always need all known endorsements.
         let endorsed = self.endorsements().collect();
-        let wvote = WireVote {
-            panorama: vote.panorama.clone(),
-            creator: vote.creator,
+        let wunit = WireUnit {
+            panorama: unit.panorama.clone(),
+            creator: unit.creator,
             instance_id,
             value,
-            seq_number: vote.seq_number,
-            timestamp: vote.timestamp,
-            round_exp: vote.round_exp,
+            seq_number: unit.seq_number,
+            timestamp: unit.timestamp,
+            round_exp: unit.round_exp,
             endorsed,
         };
-        Some(SignedWireVote {
-            wire_vote: wvote,
-            signature: vote.signature,
+        Some(SignedWireUnit {
+            wire_unit: wunit,
+            signature: unit.signature,
         })
     }
 
     /// Returns the fork choice from `pan`'s view, or `None` if there are no blocks yet.
     ///
-    /// The correct validators' latest votes count as votes for the block they point to, as well as
+    /// The correct validators' latest units count as votes for the block they point to, as well as
     /// all of its ancestors. At each level the block with the highest score is selected from the
     /// children of the previously selected block (or from all blocks at height 0), until a block
     /// is reached that has no children with any votes.
@@ -449,7 +449,7 @@ impl<C: Context> State<C> {
         let start = self.clock.start();
         // Collect all correct votes in a `Tallies` map, sorted by height.
         let to_entry = |(obs, w): (&Observation<C>, &Weight)| {
-            let bhash = &self.vote(obs.correct()?).block;
+            let bhash = &self.unit(obs.correct()?).block;
             Some((self.block(bhash).height, bhash, *w))
         };
         let mut tallies: Tallies<C> = pan.iter().zip(&self.weights).filter_map(to_entry).collect();
@@ -489,81 +489,81 @@ impl<C: Context> State<C> {
         self.find_ancestor(&block.skip_idx[i], height)
     }
 
-    /// Returns an error if `swvote` is invalid. This can be called even if the dependencies are
+    /// Returns an error if `swunit` is invalid. This can be called even if the dependencies are
     /// not present yet.
-    pub(crate) fn pre_validate_vote(&self, swvote: &SignedWireVote<C>) -> Result<(), VoteError> {
-        let wvote = &swvote.wire_vote;
-        let creator = wvote.creator;
+    pub(crate) fn pre_validate_unit(&self, swunit: &SignedWireUnit<C>) -> Result<(), UnitError> {
+        let wunit = &swunit.wire_unit;
+        let creator = wunit.creator;
         if creator.0 as usize >= self.validator_count() {
-            error!("Nonexistent validator should be rejected in Highway::pre_validate_vote.");
-            return Err(VoteError::Creator); // Should be unreachable.
+            error!("Nonexistent validator should be rejected in Highway::pre_validate_unit.");
+            return Err(UnitError::Creator); // Should be unreachable.
         }
         if Some(&Fault::Banned) == self.faults.get(&creator) {
-            return Err(VoteError::Banned);
+            return Err(UnitError::Banned);
         }
-        if wvote.round_exp < self.params.min_round_exp() {
-            return Err(VoteError::RoundLengthExpLessThanMinimum);
+        if wunit.round_exp < self.params.min_round_exp() {
+            return Err(UnitError::RoundLengthExpLessThanMinimum);
         }
-        if wvote.round_exp > self.params.max_round_exp() {
-            return Err(VoteError::RoundLengthExpGreaterThanMaximum);
+        if wunit.round_exp > self.params.max_round_exp() {
+            return Err(UnitError::RoundLengthExpGreaterThanMaximum);
         }
-        if wvote.value.is_none() && !wvote.panorama.has_correct() {
-            return Err(VoteError::MissingBlock);
+        if wunit.value.is_none() && !wunit.panorama.has_correct() {
+            return Err(UnitError::MissingBlock);
         }
-        if wvote.panorama.len() != self.validator_count() {
-            return Err(VoteError::PanoramaLength(wvote.panorama.len()));
+        if wunit.panorama.len() != self.validator_count() {
+            return Err(UnitError::PanoramaLength(wunit.panorama.len()));
         }
-        if wvote.panorama.get(creator).is_faulty() {
-            return Err(VoteError::FaultyCreator);
+        if wunit.panorama.get(creator).is_faulty() {
+            return Err(UnitError::FaultyCreator);
         }
         Ok(())
     }
 
-    /// Returns an error if `swvote` is invalid. Must only be called once all dependencies have
+    /// Returns an error if `swunit` is invalid. Must only be called once all dependencies have
     /// been added to the state.
-    pub(crate) fn validate_vote(&self, swvote: &SignedWireVote<C>) -> Result<(), VoteError> {
-        let wvote = &swvote.wire_vote;
-        let creator = wvote.creator;
-        let panorama = &wvote.panorama;
-        let timestamp = wvote.timestamp;
+    pub(crate) fn validate_unit(&self, swunit: &SignedWireUnit<C>) -> Result<(), UnitError> {
+        let wunit = &swunit.wire_unit;
+        let creator = wunit.creator;
+        let panorama = &wunit.panorama;
+        let timestamp = wunit.timestamp;
         panorama.validate(self)?;
         if panorama.iter_correct(self).any(|v| v.timestamp > timestamp) {
-            return Err(VoteError::Timestamps);
+            return Err(UnitError::Timestamps);
         }
-        if wvote.seq_number != panorama.next_seq_num(self, creator) {
-            return Err(VoteError::SequenceNumber);
+        if wunit.seq_number != panorama.next_seq_num(self, creator) {
+            return Err(UnitError::SequenceNumber);
         }
-        let r_id = round_id(timestamp, wvote.round_exp);
-        let opt_prev_vote = panorama[creator].correct().map(|vh| self.vote(vh));
-        if let Some(prev_vote) = opt_prev_vote {
-            if prev_vote.round_exp != wvote.round_exp {
+        let r_id = round_id(timestamp, wunit.round_exp);
+        let opt_prev_unit = panorama[creator].correct().map(|vh| self.unit(vh));
+        if let Some(prev_unit) = opt_prev_unit {
+            if prev_unit.round_exp != wunit.round_exp {
                 // The round exponent must not change within a round: Even with respect to the
-                // greater of the two exponents, a round boundary must be between the votes.
-                let max_re = prev_vote.round_exp.max(wvote.round_exp);
-                if prev_vote.timestamp >> max_re == timestamp >> max_re {
-                    return Err(VoteError::RoundLengthExpChangedWithinRound);
+                // greater of the two exponents, a round boundary must be between the units.
+                let max_re = prev_unit.round_exp.max(wunit.round_exp);
+                if prev_unit.timestamp >> max_re == timestamp >> max_re {
+                    return Err(UnitError::RoundLengthExpChangedWithinRound);
                 }
             }
-            // There can be at most two votes per round: proposal/confirmation and witness.
-            if let Some(prev2_vote) = prev_vote.previous().map(|h2| self.vote(h2)) {
-                if prev2_vote.round_id() == r_id {
-                    return Err(VoteError::ThreeVotesInRound);
+            // There can be at most two units per round: proposal/confirmation and witness.
+            if let Some(prev2_unit) = prev_unit.previous().map(|h2| self.unit(h2)) {
+                if prev2_unit.round_id() == r_id {
+                    return Err(UnitError::ThreeUnitsInRound);
                 }
             }
         }
-        if wvote.value.is_some() {
-            // If this vote is a block, it must be the first vote in this round, its timestamp must
+        if wunit.value.is_some() {
+            // If this unit is a block, it must be the first unit in this round, its timestamp must
             // match the round ID, and the creator must be the round leader.
-            if opt_prev_vote.map_or(false, |pv| pv.round_id() == r_id)
+            if opt_prev_unit.map_or(false, |pv| pv.round_id() == r_id)
                 || timestamp != r_id
                 || self.leader(r_id) != creator
             {
-                return Err(VoteError::NonLeaderBlock(self.leader(r_id)));
+                return Err(UnitError::NonLeaderBlock(self.leader(r_id)));
             }
             // It's not allowed to create a child block of a terminal block.
             let is_terminal = |hash: &C::Hash| self.is_terminal_block(hash);
             if self.fork_choice(panorama).map_or(false, is_terminal) {
-                return Err(VoteError::ValueAfterTerminalBlock);
+                return Err(UnitError::ValueAfterTerminalBlock);
             }
         }
         // TODO: Validate against LNC.
@@ -574,73 +574,73 @@ impl<C: Context> State<C> {
     pub(crate) fn is_terminal_block(&self, bhash: &C::Hash) -> bool {
         self.blocks.get(bhash).map_or(false, |block| {
             block.height >= self.params.end_height()
-                && self.vote(bhash).timestamp >= self.params.end_timestamp()
+                && self.unit(bhash).timestamp >= self.params.end_timestamp()
         })
     }
 
-    /// Updates `self.panorama` with an incoming vote. Panics if dependencies are missing.
+    /// Updates `self.panorama` with an incoming unit. Panics if dependencies are missing.
     ///
-    /// If the new vote is valid, it will just add `Observation::Correct(wvote.hash())` to the
+    /// If the new unit is valid, it will just add `Observation::Correct(wunit.hash())` to the
     /// panorama. If it represents an equivocation, it adds `Observation::Faulty` and updates
     /// `self.faults`.
     ///
-    /// Panics unless all dependencies of `wvote` have already been added to `self`.
-    fn update_panorama(&mut self, swvote: &SignedWireVote<C>) {
-        let wvote = &swvote.wire_vote;
-        let creator = wvote.creator;
-        let new_obs = match (self.panorama.get(creator), wvote.panorama.get(creator)) {
+    /// Panics unless all dependencies of `wunit` have already been added to `self`.
+    fn update_panorama(&mut self, swunit: &SignedWireUnit<C>) {
+        let wunit = &swunit.wire_unit;
+        let creator = wunit.creator;
+        let new_obs = match (self.panorama.get(creator), wunit.panorama.get(creator)) {
             (Observation::Faulty, _) => Observation::Faulty,
-            (obs0, obs1) if obs0 == obs1 => Observation::Correct(wvote.hash()),
-            (Observation::None, _) => panic!("missing creator's previous vote"),
+            (obs0, obs1) if obs0 == obs1 => Observation::Correct(wunit.hash()),
+            (Observation::None, _) => panic!("missing creator's previous unit"),
             (Observation::Correct(hash0), _) => {
-                // If we have all dependencies of wvote and still see the sender as correct, the
-                // predecessor of wvote must be a predecessor of hash0. So we already have a
-                // conflicting vote with the same sequence number:
-                let prev0 = self.find_in_swimlane(hash0, wvote.seq_number).unwrap();
-                let wvote0 = self.wire_vote(prev0, wvote.instance_id).unwrap();
-                self.add_evidence(Evidence::Equivocation(wvote0, swvote.clone()));
+                // If we have all dependencies of wunit and still see the sender as correct, the
+                // predecessor of wunit must be a predecessor of hash0. So we already have a
+                // conflicting unit with the same sequence number:
+                let prev0 = self.find_in_swimlane(hash0, wunit.seq_number).unwrap();
+                let wunit0 = self.wire_unit(prev0, wunit.instance_id).unwrap();
+                self.add_evidence(Evidence::Equivocation(wunit0, swunit.clone()));
                 Observation::Faulty
             }
         };
-        self.panorama[wvote.creator] = new_obs;
+        self.panorama[wunit.creator] = new_obs;
     }
 
     /// Returns `true` if this is a proposal and the creator is not faulty.
-    pub(super) fn is_correct_proposal(&self, vote: &Vote<C>) -> bool {
-        !self.is_faulty(vote.creator)
-            && self.leader(vote.timestamp) == vote.creator
-            && vote.timestamp == round_id(vote.timestamp, vote.round_exp)
+    pub(super) fn is_correct_proposal(&self, unit: &Unit<C>) -> bool {
+        !self.is_faulty(unit.creator)
+            && self.leader(unit.timestamp) == unit.creator
+            && unit.timestamp == round_id(unit.timestamp, unit.round_exp)
     }
 
     /// Returns the hash of the message with the given sequence number from the creator of `hash`,
-    /// or `None` if the sequence number is higher than that of the vote with `hash`.
+    /// or `None` if the sequence number is higher than that of the unit with `hash`.
     fn find_in_swimlane<'a>(&'a self, hash: &'a C::Hash, seq_number: u64) -> Option<&'a C::Hash> {
-        let vote = self.vote(hash);
-        match vote.seq_number.cmp(&seq_number) {
+        let unit = self.unit(hash);
+        match unit.seq_number.cmp(&seq_number) {
             Ordering::Equal => Some(hash),
             Ordering::Less => None,
             Ordering::Greater => {
-                let diff = vote.seq_number - seq_number;
+                let diff = unit.seq_number - seq_number;
                 // We want to make the greatest step 2^i such that 2^i <= diff.
                 let max_i = log2(diff) as usize;
-                let i = max_i.min(vote.skip_idx.len() - 1);
-                self.find_in_swimlane(&vote.skip_idx[i], seq_number)
+                let i = max_i.min(unit.skip_idx.len() - 1);
+                self.find_in_swimlane(&unit.skip_idx[i], seq_number)
             }
         }
     }
 
-    /// Returns an iterator over votes (with hashes) by the same creator, in reverse chronological
-    /// order, starting with the specified vote.
+    /// Returns an iterator over units (with hashes) by the same creator, in reverse chronological
+    /// order, starting with the specified unit.
     pub(crate) fn swimlane<'a>(
         &'a self,
         vhash: &'a C::Hash,
-    ) -> impl Iterator<Item = (&'a C::Hash, &'a Vote<C>)> {
+    ) -> impl Iterator<Item = (&'a C::Hash, &'a Unit<C>)> {
         let mut next = Some(vhash);
         iter::from_fn(move || {
             let current = next?;
-            let vote = self.vote(current);
-            next = vote.previous();
-            Some((current, vote))
+            let unit = self.unit(current);
+            next = unit.previous();
+            Some((current, unit))
         })
     }
 
@@ -665,13 +665,13 @@ impl<C: Context> State<C> {
         weighted_median(
             self.panorama
                 .iter_correct(self)
-                .map(|vote| (vote.round_exp, self.weight(vote.creator))),
+                .map(|unit| (unit.round_exp, self.weight(unit.creator))),
         )
     }
 
-    /// Returns `true` if the state contains no votes.
+    /// Returns `true` if the state contains no units.
     pub(crate) fn is_empty(&self) -> bool {
-        self.votes.is_empty()
+        self.units.is_empty()
     }
 }
 

--- a/node/src/components/consensus/highway_core/state/tallies.rs
+++ b/node/src/components/consensus/highway_core/state/tallies.rs
@@ -47,7 +47,7 @@ impl<'a, C: Context> Tally<'a, C> {
         }
     }
 
-    /// Creates a tally from a list of votes. Returns `None` if the iterator is empty.
+    /// Creates a tally from a list of units. Returns `None` if the iterator is empty.
     fn try_from_iter<T: IntoIterator<Item = (&'a C::Hash, Weight)>>(iter: T) -> Option<Self> {
         let mut iter = iter.into_iter();
         let (bhash, w) = iter.next()?;
@@ -102,7 +102,7 @@ impl<'a, C: Context> Tally<'a, C> {
     }
 }
 
-/// A list of tallies by block height. The tally at each height contains only the votes that point
+/// A list of tallies by block height. The tally at each height contains only the units that point
 /// directly to a block at that height, not at a descendant.
 ///
 /// Each validator must contribute their weight to at most one entry: The height of the block that
@@ -143,7 +143,7 @@ impl<'a, C: Context> Tallies<'a, C> {
         let mut prev_tally = self[max_height].clone();
         // Start from `max_height - 1` and find the greatest height where a decision can be made.
         for height in (0..max_height).rev() {
-            // The tally at `height` is the sum of the parents of `height + 1` and the votes that
+            // The tally at `height` is the sum of the parents of `height + 1` and the units that
             // point directly to blocks at `height`.
             let mut h_tally = prev_tally.parents(state);
             if let Some(tally) = self.0.get(&height) {
@@ -210,7 +210,7 @@ mod tests {
     }
 
     #[test]
-    fn tallies() -> Result<(), AddVoteError<TestContext>> {
+    fn tallies() -> Result<(), AddUnitError<TestContext>> {
         let mut state = State::new_test(WEIGHTS, 0);
         let mut rng = crate::new_rng();
 
@@ -221,13 +221,13 @@ mod tests {
         // b0: 12           b2: 4
         //        \
         //          c0: 5 — c1: 5
-        let b0 = add_vote!(state, rng, BOB, 0xB0; N, N, N)?;
-        let c0 = add_vote!(state, rng, CAROL, 0xC0; N, b0, N)?;
-        let c1 = add_vote!(state, rng, CAROL, 0xC1; N, b0, c0)?;
-        let a0 = add_vote!(state, rng, ALICE, 0xA0; N, b0, N)?;
-        let b1 = add_vote!(state, rng, BOB, None; a0, b0, N)?; // Just a ballot; not shown above.
-        let a1 = add_vote!(state, rng, ALICE, 0xA1; a0, b1, c1)?;
-        let b2 = add_vote!(state, rng, BOB, 0xB2; a0, b1, N)?;
+        let b0 = add_unit!(state, rng, BOB, 0xB0; N, N, N)?;
+        let c0 = add_unit!(state, rng, CAROL, 0xC0; N, b0, N)?;
+        let c1 = add_unit!(state, rng, CAROL, 0xC1; N, b0, c0)?;
+        let a0 = add_unit!(state, rng, ALICE, 0xA0; N, b0, N)?;
+        let b1 = add_unit!(state, rng, BOB, None; a0, b0, N)?; // Just a ballot; not shown above.
+        let a1 = add_unit!(state, rng, ALICE, 0xA1; a0, b1, c1)?;
+        let b2 = add_unit!(state, rng, BOB, 0xB2; a0, b1, N)?;
 
         // These are the entries of a panorama seeing `a1`, `b2` and `c0`.
         let vote_entries = vec![
@@ -237,12 +237,12 @@ mod tests {
         ];
         let tallies: Tallies<TestContext> = vote_entries.into_iter().collect();
         assert_eq!(2, tallies.len());
-        assert_eq!(Weight(5), tallies[1].weight()); // Carol's vote is on height 1.
-        assert_eq!(Weight(7), tallies[2].weight()); // Alice's and Bob's votes are on height 2.
+        assert_eq!(Weight(5), tallies[1].weight()); // Carol's unit is on height 1.
+        assert_eq!(Weight(7), tallies[2].weight()); // Alice's and Bob's units are on height 2.
 
         // Compute the tally at height 1: Take the parents of the blocks Alice and Bob vote for...
         let mut h1_tally = tallies[2].parents(&state);
-        // (Their votes have the same parent: `a0`.)
+        // (Their units have the same parent: `a0`.)
         assert_eq!(1, h1_tally.votes.len());
         assert_eq!(Weight(7), h1_tally.votes[&a0]);
         // ...and adding Carol's vote.

--- a/node/src/components/consensus/highway_core/state/unit.rs
+++ b/node/src/components/consensus/highway_core/state/unit.rs
@@ -1,7 +1,7 @@
 use crate::{
     components::consensus::{
         highway_core::{
-            highway::SignedWireVote,
+            highway::SignedWireUnit,
             state::{self, Panorama, State},
             validators::ValidatorIndex,
         },
@@ -10,25 +10,25 @@ use crate::{
     types::{TimeDiff, Timestamp},
 };
 
-/// A vote sent to or received from the network.
+/// A unit sent to or received from the network.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct Vote<C: Context> {
+pub(crate) struct Unit<C: Context> {
     /// The list of latest messages and faults observed by the creator of this message.
     pub(crate) panorama: Panorama<C>,
     /// The number of earlier messages by the same creator.
     pub(crate) seq_number: u64,
-    /// The validator who created and sent this vote.
+    /// The validator who created and sent this unit.
     pub(crate) creator: ValidatorIndex,
-    /// The block this is a vote for. Either it or its parent must be the fork choice.
+    /// The block this unit votes for. Either it or its parent must be the fork choice.
     pub(crate) block: C::Hash,
-    /// A skip list index of the creator's swimlane, i.e. the previous vote by the same creator.
+    /// A skip list index of the creator's swimlane, i.e. the previous unit by the same creator.
     ///
     /// For every `p = 1 << i` that divides `seq_number`, this contains an `i`-th entry pointing to
-    /// the older vote with `seq_number - p`.
+    /// the older unit with `seq_number - p`.
     pub(crate) skip_idx: Vec<C::Hash>,
-    /// This vote's timestamp, in milliseconds since the epoch.
+    /// This unit's timestamp, in milliseconds since the epoch.
     pub(crate) timestamp: Timestamp,
-    /// Original signature of the `SignedWireVote`.
+    /// Original signature of the `SignedWireUnit`.
     pub(crate) signature: C::Signature,
     /// The round exponent of the current round, that this message belongs to.
     ///
@@ -37,46 +37,46 @@ pub(crate) struct Vote<C: Context> {
     pub(crate) round_exp: u8,
 }
 
-impl<C: Context> Vote<C> {
-    /// Creates a new `Vote` from the `WireVote`, and returns the value if it contained any.
+impl<C: Context> Unit<C> {
+    /// Creates a new `Unit` from the `WireUnit`, and returns the value if it contained any.
     /// Values must be stored as a block, with the same hash.
     pub(crate) fn new(
-        swvote: SignedWireVote<C>,
+        swunit: SignedWireUnit<C>,
         fork_choice: Option<&C::Hash>,
         state: &State<C>,
-    ) -> (Vote<C>, Option<C::ConsensusValue>) {
-        let SignedWireVote {
-            wire_vote: wvote,
+    ) -> (Unit<C>, Option<C::ConsensusValue>) {
+        let SignedWireUnit {
+            wire_unit: wunit,
             signature,
-        } = swvote;
-        let block = if wvote.value.is_some() {
-            wvote.hash() // A vote with a new block votes for itself.
+        } = swunit;
+        let block = if wunit.value.is_some() {
+            wunit.hash() // A unit with a new block votes for itself.
         } else {
-            // If the vote didn't introduce a new block, it votes for the fork choice itself.
-            // `Highway::add_vote` checks that the panorama is not empty.
+            // If the unit didn't introduce a new block, it votes for the fork choice itself.
+            // `Highway::add_unit` checks that the panorama is not empty.
             fork_choice
                 .cloned()
                 .expect("nonempty panorama has nonempty fork choice")
         };
         let mut skip_idx = Vec::new();
-        if let Some(hash) = wvote.panorama.get(wvote.creator).correct() {
+        if let Some(hash) = wunit.panorama.get(wunit.creator).correct() {
             skip_idx.push(*hash);
-            for i in 0..wvote.seq_number.trailing_zeros() as usize {
-                let old_vote = state.vote(&skip_idx[i]);
-                skip_idx.push(old_vote.skip_idx[i]);
+            for i in 0..wunit.seq_number.trailing_zeros() as usize {
+                let old_unit = state.unit(&skip_idx[i]);
+                skip_idx.push(old_unit.skip_idx[i]);
             }
         }
-        let vote = Vote {
-            panorama: wvote.panorama,
-            seq_number: wvote.seq_number,
-            creator: wvote.creator,
+        let unit = Unit {
+            panorama: wunit.panorama,
+            seq_number: wunit.seq_number,
+            creator: wunit.creator,
             block,
             skip_idx,
-            timestamp: wvote.timestamp,
+            timestamp: wunit.timestamp,
             signature,
-            round_exp: wvote.round_exp,
+            round_exp: wunit.round_exp,
         };
-        (vote, wvote.value)
+        (unit, wunit.value)
     }
 
     /// Returns the creator's previous message.
@@ -84,26 +84,26 @@ impl<C: Context> Vote<C> {
         self.skip_idx.first()
     }
 
-    /// Returns the time at which the round containing this vote began.
+    /// Returns the time at which the round containing this unit began.
     pub(crate) fn round_id(&self) -> Timestamp {
         state::round_id(self.timestamp, self.round_exp)
     }
 
-    /// Returns the length of the round containing this vote.
+    /// Returns the length of the round containing this unit.
     pub(crate) fn round_len(&self) -> TimeDiff {
         state::round_len(self.round_exp)
     }
 
-    /// Returns whether `vote` cites a new vote from `vidx` in the last panorama.
-    /// i.e. whether previous vote from creator of `vhash` cites different vote by `vidx`.
+    /// Returns whether `unit` cites a new unit from `vidx` in the last panorama.
+    /// i.e. whether previous unit from creator of `vhash` cites different unit by `vidx`.
     ///
-    /// NOTE: Returns `false` if `vidx` is faulty or hasn't produced any votes according to the
+    /// NOTE: Returns `false` if `vidx` is faulty or hasn't produced any units according to the
     /// creator of `vhash`.
     pub(crate) fn new_hash_obs(&self, state: &State<C>, vidx: ValidatorIndex) -> bool {
         let latest_obs = self.panorama[vidx].correct();
         let penultimate_obs = self
             .previous()
-            .and_then(|v| state.vote(v).panorama[vidx].correct());
+            .and_then(|v| state.unit(v).panorama[vidx].correct());
         match (latest_obs, penultimate_obs) {
             (Some(latest_hash), Some(penultimate_hash)) => latest_hash != penultimate_hash,
             _ => false,

--- a/node/src/components/consensus/highway_core/test_macros.rs
+++ b/node/src/components/consensus/highway_core/test_macros.rs
@@ -1,6 +1,6 @@
 //! Macros for concise test setup.
 
-/// Creates a panorama from a list of either observations or vote hashes. Vote hashes are converted
+/// Creates a panorama from a list of either observations or unit hashes. Unit hashes are converted
 /// to `Correct` observations.
 macro_rules! panorama {
     ($($obs:expr),*) => {{
@@ -10,18 +10,18 @@ macro_rules! panorama {
     }};
 }
 
-/// Creates a vote, adds it to `$state` and returns its hash.
-/// Returns an error if vote addition fails.
+/// Creates a unit, adds it to `$state` and returns its hash.
+/// Returns an error if unit addition fails.
 ///
 /// The short variant is for tests that don't care about timestamps and round lengths: It
 /// automatically picks reasonable values for those.
-macro_rules! add_vote {
+macro_rules! add_unit {
     ($state: ident, $rng: ident, $creator: expr, $val: expr; $($obs:expr),*) => {{
         #[allow(unused_imports)] // These might be already imported at the call site.
         use crate::{
             components::consensus::highway_core::{
                 state::{self, tests::TestSecret},
-                highway::{SignedWireVote, WireVote},
+                highway::{SignedWireUnit, WireUnit},
             },
             types::{TimeDiff, Timestamp},
         };
@@ -33,19 +33,19 @@ macro_rules! add_vote {
         // Use our most recent round exponent, or the configured initial one.
         let round_exp = opt_parent_hash.map_or_else(
             || $state.params().init_round_exp(),
-            |vh| $state.vote(vh).round_exp,
+            |vh| $state.unit(vh).round_exp,
         );
         let value = Option::from($val);
-        // At most two votes per round are allowed.
-        let two_votes_limit = opt_parent_hash
-            .and_then(|ph| $state.vote(ph).previous())
-            .map(|pph| $state.vote(pph))
-            .map(|vote| vote.round_id() + vote.round_len());
+        // At most two units per round are allowed.
+        let two_units_limit = opt_parent_hash
+            .and_then(|ph| $state.unit(ph).previous())
+            .map(|pph| $state.unit(pph))
+            .map(|unit| unit.round_id() + unit.round_len());
         // And our timestamp must not be less than any justification's.
         let mut timestamp = panorama
             .iter_correct(&$state)
-            .map(|vote| vote.timestamp + TimeDiff::from(1))
-            .chain(two_votes_limit)
+            .map(|unit| unit.timestamp + TimeDiff::from(1))
+            .chain(two_units_limit)
             .max()
             .unwrap_or_else(Timestamp::zero);
         // If this is a block: Find the next time we're a leader.
@@ -56,7 +56,7 @@ macro_rules! add_vote {
                 timestamp += r_len;
             }
         }
-        let wvote = WireVote {
+        let wunit = WireUnit {
             panorama,
             creator,
             instance_id: 1u64,
@@ -66,23 +66,23 @@ macro_rules! add_vote {
             round_exp,
             endorsed: vec![],
         };
-        let hash = wvote.hash();
-        let swvote = SignedWireVote::new(wvote, &TestSecret(($creator).0), &mut $rng);
-        $state.add_vote(swvote).map(|()| hash)
+        let hash = wunit.hash();
+        let swunit = SignedWireUnit::new(wunit, &TestSecret(($creator).0), &mut $rng);
+        $state.add_unit(swunit).map(|()| hash)
     }};
     ($state: ident, $rng: ident, $creator: expr, $time: expr, $round_exp: expr, $val: expr; $($obs:expr),*) => {{
-        add_vote!($state, $rng, $creator, $time, $round_exp, $val; $($obs),*; vec![])
+        add_unit!($state, $rng, $creator, $time, $round_exp, $val; $($obs),*; vec![])
     }};
     ($state: ident, $rng: ident, $creator: expr, $time: expr, $round_exp: expr, $val: expr; $($obs:expr),*; $($ends:expr),*) => {{
         use crate::components::consensus::highway_core::{
             state::tests::TestSecret,
-            highway::{SignedWireVote, WireVote},
+            highway::{SignedWireUnit, WireUnit},
         };
 
         let creator = $creator;
         let panorama = panorama!($($obs),*);
         let seq_number = panorama.next_seq_num(&$state, creator);
-        let wvote = WireVote {
+        let wunit = WireUnit {
             panorama,
             creator,
             instance_id: 1u64,
@@ -92,8 +92,8 @@ macro_rules! add_vote {
             round_exp: $round_exp,
             endorsed: $($ends.into()),*
         };
-        let hash = wvote.hash();
-        let swvote = SignedWireVote::new(wvote, &TestSecret(($creator).0), &mut $rng);
-        $state.add_vote(swvote).map(|()| hash)
+        let hash = wunit.hash();
+        let swunit = SignedWireUnit::new(wunit, &TestSecret(($creator).0), &mut $rng);
+        $state.add_unit(swunit).map(|()| hash)
     }};
 }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -304,14 +304,14 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         // register the proposal before the meter is aware that a new round has started, and it
         // will reject the proposal.
         if vv.is_proposal() {
-            // unwraps are safe, as if value is `Some`, this is already a vote
+            // unwraps are safe, as if value is `Some`, this is already a unit
             trace!(
                 now = Timestamp::now().millis(),
                 timestamp = vv.inner().timestamp().unwrap().millis(),
                 "adding proposal to protocol state",
             );
             self.round_success_meter.new_proposal(
-                vv.inner().vote_hash().unwrap(),
+                vv.inner().unit_hash().unwrap(),
                 vv.inner().timestamp().unwrap(),
             );
         }

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -22,7 +22,7 @@ pub(crate) trait ConsensusValueT:
 }
 impl<T> ConsensusValueT for T where T: Eq + Clone + Debug + Hash + Serialize + DeserializeOwned {}
 
-/// A hash, as an identifier for a block or vote.
+/// A hash, as an identifier for a block or unit.
 pub(crate) trait HashT:
     Eq + Ord + Copy + Clone + Debug + Display + Hash + Serialize + DeserializeOwned
 {
@@ -53,7 +53,7 @@ pub(crate) trait Context: Clone + Debug + Eq + Ord + Hash {
     type ValidatorSecret: ValidatorSecret<Hash = Self::Hash, Signature = Self::Signature>;
     /// A signature type.
     type Signature: Copy + Clone + Debug + Eq + Hash + Serialize + DeserializeOwned;
-    /// Unique identifiers for votes.
+    /// Unique identifiers for units.
     type Hash: HashT;
     /// The ID of a consensus protocol instance.
     type InstanceId: HashT;


### PR DESCRIPTION
Use the term "unit" for what we called "votes" so far, to be in line with the paper.

The word "vote" is still used in the `tallies` modules and a few other places, where it is appropriate: A "unit" is considered to carry multiple "votes", one at each block height, for the block that is the ancestor of the unit's new block or fork choice.

https://casperlabs.atlassian.net/browse/NDRS-573