### PR TITLE
EE-1106: auction: remove BidPurses map

### DIFF
--- a/execution_engine/src/core/runtime/auction_internal.rs
+++ b/execution_engine/src/core/runtime/auction_internal.rs
@@ -106,7 +106,7 @@ where
         source: URef,
         target: URef,
         amount: U512,
-    ) -> Result<(), ()> {
+    ) -> Result<(), Error> {
         let mint_contract_key = self.get_mint_contract();
         if self
             .mint_transfer(mint_contract_key, source, target, amount)
@@ -114,7 +114,7 @@ where
         {
             Ok(())
         } else {
-            Err(())
+            Err(Error::Transfer)
         }
     }
 

--- a/grpc/tests/src/test/regression/ee_598.rs
+++ b/grpc/tests/src/test/regression/ee_598.rs
@@ -91,11 +91,11 @@ fn should_fail_unbonding_more_than_it_was_staked_ee_598_regression() {
         .to_owned();
     let error_message = utils::get_error_message(response);
 
-    // Error::UnbondTooLarge => 7,
+    // Error::UnbondTooLarge,
     assert!(
         error_message.contains(&format!(
             "{:?}",
-            ApiError::from(auction::Error::InvalidAmount)
+            ApiError::from(auction::Error::UnbondTooLarge)
         )),
         error_message
     );

--- a/grpc/tests/src/test/step.rs
+++ b/grpc/tests/src/test/step.rs
@@ -9,7 +9,7 @@ use casper_execution_engine::{
 use casper_types::{
     account::AccountHash,
     auction::{
-        BidPurses, Bids, SeigniorageRecipientsSnapshot, BIDS_KEY, BID_PURSES_KEY, BLOCK_REWARD,
+        Bids, SeigniorageRecipientsSnapshot, BIDS_KEY, BLOCK_REWARD,
         SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, VALIDATOR_REWARD_PURSE_KEY,
     },
     ContractHash, Key, ProtocolVersion, PublicKey,
@@ -95,11 +95,11 @@ fn should_step() {
         bids_before_slashing
     );
 
-    let bid_purses_before_slashing: BidPurses = builder.get_value(auction_hash, BID_PURSES_KEY);
+    let bids_before_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
     assert!(
-        bid_purses_before_slashing.contains_key(&ACCOUNT_1_PK),
-        "should have bid purse in the bids purses table {:?}",
-        bid_purses_before_slashing
+        bids_before_slashing.contains_key(&ACCOUNT_1_PK),
+        "should have entry in bids table before slashing {:?}",
+        bids_before_slashing
     );
 
     builder.step(step_request);
@@ -109,13 +109,6 @@ fn should_step() {
         !bids_after_slashing.contains_key(&ACCOUNT_1_PK),
         "should not have entry in bids table after slashing {:?}",
         bids_after_slashing
-    );
-
-    // bid purses should not have slashed validator after slashing
-    let bid_purses_after_slashing: BidPurses = builder.get_value(auction_hash, BID_PURSES_KEY);
-    assert!(
-        !bid_purses_after_slashing.contains_key(&ACCOUNT_1_PK),
-        "should not contain slashed validator)"
     );
 
     // reward purse balance should not be the same after reward distribution

--- a/grpc/tests/src/test/system_contracts/auction/bids.rs
+++ b/grpc/tests/src/test/system_contracts/auction/bids.rs
@@ -203,11 +203,11 @@ fn should_run_add_bid() {
         .get(&BID_ACCOUNT_1_PK)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
-    assert_eq!(unbond_list[0].origin, BID_ACCOUNT_1_PK);
+    assert_eq!(unbond_list[0].public_key, BID_ACCOUNT_1_PK);
     // `WITHDRAW_BID_AMOUNT_2` is in unbonding list
 
     assert_eq!(
-        unbonding_purse, unbond_list[0].purse,
+        unbonding_purse, unbond_list[0].unbonding_purse,
         "unbonding queue should have account's unbonding purse"
     );
     assert_eq!(unbond_list[0].amount, U512::from(WITHDRAW_BID_AMOUNT_2),);
@@ -841,18 +841,18 @@ fn should_release_founder_stake() {
         .get(&ACCOUNT_1_PK)
         .expect("should have unbond");
     assert_eq!(pre_unbond_list.len(), 2);
-    assert_eq!(pre_unbond_list[0].origin, ACCOUNT_1_PK);
+    assert_eq!(pre_unbond_list[0].public_key, ACCOUNT_1_PK);
     assert_eq!(pre_unbond_list[0].amount, ACCOUNT_1_WITHDRAW_1.into());
-    assert_eq!(pre_unbond_list[1].origin, ACCOUNT_1_PK);
+    assert_eq!(pre_unbond_list[1].public_key, ACCOUNT_1_PK);
     assert_eq!(pre_unbond_list[1].amount, ACCOUNT_1_WITHDRAW_2.into());
 
     // Funds are not transferred yet from the original bonding purse
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[0].purse),
+        builder.get_purse_balance(pre_unbond_list[0].unbonding_purse),
         U512::zero(),
     );
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[1].purse),
+        builder.get_purse_balance(pre_unbond_list[1].unbonding_purse),
         U512::zero(),
     );
     // check that bids are updated for given validator
@@ -879,11 +879,11 @@ fn should_release_founder_stake() {
     // Funds are transferred from the original bonding purse to the unbonding purses
     //
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[0].purse), // still valid
+        builder.get_purse_balance(pre_unbond_list[0].unbonding_purse), // still valid
         ACCOUNT_1_WITHDRAW_1.into(),
     );
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[1].purse), // still valid
+        builder.get_purse_balance(pre_unbond_list[1].unbonding_purse), // still valid
         U512::zero(),
     );
 
@@ -901,11 +901,11 @@ fn should_release_founder_stake() {
     builder.exec(exec_request_4).expect_success().commit();
 
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[0].purse), // still valid ref
+        builder.get_purse_balance(pre_unbond_list[0].unbonding_purse), // still valid ref
         ACCOUNT_1_WITHDRAW_1.into(),
     );
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[1].purse), // still valid ref
+        builder.get_purse_balance(pre_unbond_list[1].unbonding_purse), // still valid ref
         ACCOUNT_1_WITHDRAW_2.into(),
     );
 

--- a/grpc/tests/src/test/system_contracts/auction_bidding.rs
+++ b/grpc/tests/src/test/system_contracts/auction_bidding.rs
@@ -9,8 +9,8 @@ use casper_execution_engine::{core::engine_state::genesis::GenesisAccount, share
 use casper_types::{
     account::AccountHash,
     auction::{
-        BidPurses, DelegationRate, UnbondingPurses, ARG_UNBOND_PURSE, ARG_VALIDATOR_PUBLIC_KEYS,
-        BID_PURSES_KEY, DEFAULT_UNBONDING_DELAY, INITIAL_ERA_ID, METHOD_RUN_AUCTION, METHOD_SLASH,
+        Bids, DelegationRate, UnbondingPurses, ARG_UNBOND_PURSE, ARG_VALIDATOR_PUBLIC_KEYS,
+        BIDS_KEY, DEFAULT_UNBONDING_DELAY, INITIAL_ERA_ID, METHOD_RUN_AUCTION, METHOD_SLASH,
         UNBONDING_PURSES_KEY,
     },
     runtime_args,
@@ -81,12 +81,13 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
 
     builder.exec(exec_request_1).expect_success().commit();
 
-    let bid_purses: BidPurses = builder.get_value(auction, BID_PURSES_KEY);
-    let bid_purse = bid_purses
+    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let default_account_bid = bids
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
-        .expect("should have bid purse");
+        .expect("should have bid");
+    let bid_purse = *default_account_bid.bonding_purse();
     assert_eq!(
-        builder.get_purse_balance(*bid_purse),
+        builder.get_purse_balance(bid_purse),
         GENESIS_ACCOUNT_STAKE.into()
     );
 
@@ -138,9 +139,9 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
-    assert_eq!(unbond_list[0].origin, default_public_key_arg,);
+    assert_eq!(unbond_list[0].public_key, default_public_key_arg,);
     assert_eq!(
-        builder.get_purse_balance(unbond_list[0].purse),
+        builder.get_purse_balance(unbond_list[0].unbonding_purse),
         U512::zero(),
     );
 
@@ -168,9 +169,9 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
-    assert_eq!(unbond_list[0].origin, default_public_key_arg,);
+    assert_eq!(unbond_list[0].public_key, default_public_key_arg,);
     assert_eq!(
-        builder.get_purse_balance(unbond_list[0].purse),
+        builder.get_purse_balance(unbond_list[0].unbonding_purse),
         U512::zero(),
     );
     assert_eq!(unbond_list[0].amount, unbond_amount,);
@@ -199,9 +200,8 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 0); // removed unbonds
 
-    let bid_purses: BidPurses = builder.get_value(auction, BID_PURSES_KEY);
-
-    assert!(bid_purses.is_empty());
+    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    assert!(bids.is_empty());
 }
 
 #[ignore]
@@ -428,12 +428,11 @@ fn should_run_successful_bond_and_unbond_with_release() {
 
     builder.exec(exec_request_1).expect_success().commit();
 
-    let bid_purses: BidPurses = builder.get_value(auction, BID_PURSES_KEY);
-    let bid_purse = bid_purses
-        .get(&default_public_key_arg)
-        .expect("should have bid purse");
+    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bid = bids.get(&default_public_key_arg).expect("should have bid");
+    let bid_purse = *bid.bonding_purse();
     assert_eq!(
-        builder.get_purse_balance(*bid_purse),
+        builder.get_purse_balance(bid_purse),
         GENESIS_ACCOUNT_STAKE.into()
     );
 
@@ -483,9 +482,9 @@ fn should_run_successful_bond_and_unbond_with_release() {
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
-    assert_eq!(unbond_list[0].origin, default_public_key_arg,);
+    assert_eq!(unbond_list[0].public_key, default_public_key_arg,);
     assert_eq!(
-        builder.get_purse_balance(unbond_list[0].purse),
+        builder.get_purse_balance(unbond_list[0].unbonding_purse),
         U512::zero(),
     );
 
@@ -513,17 +512,8 @@ fn should_run_successful_bond_and_unbond_with_release() {
         .get(&default_public_key_arg)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
-    assert_eq!(unbond_list[0].origin, default_public_key_arg,);
-
-    assert_eq!(unbonding_purse, unbond_list[0].purse);
-    assert_ne!(
-        unbond_list[0].purse,
-        *bid_purse // unbond purse is different than bid purse
-    );
-    assert_eq!(
-        unbond_list[0].purse,
-        unbonding_purse, // unbond purse is not changed
-    );
+    assert_eq!(unbond_list[0].public_key, default_public_key_arg,);
+    assert_eq!(unbond_list[0].unbonding_purse, unbonding_purse,);
     assert_eq!(
         builder.get_purse_balance(unbonding_purse),
         U512::zero(), // Not paid yet
@@ -573,15 +563,13 @@ fn should_run_successful_bond_and_unbond_with_release() {
         "Unbond entry should be removed"
     );
 
-    let bid_purses: BidPurses = builder.get_value(auction, BID_PURSES_KEY);
+    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    assert!(!bids.is_empty());
 
-    assert!(!bid_purses.is_empty());
+    let bid = bids.get(&default_public_key_arg).expect("should have bid");
+    let bid_purse = *bid.bonding_purse();
     assert_eq!(
-        builder.get_purse_balance(
-            *bid_purses
-                .get(&default_public_key_arg)
-                .expect("should have unbond")
-        ),
+        builder.get_purse_balance(bid_purse),
         U512::from(GENESIS_ACCOUNT_STAKE) - unbond_amount, // remaining funds
     );
 }

--- a/grpc/tests/src/test/system_contracts/auction_install.rs
+++ b/grpc/tests/src/test/system_contracts/auction_install.rs
@@ -14,9 +14,9 @@ use casper_types::{
     auction::{
         ARG_AUCTION_DELAY, ARG_GENESIS_VALIDATORS, ARG_LOCKED_FUNDS_PERIOD,
         ARG_MINT_CONTRACT_PACKAGE_HASH, ARG_VALIDATOR_SLOTS, AUCTION_DELAY_KEY, BIDS_KEY,
-        BID_PURSES_KEY, DELEGATOR_REWARD_MAP_KEY, DELEGATOR_REWARD_PURSE_KEY, ERA_ID_KEY,
-        ERA_VALIDATORS_KEY, LOCKED_FUNDS_PERIOD_KEY, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
-        UNBONDING_PURSES_KEY, VALIDATOR_REWARD_MAP_KEY, VALIDATOR_REWARD_PURSE_KEY,
+        DELEGATOR_REWARD_MAP_KEY, DELEGATOR_REWARD_PURSE_KEY, ERA_ID_KEY, ERA_VALIDATORS_KEY,
+        LOCKED_FUNDS_PERIOD_KEY, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_PURSES_KEY,
+        VALIDATOR_REWARD_MAP_KEY, VALIDATOR_REWARD_PURSE_KEY,
     },
     runtime_args, ContractHash, RuntimeArgs, U512,
 };
@@ -28,7 +28,7 @@ const DEPLOY_HASH_2: [u8; 32] = [2u8; 32];
 
 // one named_key for each validator and three for the purses, one for validator slots, one for
 // auction_delay, one for locked_funds_period.
-const EXPECTED_KNOWN_KEYS_LEN: usize = 13;
+const EXPECTED_KNOWN_KEYS_LEN: usize = 12;
 
 #[ignore]
 #[test]
@@ -107,7 +107,6 @@ fn should_run_auction_install_contract() {
     assert!(named_keys.contains_key(LOCKED_FUNDS_PERIOD_KEY));
     assert!(named_keys.contains_key(ERA_ID_KEY));
     assert!(named_keys.contains_key(SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY));
-    assert!(named_keys.contains_key(BID_PURSES_KEY));
     assert!(named_keys.contains_key(UNBONDING_PURSES_KEY));
     assert!(named_keys.contains_key(DELEGATOR_REWARD_PURSE_KEY));
     assert!(named_keys.contains_key(VALIDATOR_REWARD_PURSE_KEY));

--- a/smart_contracts/contracts/system/auction-install/src/main.rs
+++ b/smart_contracts/contracts/system/auction-install/src/main.rs
@@ -10,14 +10,14 @@ use casper_contract::{
 };
 use casper_types::{
     auction::{
-        Bid, BidPurses, Bids, DelegatorRewardMap, EraId, EraValidators, SeigniorageRecipient,
+        Bid, Bids, DelegatorRewardMap, EraId, EraValidators, SeigniorageRecipient,
         SeigniorageRecipients, SeigniorageRecipientsSnapshot, UnbondingPurses, ValidatorRewardMap,
         ValidatorWeights, ARG_AUCTION_DELAY, ARG_GENESIS_VALIDATORS, ARG_LOCKED_FUNDS_PERIOD,
         ARG_MINT_CONTRACT_PACKAGE_HASH, ARG_VALIDATOR_SLOTS, AUCTION_DELAY_KEY, BIDS_KEY,
-        BID_PURSES_KEY, DELEGATOR_REWARD_MAP_KEY, DELEGATOR_REWARD_PURSE_KEY, ERA_ID_KEY,
-        ERA_VALIDATORS_KEY, INITIAL_ERA_ID, LOCKED_FUNDS_PERIOD_KEY,
-        SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_PURSES_KEY, VALIDATOR_REWARD_MAP_KEY,
-        VALIDATOR_REWARD_PURSE_KEY, VALIDATOR_SLOTS_KEY,
+        DELEGATOR_REWARD_MAP_KEY, DELEGATOR_REWARD_PURSE_KEY, ERA_ID_KEY, ERA_VALIDATORS_KEY,
+        INITIAL_ERA_ID, LOCKED_FUNDS_PERIOD_KEY, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
+        UNBONDING_PURSES_KEY, VALIDATOR_REWARD_MAP_KEY, VALIDATOR_REWARD_PURSE_KEY,
+        VALIDATOR_SLOTS_KEY,
     },
     contracts::{NamedKeys, CONTRACT_INITIAL_VERSION},
     runtime_args,
@@ -51,9 +51,6 @@ pub extern "C" fn install() {
         let genesis_validators: BTreeMap<PublicKey, U512> =
             runtime::get_named_arg(ARG_GENESIS_VALIDATORS);
 
-        // Initial bid purses calculated based on founder validator stakes
-        let mut bid_purses = BidPurses::new();
-
         // List of validators for initial era.
         let mut initial_validator_weights = ValidatorWeights::new();
 
@@ -62,7 +59,6 @@ pub extern "C" fn install() {
             let founding_validator = Bid::locked(bonding_purse, amount, locked_funds_period);
             validators.insert(validator_public_key, founding_validator);
             initial_validator_weights.insert(validator_public_key, amount);
-            bid_purses.insert(validator_public_key, bonding_purse);
         }
 
         let auction_delay: u64 = runtime::get_named_arg(ARG_AUCTION_DELAY);
@@ -91,7 +87,6 @@ pub extern "C" fn install() {
             ERA_VALIDATORS_KEY.into(),
             storage::new_uref(era_validators).into(),
         );
-        named_keys.insert(BID_PURSES_KEY.into(), storage::new_uref(bid_purses).into());
         named_keys.insert(
             UNBONDING_PURSES_KEY.into(),
             storage::new_uref(UnbondingPurses::new()).into(),

--- a/smart_contracts/contracts/system/auction/src/lib.rs
+++ b/smart_contracts/contracts/system/auction/src/lib.rs
@@ -95,8 +95,8 @@ impl MintProvider for AuctionContract {
         source: URef,
         target: URef,
         amount: U512,
-    ) -> Result<(), ()> {
-        system::transfer_from_purse_to_purse(source, target, amount).map_err(|_| ())
+    ) -> Result<(), Error> {
+        system::transfer_from_purse_to_purse(source, target, amount).map_err(|_| Error::Transfer)
     }
 
     fn balance(&mut self, purse: URef) -> Option<U512> {

--- a/types/src/auction/constants.rs
+++ b/types/src/auction/constants.rs
@@ -84,8 +84,6 @@ pub const METHOD_WITHDRAW_VALIDATOR_REWARD: &str = "withdraw_validator_reward";
 /// Named constant for method `read_era_id`.
 pub const METHOD_READ_ERA_ID: &str = "read_era_id";
 
-/// Storage for `BidPurses`.
-pub const BID_PURSES_KEY: &str = "bid_purses";
 /// Storage for `UnbondingPurses`
 pub const UNBONDING_PURSES_KEY: &str = "unbonding_purses";
 /// Storage for `Bids`.

--- a/types/src/auction/delegator.rs
+++ b/types/src/auction/delegator.rs
@@ -31,6 +31,11 @@ impl Delegator {
         &self.staked_amount
     }
 
+    /// Returns the bonding purse
+    pub fn bonding_purse(&self) -> &URef {
+        &self.bonding_purse
+    }
+
     /// Decreases the stake of the provided bid
     pub fn decrease_stake(&mut self, amount: U512) -> Result<U512, Error> {
         let updated_staked_amount = self

--- a/types/src/auction/detail.rs
+++ b/types/src/auction/detail.rs
@@ -5,13 +5,13 @@ use num_rational::Ratio;
 
 use crate::{
     auction::{
-        constants::*, Auction, BidPurses, Bids, DelegatorRewardMap, EraId, EraValidators,
-        MintProvider, RuntimeProvider, SeigniorageRecipientsSnapshot, StorageProvider,
-        SystemProvider, UnbondingPurse, UnbondingPurses, ValidatorRewardMap,
+        constants::*, Auction, Bids, DelegatorRewardMap, EraId, EraValidators, MintProvider,
+        RuntimeProvider, SeigniorageRecipientsSnapshot, StorageProvider, SystemProvider,
+        UnbondingPurse, UnbondingPurses, ValidatorRewardMap,
     },
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::auction::{Error, Result},
-    CLTyped, Key, PublicKey, URef, U512,
+    CLTyped, PublicKey, URef, U512,
 };
 
 fn read_from<P, T>(provider: &mut P, name: &str) -> Result<T>
@@ -48,6 +48,20 @@ where
     P: StorageProvider + RuntimeProvider + ?Sized,
 {
     write_to(provider, BIDS_KEY, validators)
+}
+
+pub fn get_unbonding_purses<P>(provider: &mut P) -> Result<UnbondingPurses>
+where
+    P: StorageProvider + RuntimeProvider + ?Sized,
+{
+    Ok(read_from(provider, UNBONDING_PURSES_KEY)?)
+}
+
+pub fn set_unbonding_purses<P>(provider: &mut P, unbonding_purses: UnbondingPurses) -> Result<()>
+where
+    P: StorageProvider + RuntimeProvider + ?Sized,
+{
+    write_to(provider, UNBONDING_PURSES_KEY, unbonding_purses)
 }
 
 pub fn get_delegator_reward_map<P>(provider: &mut P) -> Result<DelegatorRewardMap>
@@ -158,38 +172,23 @@ pub(crate) fn process_unbond_requests<P: Auction + ?Sized>(provider: &mut P) -> 
     if provider.get_caller() != SYSTEM_ACCOUNT {
         return Err(Error::InvalidCaller);
     }
-    let bid_purses_uref = provider
-        .get_key(BID_PURSES_KEY)
-        .and_then(Key::into_uref)
-        .ok_or(Error::MissingKey)?;
-
-    let bid_purses: BidPurses = provider.read(bid_purses_uref)?.ok_or(Error::Storage)?;
 
     // Update `unbonding_purses` data
-    let unbonding_purses_uref = provider
-        .get_key(UNBONDING_PURSES_KEY)
-        .and_then(Key::into_uref)
-        .ok_or(Error::MissingKey)?;
-    let mut unbonding_purses: UnbondingPurses = provider
-        .read(unbonding_purses_uref)?
-        .ok_or(Error::Storage)?;
+    let mut unbonding_purses: UnbondingPurses = get_unbonding_purses(provider)?;
 
     let current_era_id = provider.read_era_id()?;
 
     for unbonding_list in unbonding_purses.values_mut() {
         let mut new_unbonding_list = Vec::new();
         for unbonding_purse in unbonding_list.iter() {
-            let source = bid_purses
-                .get(&unbonding_purse.origin)
-                .ok_or(Error::BondNotFound)?;
             // Since `process_unbond_requests` is run before `run_auction`, we should check
             // if current era id is equal or greater than the `era_of_withdrawal` that was
             // calculated on `unbond` attempt.
             if current_era_id >= unbonding_purse.era_of_withdrawal as u64 {
                 // Move funds from bid purse to unbonding purse
                 provider.transfer_from_purse_to_purse(
-                    *source,
-                    unbonding_purse.purse,
+                    unbonding_purse.bonding_purse,
+                    unbonding_purse.unbonding_purse,
                     unbonding_purse.amount,
                 )?;
             } else {
@@ -200,101 +199,46 @@ pub(crate) fn process_unbond_requests<P: Auction + ?Sized>(provider: &mut P) -> 
     }
 
     // Prune empty entries
-    let new_unbonding_purses: UnbondingPurses = unbonding_purses
+    let unbonding_purses = unbonding_purses
         .into_iter()
         .filter(|(_k, unbonding_purses)| !unbonding_purses.is_empty())
         .collect();
 
-    provider.write(unbonding_purses_uref, new_unbonding_purses)?;
+    set_unbonding_purses(provider, unbonding_purses)?;
     Ok(())
-}
-
-/// Creates a new purse in bid_purses corresponding to a validator's key, or tops off an
-/// existing one.
-///
-/// Returns the bid purse's key and current amount of motes.
-pub(crate) fn bond<P: Auction + ?Sized>(
-    provider: &mut P,
-    public_key: PublicKey,
-    source: URef,
-    amount: U512,
-) -> Result<(URef, U512)> {
-    if amount.is_zero() {
-        return Err(Error::BondTooSmall);
-    }
-
-    let bid_purses_uref = provider
-        .get_key(BID_PURSES_KEY)
-        .and_then(Key::into_uref)
-        .ok_or(Error::MissingKey)?;
-
-    let mut bid_purses: BidPurses = provider.read(bid_purses_uref)?.ok_or(Error::Storage)?;
-
-    let target = match bid_purses.get(&public_key) {
-        Some(purse) => *purse,
-        None => {
-            let new_purse = provider.create_purse();
-            bid_purses.insert(public_key, new_purse);
-            provider.write(bid_purses_uref, bid_purses)?;
-            new_purse
-        }
-    };
-
-    provider.transfer_from_purse_to_purse(source, target, amount)?;
-
-    let total_amount = provider.get_balance(target)?.unwrap();
-
-    Ok((target, total_amount))
 }
 
 /// Creates a new purse in unbonding_purses given a validator's key, amount, and a destination
 /// unbonding purse. Returns the amount of motes remaining in the validator's bid purse.
-pub(crate) fn unbond<P: Auction + ?Sized>(
+pub(crate) fn create_unbonding_purse<P: Auction + ?Sized>(
     provider: &mut P,
     public_key: PublicKey,
+    bonding_purse: URef,
+    unbonding_purse: URef,
     amount: U512,
-    unbond_purse: URef,
 ) -> Result<U512> {
-    let bid_purses_uref = provider
-        .get_key(BID_PURSES_KEY)
-        .and_then(Key::into_uref)
-        .ok_or(Error::MissingKey)?;
-
-    let bid_purses: BidPurses = provider.read(bid_purses_uref)?.ok_or(Error::Storage)?;
-
-    let bid_purse = bid_purses
-        .get(&public_key)
-        .copied()
-        .ok_or(Error::BondNotFound)?;
-
-    if provider.get_balance(bid_purse)?.unwrap_or_default() < amount {
+    if provider.get_balance(bonding_purse)?.unwrap_or_default() < amount {
         return Err(Error::UnbondTooLarge);
     }
 
-    // Update `unbonding_purses` data
-    let unbonding_purses_uref = provider
-        .get_key(UNBONDING_PURSES_KEY)
-        .and_then(Key::into_uref)
-        .ok_or(Error::MissingKey)?;
-    let mut unbonding_purses: UnbondingPurses = provider
-        .read(unbonding_purses_uref)?
-        .ok_or(Error::Storage)?;
-
-    let current_era_id = provider.read_era_id()?;
+    let mut unbonding_purses: UnbondingPurses = get_unbonding_purses(provider)?;
+    let era_of_withdrawal = provider.read_era_id()? + DEFAULT_UNBONDING_DELAY;
     let new_unbonding_purse = UnbondingPurse {
-        purse: unbond_purse,
-        origin: public_key,
-        era_of_withdrawal: current_era_id + DEFAULT_UNBONDING_DELAY,
+        bonding_purse,
+        unbonding_purse,
+        public_key,
+        era_of_withdrawal,
         amount,
     };
     unbonding_purses
         .entry(public_key)
         .or_default()
         .push(new_unbonding_purse);
-    provider.write(unbonding_purses_uref, unbonding_purses)?;
+    set_unbonding_purses(provider, unbonding_purses)?;
 
     // Remaining motes in the validator's bid purse
-    let remaining_bond = provider.get_balance(bid_purse)?.unwrap_or_default();
+    let remaining_bond = provider.get_balance(bonding_purse)?.unwrap_or_default();
+
     Ok(remaining_bond)
 }
 

--- a/types/src/auction/providers.rs
+++ b/types/src/auction/providers.rs
@@ -62,7 +62,7 @@ pub trait MintProvider {
         source: URef,
         target: URef,
         amount: U512,
-    ) -> Result<(), ()>;
+    ) -> Result<(), Error>;
 
     /// Checks balance of a `purse`. Returns `None` if given purse does not exist.
     fn balance(&mut self, purse: URef) -> Option<U512>;

--- a/types/src/auction/types.rs
+++ b/types/src/auction/types.rs
@@ -2,7 +2,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 
 use crate::{
     auction::{Bid, SeigniorageRecipient, UnbondingPurse},
-    PublicKey, URef, U512,
+    PublicKey, U512,
 };
 
 /// Representation of delegation rate of tokens. Fraction of 1 in trillionths (12 decimal places).
@@ -16,11 +16,6 @@ pub type ValidatorRewardMap = BTreeMap<PublicKey, U512>;
 
 /// Validators mapped to their bids.
 pub type Bids = BTreeMap<PublicKey, Bid>;
-
-/// Bidders mapped to their bidding purses and tokens contained therein. Delegators' tokens
-/// are kept in the validator bid purses, available for withdrawal up to the delegated number
-/// of tokens. Withdrawal moves the tokens to a delegator-controlled unbonding purse.
-pub type BidPurses = BTreeMap<PublicKey, URef>;
 
 /// Weights of validators. "Weight" in this context means a sum of their stakes.
 pub type ValidatorWeights = BTreeMap<PublicKey, U512>;

--- a/types/src/auction/unbonding_purse.rs
+++ b/types/src/auction/unbonding_purse.rs
@@ -9,10 +9,12 @@ use crate::{
 #[cfg_attr(test, derive(Debug))]
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct UnbondingPurse {
+    /// Bonding Purse
+    pub bonding_purse: URef,
     /// Unbonding Purse.
-    pub purse: URef,
+    pub unbonding_purse: URef,
     /// Unbonding Origin.
-    pub origin: PublicKey,
+    pub public_key: PublicKey,
     /// Unbonding Era.
     pub era_of_withdrawal: u64,
     /// Unbonding Amount.
@@ -22,15 +24,17 @@ pub struct UnbondingPurse {
 impl ToBytes for UnbondingPurse {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut result = bytesrepr::allocate_buffer(self)?;
-        result.extend(&self.purse.to_bytes()?);
-        result.extend(&self.origin.to_bytes()?);
+        result.extend(&self.bonding_purse.to_bytes()?);
+        result.extend(&self.unbonding_purse.to_bytes()?);
+        result.extend(&self.public_key.to_bytes()?);
         result.extend(&self.era_of_withdrawal.to_bytes()?);
         result.extend(&self.amount.to_bytes()?);
         Ok(result)
     }
     fn serialized_length(&self) -> usize {
-        self.purse.serialized_length()
-            + self.origin.serialized_length()
+        self.bonding_purse.serialized_length()
+            + self.unbonding_purse.serialized_length()
+            + self.public_key.serialized_length()
             + self.era_of_withdrawal.serialized_length()
             + self.amount.serialized_length()
     }
@@ -38,14 +42,16 @@ impl ToBytes for UnbondingPurse {
 
 impl FromBytes for UnbondingPurse {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (purse, bytes) = FromBytes::from_bytes(bytes)?;
-        let (origin, bytes) = FromBytes::from_bytes(bytes)?;
+        let (bonding_purse, bytes) = FromBytes::from_bytes(bytes)?;
+        let (unbonding_purse, bytes) = FromBytes::from_bytes(bytes)?;
+        let (public_key, bytes) = FromBytes::from_bytes(bytes)?;
         let (era_of_withdrawal, bytes) = FromBytes::from_bytes(bytes)?;
         let (amount, bytes) = FromBytes::from_bytes(bytes)?;
         Ok((
             UnbondingPurse {
-                purse,
-                origin,
+                bonding_purse,
+                unbonding_purse,
+                public_key,
                 era_of_withdrawal,
                 amount,
             },
@@ -62,15 +68,14 @@ impl CLTyped for UnbondingPurse {
 
 #[cfg(test)]
 mod tests {
-    use super::UnbondingPurse;
-    use crate::{bytesrepr, AccessRights, PublicKey, URef, U512};
+    use crate::{auction::UnbondingPurse, bytesrepr, AccessRights, PublicKey, URef, U512};
 
     #[test]
     fn serialization_roundtrip() {
-        let public_key = PublicKey::Ed25519([42; 32]);
         let unbonding_purse = UnbondingPurse {
-            purse: URef::new([42; 32], AccessRights::READ_ADD_WRITE),
-            origin: public_key,
+            bonding_purse: URef::new([41; 32], AccessRights::READ_ADD_WRITE),
+            unbonding_purse: URef::new([42; 32], AccessRights::READ_ADD_WRITE),
+            public_key: PublicKey::Ed25519([42; 32]),
             era_of_withdrawal: u64::max_value(),
             amount: U512::max_value() - 1,
         };


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1106

This PR follows #524, removing the needless `BidPurses` map.