### PR TITLE
NO-TICK: run setup before packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ build-for-packaging: build-system-contracts build-client-contracts
 	$(CARGO) build --release
 
 .PHONY: deb
-deb: build-for-packaging
+deb: setup build-for-packaging
 	cd grpc/server && $(CARGO) deb -p casper-engine-grpc-server --no-build
 	cd node && $(CARGO) deb -p casper-node --no-build
 	cd client && $(CARGO) deb -p casper-client --no-build


### PR DESCRIPTION
This came about because docker_make.sh was failing on fresh boxes when building the deb due to missing wasm32-unknown-unknown. I think it makes sense to run setup prior to anytime you build the deb.