### PR TITLE
NDRS-473: Optimize bytes/array serialization without nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,6 @@ dependencies = [
  "criterion",
  "datasize",
  "failure",
- "generic-array 0.14.4",
  "hex_fmt",
  "num-derive",
  "num-integer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,6 @@ dependencies = [
  "rand 0.7.3",
  "serde_json",
  "tempfile",
- "wabt",
 ]
 
 [[package]]
@@ -830,7 +829,6 @@ dependencies = [
  "tracing",
  "uint",
  "uuid",
- "wabt",
  "wasmi",
 ]
 
@@ -920,7 +918,6 @@ dependencies = [
  "untrusted",
  "uuid",
  "vergen",
- "wabt",
  "warp",
  "warp-json-rpc",
  "wasmi",
@@ -1083,15 +1080,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags 1.2.1",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -6590,29 +6578,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wabt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bef93d5e6c81a293bccf107cf43aa47239382f455ba14869d36695d8963b9c"
-dependencies = [
- "serde",
- "serde_derive",
- "serde_json",
- "wabt-sys",
-]
-
-[[package]]
-name = "wabt-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a4e043159f63e16986e713e9b5e1c06043df4848565bf672e27c523864c7791"
-dependencies = [
- "cc",
- "cmake",
- "glob",
-]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,7 @@ dependencies = [
  "criterion",
  "datasize",
  "failure",
+ "generic-array 0.14.4",
  "hex_fmt",
  "num-derive",
  "num-integer",

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -44,7 +44,6 @@ thiserror = "1.0.18"
 tracing = "0.1.18"
 uint = "0.8.3"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
-wabt = "0.10.0"
 wasmi = "0.6.2"
 
 [dev-dependencies]

--- a/execution_engine/src/shared/account.rs
+++ b/execution_engine/src/shared/account.rs
@@ -212,7 +212,7 @@ impl Account {
 impl ToBytes for Account {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        result.append(&mut self.account_hash.to_bytes()?);
+        result.extend(self.account_hash.to_bytes()?);
         result.append(&mut self.named_keys.to_bytes()?);
         result.append(&mut self.main_purse.to_bytes()?);
         result.append(&mut self.associated_keys.to_bytes()?);

--- a/execution_engine/src/shared/newtypes/blake2b256.rs
+++ b/execution_engine/src/shared/newtypes/blake2b256.rs
@@ -98,16 +98,16 @@ impl Into<[u8; Blake2bHash::LENGTH]> for Blake2bHash {
 
 impl ToBytes for Blake2bHash {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        self.0.to_bytes()
+        bytesrepr::serialize_array(&self.0)
     }
 
     fn serialized_length(&self) -> usize {
-        self.0.serialized_length()
+        bytesrepr::array_serialized_length(&self.0)
     }
 }
 
 impl FromBytes for Blake2bHash {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        FromBytes::from_bytes(bytes).map(|(arr, rem)| (Blake2bHash(arr), rem))
+        bytesrepr::deserialize_array(bytes).map(|(arr, rem)| (Blake2bHash(arr), rem))
     }
 }

--- a/execution_engine/src/shared/wasm.rs
+++ b/execution_engine/src/shared/wasm.rs
@@ -1,24 +1,27 @@
-use parity_wasm::elements::Module;
+use casper_types::contracts::DEFAULT_ENTRY_POINT_NAME;
+use parity_wasm::{builder, elements::Module};
 
 use crate::shared::wasm_prep::{PreprocessingError, Preprocessor};
 
-static DO_NOTHING: &str = r#"
-    (module
-      (type (;0;) (func))
-      (func $call (type 0))
-      (table (;0;) 1 1 funcref)
-      (memory (;0;) 16)
-      (global (;0;) (mut i32) (i32.const 1048576))
-      (global (;1;) i32 (i32.const 1048576))
-      (global (;2;) i32 (i32.const 1048576))
-      (export "memory" (memory 0))
-      (export "call" (func $call))
-      (export "__data_end" (global 1))
-      (export "__heap_base" (global 2)))
-    "#;
-
-pub fn do_nothing_bytes() -> Vec<u8> {
-    wabt::wat2wasm(DO_NOTHING).expect("failed to parse wat")
+/// Creates minimal session code that does nothing
+fn do_nothing_bytes() -> Vec<u8> {
+    let module = builder::module()
+        .function()
+        // A signature with 0 params and no return type
+        .signature()
+        .build()
+        .body()
+        .build()
+        .build()
+        // Export above function
+        .export()
+        .field(DEFAULT_ENTRY_POINT_NAME)
+        .build()
+        // Memory section is mandatory
+        .memory()
+        .build()
+        .build();
+    parity_wasm::serialize(module).expect("should serialize")
 }
 
 pub fn do_nothing_module(preprocessor: &Preprocessor) -> Result<Module, PreprocessingError> {

--- a/execution_engine/src/storage/protocol_data.rs
+++ b/execution_engine/src/storage/protocol_data.rs
@@ -139,19 +139,19 @@ impl ToBytes for ProtocolData {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut ret = bytesrepr::unchecked_allocate_buffer(self);
         ret.append(&mut self.wasm_config.to_bytes()?);
-        ret.append(&mut self.mint.to_bytes()?);
-        ret.append(&mut self.proof_of_stake.to_bytes()?);
-        ret.append(&mut self.standard_payment.to_bytes()?);
-        ret.append(&mut self.auction.to_bytes()?);
+        ret.append(&mut bytesrepr::serialize_array(&self.mint)?);
+        ret.append(&mut bytesrepr::serialize_array(&self.proof_of_stake)?);
+        ret.append(&mut bytesrepr::serialize_array(&self.standard_payment)?);
+        ret.append(&mut bytesrepr::serialize_array(&self.auction)?);
         Ok(ret)
     }
 
     fn serialized_length(&self) -> usize {
         self.wasm_config.serialized_length()
-            + self.mint.serialized_length()
-            + self.proof_of_stake.serialized_length()
-            + self.standard_payment.serialized_length()
-            + self.auction.serialized_length()
+            + bytesrepr::array_serialized_length(&self.mint)
+            + bytesrepr::array_serialized_length(&self.proof_of_stake)
+            + bytesrepr::array_serialized_length(&self.standard_payment)
+            + bytesrepr::array_serialized_length(&self.auction)
     }
 }
 

--- a/execution_engine/src/storage/trie/mod.rs
+++ b/execution_engine/src/storage/trie/mod.rs
@@ -312,7 +312,7 @@ impl<K: FromBytes, V: FromBytes> FromBytes for Trie<K, V> {
                 ))
             }
             2 => {
-                let (affix, rem) = Vec::<u8>::from_bytes(rem)?;
+                let (affix, rem) = bytesrepr::deserialize_bytes(rem)?;
                 let (pointer, rem) = Pointer::from_bytes(rem)?;
                 Ok((Trie::Extension { affix, pointer }, rem))
             }

--- a/grpc/tests/Cargo.toml
+++ b/grpc/tests/Cargo.toml
@@ -28,7 +28,6 @@ num-rational = "0.3.0"
 num-traits = "0.2.10"
 serde_json = "1"
 tempfile = "3"
-wabt = "0.10.0"
 
 [features]
 default = [

--- a/grpc/tests/benches/transfer_bench.rs
+++ b/grpc/tests/benches/transfer_bench.rs
@@ -19,7 +19,6 @@ const CONTRACT_TRANSFER_TO_PURSE: &str = "transfer_to_purse.wasm";
 
 /// Size of batch used in multiple execs benchmark, and multiple deploys per exec cases.
 const TRANSFER_BATCH_SIZE: u64 = 3;
-const PER_RUN_FUNDING: u64 = 10_000_000;
 const TARGET_ADDR: AccountHash = AccountHash::new([127; 32]);
 const ARG_AMOUNT: &str = "amount";
 const ARG_ACCOUNTS: &str = "accounts";
@@ -133,7 +132,7 @@ fn transfer_to_account_multiple_deploys(
     for i in 0..TRANSFER_BATCH_SIZE {
         let deploy = DeployItemBuilder::default()
             .with_address(*DEFAULT_ACCOUNT_ADDR)
-            .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => U512::from(PER_RUN_FUNDING) })
+            .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => *DEFAULT_PAYMENT })
             .with_session_code(
                 CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT,
                 runtime_args! {

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -86,7 +86,6 @@ tracing-subscriber = { version = "0.2.10", features = ["fmt", "json"] }
 uint = "0.8.3"
 untrusted = "0.7.1"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
-wabt = "0.10.0"
 warp = "0.2.4"
 warp-json-rpc = "0.2.0"
 wasmi = "0.6.2"

--- a/node/src/crypto/hash.rs
+++ b/node/src/crypto/hash.rs
@@ -111,18 +111,17 @@ impl UpperHex for Digest {
 
 impl ToBytes for Digest {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        self.0.to_bytes()
+        bytesrepr::serialize_array(&self.0)
     }
 
     fn serialized_length(&self) -> usize {
-        self.0.serialized_length()
+        bytesrepr::array_serialized_length(&self.0)
     }
 }
 
 impl FromBytes for Digest {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        <[u8; Digest::LENGTH]>::from_bytes(bytes)
-            .map(|(inner, remainder)| (Digest(inner), remainder))
+        bytesrepr::deserialize_array(bytes).map(|(inner, remainder)| (Digest(inner), remainder))
     }
 }
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -26,7 +26,6 @@ proptest = { version = "0.10.0", optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.59", default-features = false }
 uint = { version = "0.8.3", default-features = false }
-generic-array = "0.14.4"
 
 [dev-dependencies]
 bincode = "1.3.1"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -26,6 +26,7 @@ proptest = { version = "0.10.0", optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.59", default-features = false }
 uint = { version = "0.8.3", default-features = false }
+generic-array = "0.14.4"
 
 [dev-dependencies]
 bincode = "1.3.1"

--- a/types/benches/bytesrepr_bench.rs
+++ b/types/benches/bytesrepr_bench.rs
@@ -44,7 +44,7 @@ fn serialize_vector_of_u8(b: &mut Bencher) {
     b.iter(|| data.to_bytes());
 }
 
-fn deserialize_vector_of_u8(b: &mut Bencher) {
+fn deserialize_vector_of_u8_slow(b: &mut Bencher) {
     // 0, 1, ... 254, 255, 0, 1, ...
     let data: Vec<u8> = prepare_vector(BATCH)
         .into_iter()
@@ -53,6 +53,17 @@ fn deserialize_vector_of_u8(b: &mut Bencher) {
         .to_bytes()
         .unwrap();
     b.iter(|| Vec::<u8>::from_bytes(&data))
+}
+
+fn deserialize_vector_of_u8(b: &mut Bencher) {
+    // 0, 1, ... 254, 255, 0, 1, ...
+    let data: Vec<u8> = prepare_vector(BATCH)
+        .into_iter()
+        .map(|value| value as u8)
+        .collect::<Vec<_>>()
+        .to_bytes()
+        .unwrap();
+    b.iter(|| bytesrepr::deserialize_bytes(&data))
 }
 
 fn serialize_u8(b: &mut Bencher) {
@@ -440,6 +451,10 @@ fn bytesrepr_bench(c: &mut Criterion) {
     c.bench_function("serialize_vector_of_i32s", serialize_vector_of_i32s);
     c.bench_function("deserialize_vector_of_i32s", deserialize_vector_of_i32s);
     c.bench_function("serialize_vector_of_u8", serialize_vector_of_u8);
+    c.bench_function(
+        "deserialize_vector_of_u8_slow",
+        deserialize_vector_of_u8_slow,
+    );
     c.bench_function("deserialize_vector_of_u8", deserialize_vector_of_u8);
     c.bench_function("serialize_u8", serialize_u8);
     c.bench_function("deserialize_u8", deserialize_u8);

--- a/types/benches/bytesrepr_bench.rs
+++ b/types/benches/bytesrepr_bench.rs
@@ -41,18 +41,7 @@ fn serialize_vector_of_u8(b: &mut Bencher) {
         .into_iter()
         .map(|value| value as u8)
         .collect::<Vec<_>>();
-    b.iter(|| data.to_bytes());
-}
-
-fn deserialize_vector_of_u8_slow(b: &mut Bencher) {
-    // 0, 1, ... 254, 255, 0, 1, ...
-    let data: Vec<u8> = prepare_vector(BATCH)
-        .into_iter()
-        .map(|value| value as u8)
-        .collect::<Vec<_>>()
-        .to_bytes()
-        .unwrap();
-    b.iter(|| Vec::<u8>::from_bytes(&data))
+    b.iter(|| bytesrepr::serialize_bytes(black_box(&data)));
 }
 
 fn deserialize_vector_of_u8(b: &mut Bencher) {
@@ -63,7 +52,7 @@ fn deserialize_vector_of_u8(b: &mut Bencher) {
         .collect::<Vec<_>>()
         .to_bytes()
         .unwrap();
-    b.iter(|| bytesrepr::deserialize_bytes(&data))
+    b.iter(|| bytesrepr::deserialize_bytes(black_box(&data)))
 }
 
 fn serialize_u8(b: &mut Bencher) {
@@ -451,10 +440,6 @@ fn bytesrepr_bench(c: &mut Criterion) {
     c.bench_function("serialize_vector_of_i32s", serialize_vector_of_i32s);
     c.bench_function("deserialize_vector_of_i32s", deserialize_vector_of_i32s);
     c.bench_function("serialize_vector_of_u8", serialize_vector_of_u8);
-    c.bench_function(
-        "deserialize_vector_of_u8_slow",
-        deserialize_vector_of_u8_slow,
-    );
     c.bench_function("deserialize_vector_of_u8", deserialize_vector_of_u8);
     c.bench_function("serialize_u8", serialize_u8);
     c.bench_function("deserialize_u8", deserialize_u8);

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -16,7 +16,7 @@ use failure::Fail;
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    bytesrepr::{Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    bytesrepr::{self, Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     CLType, CLTyped, PublicKey, BLAKE2B_DIGEST_LENGTH,
 };
 
@@ -190,9 +190,6 @@ impl CLTyped for Weight {
 /// The length in bytes of a [`AccountHash`].
 pub const ACCOUNT_HASH_LENGTH: usize = 32;
 
-/// The number of bytes in a serialized [`AccountHash`].
-pub const ACCOUNT_HASH_SERIALIZED_LENGTH: usize = 32;
-
 /// A type alias for the raw bytes of an Account Hash.
 pub type AccountHashBytes = [u8; ACCOUNT_HASH_LENGTH];
 
@@ -343,17 +340,17 @@ impl CLTyped for AccountHash {
 
 impl ToBytes for AccountHash {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        self.0.to_bytes()
+        bytesrepr::serialize_array(&self.0)
     }
 
     fn serialized_length(&self) -> usize {
-        ACCOUNT_HASH_SERIALIZED_LENGTH
+        bytesrepr::array_serialized_length(&self.0)
     }
 }
 
 impl FromBytes for AccountHash {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (bytes, rem) = <[u8; 32]>::from_bytes(bytes)?;
+        let (bytes, rem) = bytesrepr::deserialize_array(bytes)?;
         Ok((AccountHash::new(bytes), rem))
     }
 }

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -13,7 +13,6 @@ use core::{
     mem::{self, MaybeUninit},
     ptr::NonNull,
 };
-use generic_array::{ArrayLength, GenericArray};
 
 use failure::Fail;
 use num_integer::Integer;
@@ -1124,15 +1123,15 @@ pub fn deserialize_array_slice(bytes: &[u8], n: usize) -> Result<(&[u8], &[u8]),
 }
 
 /// Deserializes a generic array.
-pub fn deserialize_array<T, N>(bytes: &[u8]) -> Result<(T, &[u8]), Error>
+pub fn deserialize_array<T>(bytes: &[u8]) -> Result<(T, &[u8]), Error>
 where
-    N: ArrayLength<u8>,
-    T: From<GenericArray<u8, N>>,
+    T: AsMut<[u8]> + Default,
 {
-    let mut result = GenericArray::default();
-    let (bytes, rem) = deserialize_array_slice(bytes, result.len())?;
-    result.copy_from_slice(bytes);
-    Ok((result.into(), rem))
+    let mut output = T::default();
+    let as_mut_ref = output.as_mut();
+    let (bytes, rem) = deserialize_array_slice(bytes, as_mut_ref.len())?;
+    as_mut_ref.copy_from_slice(bytes);
+    Ok((output, rem))
 }
 
 /// Calculate serialized length of an array.
@@ -1256,8 +1255,8 @@ mod tests {
 
     #[test]
     fn should_serialize_deserialize_array() {
-        type Arr = [u8; 5];
-        let data: Arr = [1, 2, 3, 4, 5];
+        type Arr = [u8; 32];
+        let data: Arr = [255; 32];
         let serialized = super::serialize_array(&data).expect("should serialize data");
         let (deserialized, rem): (Arr, &[u8]) =
             super::deserialize_array(&serialized).expect("should deserialize data");

--- a/types/src/cl_value.rs
+++ b/types/src/cl_value.rs
@@ -230,13 +230,13 @@ impl ToBytes for CLValue {
     }
 
     fn serialized_length(&self) -> usize {
-        self.bytes.serialized_length() + self.cl_type.serialized_length()
+        bytesrepr::bytes_serialized_length(&self.bytes) + self.cl_type.serialized_length()
     }
 }
 
 impl FromBytes for CLValue {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (bytes, remainder) = Vec::<u8>::from_bytes(bytes)?;
+        let (bytes, remainder) = bytesrepr::deserialize_bytes(bytes)?;
         let (cl_type, remainder) = CLType::from_bytes(remainder)?;
         let cl_value = CLValue { cl_type, bytes };
         Ok((cl_value, remainder))

--- a/types/src/contract_wasm.rs
+++ b/types/src/contract_wasm.rs
@@ -1,6 +1,7 @@
-use crate::bytesrepr::{Error, FromBytes, ToBytes};
 use alloc::vec::Vec;
 use core::fmt::Debug;
+
+use crate::bytesrepr::{self, Error, FromBytes, ToBytes};
 
 const CONTRACT_WASM_MAX_DISPLAY_LEN: usize = 16;
 
@@ -43,17 +44,17 @@ impl ContractWasm {
 
 impl ToBytes for ContractWasm {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        self.bytes.to_bytes()
+        bytesrepr::serialize_bytes(&self.bytes)
     }
 
     fn serialized_length(&self) -> usize {
-        self.bytes.serialized_length()
+        bytesrepr::bytes_serialized_length(&self.bytes)
     }
 }
 
 impl FromBytes for ContractWasm {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (bytes, rem1) = Vec::<u8>::from_bytes(bytes)?;
+        let (bytes, rem1) = bytesrepr::deserialize_bytes(bytes)?;
         Ok((ContractWasm { bytes }, rem1))
     }
 }

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -574,8 +574,10 @@ impl Contract {
 impl ToBytes for Contract {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        result.append(&mut self.contract_package_hash.to_bytes()?);
-        result.append(&mut self.contract_wasm_hash.to_bytes()?);
+        result.append(&mut bytesrepr::serialize_array(
+            &self.contract_package_hash,
+        )?);
+        result.append(&mut bytesrepr::serialize_array(&self.contract_wasm_hash)?);
         result.append(&mut self.named_keys.to_bytes()?);
         result.append(&mut self.entry_points.to_bytes()?);
         result.append(&mut self.protocol_version.to_bytes()?);
@@ -584,8 +586,8 @@ impl ToBytes for Contract {
 
     fn serialized_length(&self) -> usize {
         ToBytes::serialized_length(&self.entry_points)
-            + ToBytes::serialized_length(&self.contract_package_hash)
-            + ToBytes::serialized_length(&self.contract_wasm_hash)
+            + bytesrepr::array_serialized_length(&self.contract_package_hash)
+            + bytesrepr::array_serialized_length(&self.contract_wasm_hash)
             + ToBytes::serialized_length(&self.protocol_version)
             + ToBytes::serialized_length(&self.named_keys)
     }

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -288,7 +288,7 @@ impl ToBytes for Key {
             }
             Key::Hash(hash) => {
                 result.push(HASH_ID);
-                result.append(&mut hash.to_bytes()?);
+                result.append(&mut bytesrepr::serialize_array(hash)?);
             }
             Key::URef(uref) => {
                 result.push(UREF_ID);
@@ -296,11 +296,11 @@ impl ToBytes for Key {
             }
             Key::Transfer(addr) => {
                 result.push(TRANSFER_ID);
-                result.append(&mut addr.to_bytes()?);
+                result.append(&mut bytesrepr::serialize_array(addr)?);
             }
             Key::DeployInfo(addr) => {
                 result.push(DEPLOY_INFO_ID);
-                result.append(&mut addr.to_bytes()?);
+                result.append(&mut bytesrepr::serialize_array(addr)?);
             }
         }
         Ok(result)
@@ -328,7 +328,7 @@ impl FromBytes for Key {
                 Ok((Key::Account(account_hash), rem))
             }
             HASH_ID => {
-                let (hash, rem) = <[u8; KEY_HASH_LENGTH]>::from_bytes(remainder)?;
+                let (hash, rem) = bytesrepr::deserialize_array(remainder)?;
                 Ok((Key::Hash(hash), rem))
             }
             UREF_ID => {
@@ -336,11 +336,11 @@ impl FromBytes for Key {
                 Ok((Key::URef(uref), rem))
             }
             TRANSFER_ID => {
-                let (transfer_addr, rem) = TransferAddr::from_bytes(remainder)?;
+                let (transfer_addr, rem) = bytesrepr::deserialize_array(remainder)?;
                 Ok((Key::Transfer(transfer_addr), rem))
             }
             DEPLOY_INFO_ID => {
-                let (deploy_hash, rem) = DeployHash::from_bytes(remainder)?;
+                let (deploy_hash, rem) = bytesrepr::deserialize_array(remainder)?;
                 Ok((Key::DeployInfo(deploy_hash), rem))
             }
             _ => Err(Error::Formatting),

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -48,7 +48,7 @@ impl Transfer {
 
 impl FromBytes for Transfer {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (deploy_hash, rem) = DeployHash::from_bytes(bytes)?;
+        let (deploy_hash, rem) = bytesrepr::deserialize_array(bytes)?;
         let (from, rem) = AccountHash::from_bytes(rem)?;
         let (source, rem) = URef::from_bytes(rem)?;
         let (target, rem) = URef::from_bytes(rem)?;
@@ -71,7 +71,7 @@ impl FromBytes for Transfer {
 impl ToBytes for Transfer {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        result.append(&mut self.deploy_hash.to_bytes()?);
+        result.append(&mut bytesrepr::serialize_array(&self.deploy_hash)?);
         result.append(&mut self.from.to_bytes()?);
         result.append(&mut self.source.to_bytes()?);
         result.append(&mut self.target.to_bytes()?);
@@ -81,7 +81,7 @@ impl ToBytes for Transfer {
     }
 
     fn serialized_length(&self) -> usize {
-        self.deploy_hash.serialized_length()
+        bytesrepr::array_serialized_length(&self.deploy_hash)
             + self.from.serialized_length()
             + self.source.serialized_length()
             + self.target.serialized_length()

--- a/types/src/uint.rs
+++ b/types/src/uint.rs
@@ -179,7 +179,7 @@ macro_rules! impl_traits_for_uint {
                 if num_bytes > $total_bytes {
                     Err(Error::Formatting)
                 } else {
-                    let (value, rem) = bytesrepr::safe_split_at(rem, num_bytes as usize)?;
+                    let (value, rem) = bytesrepr::deserialize_array_slice(rem, num_bytes as usize)?;
                     let result = $type::from_little_endian(value);
                     Ok((result, rem))
                 }

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -185,7 +185,7 @@ impl Debug for URef {
 impl bytesrepr::ToBytes for URef {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::unchecked_allocate_buffer(self);
-        result.append(&mut self.0.to_bytes()?);
+        result.append(&mut bytesrepr::serialize_array(&self.0)?);
         result.append(&mut self.1.to_bytes()?);
         Ok(result)
     }
@@ -197,8 +197,8 @@ impl bytesrepr::ToBytes for URef {
 
 impl bytesrepr::FromBytes for URef {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (id, rem): ([u8; 32], &[u8]) = bytesrepr::FromBytes::from_bytes(bytes)?;
-        let (access_rights, rem): (AccessRights, &[u8]) = bytesrepr::FromBytes::from_bytes(rem)?;
+        let (id, rem) = bytesrepr::deserialize_array(bytes)?;
+        let (access_rights, rem) = bytesrepr::FromBytes::from_bytes(rem)?;
         Ok((URef(id, access_rights), rem))
     }
 }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-473

One step forward for getting stable support. Removes all default impls, and where applicable `Vec<u8>`/`[u8; N]` serialiation/deserialization is done through separate free standing functions.

As expected bytesrepr_bench for `Vec<u8>` is slower, although `serialize_bytes` bench is faster. Same result is expected for arrays of u8.

**NOTE: I kept getting undefined references while linking for `wabt-sys` only when I was building benchmarks -> I decided to get rid of dependency on wabt as it was only used in ~3 places and its usage was suboptimal anyway. No more issues with cmake.**