### PR TITLE
EE-1071: Added regression test for the issue.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,6 +1740,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ee-1071-regression"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "ee-221-regression"
 version = "0.1.0"
 dependencies = [

--- a/execution_engine/src/core/resolvers/v1_resolver.rs
+++ b/execution_engine/src/core/resolvers/v1_resolver.rs
@@ -40,47 +40,47 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
         _signature: &Signature,
     ) -> Result<FuncRef, InterpreterError> {
         let func_ref = match field_name {
-            "read_value" => FuncInstance::alloc_host(
+            "casper_read_value" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::ReadFuncIndex.into(),
             ),
-            "read_value_local" => FuncInstance::alloc_host(
+            "casper_read_value_local" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::ReadLocalFuncIndex.into(),
             ),
-            "load_named_keys" => FuncInstance::alloc_host(
+            "casper_load_named_keys" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::LoadNamedKeysFuncIndex.into(),
             ),
-            "write" => FuncInstance::alloc_host(
+            "casper_write" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], None),
                 FunctionIndex::WriteFuncIndex.into(),
             ),
-            "write_local" => FuncInstance::alloc_host(
+            "casper_write_local" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], None),
                 FunctionIndex::WriteLocalFuncIndex.into(),
             ),
-            "add" => FuncInstance::alloc_host(
+            "casper_add" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], None),
                 FunctionIndex::AddFuncIndex.into(),
             ),
-            "new_uref" => FuncInstance::alloc_host(
+            "casper_new_uref" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 3][..], None),
                 FunctionIndex::NewFuncIndex.into(),
             ),
-            "ret" => FuncInstance::alloc_host(
+            "casper_ret" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], None),
                 FunctionIndex::RetFuncIndex.into(),
             ),
-            "get_key" => FuncInstance::alloc_host(
+            "casper_get_key" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 5][..], Some(ValueType::I32)),
                 FunctionIndex::GetKeyFuncIndex.into(),
             ),
-            "has_key" => FuncInstance::alloc_host(
+            "casper_has_key" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::HasKeyFuncIndex.into(),
             ),
-            "put_key" => FuncInstance::alloc_host(
+            "casper_put_key" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], None),
                 FunctionIndex::PutKeyFuncIndex.into(),
             ),
@@ -88,132 +88,132 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 1][..], None),
                 FunctionIndex::GasFuncIndex.into(),
             ),
-            "is_valid_uref" => FuncInstance::alloc_host(
+            "casper_is_valid_uref" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::IsValidURefFnIndex.into(),
             ),
-            "revert" => FuncInstance::alloc_host(
+            "casper_revert" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 1][..], None),
                 FunctionIndex::RevertFuncIndex.into(),
             ),
-            "add_associated_key" => FuncInstance::alloc_host(
+            "casper_add_associated_key" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::AddAssociatedKeyFuncIndex.into(),
             ),
-            "remove_associated_key" => FuncInstance::alloc_host(
+            "casper_remove_associated_key" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::RemoveAssociatedKeyFuncIndex.into(),
             ),
-            "update_associated_key" => FuncInstance::alloc_host(
+            "casper_update_associated_key" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::UpdateAssociatedKeyFuncIndex.into(),
             ),
-            "set_action_threshold" => FuncInstance::alloc_host(
+            "casper_set_action_threshold" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::SetActionThresholdFuncIndex.into(),
             ),
-            "remove_key" => FuncInstance::alloc_host(
+            "casper_remove_key" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], None),
                 FunctionIndex::RemoveKeyFuncIndex.into(),
             ),
-            "get_caller" => FuncInstance::alloc_host(
+            "casper_get_caller" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 1][..], Some(ValueType::I32)),
                 FunctionIndex::GetCallerIndex.into(),
             ),
-            "get_blocktime" => FuncInstance::alloc_host(
+            "casper_get_blocktime" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 1][..], None),
                 FunctionIndex::GetBlocktimeIndex.into(),
             ),
-            "create_purse" => FuncInstance::alloc_host(
+            "casper_create_purse" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::CreatePurseIndex.into(),
             ),
-            "transfer_to_account" => FuncInstance::alloc_host(
+            "casper_transfer_to_account" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::TransferToAccountIndex.into(),
             ),
-            "transfer_from_purse_to_account" => FuncInstance::alloc_host(
+            "casper_transfer_from_purse_to_account" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 6][..], Some(ValueType::I32)),
                 FunctionIndex::TransferFromPurseToAccountIndex.into(),
             ),
-            "transfer_from_purse_to_purse" => FuncInstance::alloc_host(
+            "casper_transfer_from_purse_to_purse" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 6][..], Some(ValueType::I32)),
                 FunctionIndex::TransferFromPurseToPurseIndex.into(),
             ),
-            "get_balance" => FuncInstance::alloc_host(
+            "casper_get_balance" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::GetBalanceIndex.into(),
             ),
-            "get_phase" => FuncInstance::alloc_host(
+            "casper_get_phase" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 1][..], None),
                 FunctionIndex::GetPhaseIndex.into(),
             ),
-            "get_system_contract" => FuncInstance::alloc_host(
+            "casper_get_system_contract" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::GetSystemContractIndex.into(),
             ),
-            "get_main_purse" => FuncInstance::alloc_host(
+            "casper_get_main_purse" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 1][..], None),
                 FunctionIndex::GetMainPurseIndex.into(),
             ),
-            "read_host_buffer" => FuncInstance::alloc_host(
+            "casper_read_host_buffer" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::ReadHostBufferIndex.into(),
             ),
-            "create_contract_package_at_hash" => FuncInstance::alloc_host(
+            "casper_create_contract_package_at_hash" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], None),
                 FunctionIndex::CreateContractPackageAtHash.into(),
             ),
-            "create_contract_user_group" => FuncInstance::alloc_host(
+            "casper_create_contract_user_group" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 8][..], Some(ValueType::I32)),
                 FunctionIndex::CreateContractUserGroup.into(),
             ),
-            "add_contract_version" => FuncInstance::alloc_host(
+            "casper_add_contract_version" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 10][..], Some(ValueType::I32)),
                 FunctionIndex::AddContractVersion.into(),
             ),
-            "disable_contract_version" => FuncInstance::alloc_host(
+            "casper_disable_contract_version" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::DisableContractVersion.into(),
             ),
-            "call_contract" => FuncInstance::alloc_host(
+            "casper_call_contract" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 7][..], Some(ValueType::I32)),
                 FunctionIndex::CallContractFuncIndex.into(),
             ),
-            "call_versioned_contract" => FuncInstance::alloc_host(
+            "casper_call_versioned_contract" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 9][..], Some(ValueType::I32)),
                 FunctionIndex::CallVersionedContract.into(),
             ),
-            "get_named_arg_size" => FuncInstance::alloc_host(
+            "casper_get_named_arg_size" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::GetRuntimeArgsizeIndex.into(),
             ),
-            "get_named_arg" => FuncInstance::alloc_host(
+            "casper_get_named_arg" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::GetRuntimeArgIndex.into(),
             ),
-            "remove_contract_user_group" => FuncInstance::alloc_host(
+            "casper_remove_contract_user_group" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::RemoveContractUserGroupIndex.into(),
             ),
-            "provision_contract_user_group_uref" => FuncInstance::alloc_host(
+            "casper_provision_contract_user_group_uref" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 5][..], Some(ValueType::I32)),
                 FunctionIndex::ExtendContractUserGroupURefsIndex.into(),
             ),
-            "remove_contract_user_group_urefs" => FuncInstance::alloc_host(
+            "casper_remove_contract_user_group_urefs" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 6][..], Some(ValueType::I32)),
                 FunctionIndex::RemoveContractUserGroupURefsIndex.into(),
             ),
-            "blake2b" => FuncInstance::alloc_host(
+            "casper_blake2b" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::Blake2b.into(),
             ),
-            "record_transfer" => FuncInstance::alloc_host(
+            "casper_record_transfer" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 6][..], Some(ValueType::I32)),
                 FunctionIndex::RecordTransfer.into(),
             ),
             #[cfg(feature = "test-support")]
-            "print" => FuncInstance::alloc_host(
+            "casper_print" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], None),
                 FunctionIndex::PrintIndex.into(),
             ),

--- a/grpc/tests/src/test/regression/ee_1071.rs
+++ b/grpc/tests/src/test/regression/ee_1071.rs
@@ -1,0 +1,60 @@
+use casper_engine_test_support::{
+    internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
+    DEFAULT_ACCOUNT_ADDR,
+};
+use casper_types::RuntimeArgs;
+
+const CONTRACT_EE_1071_REGRESSION: &str = "ee_1071_regression.wasm";
+const CONTRACT_HASH_NAME: &str = "contract";
+const NEW_UREF_ENTRYPOINT: &str = "new_uref";
+
+#[ignore]
+#[test]
+fn should_run_ee_1071_regression() {
+    let exec_request_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_EE_1071_REGRESSION,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+
+    let account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+
+    let contract_hash = account
+        .named_keys()
+        .get(CONTRACT_HASH_NAME)
+        .expect("should have hash")
+        .clone()
+        .into_hash()
+        .expect("should be hash");
+
+    let exec_request_2 = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        contract_hash,
+        NEW_UREF_ENTRYPOINT,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    let contract_before = builder
+        .get_contract(contract_hash)
+        .expect("should have account");
+
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let contract_after = builder
+        .get_contract(contract_hash)
+        .expect("should have account");
+    assert_ne!(
+        contract_after, contract_before,
+        "contract object should be modified"
+    );
+}

--- a/grpc/tests/src/test/regression/mod.rs
+++ b/grpc/tests/src/test/regression/mod.rs
@@ -1,4 +1,5 @@
 mod ee_1045;
+mod ee_1071;
 mod ee_1103;
 mod ee_221;
 mod ee_401;

--- a/smart_contracts/contract/src/contract_api/account.rs
+++ b/smart_contracts/contract/src/contract_api/account.rs
@@ -18,7 +18,7 @@ use crate::{contract_api, ext_ffi, unwrap_or_revert::UnwrapOrRevert};
 pub fn get_main_purse() -> URef {
     let dest_non_null_ptr = contract_api::alloc_bytes(UREF_SERIALIZED_LENGTH);
     let bytes = unsafe {
-        ext_ffi::get_main_purse(dest_non_null_ptr.as_ptr());
+        ext_ffi::casper_get_main_purse(dest_non_null_ptr.as_ptr());
         Vec::from_raw_parts(
             dest_non_null_ptr.as_ptr(),
             UREF_SERIALIZED_LENGTH,
@@ -35,7 +35,7 @@ pub fn set_action_threshold(
 ) -> Result<(), SetThresholdFailure> {
     let action_type = action_type as u32;
     let threshold = threshold.value().into();
-    let result = unsafe { ext_ffi::set_action_threshold(action_type, threshold) };
+    let result = unsafe { ext_ffi::casper_set_action_threshold(action_type, threshold) };
     if result == 0 {
         Ok(())
     } else {
@@ -48,7 +48,11 @@ pub fn add_associated_key(account_hash: AccountHash, weight: Weight) -> Result<(
     let (account_hash_ptr, account_hash_size, _bytes) = to_ptr(account_hash);
     // Cast of u8 (weight) into i32 is assumed to be always safe
     let result = unsafe {
-        ext_ffi::add_associated_key(account_hash_ptr, account_hash_size, weight.value().into())
+        ext_ffi::casper_add_associated_key(
+            account_hash_ptr,
+            account_hash_size,
+            weight.value().into(),
+        )
     };
     if result == 0 {
         Ok(())
@@ -60,7 +64,8 @@ pub fn add_associated_key(account_hash: AccountHash, weight: Weight) -> Result<(
 /// Removes the given [`AccountHash`] from the account's associated keys.
 pub fn remove_associated_key(account_hash: AccountHash) -> Result<(), RemoveKeyFailure> {
     let (account_hash_ptr, account_hash_size, _bytes) = to_ptr(account_hash);
-    let result = unsafe { ext_ffi::remove_associated_key(account_hash_ptr, account_hash_size) };
+    let result =
+        unsafe { ext_ffi::casper_remove_associated_key(account_hash_ptr, account_hash_size) };
     if result == 0 {
         Ok(())
     } else {
@@ -76,7 +81,11 @@ pub fn update_associated_key(
     let (account_hash_ptr, account_hash_size, _bytes) = to_ptr(account_hash);
     // Cast of u8 (weight) into i32 is assumed to be always safe
     let result = unsafe {
-        ext_ffi::update_associated_key(account_hash_ptr, account_hash_size, weight.value().into())
+        ext_ffi::casper_update_associated_key(
+            account_hash_ptr,
+            account_hash_size,
+            weight.value().into(),
+        )
     };
     if result == 0 {
         Ok(())

--- a/smart_contracts/contract/src/contract_api/system.rs
+++ b/smart_contracts/contract/src/contract_api/system.rs
@@ -20,7 +20,7 @@ fn get_system_contract(system_contract: SystemContractType) -> ContractHash {
         let result = {
             let mut hash_data_raw = ContractHash::default();
             let value = unsafe {
-                ext_ffi::get_system_contract(
+                ext_ffi::casper_get_system_contract(
                     system_contract_index,
                     hash_data_raw.as_mut_ptr(),
                     hash_data_raw.len(),
@@ -68,7 +68,7 @@ pub fn get_auction() -> ContractHash {
 pub fn create_purse() -> URef {
     let purse_non_null_ptr = contract_api::alloc_bytes(UREF_SERIALIZED_LENGTH);
     unsafe {
-        let ret = ext_ffi::create_purse(purse_non_null_ptr.as_ptr(), UREF_SERIALIZED_LENGTH);
+        let ret = ext_ffi::casper_create_purse(purse_non_null_ptr.as_ptr(), UREF_SERIALIZED_LENGTH);
         if ret == 0 {
             let bytes = Vec::from_raw_parts(
                 purse_non_null_ptr.as_ptr(),
@@ -88,7 +88,8 @@ pub fn get_balance(purse: URef) -> Option<U512> {
 
     let value_size = {
         let mut output_size = MaybeUninit::uninit();
-        let ret = unsafe { ext_ffi::get_balance(purse_ptr, purse_size, output_size.as_mut_ptr()) };
+        let ret =
+            unsafe { ext_ffi::casper_get_balance(purse_ptr, purse_size, output_size.as_mut_ptr()) };
         match api_error::result_from(ret) {
             Ok(_) => unsafe { output_size.assume_init() },
             Err(ApiError::InvalidPurse) => return None,
@@ -105,8 +106,9 @@ pub fn get_balance(purse: URef) -> Option<U512> {
 pub fn transfer_to_account(target: AccountHash, amount: U512) -> TransferResult {
     let (target_ptr, target_size, _bytes1) = contract_api::to_ptr(target);
     let (amount_ptr, amount_size, _bytes2) = contract_api::to_ptr(amount);
-    let return_code =
-        unsafe { ext_ffi::transfer_to_account(target_ptr, target_size, amount_ptr, amount_size) };
+    let return_code = unsafe {
+        ext_ffi::casper_transfer_to_account(target_ptr, target_size, amount_ptr, amount_size)
+    };
     TransferredTo::result_from(return_code)
 }
 
@@ -121,7 +123,7 @@ pub fn transfer_from_purse_to_account(
     let (target_ptr, target_size, _bytes2) = contract_api::to_ptr(target);
     let (amount_ptr, amount_size, _bytes3) = contract_api::to_ptr(amount);
     let return_code = unsafe {
-        ext_ffi::transfer_from_purse_to_account(
+        ext_ffi::casper_transfer_from_purse_to_account(
             source_ptr,
             source_size,
             target_ptr,
@@ -144,7 +146,7 @@ pub fn transfer_from_purse_to_purse(
     let (target_ptr, target_size, _bytes2) = contract_api::to_ptr(target);
     let (amount_ptr, amount_size, _bytes3) = contract_api::to_ptr(amount);
     let result = unsafe {
-        ext_ffi::transfer_from_purse_to_purse(
+        ext_ffi::casper_transfer_from_purse_to_purse(
             source_ptr,
             source_size,
             target_ptr,
@@ -168,7 +170,7 @@ pub fn record_transfer(source: URef, target: URef, amount: U512) -> Result<(), A
     let (target_ptr, target_size, _bytes2) = contract_api::to_ptr(target);
     let (amount_ptr, amount_size, _bytes3) = contract_api::to_ptr(amount);
     let result = unsafe {
-        ext_ffi::record_transfer(
+        ext_ffi::casper_record_transfer(
             source_ptr,
             source_size,
             target_ptr,

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -6,18 +6,19 @@ extern "C" {
     /// The bytes in the span of wasm memory from `key_ptr` to `key_ptr + key_size` must correspond
     /// to a valid global state key, otherwise the function will fail. If the key is de-serialized
     /// successfully, then the result of the read is serialized and buffered in the runtime. This
-    /// result can be obtained via the [`read_host_buffer`] function. Returns standard error code.
+    /// result can be obtained via the [`casper_read_host_buffer`] function. Returns standard error
+    /// code.
     ///
     /// # Arguments
     ///
     /// * `key_ptr` - pointer (offset in wasm linear memory) to serialized form of the key to read
     /// * `key_size` - size of the serialized key (in bytes)
     /// * `output_size` - pointer to a value where host will write size of bytes read from given key
-    pub fn read_value(key_ptr: *const u8, key_size: usize, output_size: *mut usize) -> i32;
+    pub fn casper_read_value(key_ptr: *const u8, key_size: usize, output_size: *mut usize) -> i32;
     /// The bytes in wasm memory from offset `key_ptr` to `key_ptr + key_size`
     /// will be used together with the current context’s seed to form a local key.
     /// The value at that local key is read from the global state, serialized and
-    /// buffered in the runtime. This result can be obtained via the [`read_host_buffer`]
+    /// buffered in the runtime. This result can be obtained via the [`casper_read_host_buffer`]
     /// function.
     ///
     /// # Arguments
@@ -25,7 +26,11 @@ extern "C" {
     /// * `key_ptr` - pointer to bytes representing the user-defined key
     /// * `key_size` - size of the key (in bytes)
     /// * `output_size` - pointer to a value where host will write size of bytes read from given key
-    pub fn read_value_local(key_ptr: *const u8, key_size: usize, output_size: *mut usize) -> i32;
+    pub fn casper_read_value_local(
+        key_ptr: *const u8,
+        key_size: usize,
+        output_size: *mut usize,
+    ) -> i32;
     /// This function writes the provided value (read via de-serializing the bytes
     /// in wasm memory from offset `value_ptr` to `value_ptr + value_size`) under
     /// the provided key (read via de-serializing the bytes in wasm memory from
@@ -39,7 +44,12 @@ extern "C" {
     /// * `key_size` - size of the key (in bytes)
     /// * `value_ptr` - pointer to bytes representing the value to write at the key
     /// * `value_size` - size of the value (in bytes)
-    pub fn write(key_ptr: *const u8, key_size: usize, value_ptr: *const u8, value_size: usize);
+    pub fn casper_write(
+        key_ptr: *const u8,
+        key_size: usize,
+        value_ptr: *const u8,
+        value_size: usize,
+    );
 
     /// The bytes in wasm memory from offset `key_ptr` to `key_ptr + key_size`
     /// will be used together with the current context’s seed to form a local key.
@@ -54,7 +64,7 @@ extern "C" {
     /// * `key_size` - size of the key (in bytes)
     /// * `value_ptr` - pointer to bytes representing the value to write at the key
     /// * `value_size` - size of the value (in bytes)
-    pub fn write_local(
+    pub fn casper_write_local(
         key_ptr: *const u8,
         key_size: usize,
         value_ptr: *const u8,
@@ -74,7 +84,7 @@ extern "C" {
     /// * `key_size` - size of the key (in bytes)
     /// * `value_ptr` - pointer to bytes representing the value to write at the key
     /// * `value_size` - size of the value (in bytes)
-    pub fn add(key_ptr: *const u8, key_size: usize, value_ptr: *const u8, value_size: usize);
+    pub fn casper_add(key_ptr: *const u8, key_size: usize, value_ptr: *const u8, value_size: usize);
     /// This function causes the runtime to generate a new [`casper_types::uref::URef`], with
     /// the provided value stored under it in the global state. The new
     /// [`casper_types::uref::URef`] is written (in serialized form) to the wasm linear
@@ -90,14 +100,14 @@ extern "C" {
     /// * `value_ptr` - pointer to bytes representing the value to write under the new
     ///   [`casper_types::uref::URef`]
     /// * `value_size` - size of the value (in bytes)
-    pub fn new_uref(uref_ptr: *mut u8, value_ptr: *const u8, value_size: usize);
+    pub fn casper_new_uref(uref_ptr: *mut u8, value_ptr: *const u8, value_size: usize);
     ///
-    pub fn load_named_keys(total_keys: *mut usize, result_size: *mut usize) -> i32;
+    pub fn casper_load_named_keys(total_keys: *mut usize, result_size: *mut usize) -> i32;
     /// This function causes a `Trap`, terminating the currently running module,
     /// but first copies the bytes from `value_ptr` to `value_ptr + value_size` to
     /// a buffer which is returned to the calling module (if this module was
-    /// invoked by [`call_contract`] or [`call_versioned_contract`]). Additionally, the known
-    /// [`casper_types::uref::URef`]s of the calling context are augmented with the
+    /// invoked by [`casper_call_contract`] or [`casper_call_versioned_contract`]). Additionally,
+    /// the known [`casper_types::uref::URef`]s of the calling context are augmented with the
     /// [`casper_types::uref::URef`]s de-serialized from wasm memory offset
     /// `extra_urefs_ptr` to `extra_urefs_ptr + extra_urefs_size`. This function will cause a
     /// `Trap` if the bytes at `extra_urefs_ptr` cannot be de-serialized as type `Vec<URef>`, or
@@ -108,9 +118,9 @@ extern "C" {
     ///
     /// * `value_ptr`: pointer to bytes representing the value to return to the caller
     /// * `value_size`: size of the value (in bytes)
-    pub fn ret(value_ptr: *const u8, value_size: usize) -> !;
+    pub fn casper_ret(value_ptr: *const u8, value_size: usize) -> !;
     ///
-    pub fn get_key(
+    pub fn casper_get_key(
         name_ptr: *const u8,
         name_size: usize,
         output_ptr: *mut u8,
@@ -118,11 +128,16 @@ extern "C" {
         bytes_written_ptr: *mut usize,
     ) -> i32;
     ///
-    pub fn has_key(name_ptr: *const u8, name_size: usize) -> i32;
+    pub fn casper_has_key(name_ptr: *const u8, name_size: usize) -> i32;
     ///
-    pub fn put_key(name_ptr: *const u8, name_size: usize, key_ptr: *const u8, key_size: usize);
+    pub fn casper_put_key(
+        name_ptr: *const u8,
+        name_size: usize,
+        key_ptr: *const u8,
+        key_size: usize,
+    );
     ///
-    pub fn remove_key(name_ptr: *const u8, name_size: usize);
+    pub fn casper_remove_key(name_ptr: *const u8, name_size: usize);
     /// This function causes a `Trap` which terminates the currently running
     /// module. Additionally, it signals that the current entire phase of
     /// execution of the deploy should be terminated as well, and that the effects
@@ -133,13 +148,13 @@ extern "C" {
     /// # Arguments
     ///
     /// * `status` - error code of the revert
-    pub fn revert(status: u32) -> !;
+    pub fn casper_revert(status: u32) -> !;
     /// This function checks if all the keys contained in the given `Value` are
     /// valid in the current context (i.e. the `Value` does not contain any forged
     /// [`casper_types::uref::URef`]s). This function causes a `Trap` if the bytes in wasm
     /// memory from offset `value_ptr` to `value_ptr + value_size` cannot be de-serialized as
     /// type `Value`.
-    pub fn is_valid_uref(uref_ptr: *const u8, uref_size: usize) -> i32;
+    pub fn casper_is_valid_uref(uref_ptr: *const u8, uref_size: usize) -> i32;
     /// This function attempts to add the given public key as an associated key to
     /// the current account. Presently only 32-byte keys are supported; it is up
     /// to the caller to ensure that the 32-bytes starting from offset
@@ -149,7 +164,7 @@ extern "C" {
     /// for adding the key where 0 represents success, 1 means no more keys can be
     /// added to this account (only 10 keys can be added), 2 means the key is
     /// already associated (if you wish to change the weight of an associated key
-    /// then used [`update_associated_key`]), and 3 means permission denied (this
+    /// then used [`casper_update_associated_key`]), and 3 means permission denied (this
     /// could be because the function was called outside of session code or
     /// because the key management threshold was not met by the keys authorizing
     /// the deploy).
@@ -162,7 +177,7 @@ extern "C" {
     /// * `public_key` - pointer to the bytes in wasm memory representing the public key to add,
     ///   presently only 32-byte public keys are supported.
     /// * `weight` - the weight to assign to this public key
-    pub fn add_associated_key(
+    pub fn casper_add_associated_key(
         account_hash_ptr: *const u8,
         account_hash_size: usize,
         weight: i32,
@@ -187,7 +202,10 @@ extern "C" {
     /// * `public_key` - pointer to the bytes in wasm memory representing the public key to update,
     ///   presently only 32-byte public keys are supported.
     /// * `weight` - the weight to assign to this public key
-    pub fn remove_associated_key(account_hash_ptr: *const u8, account_hash_size: usize) -> i32;
+    pub fn casper_remove_associated_key(
+        account_hash_ptr: *const u8,
+        account_hash_size: usize,
+    ) -> i32;
     /// This function attempts to update the given public key as an associated key
     /// to the current account. Presently only 32-byte keys are supported; it is
     /// up to the caller to ensure that the 32-bytes starting from offset
@@ -208,7 +226,7 @@ extern "C" {
     /// * `public_key` - pointer to the bytes in wasm memory representing the
     ///  public key to update, presently only 32-byte public keys are supported
     /// * `weight` - the weight to assign to this public key
-    pub fn update_associated_key(
+    pub fn casper_update_associated_key(
         account_hash_ptr: *const u8,
         account_hash_size: usize,
         weight: i32,
@@ -230,7 +248,7 @@ extern "C" {
     ///
     /// * `action` - index representing the action threshold to set
     /// * `threshold` - new value of the threshold for performing this action
-    pub fn set_action_threshold(permission_level: u32, threshold: u32) -> i32;
+    pub fn casper_set_action_threshold(permission_level: u32, threshold: u32) -> i32;
     /// This function returns the public key of the account for this deploy. The
     /// result is always 36-bytes in length (4 bytes prefix on a 32-byte public
     /// key); it is up to the caller to ensure the right amount of memory is
@@ -240,7 +258,7 @@ extern "C" {
     /// # Arguments
     ///
     /// * `dest_ptr` - pointer to position in wasm memory where to write the result
-    pub fn get_caller(output_size: *mut usize) -> i32;
+    pub fn casper_get_caller(output_size: *mut usize) -> i32;
     /// This function gets the timestamp which will be in the block this deploy is
     /// included in. The return value is always a 64-bit unsigned integer,
     /// representing the number of milliseconds since the Unix epoch. It is up to
@@ -250,7 +268,7 @@ extern "C" {
     /// # Arguments
     ///
     /// * `dest_ptr` - pointer in wasm memory where to write the result
-    pub fn get_blocktime(dest_ptr: *const u8);
+    pub fn casper_get_blocktime(dest_ptr: *const u8);
     /// This function uses the mint contract to create a new, empty purse. If the
     /// call is successful then the [`casper_types::uref::URef`] (in serialized form) is written
     /// to the indicated place in wasm memory. It is up to the caller to ensure at
@@ -263,7 +281,7 @@ extern "C" {
     /// * `purse_ptr` - pointer to position in wasm memory where to write the created
     ///   [`casper_types::uref::URef`]
     /// * `purse_size` - allocated size for the [`casper_types::uref::URef`]
-    pub fn create_purse(purse_ptr: *const u8, purse_size: usize) -> i32;
+    pub fn casper_create_purse(purse_ptr: *const u8, purse_size: usize) -> i32;
     /// This function uses the mint contract’s transfer function to transfer
     /// tokens from the current account’s main purse to the main purse of the
     /// target account. If the target account does not exist then it is
@@ -288,7 +306,7 @@ extern "C" {
     /// * `amount_ptr` - pointer in wasm memory to bytes representing the amount to transfer to the
     ///   target account
     /// * `amount_size` - size of the amount (in bytes)
-    pub fn transfer_to_account(
+    pub fn casper_transfer_to_account(
         target_ptr: *const u8,
         target_size: usize,
         amount_ptr: *const u8,
@@ -322,7 +340,7 @@ extern "C" {
     /// * `amount_ptr` - pointer in wasm memory to bytes representing the amount to transfer to the
     ///   target account
     /// * `amount_size` - size of the amount (in bytes)
-    pub fn transfer_from_purse_to_account(
+    pub fn casper_transfer_from_purse_to_account(
         source_ptr: *const u8,
         source_size: usize,
         target_ptr: *const u8,
@@ -354,7 +372,7 @@ extern "C" {
     /// * `amount_ptr` - pointer in wasm memory to bytes representing the amount to transfer to the
     ///   target account
     /// * `amount_size` - size of the amount (in bytes)
-    pub fn transfer_from_purse_to_purse(
+    pub fn casper_transfer_from_purse_to_purse(
         source_ptr: *const u8,
         source_size: usize,
         target_ptr: *const u8,
@@ -376,7 +394,7 @@ extern "C" {
     /// * `amount_ptr` - pointer in wasm memory to bytes representing the amount to transfer to the
     ///   target account
     /// * `amount_size` - size of the amount (in bytes)
-    pub fn record_transfer(
+    pub fn casper_record_transfer(
         source_ptr: *const u8,
         source_size: usize,
         target_ptr: *const u8,
@@ -398,7 +416,11 @@ extern "C" {
     /// * `purse_ptr` - pointer in wasm memory to the bytes representing the
     ///   [`casper_types::uref::URef`] of the purse to get the balance of
     /// * `purse_size` - size of the [`casper_types::uref::URef`] (in bytes)
-    pub fn get_balance(purse_ptr: *const u8, purse_size: usize, result_size: *mut usize) -> i32;
+    pub fn casper_get_balance(
+        purse_ptr: *const u8,
+        purse_size: usize,
+        result_size: *mut usize,
+    ) -> i32;
     /// This function writes bytes representing the current phase of the deploy
     /// execution to the specified pointer. The size of the result is always one
     /// byte, it is up to the caller to ensure one byte of memory is allocated at
@@ -411,15 +433,15 @@ extern "C" {
     /// # Arguments
     ///
     /// * `dest_ptr` - pointer to position in wasm memory to write the result
-    pub fn get_phase(dest_ptr: *mut u8);
+    pub fn casper_get_phase(dest_ptr: *mut u8);
     ///
-    pub fn get_system_contract(
+    pub fn casper_get_system_contract(
         system_contract_index: u32,
         dest_ptr: *mut u8,
         dest_size: usize,
     ) -> i32;
     ///
-    pub fn get_main_purse(dest_ptr: *mut u8);
+    pub fn casper_get_main_purse(dest_ptr: *mut u8);
     /// This function copies the contents of the current runtime buffer into the
     /// wasm memory, beginning at the provided offset. It is intended that this
     /// function be called after a call to a function that uses host buffer. It is up to the caller
@@ -436,11 +458,15 @@ extern "C" {
     ///   be written
     /// * `dest_size` - size of output buffer
     /// * `bytes_written` - a pointer to a value where amount of bytes written will be set
-    pub fn read_host_buffer(dest_ptr: *mut u8, dest_size: usize, bytes_written: *mut usize) -> i32;
+    pub fn casper_read_host_buffer(
+        dest_ptr: *mut u8,
+        dest_size: usize,
+        bytes_written: *mut usize,
+    ) -> i32;
     /// Creates new contract package at hash. Returns both newly generated
     /// [`casper_types::ContractPackageHash`] and a [`casper_types::URef`] for further
     /// modifying access.
-    pub fn create_contract_package_at_hash(hash_addr_ptr: *mut u8, access_addr_ptr: *mut u8);
+    pub fn casper_create_contract_package_at_hash(hash_addr_ptr: *mut u8, access_addr_ptr: *mut u8);
     /// Creates new named contract user group under a contract package.
     ///
     /// # Arguments
@@ -454,7 +480,7 @@ extern "C" {
     /// * `existing_urefs_size` - size of serialized list of  [`casper_types::URef`]s
     /// * `output_size_ptr` - pointer to a value where a size of list of [`casper_types::URef`]s
     ///   written to host buffer will be set.
-    pub fn create_contract_user_group(
+    pub fn casper_create_contract_user_group(
         contract_package_hash_ptr: *const u8,
         contract_package_hash_size: usize,
         label_ptr: *const u8,
@@ -479,7 +505,7 @@ extern "C" {
     /// * `output_size` - size of memory area that host can write to
     /// * `bytes_written_ptr` - pointer to a value where host will set a number of bytes written to
     ///   the `output_size` pointer
-    pub fn add_contract_version(
+    pub fn casper_add_contract_version(
         contract_package_hash_ptr: *const u8,
         contract_package_hash_size: usize,
         version_ptr: *const u32,
@@ -500,7 +526,7 @@ extern "C" {
     /// * `contract_package_hash_size` - size of contract package hash in serialized form.
     /// * `contract_hash_ptr` - pointer to serialized contract hash.
     /// * `contract_hash_size` - size of contract hash in serialized form.
-    pub fn disable_contract_version(
+    pub fn casper_disable_contract_version(
         contract_package_hash_ptr: *const u8,
         contract_package_hash_size: usize,
         contract_hash_ptr: *const u8,
@@ -520,7 +546,7 @@ extern "C" {
     /// * `runtime_args_size` - size of serialized runtime arguments
     /// * `result_size` - a pointer to a value which will be set to a size of bytes of called
     ///   contract return value
-    pub fn call_contract(
+    pub fn casper_call_contract(
         contract_hash_ptr: *const u8,
         contract_hash_size: usize,
         entry_point_name_ptr: *const u8,
@@ -547,7 +573,7 @@ extern "C" {
     /// * `runtime_args_ptr` -
     /// * `runtime_args_size` -
     /// * `result_size` -
-    pub fn call_versioned_contract(
+    pub fn casper_call_versioned_contract(
         contract_package_hash_ptr: *const u8,
         contract_package_hash_size: usize,
         contract_version_ptr: *const u8,
@@ -570,7 +596,11 @@ extern "C" {
     /// * `dest_ptr` - pointer to the location where argument bytes will be copied from the host
     ///   side
     /// * `dest_size` - size of destination pointer
-    pub fn get_named_arg_size(name_ptr: *const u8, name_size: usize, dest_size: *mut usize) -> i32;
+    pub fn casper_get_named_arg_size(
+        name_ptr: *const u8,
+        name_size: usize,
+        dest_size: *mut usize,
+    ) -> i32;
     /// This function copies the contents of the current runtime buffer into the
     /// wasm memory, beginning at the provided offset. It is intended that this
     /// function be called after a call to `load_arg`. It is up to the caller to
@@ -589,7 +619,7 @@ extern "C" {
     /// * `dest_ptr` - pointer to the location where argument bytes will be copied from the host
     ///   side
     /// * `dest_size` - size of destination pointer
-    pub fn get_named_arg(
+    pub fn casper_get_named_arg(
         name_ptr: *const u8,
         name_size: usize,
         dest_ptr: *mut u8,
@@ -603,7 +633,7 @@ extern "C" {
     /// * `contract_package_hash_size` - size of contract package hash in serialized form.
     /// * `label_ptr` - serialized group label
     /// * `label_size` - size of serialized group label
-    pub fn remove_contract_user_group(
+    pub fn casper_remove_contract_user_group(
         contract_package_hash_ptr: *const u8,
         contract_package_hash_size: usize,
         label_ptr: *const u8,
@@ -620,7 +650,7 @@ extern "C" {
     /// * `label_ptr` - serialized group label
     /// * `label_size` - size of serialized group label
     /// * `value_size_ptr` - size of data written to a host buffer will be saved here
-    pub fn provision_contract_user_group_uref(
+    pub fn casper_provision_contract_user_group_uref(
         contract_package_hash_ptr: *const u8,
         contract_package_hash_size: usize,
         label_ptr: *const u8,
@@ -638,7 +668,7 @@ extern "C" {
     /// * `label_size` - size of serialized group label
     /// * `urefs_ptr` - pointer to serialized list of urefs
     /// * `urefs_size` - size of serialized list of urefs
-    pub fn remove_contract_user_group_urefs(
+    pub fn casper_remove_contract_user_group_urefs(
         contract_package_hash_ptr: *const u8,
         contract_package_hash_size: usize,
         label_ptr: *const u8,
@@ -653,7 +683,12 @@ extern "C" {
     /// * `in_size` - length of bytes
     /// * `out_ptr` - pointer to the location where argument bytes will be copied from the host side
     /// * `out_size` - size of output pointer
-    pub fn blake2b(in_ptr: *const u8, in_size: usize, out_ptr: *mut u8, out_size: usize) -> i32;
+    pub fn casper_blake2b(
+        in_ptr: *const u8,
+        in_size: usize,
+        out_ptr: *mut u8,
+        out_size: usize,
+    ) -> i32;
     /// Prints data directly to stanadard output on the host.
     ///
     /// # Arguments
@@ -661,5 +696,5 @@ extern "C" {
     /// * `text_ptr` - pointer to serialized text to print
     /// * `text_size` - size of serialized text to print
     #[cfg(feature = "test-support")]
-    pub fn print(text_ptr: *const u8, text_size: usize);
+    pub fn casper_print(text_ptr: *const u8, text_size: usize);
 }

--- a/smart_contracts/contract_as/assembly/externals.ts
+++ b/smart_contracts/contract_as/assembly/externals.ts
@@ -1,37 +1,37 @@
 /** @hidden */
-@external("env", "read_value")
+@external("env", "casper_read_value")
 export declare function read_value(key_ptr: usize, key_size: usize, value_size: usize): i32;
 /** @hidden */
-@external("env", "read_value_local")
+@external("env", "casper_read_value_local")
 export declare function read_value_local(key_ptr: usize, key_size: usize, output_size: usize): i32;
 /** @hidden */
-@external("env", "write")
+@external("env", "casper_write")
 export declare function write(key_ptr: usize, key_size: usize, value_ptr: usize, value_size: usize): void;
 /** @hidden */
-@external("env", "write_local")
+@external("env", "casper_write_local")
 export declare function write_local(key_ptr: usize, key_size: usize, value_ptr: usize, value_size: usize): void;
 /** @hidden */
-@external("env", "add")
+@external("env", "casper_add")
 export declare function add(key_ptr: usize, key_size: usize, value_ptr: usize, value_size: usize): void;
 /** @hidden */
-@external("env", "new_uref")
+@external("env", "casper_new_uref")
 export declare function new_uref(uref_ptr: usize, value_ptr: usize, value_size: usize): void;
-@external("env", "load_named_keys")
+@external("env", "casper_load_named_keys")
 export declare function load_named_keys(total_keys: usize, result_size: usize): i32;
 /** @hidden */
-@external("env", "get_named_arg")
+@external("env", "casper_get_named_arg")
 export declare function get_named_arg(name_ptr: usize, name_size: usize, dest_ptr: usize, dest_size: usize): i32;
 /** @hidden */
-@external("env", "get_named_arg_size")
+@external("env", "casper_get_named_arg_size")
 export declare function get_named_arg_size(name_ptr: usize, name_size: usize, dest_size: usize): i32;
 /** @hidden */
-@external("env", "ret")
+@external("env", "casper_ret")
 export declare function ret(value_ptr: usize, value_size: usize): void;
 /** @hidden */
-@external("env", "call_contract")
+@external("env", "casper_call_contract")
 export declare function call_contract(contract_hash_ptr: usize, contract_hash_size: usize, entry_point_name_ptr: usize, entry_point_name_size: usize, runtime_args_ptr: usize, runtime_args_size: usize, result_size: usize): i32;
 /** @hidden */
-@external("env", "call_versioned_contract")
+@external("env", "casper_call_versioned_contract")
 export declare function call_versioned_contract(
     contract_package_hash_ptr: usize,
     contract_package_hash_size: usize,
@@ -44,7 +44,7 @@ export declare function call_versioned_contract(
     result_size: usize,
 ): i32;
 /** @hidden */
-@external("env", "get_key")
+@external("env", "casper_get_key")
 export declare function get_key(
     name_ptr: usize,
     name_size: usize,
@@ -53,43 +53,43 @@ export declare function get_key(
     bytes_written_ptr: usize,
 ): i32;
 /** @hidden */
-@external("env", "has_key")
+@external("env", "casper_has_key")
 export declare function has_key(name_ptr: usize, name_size: usize): i32;
 /** @hidden */
-@external("env", "put_key")
+@external("env", "casper_put_key")
 export declare function put_key(name_ptr: usize, name_size: usize, key_ptr: usize, key_size: usize): void;
 /** @hidden */
-@external("env", "remove_key")
+@external("env", "casper_remove_key")
 export declare function remove_key(name_ptr: usize, name_size: u32): void;
 /** @hidden */
-@external("env", "revert")
+@external("env", "casper_revert")
 export declare function revert(err_code: i32): void;
 /** @hidden */
-@external("env", "is_valid_uref")
+@external("env", "casper_is_valid_uref")
 export declare function is_valid_uref(target_ptr: usize, target_size: u32): i32;
 /** @hidden */
-@external("env", "add_associated_key")
+@external("env", "casper_add_associated_key")
 export declare function add_associated_key(account_hash_ptr: usize, account_hash_size: usize, weight: i32): i32;
 /** @hidden */
-@external("env", "remove_associated_key")
+@external("env", "casper_remove_associated_key")
 export declare function remove_associated_key(account_hash_ptr: usize, account_hash_size: usize): i32;
 /** @hidden */
-@external("env", "update_associated_key")
+@external("env", "casper_update_associated_key")
 export declare function update_associated_key(account_hash_ptr: usize, account_hash_size: usize, weight: i32): i32;
 /** @hidden */
-@external("env", "set_action_threshold")
+@external("env", "casper_set_action_threshold")
 export declare function set_action_threshold(permission_level: u32, threshold: i32): i32;
 /** @hidden */
-@external("env", "get_blocktime")
+@external("env", "casper_get_blocktime")
 export declare function get_blocktime(dest_ptr: usize): void;
 /** @hidden */
-@external("env", "get_caller")
+@external("env", "casper_get_caller")
 export declare function get_caller(output_size: usize): i32;
 /** @hidden */
-@external("env", "create_purse")
+@external("env", "casper_create_purse")
 export declare function create_purse(purse_ptr: usize, purse_size: u32): i32;
 /** @hidden */
-@external("env", "transfer_to_account")
+@external("env", "casper_transfer_to_account")
 export declare function transfer_to_account(
     target_ptr: usize,
     target_size: u32,
@@ -97,7 +97,7 @@ export declare function transfer_to_account(
     amount_size: u32,
 ): i32;
 /** @hidden */
-@external("env", "transfer_from_purse_to_account")
+@external("env", "casper_transfer_from_purse_to_account")
 export declare function transfer_from_purse_to_account(
     source_ptr: usize,
     source_size: u32,
@@ -107,7 +107,7 @@ export declare function transfer_from_purse_to_account(
     amount_size: u32,
 ):  i32;
 /** @hidden */
-@external("env", "transfer_from_purse_to_purse")
+@external("env", "casper_transfer_from_purse_to_purse")
 export declare function transfer_from_purse_to_purse(
     source_ptr: usize,
     source_size: u32,
@@ -117,13 +117,13 @@ export declare function transfer_from_purse_to_purse(
     amount_size: u32,
 ): i32;
 /** @hidden */
-@external("env", "get_balance")
+@external("env", "casper_get_balance")
 export declare function get_balance(purse_ptr: usize, purse_size: usize, result_size: usize): i32;
 /** @hidden */
-@external("env", "get_phase")
+@external("env", "casper_get_phase")
 export declare function get_phase(dest_ptr: usize): void;
 /** @hidden */
-@external("env", "upgrade_contract_at_uref")
+@external("env", "casper_upgrade_contract_at_uref")
 export declare function upgrade_contract_at_uref(
     name_ptr: usize,
     name_size: u32,
@@ -131,23 +131,23 @@ export declare function upgrade_contract_at_uref(
     key_size: u32
 ): i32;
 /** @hidden */
-@external("env", "get_system_contract")
+@external("env", "casper_get_system_contract")
 export declare function get_system_contract(system_contract_index: u32, dest_ptr: usize, dest_size: u32): i32;
 /** @hidden */
-@external("env", "get_main_purse")
+@external("env", "casper_get_main_purse")
 export declare function get_main_purse(dest_ptr: usize): void;
 /** @hidden */
-@external("env", "read_host_buffer")
+@external("env", "casper_read_host_buffer")
 export declare function read_host_buffer(dest_ptr: usize, dest_size: u32, bytes_written: usize): i32;
 /** @hidden */
-@external("env", "remove_contract_user_group")
+@external("env", "casper_remove_contract_user_group")
 export declare function remove_contract_user_group(
     contract_package_hash_ptr: usize,
     contract_package_hash_size: usize,
     label_ptr: usize,
     label_size: usize): i32;
 /** @hidden */
-@external("env", "provision_contract_user_group_uref")
+@external("env", "casper_provision_contract_user_group_uref")
 export declare function provision_contract_user_group_uref(
     contract_package_hash_ptr: usize,
     contract_package_hash_size: usize,
@@ -156,7 +156,7 @@ export declare function provision_contract_user_group_uref(
     value_size_ptr: usize,
 ): i32;
 /** @hidden */
-@external("env", "remove_contract_user_group_urefs")
+@external("env", "casper_remove_contract_user_group_urefs")
 export declare function remove_contract_user_group_urefs(
     contract_package_hash_ptr: usize,
     contract_package_hash_size: usize,
@@ -166,10 +166,10 @@ export declare function remove_contract_user_group_urefs(
     urefs_size: usize,
 ): i32;
 /** @hidden */
-@external("env", "create_contract_package_at_hash")
+@external("env", "casper_create_contract_package_at_hash")
 export declare function create_contract_package_at_hash(hash_addr_ptr: usize, access_addr_ptr: usize): void;
 /** @hidden */
-@external("env", "add_contract_version")
+@external("env", "casper_add_contract_version")
 export declare function add_contract_version(
     contract_package_hash_ptr: usize,
     contract_package_hash_size: usize,
@@ -183,7 +183,7 @@ export declare function add_contract_version(
     bytes_written_ptr: usize,
 ): i32;
 /** @hidden */
-@external("env", "create_contract_user_group")
+@external("env", "casper_create_contract_user_group")
 export declare function create_contract_user_group(
     contract_package_hash_ptr: usize,
     contract_package_hash_size: usize,
@@ -195,7 +195,7 @@ export declare function create_contract_user_group(
     output_size_ptr: usize,
 ): i32;
 /** @hidden */
-@external("env", "disable_contract_version")
+@external("env", "casper_disable_contract_version")
 export declare function disable_contract_version(
     contract_package_hash_ptr: usize,
     contract_package_hash_size: usize,

--- a/smart_contracts/contracts/client/counter-define/src/main.rs
+++ b/smart_contracts/contracts/client/counter-define/src/main.rs
@@ -121,7 +121,7 @@ fn get_counter_key() -> Key {
     let arg = {
         let mut arg_size: usize = 0;
         let ret = unsafe {
-            ext_ffi::get_named_arg_size(
+            ext_ffi::casper_get_named_arg_size(
                 name.as_bytes().as_ptr(),
                 name.len(),
                 &mut arg_size as *mut usize,
@@ -146,7 +146,7 @@ fn get_counter_key() -> Key {
                 let res = {
                     let data_non_null_ptr = contract_api::alloc_bytes(arg_size);
                     let ret = unsafe {
-                        ext_ffi::get_named_arg(
+                        ext_ffi::casper_get_named_arg(
                             name.as_bytes().as_ptr(),
                             name.len(),
                             data_non_null_ptr.as_ptr(),

--- a/smart_contracts/contracts/test/deserialize-error/src/main.rs
+++ b/smart_contracts/contracts/test/deserialize-error/src/main.rs
@@ -28,7 +28,7 @@ fn to_ptr<T: ToBytes>(t: T) -> (*const u8, usize, Vec<u8>) {
 mod malicious_ffi {
     // Potential attacker has available every FFI for himself
     extern "C" {
-        pub fn cl_call_contract(
+        pub fn casper_call_contract(
             contract_hash_ptr: *const u8,
             contract_hash_size: usize,
             entry_point_name_ptr: *const u8,
@@ -56,7 +56,7 @@ pub fn my_call_contract(
     {
         let mut bytes_written = 0usize;
         let ret = unsafe {
-            malicious_ffi::cl_call_contract(
+            malicious_ffi::casper_call_contract(
                 contract_hash_ptr,
                 contract_hash_size,
                 malicious_string.as_ptr(),

--- a/smart_contracts/contracts/test/deserialize-error/src/main.rs
+++ b/smart_contracts/contracts/test/deserialize-error/src/main.rs
@@ -28,7 +28,7 @@ fn to_ptr<T: ToBytes>(t: T) -> (*const u8, usize, Vec<u8>) {
 mod malicious_ffi {
     // Potential attacker has available every FFI for himself
     extern "C" {
-        pub fn call_contract(
+        pub fn cl_call_contract(
             contract_hash_ptr: *const u8,
             contract_hash_size: usize,
             entry_point_name_ptr: *const u8,
@@ -56,7 +56,7 @@ pub fn my_call_contract(
     {
         let mut bytes_written = 0usize;
         let ret = unsafe {
-            malicious_ffi::call_contract(
+            malicious_ffi::cl_call_contract(
                 contract_hash_ptr,
                 contract_hash_size,
                 malicious_string.as_ptr(),

--- a/smart_contracts/contracts/test/ee-1071-regression/Cargo.toml
+++ b/smart_contracts/contracts/test/ee-1071-regression/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ee-1071-regression"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "ee_1071_regression"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[features]
+std = ["casper-contract/std", "casper-types/std"]
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/ee-1071-regression/src/lib.rs
+++ b/smart_contracts/contracts/test/ee-1071-regression/src/lib.rs
@@ -1,0 +1,9 @@
+#![no_std]
+
+use casper_contract::contract_api::{runtime, storage};
+
+#[no_mangle]
+pub extern "C" fn new_uref() {
+    let new_uref = storage::new_uref(0);
+    runtime::put_key(&new_uref.to_formatted_string(), new_uref.into())
+}

--- a/smart_contracts/contracts/test/ee-1071-regression/src/main.rs
+++ b/smart_contracts/contracts/test/ee-1071-regression/src/main.rs
@@ -1,0 +1,38 @@
+#![no_std]
+#![no_main]
+
+use casper_contract::contract_api::{runtime, storage};
+use casper_types::{
+    contracts::Parameters, CLType, EntryPoint, EntryPointAccess, EntryPointType, EntryPoints,
+};
+
+const CONTRACT_HASH_NAME: &str = "contract";
+
+const NEW_UREF: &str = "new_uref";
+
+// This import below somehow bypasses linkers ability to verify that ext_ffi's new_uref import has
+// different signature than the new_uref we're defining in a lib.
+#[allow(unused_imports)]
+use ee_1071_regression::new_uref;
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let entry_points = {
+        let mut entry_points = EntryPoints::new();
+
+        let entry_point = EntryPoint::new(
+            NEW_UREF,
+            Parameters::default(),
+            CLType::Unit,
+            EntryPointAccess::Public,
+            EntryPointType::Contract,
+        );
+
+        entry_points.add_entry_point(entry_point);
+
+        entry_points
+    };
+    let (contract_hash, _contract_version) = storage::new_contract(entry_points, None, None, None);
+
+    runtime::put_key(CONTRACT_HASH_NAME, contract_hash.into());
+}

--- a/types/src/api_error.rs
+++ b/types/src/api_error.rs
@@ -68,7 +68,8 @@ const AUCTION_ERROR_MAX: u32 = AUCTION_ERROR_OFFSET + u8::MAX as u32;
 /// Errors which can be encountered while running a smart contract.
 ///
 /// An `ApiError` can be converted to a `u32` in order to be passed via the execution engine's
-/// `ext_ffi::revert()` function.  This means the information each variant can convey is limited.
+/// `ext_ffi::casper_revert()` function.  This means the information each variant can convey is
+/// limited.
 ///
 /// The variants are split into numeric ranges as follows:
 ///

--- a/types/src/system_contract_type.rs
+++ b/types/src/system_contract_type.rs
@@ -10,7 +10,7 @@ use crate::ApiError;
 /// System contract types.
 ///
 /// Used by converting to a `u32` and passing as the `system_contract_index` argument of
-/// `ext_ffi::get_system_contract()`.
+/// `ext_ffi::casper_get_system_contract()`.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum SystemContractType {
     /// Mint contract.


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1071

By naming a function inside a library that's part of a contract the same as one of FFI functions we export results in infinite loop if we'd call contract API function that internally uses imported FFI function of said name.

Example:

```rust
// Contract's lib.rs
#[no_mangle]
pub extern "C" fn new_uref() {
    let new_uref = storage::new_uref(0); // This results in calling `new_uref` (itself) rather than imported one
    runtime::put_key(&new_uref.to_formatted_string(), new_uref.into())
}
// Contract's main.rs
#[allow(unused_imports)]
use ee_1071_regression::new_uref; // doesn't import `new_uref` from the host
```

With this change I prefixed host functions with a `casper_` prefix to avoid obvious naming clashes.

NOTE: Originally I was thinking about using `__cl_` prefix although this might be controversial as this would be exploiting UB in some of the languages like C/C++