### PR TITLE
NO-TICKET: Call announce_proposed_proto_block later.

### DIFF
--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -30,3 +30,8 @@ impl CandidateBlock {
         &self.accusations
     }
 }
+impl From<CandidateBlock> for ProtoBlock {
+    fn from(cb: CandidateBlock) -> ProtoBlock {
+        cb.proto_block
+    }
+}

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -30,6 +30,7 @@ impl CandidateBlock {
         &self.accusations
     }
 }
+
 impl From<CandidateBlock> for ProtoBlock {
     fn from(cb: CandidateBlock) -> ProtoBlock {
         cb.proto_block

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -539,13 +539,13 @@ where
             effects.extend(self.delegate_to_era(era_id, |consensus, rng| {
                 consensus.resolve_validity(&candidate_block, valid, rng)
             }));
-        }
-        if valid {
-            effects.extend(
-                self.effect_builder
-                    .announce_proposed_proto_block(proto_block)
-                    .ignore(),
-            );
+            if valid {
+                effects.extend(
+                    self.effect_builder
+                        .announce_proposed_proto_block(candidate_block.into())
+                        .ignore(),
+                );
+            }
         }
         effects
     }
@@ -701,6 +701,11 @@ where
                         effects.extend(self.delegate_to_era(e_id, |consensus, rng| {
                             consensus.resolve_validity(&candidate_block, true, rng)
                         }));
+                        effects.extend(
+                            self.effect_builder
+                                .announce_proposed_proto_block(candidate_block.into())
+                                .ignore(),
+                        );
                     }
                 }
                 effects


### PR DESCRIPTION
It's wrong to call it when the proto block has been validated, because at that point it's not necessarily passed into the consensus protocol yet: It may still be waiting for evidence that it depends on.

Only once it's passed in will the protocol be able to detect finalization (or later maybe orphans).