### PR TITLE
NDRS-168: Don't rely on event order in deploy buffer; fix block handling.

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -41,7 +41,10 @@ pub enum Event {
     /// The deploy-buffer has been asked to prune stale deploys
     BufferPrune,
     /// A proto block has been finalized. We should never propose its deploys again.
-    FinalizedProtoBlock(ProtoBlock),
+    FinalizedProtoBlock {
+        block: ProtoBlock,
+        parent: Option<ProtoBlockHash>,
+    },
     /// The result of the `BlockProposer` getting the chainspec from the storage component.
     GetChainspecResult {
         maybe_deploy_config: Box<Option<DeployConfig>>,
@@ -56,7 +59,7 @@ impl Display for Event {
             Event::BufferPrune => write!(f, "buffer prune"),
             Event::Request(req) => write!(f, "deploy-buffer request: {}", req),
             Event::Buffer { hash, .. } => write!(f, "deploy-buffer add {}", hash),
-            Event::FinalizedProtoBlock(block) => {
+            Event::FinalizedProtoBlock { block, parent: _ } => {
                 write!(f, "deploy-buffer finalized proto block {}", block)
             }
             Event::GetChainspecResult {
@@ -353,7 +356,7 @@ where
                 return self.get_chainspec(effect_builder, request);
             }
             Event::Buffer { hash, header } => self.add_deploy(Timestamp::now(), hash, *header),
-            Event::FinalizedProtoBlock(block) => {
+            Event::FinalizedProtoBlock { block, parent: _ } => {
                 let (hash, deploys, _) = block.destructure();
                 self.finalized_block(hash, deploys)
             }

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -368,6 +368,7 @@ where
             Event::Request(BlockProposerRequest::ListForInclusion {
                 current_instant,
                 past_deploys,
+                last_finalized_block: _,
                 responder,
             }) => {
                 return self.get_chainspec(

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -578,32 +578,17 @@ mod tests {
         assert!(deploys.contains(&hash2));
 
         // the deploys should not have been removed
-        assert!(!buffer
-            .remaining_deploys(DeployConfig::default(), block_time2, no_deploys.clone())
-            .is_empty());
-
-        let mut deploys = HashSet::new();
-        deploys.insert(hash1);
-        deploys.insert(hash2);
-
-        assert!(buffer
-            .remaining_deploys(DeployConfig::default(), block_time2, deploys.clone())
-            .is_empty());
-
-        // try adding the same deploy again
-        buffer.add_deploy(block_time2, hash2, deploy2);
-
-        // it shouldn't be returned if we include it in the past blocks
-        assert!(buffer
-            .remaining_deploys(DeployConfig::default(), block_time2, deploys.clone())
-            .is_empty());
-        // ...but it should be returned if we don't include it
-        assert!(
+        assert_eq!(
             buffer
                 .remaining_deploys(DeployConfig::default(), block_time2, no_deploys.clone())
-                .len()
-                == 1
+                .len(),
+            2
         );
+
+        // but they shouldn't be returned if we include it in the past deploys
+        assert!(buffer
+            .remaining_deploys(DeployConfig::default(), block_time2, deploys.clone())
+            .is_empty());
 
         let block_hash1 = ProtoBlockHash::new(hash(random::<[u8; 16]>()));
 
@@ -616,7 +601,8 @@ mod tests {
 
         let deploys = buffer.remaining_deploys(DeployConfig::default(), block_time2, no_deploys);
 
-        // since block 1 is now finalized, deploy2 shouldn't be among the ones returned
+        // since block 1 is now finalized, neither deploy1 nor deploy2 should be among the ones
+        // returned
         assert_eq!(deploys.len(), 2);
         assert!(deploys.contains(&hash3));
         assert!(deploys.contains(&hash4));

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -242,7 +242,7 @@ impl BlockProposer {
             .finalized_deploys
             .keys()
             .cloned()
-            .chain(past_deploys.into_iter())
+            .chain(past_deploys)
             .collect::<HashSet<_>>();
 
         // deploys_to_return = all deploys in pending that aren't in finalized blocks or
@@ -359,7 +359,7 @@ where
                     self.state
                         .request_queue
                         .entry(request.next_block_height)
-                        .or_insert_with(Vec::new)
+                        .or_default()
                         .push(request);
                 } else {
                     return self.get_chainspec(effect_builder, request);

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -303,8 +303,9 @@ impl BlockProposer {
         REv: ReactorEventT,
     {
         self.finalized_block(deploys);
+        self.state.next_finalized = height + 1;
 
-        if let Some(requests) = self.state.request_queue.remove(&(height + 1)) {
+        if let Some(requests) = self.state.request_queue.remove(&self.state.next_finalized) {
             requests
                 .into_iter()
                 .flat_map(|request| self.get_chainspec(effect_builder, request))
@@ -365,12 +366,12 @@ where
                 } else {
                     let mut effects = self.handle_finalized_block(effect_builder, height, deploys);
                     while let Some(deploys) = self.state.finalization_queue.remove(&height) {
+                        height += 1;
                         effects.extend(self.handle_finalized_block(
                             effect_builder,
                             height,
                             deploys,
                         ));
-                        height += 1;
                     }
                     return effects;
                 }

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -260,10 +260,9 @@ impl BlockProposer {
         past_deploys: &HashSet<DeployHash>,
     ) -> bool {
         let all_deps_resolved = || {
-            deploy
-                .dependencies()
-                .iter()
-                .all(|dep| past_deploys.contains(dep))
+            deploy.dependencies().iter().all(|dep| {
+                past_deploys.contains(dep) || self.state.finalized_deploys.contains_key(dep)
+            })
         };
         let ttl_valid = deploy.ttl() <= deploy_config.max_ttl;
         let timestamp_valid = deploy.timestamp() <= block_timestamp;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -50,7 +50,7 @@ use crate::{
     },
     effect::{EffectBuilder, EffectExt, Effects, Responder},
     fatal,
-    types::{BlockHash, BlockHeader, FinalizedBlock, ProtoBlock, Timestamp},
+    types::{BlockHash, BlockHeader, FinalizedBlock, ProtoBlock, ProtoBlockHash, Timestamp},
     utils::WithDir,
     NodeRng,
 };
@@ -93,6 +93,8 @@ pub struct EraSupervisor<I> {
     /// A node keeps `2 * bonded_eras` past eras around, because the oldest bonded era could still
     /// receive blocks that refer to `bonded_eras` before that.
     bonded_eras: u64,
+    /// The hash of the last finalized proto-block; needed for interactions with the block proposer
+    last_finalized_proto_block: Option<ProtoBlockHash>,
     #[data_size(skip)]
     metrics: ConsensusMetrics,
 }
@@ -137,6 +139,7 @@ where
             new_consensus,
             node_start_time: Timestamp::now(),
             bonded_eras,
+            last_finalized_proto_block: None,
             metrics,
         };
 
@@ -599,7 +602,11 @@ where
             }
             ProtocolOutcome::CreateNewBlock { block_context } => self
                 .effect_builder
-                .request_proto_block(block_context, self.rng.gen())
+                .request_proto_block(
+                    block_context,
+                    self.era_supervisor.last_finalized_proto_block,
+                    self.rng.gen(),
+                )
                 .event(move |(proto_block, block_context)| Event::NewProtoBlock {
                     era_id,
                     proto_block,
@@ -637,6 +644,8 @@ where
                     .effect_builder
                     .announce_finalized_block(finalized_block.clone())
                     .ignore();
+                self.era_supervisor.last_finalized_proto_block =
+                    Some(*finalized_block.proto_block().hash());
                 // Request execution of the finalized block.
                 effects.extend(self.effect_builder.execute_block(finalized_block).ignore());
                 effects

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -642,7 +642,10 @@ where
                 // Announce the finalized proto block.
                 let mut effects = self
                     .effect_builder
-                    .announce_finalized_block(finalized_block.clone())
+                    .announce_finalized_block(
+                        finalized_block.clone(),
+                        self.era_supervisor.last_finalized_proto_block,
+                    )
                     .ignore();
                 self.era_supervisor.last_finalized_proto_block =
                     Some(*finalized_block.proto_block().hash());

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -93,7 +93,12 @@ pub struct EraSupervisor<I> {
     /// A node keeps `2 * bonded_eras` past eras around, because the oldest bonded era could still
     /// receive blocks that refer to `bonded_eras` before that.
     bonded_eras: u64,
-    /// The height of the next block to be finalized
+    /// The height of the next block to be finalized.
+    /// We keep that in order to be able to signal to the Block Proposer how many blocks have been
+    /// finalized when we request a new block. This way the Block Proposer can know whether it's up
+    /// to date, or whether it has to wait for more finalized blocks before responding.
+    /// This value could be obtained from the consensus instance in a relevant era, but caching it
+    /// here is the easiest way of achieving the desired effect.
     next_block_height: u64,
     #[data_size(skip)]
     metrics: ConsensusMetrics,

--- a/node/src/components/consensus/era_supervisor/tests.rs
+++ b/node/src/components/consensus/era_supervisor/tests.rs
@@ -115,11 +115,7 @@ impl MockReactor {
 
     async fn expect_finalized(&self) -> FinalizedBlock {
         let (event, _) = self.scheduler.pop().await;
-        if let Event::ConsensusAnnouncement(ConsensusAnnouncement::Finalized {
-            block: fb,
-            parent: _,
-        }) = event
-        {
+        if let Event::ConsensusAnnouncement(ConsensusAnnouncement::Finalized(fb)) = event {
             *fb
         } else {
             panic!(

--- a/node/src/components/consensus/era_supervisor/tests.rs
+++ b/node/src/components/consensus/era_supervisor/tests.rs
@@ -115,7 +115,11 @@ impl MockReactor {
 
     async fn expect_finalized(&self) -> FinalizedBlock {
         let (event, _) = self.scheduler.pop().await;
-        if let Event::ConsensusAnnouncement(ConsensusAnnouncement::Finalized(fb)) = event {
+        if let Event::ConsensusAnnouncement(ConsensusAnnouncement::Finalized {
+            block: fb,
+            parent: _,
+        }) = event
+        {
             *fb
         } else {
             panic!(

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -122,8 +122,8 @@ use announcements::{
 };
 use requests::{
     BlockExecutorRequest, BlockProposerRequest, BlockValidationRequest, ChainspecLoaderRequest,
-    ConsensusRequest, ContractRuntimeRequest, FetcherRequest, MetricsRequest, NetworkInfoRequest,
-    NetworkRequest, StorageRequest,
+    ConsensusRequest, ContractRuntimeRequest, FetcherRequest, ListForInclusionRequest,
+    MetricsRequest, NetworkInfoRequest, NetworkRequest, StorageRequest,
 };
 
 /// A pinned, boxed future that produces one or more events.
@@ -823,11 +823,13 @@ impl<REv> EffectBuilder<REv> {
     {
         let deploys = self
             .make_request(
-                |responder| BlockProposerRequest::ListForInclusion {
-                    current_instant: block_context.timestamp(),
-                    past_deploys: Default::default(), // TODO
-                    last_finalized_block,
-                    responder,
+                |responder| {
+                    BlockProposerRequest::ListForInclusion(ListForInclusionRequest {
+                        current_instant: block_context.timestamp(),
+                        past_deploys: Default::default(), // TODO
+                        last_finalized_block,
+                        responder,
+                    })
                 },
                 QueueKind::Regular,
             )

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -874,20 +874,6 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Announces that a proto block has been proposed and will either be finalized or orphaned
-    /// soon.
-    pub(crate) async fn announce_proposed_proto_block(self, proto_block: ProtoBlock)
-    where
-        REv: From<ConsensusAnnouncement>,
-    {
-        self.0
-            .schedule(
-                ConsensusAnnouncement::Proposed(proto_block),
-                QueueKind::Regular,
-            )
-            .await
-    }
-
     /// Announces that a proto block has been finalized.
     pub(crate) async fn announce_finalized_block(self, finalized_block: FinalizedBlock)
     where

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -824,7 +824,7 @@ impl<REv> EffectBuilder<REv> {
             .make_request(
                 |responder| BlockProposerRequest::ListForInclusion {
                     current_instant: block_context.timestamp(),
-                    past_blocks: Default::default(), // TODO
+                    past_deploys: Default::default(), // TODO
                     responder,
                 },
                 QueueKind::Regular,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -879,13 +879,19 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announces that a proto block has been finalized.
-    pub(crate) async fn announce_finalized_block(self, finalized_block: FinalizedBlock)
-    where
+    pub(crate) async fn announce_finalized_block(
+        self,
+        finalized_block: FinalizedBlock,
+        parent: Option<ProtoBlockHash>,
+    ) where
         REv: From<ConsensusAnnouncement>,
     {
         self.0
             .schedule(
-                ConsensusAnnouncement::Finalized(Box::new(finalized_block)),
+                ConsensusAnnouncement::Finalized {
+                    block: Box::new(finalized_block),
+                    parent,
+                },
                 QueueKind::Regular,
             )
             .await

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -810,12 +810,10 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Passes the timestamp of a future block for which deploys are to be proposed.
-    // TODO: The input `BlockContext` will probably be a different type than the context in the
-    //       return value in the future.
     pub(crate) async fn request_proto_block(
         self,
         block_context: BlockContext,
-        next_block_height: u64,
+        next_finalized: u64,
         random_bit: bool,
     ) -> (ProtoBlock, BlockContext)
     where
@@ -827,7 +825,7 @@ impl<REv> EffectBuilder<REv> {
                     BlockProposerRequest::ListForInclusion(ListForInclusionRequest {
                         current_instant: block_context.timestamp(),
                         past_deploys: Default::default(), // TODO
-                        next_block_height,
+                        next_finalized,
                         responder,
                     })
                 },

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -111,7 +111,7 @@ use crate::{
     types::{
         json_compatibility::ExecutionResult, Block, BlockByHeight, BlockHash, BlockHeader,
         BlockLike, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock, Item,
-        ProtoBlock, Timestamp,
+        ProtoBlock, ProtoBlockHash, Timestamp,
     },
     utils::Source,
     Chainspec,
@@ -815,6 +815,7 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn request_proto_block(
         self,
         block_context: BlockContext,
+        last_finalized_block: Option<ProtoBlockHash>,
         random_bit: bool,
     ) -> (ProtoBlock, BlockContext)
     where
@@ -825,6 +826,7 @@ impl<REv> EffectBuilder<REv> {
                 |responder| BlockProposerRequest::ListForInclusion {
                     current_instant: block_context.timestamp(),
                     past_deploys: Default::default(), // TODO
+                    last_finalized_block,
                     responder,
                 },
                 QueueKind::Regular,

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -12,7 +12,7 @@ use crate::{
     components::small_network::GossipedAddress,
     types::{
         json_compatibility::ExecutionResult, Block, BlockHash, BlockHeader, Deploy, DeployHash,
-        DeployHeader, FinalizedBlock, Item,
+        DeployHeader, FinalizedBlock, Item, ProtoBlockHash,
     },
     utils::Source,
 };
@@ -117,7 +117,12 @@ impl<I: Display> Display for DeployAcceptorAnnouncement<I> {
 #[derive(Debug)]
 pub enum ConsensusAnnouncement {
     /// A block was finalized.
-    Finalized(Box<FinalizedBlock>),
+    Finalized {
+        /// The finalized block.
+        block: Box<FinalizedBlock>,
+        /// The hash of the parent proto-block.
+        parent: Option<ProtoBlockHash>,
+    },
     /// A linear chain block has been handled.
     Handled(Box<BlockHeader>),
 }
@@ -125,7 +130,7 @@ pub enum ConsensusAnnouncement {
 impl Display for ConsensusAnnouncement {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ConsensusAnnouncement::Finalized(block) => {
+            ConsensusAnnouncement::Finalized { block, parent: _ } => {
                 write!(formatter, "finalized proto block {}", block)
             }
             ConsensusAnnouncement::Handled(block_header) => write!(

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -12,7 +12,7 @@ use crate::{
     components::small_network::GossipedAddress,
     types::{
         json_compatibility::ExecutionResult, Block, BlockHash, BlockHeader, Deploy, DeployHash,
-        DeployHeader, FinalizedBlock, Item, ProtoBlock,
+        DeployHeader, FinalizedBlock, Item,
     },
     utils::Source,
 };
@@ -116,12 +116,8 @@ impl<I: Display> Display for DeployAcceptorAnnouncement<I> {
 /// A consensus announcement.
 #[derive(Debug)]
 pub enum ConsensusAnnouncement {
-    /// A block was proposed and will either be finalized or orphaned soon.
-    Proposed(ProtoBlock),
     /// A block was finalized.
     Finalized(Box<FinalizedBlock>),
-    /// A block was orphaned.
-    Orphaned(ProtoBlock),
     /// A linear chain block has been handled.
     Handled(Box<BlockHeader>),
 }
@@ -129,14 +125,8 @@ pub enum ConsensusAnnouncement {
 impl Display for ConsensusAnnouncement {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ConsensusAnnouncement::Proposed(block) => {
-                write!(formatter, "proposed proto block {}", block)
-            }
             ConsensusAnnouncement::Finalized(block) => {
                 write!(formatter, "finalized proto block {}", block)
-            }
-            ConsensusAnnouncement::Orphaned(block) => {
-                write!(formatter, "orphaned proto block {}", block)
             }
             ConsensusAnnouncement::Handled(block_header) => write!(
                 formatter,

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -12,7 +12,7 @@ use crate::{
     components::small_network::GossipedAddress,
     types::{
         json_compatibility::ExecutionResult, Block, BlockHash, BlockHeader, Deploy, DeployHash,
-        DeployHeader, FinalizedBlock, Item, ProtoBlockHash,
+        DeployHeader, FinalizedBlock, Item,
     },
     utils::Source,
 };
@@ -117,12 +117,7 @@ impl<I: Display> Display for DeployAcceptorAnnouncement<I> {
 #[derive(Debug)]
 pub enum ConsensusAnnouncement {
     /// A block was finalized.
-    Finalized {
-        /// The finalized block.
-        block: Box<FinalizedBlock>,
-        /// The hash of the parent proto-block.
-        parent: Option<ProtoBlockHash>,
-    },
+    Finalized(Box<FinalizedBlock>),
     /// A linear chain block has been handled.
     Handled(Box<BlockHeader>),
 }
@@ -130,7 +125,7 @@ pub enum ConsensusAnnouncement {
 impl Display for ConsensusAnnouncement {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ConsensusAnnouncement::Finalized { block, parent: _ } => {
+            ConsensusAnnouncement::Finalized(block) => {
                 write!(formatter, "finalized proto block {}", block)
             }
             ConsensusAnnouncement::Handled(block_header) => write!(

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -321,32 +321,36 @@ impl Display for StorageRequest {
     }
 }
 
+/// Details of a request for a list of deploys to propose in a new block.
+#[derive(Debug)]
+pub struct ListForInclusionRequest {
+    /// The instant for which the deploy is requested.
+    pub(crate) current_instant: Timestamp,
+    /// Set of block hashes pointing to blocks whose deploys should be excluded.
+    pub(crate) past_deploys: HashSet<DeployHash>,
+    /// The hash of the last block that was finalized at the point when the request was made.
+    pub(crate) last_finalized_block: Option<ProtoBlockHash>,
+    /// Responder to call with the result.
+    pub(crate) responder: Responder<HashSet<DeployHash>>,
+}
+
 /// A `BlockProposer` request.
 #[derive(Debug)]
 #[must_use]
 pub enum BlockProposerRequest {
     /// Request a list of deploys to propose in a new block.
-    ListForInclusion {
-        /// The instant for which the deploy is requested.
-        current_instant: Timestamp,
-        /// Set of block hashes pointing to blocks whose deploys should be excluded.
-        past_deploys: HashSet<DeployHash>,
-        /// The hash of the last block that was finalized at the point when the request was made.
-        last_finalized_block: Option<ProtoBlockHash>,
-        /// Responder to call with the result.
-        responder: Responder<HashSet<DeployHash>>,
-    },
+    ListForInclusion(ListForInclusionRequest),
 }
 
 impl Display for BlockProposerRequest {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            BlockProposerRequest::ListForInclusion {
+            BlockProposerRequest::ListForInclusion(ListForInclusionRequest {
                 current_instant,
                 past_deploys,
                 last_finalized_block: _,
                 responder: _,
-            } => write!(
+            }) => write!(
                 formatter,
                 "list for inclusion: instant {} past {}",
                 current_instant,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -322,7 +322,7 @@ impl Display for StorageRequest {
 }
 
 /// Details of a request for a list of deploys to propose in a new block.
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub struct ListForInclusionRequest {
     /// The instant for which the deploy is requested.
     pub(crate) current_instant: Timestamp,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -326,10 +326,13 @@ impl Display for StorageRequest {
 pub struct ListForInclusionRequest {
     /// The instant for which the deploy is requested.
     pub(crate) current_instant: Timestamp,
-    /// Set of block hashes pointing to blocks whose deploys should be excluded.
+    /// Set of deploy hashes of deploys that should be excluded in addition to the finalized ones.
     pub(crate) past_deploys: HashSet<DeployHash>,
-    /// The height of the next block to be finalized
-    pub(crate) next_block_height: u64,
+    /// The height of the next block to be finalized at the point the request was made.
+    /// This is _only_ a way of expressing how many blocks have been finalized at the moment the
+    /// request was made. Block Proposer uses this in order to determine if there might be any
+    /// deploys that are neither in `past_deploys`, nor among the finalized deploys it knows of.
+    pub(crate) next_finalized: u64,
     /// Responder to call with the result.
     pub(crate) responder: Responder<HashSet<DeployHash>>,
 }
@@ -348,14 +351,14 @@ impl Display for BlockProposerRequest {
             BlockProposerRequest::ListForInclusion(ListForInclusionRequest {
                 current_instant,
                 past_deploys,
-                next_block_height,
+                next_finalized,
                 responder: _,
             }) => write!(
                 formatter,
-                "list for inclusion: instant {} past {} next_block_height {}",
+                "list for inclusion: instant {} past {} next_finalized {}",
                 current_instant,
                 past_deploys.len(),
-                next_block_height
+                next_finalized
             ),
         }
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -45,8 +45,8 @@ use crate::{
     rpcs::chain::BlockIdentifier,
     types::{
         json_compatibility::ExecutionResult, Block as LinearBlock, Block, BlockHash, BlockHeader,
-        Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock, Item, ProtoBlockHash,
-        StatusFeed, Timestamp,
+        Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock, Item, StatusFeed,
+        Timestamp,
     },
     utils::DisplayIter,
     Chainspec,
@@ -330,7 +330,7 @@ pub enum BlockProposerRequest {
         /// The instant for which the deploy is requested.
         current_instant: Timestamp,
         /// Set of block hashes pointing to blocks whose deploys should be excluded.
-        past_blocks: HashSet<ProtoBlockHash>,
+        past_deploys: HashSet<DeployHash>,
         /// Responder to call with the result.
         responder: Responder<HashSet<DeployHash>>,
     },
@@ -341,13 +341,13 @@ impl Display for BlockProposerRequest {
         match self {
             BlockProposerRequest::ListForInclusion {
                 current_instant,
-                past_blocks,
+                past_deploys,
                 responder: _,
             } => write!(
                 formatter,
                 "list for inclusion: instant {} past {}",
                 current_instant,
-                past_blocks.len()
+                past_deploys.len()
             ),
         }
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -45,8 +45,8 @@ use crate::{
     rpcs::chain::BlockIdentifier,
     types::{
         json_compatibility::ExecutionResult, Block as LinearBlock, Block, BlockHash, BlockHeader,
-        Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock, Item, ProtoBlockHash,
-        StatusFeed, Timestamp,
+        Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock, Item, StatusFeed,
+        Timestamp,
     },
     utils::DisplayIter,
     Chainspec,
@@ -328,8 +328,8 @@ pub struct ListForInclusionRequest {
     pub(crate) current_instant: Timestamp,
     /// Set of block hashes pointing to blocks whose deploys should be excluded.
     pub(crate) past_deploys: HashSet<DeployHash>,
-    /// The hash of the last block that was finalized at the point when the request was made.
-    pub(crate) last_finalized_block: Option<ProtoBlockHash>,
+    /// The height of the next block to be finalized
+    pub(crate) next_block_height: u64,
     /// Responder to call with the result.
     pub(crate) responder: Responder<HashSet<DeployHash>>,
 }
@@ -348,13 +348,14 @@ impl Display for BlockProposerRequest {
             BlockProposerRequest::ListForInclusion(ListForInclusionRequest {
                 current_instant,
                 past_deploys,
-                last_finalized_block: _,
+                next_block_height,
                 responder: _,
             }) => write!(
                 formatter,
-                "list for inclusion: instant {} past {}",
+                "list for inclusion: instant {} past {} next_block_height {}",
                 current_instant,
-                past_deploys.len()
+                past_deploys.len(),
+                next_block_height
             ),
         }
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -45,8 +45,8 @@ use crate::{
     rpcs::chain::BlockIdentifier,
     types::{
         json_compatibility::ExecutionResult, Block as LinearBlock, Block, BlockHash, BlockHeader,
-        Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock, Item, StatusFeed,
-        Timestamp,
+        Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock, Item, ProtoBlockHash,
+        StatusFeed, Timestamp,
     },
     utils::DisplayIter,
     Chainspec,
@@ -331,6 +331,8 @@ pub enum BlockProposerRequest {
         current_instant: Timestamp,
         /// Set of block hashes pointing to blocks whose deploys should be excluded.
         past_deploys: HashSet<DeployHash>,
+        /// The hash of the last block that was finalized at the point when the request was made.
+        last_finalized_block: Option<ProtoBlockHash>,
         /// Responder to call with the result.
         responder: Responder<HashSet<DeployHash>>,
     },
@@ -342,6 +344,7 @@ impl Display for BlockProposerRequest {
             BlockProposerRequest::ListForInclusion {
                 current_instant,
                 past_deploys,
+                last_finalized_block: _,
                 responder: _,
             } => write!(
                 formatter,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -696,10 +696,6 @@ impl reactor::Reactor for Reactor {
                         event_stream_server::Event::BlockFinalized(block),
                     ),
                 ),
-                other => {
-                    warn!("Ignoring consensus announcement {}", other);
-                    Effects::new()
-                }
             },
             Event::BlockProposerRequest(request) => {
                 // Consensus component should not be trying to create new blocks during joining

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -688,7 +688,7 @@ impl reactor::Reactor for Reactor {
                         linear_chain_sync::Event::BlockHandled(block_header),
                     ),
                 ),
-                ConsensusAnnouncement::Finalized(block) => reactor::wrap_effects(
+                ConsensusAnnouncement::Finalized { block, parent: _ } => reactor::wrap_effects(
                     Event::EventStreamServer,
                     self.event_stream_server.handle_event(
                         effect_builder,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -688,7 +688,7 @@ impl reactor::Reactor for Reactor {
                         linear_chain_sync::Event::BlockHandled(block_header),
                     ),
                 ),
-                ConsensusAnnouncement::Finalized { block, parent: _ } => reactor::wrap_effects(
+                ConsensusAnnouncement::Finalized(block) => reactor::wrap_effects(
                     Event::EventStreamServer,
                     self.event_stream_server.handle_event(
                         effect_builder,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -733,10 +733,12 @@ impl reactor::Reactor for Reactor {
                 };
 
                 match consensus_announcement {
-                    ConsensusAnnouncement::Finalized(block) => {
-                        let mut effects = reactor_event_dispatch(
-                            block_proposer::Event::FinalizedProtoBlock(block.proto_block().clone()),
-                        );
+                    ConsensusAnnouncement::Finalized { block, parent } => {
+                        let mut effects =
+                            reactor_event_dispatch(block_proposer::Event::FinalizedProtoBlock {
+                                block: block.proto_block().clone(),
+                                parent,
+                            });
                         let reactor_event = Event::EventStreamServer(
                             event_stream_server::Event::BlockFinalized(block),
                         );

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -733,9 +733,7 @@ impl reactor::Reactor for Reactor {
                 };
 
                 match consensus_announcement {
-                    ConsensusAnnouncement::Proposed(block) => {
-                        reactor_event_dispatch(block_proposer::Event::ProposedProtoBlock(block))
-                    }
+                    ConsensusAnnouncement::Proposed(_block) => Effects::new(),
                     ConsensusAnnouncement::Finalized(block) => {
                         let mut effects = reactor_event_dispatch(
                             block_proposer::Event::FinalizedProtoBlock(block.proto_block().clone()),
@@ -746,9 +744,7 @@ impl reactor::Reactor for Reactor {
                         effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                         effects
                     }
-                    ConsensusAnnouncement::Orphaned(block) => {
-                        reactor_event_dispatch(block_proposer::Event::OrphanedProtoBlock(block))
-                    }
+                    ConsensusAnnouncement::Orphaned(_block) => Effects::new(),
                     ConsensusAnnouncement::Handled(_) => {
                         debug!("Ignoring `Handled` announcement in `validator` reactor.");
                         Effects::new()

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -733,7 +733,6 @@ impl reactor::Reactor for Reactor {
                 };
 
                 match consensus_announcement {
-                    ConsensusAnnouncement::Proposed(_block) => Effects::new(),
                     ConsensusAnnouncement::Finalized(block) => {
                         let mut effects = reactor_event_dispatch(
                             block_proposer::Event::FinalizedProtoBlock(block.proto_block().clone()),
@@ -744,7 +743,6 @@ impl reactor::Reactor for Reactor {
                         effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                         effects
                     }
-                    ConsensusAnnouncement::Orphaned(_block) => Effects::new(),
                     ConsensusAnnouncement::Handled(_) => {
                         debug!("Ignoring `Handled` announcement in `validator` reactor.");
                         Effects::new()

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -733,11 +733,11 @@ impl reactor::Reactor for Reactor {
                 };
 
                 match consensus_announcement {
-                    ConsensusAnnouncement::Finalized { block, parent } => {
+                    ConsensusAnnouncement::Finalized(block) => {
                         let mut effects =
                             reactor_event_dispatch(block_proposer::Event::FinalizedProtoBlock {
                                 block: block.proto_block().clone(),
-                                parent,
+                                height: block.height(),
                             });
                         let reactor_event = Event::EventStreamServer(
                             event_stream_server::Event::BlockFinalized(block),

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -15,7 +15,7 @@ use rand::{CryptoRng, RngCore};
 use rand_chacha::ChaCha20Rng;
 
 pub use block::{Block, BlockHash, BlockHeader, BlockValidationError};
-pub(crate) use block::{BlockByHeight, BlockLike, FinalizedBlock, ProtoBlock, ProtoBlockHash};
+pub(crate) use block::{BlockByHeight, BlockLike, FinalizedBlock, ProtoBlock};
 pub use deploy::{
     Approval, Deploy, DeployHash, DeployHeader, DeployMetadata, Error as DeployError,
 };

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -93,20 +93,9 @@ impl ProtoBlockHash {
         ProtoBlockHash(hash)
     }
 
-    pub fn from_parts(deploys: &[DeployHash], random_bit: bool) -> Self {
-        ProtoBlockHash::new(hash::hash(
-            &bincode::serialize(&(deploys, random_bit)).expect("serialize ProtoBlock"),
-        ))
-    }
-
     /// Returns the wrapped inner hash.
     pub fn inner(&self) -> &Digest {
         &self.0
-    }
-
-    /// Returns `true` is `self` is a hash of empty `ProtoBlock`.
-    pub(crate) fn is_empty(self) -> bool {
-        self == ProtoBlock::empty_random_bit_false() || self == ProtoBlock::empty_random_bit_true()
     }
 }
 
@@ -161,18 +150,6 @@ impl ProtoBlock {
 
     pub(crate) fn destructure(self) -> (ProtoBlockHash, Vec<DeployHash>, bool) {
         (self.hash, self.deploys, self.random_bit)
-    }
-
-    /// Returns hash of empty ProtoBlock (no deploys) with a random bit set to false.
-    /// Added here so that it's always aligned with how hash is calculated.
-    pub(crate) fn empty_random_bit_false() -> ProtoBlockHash {
-        *ProtoBlock::new(vec![], false).hash()
-    }
-
-    /// Returns hash of empty ProtoBlock (no deploys) with a random bit set to true.
-    /// Added here so that it's always aligned with how hash is calculated.
-    pub(crate) fn empty_random_bit_true() -> ProtoBlockHash {
-        *ProtoBlock::new(vec![], true).hash()
     }
 }
 


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-168

This implements [CEP-20](https://github.com/CasperLabs/ceps/blob/master/text/0020-block-proposer-improvements.md). (EDIT 2020-11-20: with some modifications. The CEP will be updated to reflect them.)