### PR TITLE
EE-{1107,1108}: clean up Auction::run_auction, remove EraValidators map

### DIFF
--- a/grpc/test_support/src/internal/wasm_test_builder.rs
+++ b/grpc/test_support/src/internal/wasm_test_builder.rs
@@ -50,7 +50,9 @@ use casper_execution_engine::{
 };
 use casper_types::{
     account::AccountHash,
-    auction::{EraId, ValidatorWeights, AUCTION_DELAY_KEY, ERA_ID_KEY, METHOD_RUN_AUCTION},
+    auction::{
+        EraId, EraValidators, ValidatorWeights, AUCTION_DELAY_KEY, ERA_ID_KEY, METHOD_RUN_AUCTION,
+    },
     bytesrepr::{self},
     mint::TOTAL_SUPPLY_KEY,
     runtime_args, CLTyped, CLValue, Contract, ContractHash, ContractWasm, DeployHash, DeployInfo,
@@ -822,15 +824,18 @@ where
             .finish()
     }
 
-    pub fn get_validator_weights(&mut self, era_id: EraId) -> Option<ValidatorWeights> {
+    pub fn get_era_validators(&mut self) -> EraValidators {
         let correlation_id = CorrelationId::new();
         let state_hash = Blake2bHash::try_from(self.get_post_state_hash().as_slice())
             .expect("should create state hash");
         let request = GetEraValidatorsRequest::new(state_hash, *DEFAULT_PROTOCOL_VERSION);
-        let mut result = self
-            .engine_state
+        self.engine_state
             .get_era_validators(correlation_id, request)
-            .expect("get era validators should not error");
+            .expect("get era validators should not error")
+    }
+
+    pub fn get_validator_weights(&mut self, era_id: EraId) -> Option<ValidatorWeights> {
+        let mut result = self.get_era_validators();
         result.remove(&era_id)
     }
 

--- a/grpc/tests/src/test/system_contracts/auction/bids.rs
+++ b/grpc/tests/src/test/system_contracts/auction/bids.rs
@@ -17,7 +17,7 @@ use casper_types::{
         Bids, DelegationRate, EraId, EraValidators, SeigniorageRecipients, UnbondingPurses,
         ValidatorWeights, ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_PUBLIC_KEY,
         ARG_UNBOND_PURSE, ARG_VALIDATOR, BIDS_KEY, DEFAULT_UNBONDING_DELAY, ERA_ID_KEY,
-        ERA_VALIDATORS_KEY, INITIAL_ERA_ID, METHOD_RUN_AUCTION, UNBONDING_PURSES_KEY,
+        INITIAL_ERA_ID, METHOD_RUN_AUCTION, UNBONDING_PURSES_KEY,
     },
     runtime_args, PublicKey, RuntimeArgs, URef, U512,
 };
@@ -473,7 +473,7 @@ fn should_calculate_era_validators() {
     let post_era_id: EraId = builder.get_value(auction_hash, ERA_ID_KEY);
     assert_eq!(post_era_id, 1);
 
-    let era_validators: EraValidators = builder.get_value(auction_hash, "era_validators");
+    let era_validators: EraValidators = builder.get_era_validators();
 
     // Check if there are no missing eras after the calculation, but we don't care about what the
     // elements are
@@ -626,7 +626,7 @@ fn should_get_first_seigniorage_recipients() {
         .unwrap();
     assert_eq!(seigniorage_recipients.len(), 2);
 
-    let mut era_validators: EraValidators = builder.get_value(auction_hash, "era_validators");
+    let mut era_validators: EraValidators = builder.get_era_validators();
     let snapshot_size = DEFAULT_AUCTION_DELAY as usize + 1;
 
     assert_eq!(era_validators.len(), snapshot_size, "{:?}", era_validators); // eraindex==1 - ran once
@@ -974,8 +974,7 @@ fn should_use_era_validators_endpoint_for_first_era() {
     assert_eq!(validator_weights.len(), 1);
     assert_eq!(validator_weights[&ACCOUNT_1_PK], ACCOUNT_1_BOND.into());
 
-    let era_validators: EraValidators =
-        builder.get_value(builder.get_auction_contract_hash(), ERA_VALIDATORS_KEY);
+    let era_validators: EraValidators = builder.get_era_validators();
     assert_eq!(era_validators[&0], validator_weights);
 }
 

--- a/grpc/tests/src/test/system_contracts/auction_install.rs
+++ b/grpc/tests/src/test/system_contracts/auction_install.rs
@@ -14,9 +14,9 @@ use casper_types::{
     auction::{
         ARG_AUCTION_DELAY, ARG_GENESIS_VALIDATORS, ARG_LOCKED_FUNDS_PERIOD,
         ARG_MINT_CONTRACT_PACKAGE_HASH, ARG_VALIDATOR_SLOTS, AUCTION_DELAY_KEY, BIDS_KEY,
-        DELEGATOR_REWARD_MAP_KEY, DELEGATOR_REWARD_PURSE_KEY, ERA_ID_KEY, ERA_VALIDATORS_KEY,
-        LOCKED_FUNDS_PERIOD_KEY, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_PURSES_KEY,
-        VALIDATOR_REWARD_MAP_KEY, VALIDATOR_REWARD_PURSE_KEY,
+        DELEGATOR_REWARD_MAP_KEY, DELEGATOR_REWARD_PURSE_KEY, ERA_ID_KEY, LOCKED_FUNDS_PERIOD_KEY,
+        SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_PURSES_KEY, VALIDATOR_REWARD_MAP_KEY,
+        VALIDATOR_REWARD_PURSE_KEY,
     },
     runtime_args, ContractHash, RuntimeArgs, U512,
 };
@@ -28,7 +28,7 @@ const DEPLOY_HASH_2: [u8; 32] = [2u8; 32];
 
 // one named_key for each validator and three for the purses, one for validator slots, one for
 // auction_delay, one for locked_funds_period.
-const EXPECTED_KNOWN_KEYS_LEN: usize = 12;
+const EXPECTED_KNOWN_KEYS_LEN: usize = 11;
 
 #[ignore]
 #[test]
@@ -102,7 +102,6 @@ fn should_run_auction_install_contract() {
     assert_eq!(named_keys.len(), EXPECTED_KNOWN_KEYS_LEN);
 
     assert!(named_keys.contains_key(BIDS_KEY));
-    assert!(named_keys.contains_key(ERA_VALIDATORS_KEY));
     assert!(named_keys.contains_key(AUCTION_DELAY_KEY));
     assert!(named_keys.contains_key(LOCKED_FUNDS_PERIOD_KEY));
     assert!(named_keys.contains_key(ERA_ID_KEY));

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -90,7 +90,10 @@ use casper_execution_engine::{
     shared::{additive_map::AdditiveMap, transform::Transform},
     storage::{global_state::CommitResult, protocol_data::ProtocolData},
 };
-use casper_types::{auction::ValidatorWeights, Key, ProtocolVersion};
+use casper_types::{
+    auction::{EraValidators, ValidatorWeights},
+    Key, ProtocolVersion,
+};
 
 use crate::{
     components::{
@@ -115,7 +118,6 @@ use announcements::{
     BlockExecutorAnnouncement, ConsensusAnnouncement, DeployAcceptorAnnouncement,
     GossiperAnnouncement, LinearChainAnnouncement, NetworkAnnouncement, RpcServerAnnouncement,
 };
-use casper_types::auction::EraValidators;
 use requests::{
     BlockExecutorRequest, BlockProposerRequest, BlockValidationRequest, ChainspecLoaderRequest,
     ConsensusRequest, ContractRuntimeRequest, FetcherRequest, MetricsRequest, NetworkInfoRequest,

--- a/smart_contracts/contracts/system/auction-install/src/main.rs
+++ b/smart_contracts/contracts/system/auction-install/src/main.rs
@@ -10,14 +10,13 @@ use casper_contract::{
 };
 use casper_types::{
     auction::{
-        Bid, Bids, DelegatorRewardMap, EraId, EraValidators, SeigniorageRecipient,
-        SeigniorageRecipients, SeigniorageRecipientsSnapshot, UnbondingPurses, ValidatorRewardMap,
-        ValidatorWeights, ARG_AUCTION_DELAY, ARG_GENESIS_VALIDATORS, ARG_LOCKED_FUNDS_PERIOD,
+        Bid, Bids, DelegatorRewardMap, EraId, SeigniorageRecipient, SeigniorageRecipients,
+        SeigniorageRecipientsSnapshot, UnbondingPurses, ValidatorRewardMap, ValidatorWeights,
+        ARG_AUCTION_DELAY, ARG_GENESIS_VALIDATORS, ARG_LOCKED_FUNDS_PERIOD,
         ARG_MINT_CONTRACT_PACKAGE_HASH, ARG_VALIDATOR_SLOTS, AUCTION_DELAY_KEY, BIDS_KEY,
-        DELEGATOR_REWARD_MAP_KEY, DELEGATOR_REWARD_PURSE_KEY, ERA_ID_KEY, ERA_VALIDATORS_KEY,
-        INITIAL_ERA_ID, LOCKED_FUNDS_PERIOD_KEY, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
-        UNBONDING_PURSES_KEY, VALIDATOR_REWARD_MAP_KEY, VALIDATOR_REWARD_PURSE_KEY,
-        VALIDATOR_SLOTS_KEY,
+        DELEGATOR_REWARD_MAP_KEY, DELEGATOR_REWARD_PURSE_KEY, ERA_ID_KEY, INITIAL_ERA_ID,
+        LOCKED_FUNDS_PERIOD_KEY, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_PURSES_KEY,
+        VALIDATOR_REWARD_MAP_KEY, VALIDATOR_REWARD_PURSE_KEY, VALIDATOR_SLOTS_KEY,
     },
     contracts::{NamedKeys, CONTRACT_INITIAL_VERSION},
     runtime_args,
@@ -67,11 +66,6 @@ pub extern "C" fn install() {
         // Starting era validators
         named_keys.insert(ERA_ID_KEY.into(), storage::new_uref(INITIAL_ERA_ID).into());
 
-        let mut era_validators = EraValidators::new();
-        for era_index in initial_snapshot_range.clone() {
-            era_validators.insert(era_index, initial_validator_weights.clone());
-        }
-
         let seigniorage_recipients = compute_seigniorage_recipients(&validators);
 
         let mut initial_seigniorage_recipients = SeigniorageRecipientsSnapshot::new();
@@ -83,10 +77,6 @@ pub extern "C" fn install() {
             storage::new_uref(initial_seigniorage_recipients).into(),
         );
         named_keys.insert(BIDS_KEY.into(), storage::new_uref(validators).into());
-        named_keys.insert(
-            ERA_VALIDATORS_KEY.into(),
-            storage::new_uref(era_validators).into(),
-        );
         named_keys.insert(
             UNBONDING_PURSES_KEY.into(),
             storage::new_uref(UnbondingPurses::new()).into(),

--- a/types/src/auction/constants.rs
+++ b/types/src/auction/constants.rs
@@ -88,8 +88,6 @@ pub const METHOD_READ_ERA_ID: &str = "read_era_id";
 pub const UNBONDING_PURSES_KEY: &str = "unbonding_purses";
 /// Storage for `Bids`.
 pub const BIDS_KEY: &str = "bids";
-/// Storage for `EraValidators`.
-pub const ERA_VALIDATORS_KEY: &str = "era_validators";
 /// Storage for `EraId`.
 pub const ERA_ID_KEY: &str = "era_id";
 /// Storage for `SeigniorageRecipientsSnapshot`.

--- a/types/src/auction/detail.rs
+++ b/types/src/auction/detail.rs
@@ -5,9 +5,9 @@ use num_rational::Ratio;
 
 use crate::{
     auction::{
-        constants::*, Auction, Bids, DelegatorRewardMap, EraId, EraValidators, MintProvider,
-        RuntimeProvider, SeigniorageRecipientsSnapshot, StorageProvider, SystemProvider,
-        UnbondingPurse, UnbondingPurses, ValidatorRewardMap,
+        constants::*, Auction, Bids, DelegatorRewardMap, EraId, MintProvider, RuntimeProvider,
+        SeigniorageRecipientsSnapshot, StorageProvider, SystemProvider, UnbondingPurse,
+        UnbondingPurses, ValidatorRewardMap,
     },
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::auction::{Error, Result},
@@ -96,20 +96,6 @@ where
     P: StorageProvider + RuntimeProvider + ?Sized,
 {
     write_to(provider, VALIDATOR_REWARD_MAP_KEY, validator_reward_map)
-}
-
-pub fn get_era_validators<P>(provider: &mut P) -> Result<EraValidators>
-where
-    P: StorageProvider + RuntimeProvider + ?Sized,
-{
-    Ok(read_from(provider, ERA_VALIDATORS_KEY)?)
-}
-
-pub fn set_era_validators<P>(provider: &mut P, era_validators: EraValidators) -> Result<()>
-where
-    P: StorageProvider + RuntimeProvider + ?Sized,
-{
-    write_to(provider, ERA_VALIDATORS_KEY, era_validators)
 }
 
 pub fn get_era_id<P>(provider: &mut P) -> Result<EraId>

--- a/types/src/auction/seigniorage_recipient.rs
+++ b/types/src/auction/seigniorage_recipient.rs
@@ -11,14 +11,29 @@ use crate::{
 #[derive(Default, PartialEq, Clone)]
 pub struct SeigniorageRecipient {
     /// Validator stake (not including delegators)
-    pub stake: U512,
+    stake: U512,
     /// Delegation rate of a seigniorage recipient.
-    pub delegation_rate: DelegationRate,
+    delegation_rate: DelegationRate,
     /// List of delegators and their accumulated bids.
-    pub delegators: BTreeMap<PublicKey, Delegator>,
+    delegators: BTreeMap<PublicKey, Delegator>,
 }
 
 impl SeigniorageRecipient {
+    /// Returns stake of the provided recipient
+    pub fn stake(&self) -> &U512 {
+        &self.stake
+    }
+
+    /// Returns delegation rate of the provided recipient
+    pub fn delegation_rate(&self) -> &DelegationRate {
+        &self.delegation_rate
+    }
+
+    /// Returns delegators of the provided recipient
+    pub fn delegators(&self) -> &BTreeMap<PublicKey, Delegator> {
+        &self.delegators
+    }
+
     /// Calculates total stake, including delegators' total stake
     pub fn total_stake(&self) -> U512 {
         self.stake + self.delegator_total_stake()
@@ -73,11 +88,11 @@ impl FromBytes for SeigniorageRecipient {
 }
 
 impl From<&Bid> for SeigniorageRecipient {
-    fn from(founding_validator: &Bid) -> Self {
+    fn from(bid: &Bid) -> Self {
         Self {
-            stake: *founding_validator.staked_amount(),
-            delegation_rate: *founding_validator.delegation_rate(),
-            ..Default::default()
+            stake: *bid.staked_amount(),
+            delegation_rate: *bid.delegation_rate(),
+            delegators: bid.delegators().clone(),
         }
     }
 }


### PR DESCRIPTION
Ref: 
https://casperlabs.atlassian.net/browse/EE-1107
https://casperlabs.atlassian.net/browse/EE-1108

This PR:
- cleans up `Auction::run_auction`
- removes the `EraValidators` map stored at `ERA_VALIDATORS_KEY`.

**IMPORTANT**:

~~This PR depends on #530.  Please review the diff here: https://github.com/henrytill/casper-node/compare/EE-1106...henrytill:EE-1107+1108~~