### PR TITLE
NDRS-581: Block proposer state persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88b9ca26f9c16ec830350d309397e74ee9abdfd8eb1f71cb6ecc71a3fc818da"
+checksum = "3dc1679af9a1ab4bea16f228b05d18f8363f8327b1fa8db00d2760cfafc6b61e"
 dependencies = [
  "doc-comment",
  "predicates",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a0b2bb8ae20fede194e779150fe283f65a4a08461b496de546ec366b174ad9"
+checksum = "458c8f66c246624e7cf87c01451f3392ab77d66a0f105a49d9353b30ea97ced8"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -326,9 +326,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1339,7 +1339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.0",
+ "crossbeam-epoch 0.9.1",
  "crossbeam-utils 0.8.1",
 ]
 
@@ -1354,21 +1354,21 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.6",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
  "crossbeam-utils 0.8.1",
  "lazy_static",
- "memoffset",
+ "memoffset 0.6.1",
  "scopeguard",
 ]
 
@@ -1972,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54532e3223c5af90a6a757c90b5c5521564b07e5e7a958681bcd2afad421cdcd"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime",
@@ -2775,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -3426,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "lru_time_cache"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebac060fafad3adedd0c66a80741a92ff4bc8e94a273df2ba3770ab206f2e29a"
+checksum = "2cc2beb26938dfd9988fc368548b70bcdfaf955f55aa788e1682198de794a451"
 
 [[package]]
 name = "mach"
@@ -3501,6 +3501,15 @@ name = "memoffset"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg 1.0.1",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -3621,9 +3630,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -3928,9 +3937,9 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "oorandom"
-version = "11.1.2"
+version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -4117,11 +4126,11 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
+checksum = "f4c220d01f863d13d96ca82359d1e81e64a7c6bf0637bcde7b2349630addf0c6"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "once_cell",
  "regex",
 ]
@@ -4339,11 +4348,11 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
+checksum = "b3fd900a291ceb8b99799cc8cd3d1d3403a51721e015bc533528b2ceafcc443c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "universal-hash",
 ]
 
@@ -5025,9 +5034,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.15"
+version = "0.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+checksum = "70017ed5c555d79ee3538fc63ca09c70ad8f317dcadc1adc2c496b60c22bb24f"
 dependencies = [
  "cc",
  "libc",
@@ -5669,9 +5678,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1e438504729046a5cfae47f97c30d6d083c7d91d94603efdae3477fc070d4c"
+checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6556,9 +6565,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ casper-node-macros = { version = "0.2.0", path = "../node_macros" }
 casper-types = { version = "0.2.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 csv = "1.1.3"
-datasize = { version = "0.2.0", features = ["fake_clock-types", "futures-types", "smallvec-types", "tokio-types"] }
+datasize = { version = "0.2.3", features = ["fake_clock-types", "futures-types", "smallvec-types", "tokio-types"] }
 derive_more = "0.99.7"
 derp = "0.0.14"
 directories = "3.0.1"
@@ -34,8 +34,8 @@ enum-iterator = "0.6.0"
 futures = "0.3.5"
 getrandom = "0.2.0"
 hex = "0.4.2"
-hex_fmt = "0.3.0"
 hex-buffer-serde = "0.2.1"
+hex_fmt = "0.3.0"
 hostname = "0.3.0"
 http = "0.2.1"
 humantime = "2.0.1"
@@ -67,10 +67,10 @@ schemars = { version = "0.8.0", features = ["preserve_order"] }
 sd-notify = "0.1.1"
 semver = { version = "0.11.0", features = ["serde"] }
 serde = { version = "1.0.110", features = ["derive"] }
+serde-big-array = "0.3.0"
 serde_bytes = "0.11.5"
 serde_json = "1.0.55"
 serde_repr = "0.1.6"
-serde-big-array = "0.3.0"
 signal-hook = "0.1.16"
 signature = "1.1.0"
 smallvec = "1.4.0"
@@ -84,7 +84,7 @@ tokio-util = { version = "0.3.1", features = ["codec"] }
 toml = "0.5.6"
 tracing = "0.1.18"
 tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.10"
+tracing-subscriber = { version = "0.2.10", features = ["fmt", "json"] }
 uint = "0.8.3"
 untrusted = "0.7.1"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -3,189 +3,273 @@
 //! The block proposer stores deploy hashes in memory, tracking their suitability for inclusion into
 //! a new block. Upon request, it returns a list of candidates that can be included.
 
+mod deploy_sets;
+mod event;
+mod metrics;
+
 use std::{
     collections::{HashMap, HashSet},
     convert::Infallible,
-    fmt::{self, Display, Formatter},
     time::Duration,
 };
 
 use datasize::DataSize;
-use derive_more::From;
-use prometheus::{self, IntGauge, Registry};
-use semver::Version;
-use tracing::{info, trace};
+use prometheus::{self, Registry};
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     components::{chainspec_loader::DeployConfig, Component},
     effect::{
-        requests::{BlockProposerRequest, ListForInclusionRequest, StorageRequest},
+        requests::{
+            BlockProposerRequest, ListForInclusionRequest, StateStoreRequest, StorageRequest,
+        },
         EffectBuilder, EffectExt, Effects,
     },
-    types::{DeployHash, DeployHeader, ProtoBlock, Timestamp},
+    types::{DeployHash, DeployHeader, Timestamp},
     NodeRng,
 };
+pub(crate) use deploy_sets::BlockProposerDeploySets;
+pub(crate) use event::Event;
+use metrics::BlockProposerMetrics;
+use semver::Version;
 
+/// Block proposer component.
+#[derive(DataSize, Debug)]
+pub(crate) struct BlockProposer {
+    /// The current state of the proposer component.
+    state: BlockProposerState,
+
+    /// Metrics, present in all states.
+    metrics: BlockProposerMetrics,
+}
+
+/// Interval after which a pruning of the internal sets is triggered.
+// TODO: Make configurable.
 const PRUNE_INTERVAL: Duration = Duration::from_secs(10);
 
 /// The type of values expressing the block height in the chain.
 type BlockHeight = u64;
 
-/// An event for when using the block proposer as a component.
-#[derive(Debug, From)]
-pub enum Event {
-    #[from]
-    Request(BlockProposerRequest),
-    /// A new deploy should be buffered.
-    Buffer {
-        hash: DeployHash,
-        header: Box<DeployHeader>,
-    },
-    /// The deploy-buffer has been asked to prune stale deploys
-    BufferPrune,
-    /// A proto block has been finalized. We should never propose its deploys again.
-    FinalizedProtoBlock {
-        block: ProtoBlock,
-        height: BlockHeight,
-    },
-    /// The result of the `BlockProposer` getting the chainspec from the storage component.
-    GetChainspecResult {
-        maybe_deploy_config: Box<Option<DeployConfig>>,
-        chainspec_version: Version,
-        request: ListForInclusionRequest,
-    },
-}
-
-impl Display for Event {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Event::BufferPrune => write!(f, "buffer prune"),
-            Event::Request(req) => write!(f, "deploy-buffer request: {}", req),
-            Event::Buffer { hash, .. } => write!(f, "deploy-buffer add {}", hash),
-            Event::FinalizedProtoBlock { block, height } => {
-                write!(
-                    f,
-                    "deploy-buffer finalized proto block {} at height {}",
-                    block, height
-                )
-            }
-            Event::GetChainspecResult {
-                maybe_deploy_config,
-                ..
-            } => {
-                if maybe_deploy_config.is_some() {
-                    write!(f, "deploy-buffer got chainspec")
-                } else {
-                    write!(f, "deploy-buffer failed to get chainspec")
-                }
-            }
-        }
-    }
-}
-
 /// A collection of deploy hashes with their corresponding deploy headers.
 type DeployCollection = HashMap<DeployHash, DeployHeader>;
+
 /// A queue of contents of blocks that we know have been finalized, but we are still missing
 /// notifications about finalization of some of their ancestors. It maps block height to the
 /// deploys contained in the corresponding block.
 type FinalizationQueue = HashMap<BlockHeight, Vec<DeployHash>>;
+
 /// A queue of requests we can't respond to yet, because we aren't up to date on finalized blocks.
 /// The key is the height of the next block we will expect to be finalized at the point when we can
 /// fulfill the corresponding requests.
 type RequestQueue = HashMap<BlockHeight, Vec<ListForInclusionRequest>>;
 
-pub(crate) trait ReactorEventT: From<Event> + From<StorageRequest> + Send + 'static {}
+/// Current operational state of a block proposer.
+#[derive(DataSize, Debug)]
+#[allow(clippy::large_enum_variant)]
+enum BlockProposerState {
+    /// Block proposer is initializing, waiting for a state snapshot.
+    Initializing { pending: Vec<Event> },
+    /// Normal operation.
+    Ready(BlockProposerReady),
+}
 
-impl<REv> ReactorEventT for REv where REv: From<Event> + From<StorageRequest> + Send + 'static {}
+impl BlockProposer {
+    /// Creates a new block proposer instance.
+    pub(crate) fn new<REv>(
+        registry: Registry,
+        effect_builder: EffectBuilder<REv>,
+    ) -> Result<(Self, Effects<Event>), prometheus::Error>
+    where
+        REv: From<Event> + From<StorageRequest> + From<StateStoreRequest> + Send + 'static,
+    {
+        // Note: Version is currently not honored by the storage component, so we just hardcode
+        // 1.0.0.
+        let effects = async move {
+            let chainspec = effect_builder
+                .get_chainspec(Version::new(1, 0, 0))
+                .await
+                // Note: Currently the storage component will always return a chainspec, however the
+                // interface has not kept up with this yet.
+                .expect("chainspec should be infallible");
 
-/// Stores the internal state of the BlockProposer.
-#[derive(DataSize, Default, Debug)]
-pub(crate) struct BlockProposerState {
-    /// The collection of deploys pending for inclusion in a block.
-    pending: DeployCollection,
-    /// The deploys that have already been included in a finalized block.
-    finalized_deploys: DeployCollection,
-    /// The next block height we expect to be finalized.
-    /// If we receive a notification of finalization of a later block, we will store it in
-    /// finalization_queue.
-    /// If we receive a request that contains a later next_finalized, we will store it in
-    /// request_queue.
-    next_finalized: BlockHeight,
-    /// The queue of finalized block contents awaiting inclusion in `self.finalized_deploys`.
-    finalization_queue: FinalizationQueue,
+            // With the chainspec, we can now load the state from storage or use a fresh instance if
+            // loading fails.
+            let key = deploy_sets::create_storage_key(&chainspec);
+            let sets = effect_builder
+                .load_state(key.into())
+                .await
+                .unwrap_or_default();
+
+            (chainspec, sets)
+        }
+        .event(|(chainspec, sets)| Event::Loaded { chainspec, sets });
+
+        let block_proposer = BlockProposer {
+            state: BlockProposerState::Initializing {
+                pending: Vec::new(),
+            },
+            metrics: BlockProposerMetrics::new(registry)?,
+        };
+
+        Ok((block_proposer, effects))
+    }
+}
+
+impl<REv> Component<REv> for BlockProposer
+where
+    REv: From<Event> + From<StorageRequest> + From<StateStoreRequest> + Send + 'static,
+{
+    type Event = Event;
+    type ConstructionError = Infallible;
+
+    fn handle_event(
+        &mut self,
+        effect_builder: EffectBuilder<REv>,
+        _rng: &mut NodeRng,
+        event: Self::Event,
+    ) -> Effects<Self::Event> {
+        let mut effects = Effects::new();
+
+        // We handle two different states in the block proposer, but our "ready" state is
+        // encapsulated in a separate type to simplify the code. The `Initializing` state is simple
+        // enough to handle it here directly.
+        match (&mut self.state, event) {
+            (
+                BlockProposerState::Initializing { ref mut pending },
+                Event::Loaded { chainspec, sets },
+            ) => {
+                let mut new_ready_state = BlockProposerReady {
+                    sets: sets.unwrap_or_default(),
+                    deploy_config: chainspec.genesis.deploy_config,
+                    state_key: deploy_sets::create_storage_key(&chainspec),
+                    request_queue: Default::default(),
+                };
+
+                // Replay postponed events onto new state.
+                for ev in pending.drain(0..pending.len()) {
+                    effects.extend(new_ready_state.handle_event(effect_builder, ev));
+                }
+
+                self.state = BlockProposerState::Ready(new_ready_state);
+
+                // Start pruning deploys after delay.
+                effects.extend(
+                    effect_builder
+                        .set_timeout(PRUNE_INTERVAL)
+                        .event(|_| Event::BufferPrune),
+                );
+            }
+            (BlockProposerState::Initializing { ref mut pending }, event) => {
+                // Any incoming events are just buffered until initialization is complete.
+                pending.push(event);
+            }
+
+            (BlockProposerState::Ready(ref mut ready_state), event) => {
+                effects.extend(ready_state.handle_event(effect_builder, event));
+
+                // Update metrics after the effects have been applied.
+                self.metrics
+                    .pending_deploys
+                    .set(ready_state.sets.pending.len() as i64);
+            }
+        };
+
+        effects
+    }
+}
+
+/// State of operational block proposer.
+#[derive(DataSize, Debug)]
+struct BlockProposerReady {
+    /// Set of deploys currently stored in the block proposer.
+    sets: BlockProposerDeploySets,
+    // We don't need the whole Chainspec here, just the deploy config.
+    deploy_config: DeployConfig,
+    /// Key for storing the block proposer state.
+    state_key: Vec<u8>,
     /// The queue of requests awaiting being handled.
     request_queue: RequestQueue,
 }
 
-impl Display for BlockProposerState {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "(pending:{}, finalized:{})",
-            self.pending.len(),
-            self.finalized_deploys.len()
-        )
-    }
-}
-
-impl BlockProposerState {
-    /// Prunes expired deploy information from the BlockProposerState, returns the total deploys
-    /// pruned
-    pub(crate) fn prune(&mut self, current_instant: Timestamp) -> usize {
-        let pending = prune::prune_deploys(&mut self.pending, current_instant);
-        let finalized = prune::prune_deploys(&mut self.finalized_deploys, current_instant);
-        pending + finalized
-    }
-}
-
-mod prune {
-    use super::*;
-
-    /// Prunes expired deploy information from an individual DeployCollection, returns the total
-    /// deploys pruned
-    pub(super) fn prune_deploys(
-        deploys: &mut DeployCollection,
-        current_instant: Timestamp,
-    ) -> usize {
-        let initial_len = deploys.len();
-        deploys.retain(|_hash, header| !header.expired(current_instant));
-        initial_len - deploys.len()
-    }
-}
-
-/// Block proposer.
-#[derive(DataSize, Debug)]
-pub(crate) struct BlockProposer {
-    state: BlockProposerState,
-    #[data_size(skip)]
-    metrics: BlockProposerMetrics,
-    // We don't need the whole Chainspec here (it's also unnecessarily big), just the deploy
-    // config.
-    #[data_size(skip)]
-    chainspecs: HashMap<Version, DeployConfig>,
-}
-
-impl BlockProposer {
-    /// Creates a new, block proposer instance with the provided internal state.
-    pub(crate) fn new<REv>(
-        registry: Registry,
+impl BlockProposerReady {
+    fn handle_event<REv>(
+        &mut self,
         effect_builder: EffectBuilder<REv>,
-        state: BlockProposerState,
-    ) -> Result<(Self, Effects<Event>), prometheus::Error>
+        event: Event,
+    ) -> Effects<Event>
     where
-        REv: ReactorEventT,
+        REv: Send + From<StateStoreRequest>,
     {
-        let effects = effect_builder
-            .set_timeout(PRUNE_INTERVAL)
-            .event(|_| Event::BufferPrune);
+        match event {
+            Event::Request(BlockProposerRequest::ListForInclusion(request)) => {
+                if request.next_finalized > self.sets.next_finalized {
+                    self.request_queue
+                        .entry(request.next_finalized)
+                        .or_default()
+                        .push(request);
+                    Effects::new()
+                } else {
+                    request
+                        .responder
+                        .respond(self.propose_deploys(
+                            self.deploy_config,
+                            request.current_instant,
+                            request.past_deploys,
+                        ))
+                        .ignore()
+                }
+            }
+            Event::Buffer { hash, header } => {
+                self.add_deploy(Timestamp::now(), hash, *header);
+                Effects::new()
+            }
+            Event::BufferPrune => {
+                let pruned = self.prune(Timestamp::now());
+                debug!("Pruned {} deploys from buffer", pruned);
 
-        let metrics = BlockProposerMetrics::new(registry)?;
-        let this = BlockProposer {
-            metrics,
-            state,
-            chainspecs: HashMap::new(),
-        };
-        Ok((this, effects))
+                // After pruning, we store a state snapshot.
+                let mut effects = effect_builder
+                    .save_state(self.state_key.clone().into(), self.sets.clone())
+                    .ignore();
+
+                // Re-trigger timer after `PRUNE_INTERVAL`.
+                effects.extend(
+                    effect_builder
+                        .set_timeout(PRUNE_INTERVAL)
+                        .event(|_| Event::BufferPrune),
+                );
+
+                effects
+            }
+            Event::Loaded { sets, .. } => {
+                // This should never happen, but we can just ignore the event and carry on.
+                warn!(
+                    ?sets,
+                    "got loaded event for block proposer state during ready state"
+                );
+                Effects::new()
+            }
+            Event::FinalizedProtoBlock { block, mut height } => {
+                let (_, deploys, _) = block.destructure();
+                if height > self.sets.next_finalized {
+                    // safe to subtract 1 - height will never be 0 in this branch, because
+                    // next_finalized is at least 0, and height has to be greater
+                    self.sets.finalization_queue.insert(height - 1, deploys);
+                    Effects::new()
+                } else {
+                    let mut effects = self.handle_finalized_block(effect_builder, height, deploys);
+                    while let Some(deploys) = self.sets.finalization_queue.remove(&height) {
+                        height += 1;
+                        effects.extend(self.handle_finalized_block(
+                            effect_builder,
+                            height,
+                            deploys,
+                        ));
+                    }
+                    effects
+                }
+            }
+        }
     }
 
     /// Adds a deploy to the block proposer.
@@ -197,80 +281,66 @@ impl BlockProposer {
             return;
         }
         // only add the deploy if it isn't contained in a finalized block
-        if !self.state.finalized_deploys.contains_key(&hash) {
-            self.state.pending.insert(hash, header);
+        if !self.sets.finalized_deploys.contains_key(&hash) {
+            self.sets.pending.insert(hash, header);
             info!("added deploy {} to the buffer", hash);
         } else {
             info!("deploy {} rejected from the buffer", hash);
         }
     }
 
-    /// Gets the chainspec from the cache or, if not cached, from the storage.
-    fn get_chainspec<REv>(
-        &mut self,
-        effect_builder: EffectBuilder<REv>,
-        request: ListForInclusionRequest,
-    ) -> Effects<Event>
+    /// Notifies the block proposer that a block has been finalized.
+    fn finalized_deploys<I>(&mut self, deploys: I)
     where
-        REv: ReactorEventT,
+        I: IntoIterator<Item = DeployHash>,
     {
-        // TODO - should the current protocol version be passed in here?
-        let chainspec_version = Version::from((1, 0, 0));
-        let cached_chainspec = self.chainspecs.get(&chainspec_version).cloned();
-        match cached_chainspec {
-            Some(chainspec) => {
-                effect_builder
-                    .immediately()
-                    .event(move |_| Event::GetChainspecResult {
-                        maybe_deploy_config: Box::new(Some(chainspec)),
-                        chainspec_version,
-                        request,
-                    })
-            }
-            None => self.get_chainspec_from_storage(effect_builder, chainspec_version, request),
-        }
-    }
-
-    /// Gets the chainspec from storage in order to call `propose_deploys()`.
-    fn get_chainspec_from_storage<REv: ReactorEventT>(
-        &mut self,
-        effect_builder: EffectBuilder<REv>,
-        chainspec_version: Version,
-        request: ListForInclusionRequest,
-    ) -> Effects<Event>
-    where
-        REv: From<StorageRequest> + Send,
-    {
-        effect_builder
-            .get_chainspec(chainspec_version.clone())
-            .event(move |maybe_chainspec| Event::GetChainspecResult {
-                maybe_deploy_config: Box::new(maybe_chainspec.map(|c| c.genesis.deploy_config)),
-                chainspec_version,
-                request,
+        // TODO: This will ignore deploys that weren't in `pending`. They might be added
+        // later, and then would be proposed as duplicates.
+        let deploys: HashMap<_, _> = deploys
+            .into_iter()
+            .filter_map(|deploy_hash| {
+                self.sets
+                    .pending
+                    .get(&deploy_hash)
+                    .map(|deploy_header| (deploy_hash, deploy_header.clone()))
             })
-    }
-
-    /// Returns a list of candidates for inclusion into a block.
-    fn propose_deploys(
-        &mut self,
-        deploy_config: DeployConfig,
-        block_timestamp: Timestamp,
-        past_deploys: HashSet<DeployHash>,
-    ) -> HashSet<DeployHash> {
-        // deploys_to_return = all deploys in pending that aren't in finalized blocks or
-        // proposed blocks from the set `past_blocks`
-        self.state
+            .collect();
+        self.sets
             .pending
-            .iter()
-            .filter(|&(hash, deploy)| {
-                self.is_deploy_valid(deploy, block_timestamp, &deploy_config, &past_deploys)
-                    && !past_deploys.contains(hash)
-                    && !self.state.finalized_deploys.contains_key(hash)
-            })
-            .map(|(hash, _deploy)| *hash)
-            .take(deploy_config.block_max_deploy_count as usize)
-            .collect::<HashSet<_>>()
-        // TODO: check gas and block size limits
+            .retain(|deploy_hash, _| !deploys.contains_key(deploy_hash));
+        self.sets.finalized_deploys.extend(deploys);
+    }
+
+    /// Handles finalization of a block.
+    fn handle_finalized_block<I, REv>(
+        &mut self,
+        _effect_builder: EffectBuilder<REv>,
+        height: BlockHeight,
+        deploys: I,
+    ) -> Effects<Event>
+    where
+        I: IntoIterator<Item = DeployHash>,
+    {
+        self.finalized_deploys(deploys);
+        self.sets.next_finalized = height + 1;
+
+        if let Some(requests) = self.request_queue.remove(&self.sets.next_finalized) {
+            requests
+                .into_iter()
+                .flat_map(|request| {
+                    request
+                        .responder
+                        .respond(self.propose_deploys(
+                            self.deploy_config,
+                            request.current_instant,
+                            request.past_deploys,
+                        ))
+                        .ignore()
+                })
+                .collect()
+        } else {
+            Effects::new()
+        }
     }
 
     /// Checks if a deploy is valid (for inclusion into the next block).
@@ -283,7 +353,7 @@ impl BlockProposer {
     ) -> bool {
         let all_deps_resolved = || {
             deploy.dependencies().iter().all(|dep| {
-                past_deploys.contains(dep) || self.state.finalized_deploys.contains_key(dep)
+                past_deploys.contains(dep) || self.sets.finalized_deploys.contains_key(dep)
             })
         };
         let ttl_valid = deploy.ttl() <= deploy_config.max_ttl;
@@ -293,155 +363,36 @@ impl BlockProposer {
         ttl_valid && timestamp_valid && deploy_valid && num_deps_valid && all_deps_resolved()
     }
 
-    /// Notifies the block proposer that a block has been finalized.
-    fn finalized_deploys<I>(&mut self, deploys: I)
-    where
-        I: IntoIterator<Item = DeployHash>,
-    {
-        let deploys: HashMap<_, _> = deploys
-            .into_iter()
-            .filter_map(|deploy_hash| {
-                self.state
-                    .pending
-                    .get(&deploy_hash)
-                    .map(|deploy_header| (deploy_hash, deploy_header.clone()))
-            })
-            .collect();
-        self.state
+    /// Returns a list of candidates for inclusion into a block.
+    // TODO:
+    /// rename to proposed deploys
+    // TODO:
+    /// maybe use cuckoofilter
+    fn propose_deploys(
+        &mut self,
+        deploy_config: DeployConfig,
+        block_timestamp: Timestamp,
+        past_deploys: HashSet<DeployHash>,
+    ) -> HashSet<DeployHash> {
+        // deploys_to_return = all deploys in pending that aren't in finalized blocks or
+        // proposed blocks from the set `past_blocks`
+        self.sets
             .pending
-            .retain(|deploy_hash, _| !deploys.contains_key(deploy_hash));
-        self.state.finalized_deploys.extend(deploys);
+            .iter()
+            .filter(|&(hash, deploy)| {
+                self.is_deploy_valid(deploy, block_timestamp, &deploy_config, &past_deploys)
+                    && !past_deploys.contains(hash)
+                    && !self.sets.finalized_deploys.contains_key(hash)
+            })
+            .map(|(hash, _deploy)| *hash)
+            .take(deploy_config.block_max_deploy_count as usize)
+            .collect::<HashSet<_>>()
+        // TODO: check gas and block size limits
     }
 
-    /// Handles finalization of a block.
-    fn handle_finalized_block<I, REv>(
-        &mut self,
-        effect_builder: EffectBuilder<REv>,
-        height: BlockHeight,
-        deploys: I,
-    ) -> Effects<Event>
-    where
-        I: IntoIterator<Item = DeployHash>,
-        REv: ReactorEventT,
-    {
-        self.finalized_deploys(deploys);
-        self.state.next_finalized = height + 1;
-
-        if let Some(requests) = self.state.request_queue.remove(&self.state.next_finalized) {
-            requests
-                .into_iter()
-                .flat_map(|request| self.get_chainspec(effect_builder, request))
-                .collect()
-        } else {
-            Effects::new()
-        }
-    }
-
-    /// Prunes expired deploy information from the BlockProposer, returns the total deploys pruned
+    /// Prunes expired deploy information from the BlockProposer, returns the total deploys pruned.
     fn prune(&mut self, current_instant: Timestamp) -> usize {
-        self.state.prune(current_instant)
-    }
-}
-
-impl<REv> Component<REv> for BlockProposer
-where
-    REv: ReactorEventT,
-{
-    type Event = Event;
-    type ConstructionError = Infallible;
-
-    fn handle_event(
-        &mut self,
-        effect_builder: EffectBuilder<REv>,
-        _rng: &mut NodeRng,
-        event: Self::Event,
-    ) -> Effects<Self::Event> {
-        self.metrics
-            .pending_deploys
-            .set(self.state.pending.len() as i64);
-        match event {
-            Event::BufferPrune => {
-                let pruned = self.prune(Timestamp::now());
-                log::debug!("Pruned {} deploys from buffer", pruned);
-                return effect_builder
-                    .set_timeout(PRUNE_INTERVAL)
-                    .event(|_| Event::BufferPrune);
-            }
-            Event::Request(BlockProposerRequest::ListForInclusion(request)) => {
-                if request.next_finalized > self.state.next_finalized {
-                    self.state
-                        .request_queue
-                        .entry(request.next_finalized)
-                        .or_default()
-                        .push(request);
-                } else {
-                    return self.get_chainspec(effect_builder, request);
-                }
-            }
-            Event::Buffer { hash, header } => self.add_deploy(Timestamp::now(), hash, *header),
-            Event::FinalizedProtoBlock { block, mut height } => {
-                let (_, deploys, _) = block.destructure();
-                if height > self.state.next_finalized {
-                    // safe to subtract 1 - height will never be 0 in this branch, because
-                    // next_finalized is at least 0, and height has to be greater
-                    self.state.finalization_queue.insert(height - 1, deploys);
-                } else {
-                    let mut effects = self.handle_finalized_block(effect_builder, height, deploys);
-                    while let Some(deploys) = self.state.finalization_queue.remove(&height) {
-                        height += 1;
-                        effects.extend(self.handle_finalized_block(
-                            effect_builder,
-                            height,
-                            deploys,
-                        ));
-                    }
-                    return effects;
-                }
-            }
-            Event::GetChainspecResult {
-                maybe_deploy_config,
-                chainspec_version,
-                request,
-            } => {
-                let deploy_config = maybe_deploy_config.expect("should return chainspec");
-                // Update chainspec cache.
-                self.chainspecs.insert(chainspec_version, deploy_config);
-                let deploys = self.propose_deploys(
-                    deploy_config,
-                    request.current_instant,
-                    request.past_deploys,
-                );
-                return request.responder.respond(deploys).ignore();
-            }
-        }
-        Effects::new()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct BlockProposerMetrics {
-    /// Amount of pending deploys
-    pending_deploys: IntGauge,
-    /// registry Component.
-    registry: Registry,
-}
-
-impl BlockProposerMetrics {
-    pub fn new(registry: Registry) -> Result<Self, prometheus::Error> {
-        let pending_deploys = IntGauge::new("pending_deploy", "amount of pending deploys")?;
-        registry.register(Box::new(pending_deploys.clone()))?;
-        Ok(BlockProposerMetrics {
-            pending_deploys,
-            registry,
-        })
-    }
-}
-
-impl Drop for BlockProposerMetrics {
-    fn drop(&mut self) {
-        self.registry
-            .unregister(Box::new(self.pending_deploys.clone()))
-            .expect("did not expect deregistering pending_deploys to fail");
+        self.sets.prune(current_instant)
     }
 }
 
@@ -455,10 +406,8 @@ mod tests {
     use super::*;
     use crate::{
         crypto::asymmetric_key::SecretKey,
-        reactor::{EventQueueHandle, QueueKind, Scheduler},
         testing::TestRng,
         types::{Deploy, DeployHash, DeployHeader, TimeDiff},
-        utils,
     };
 
     fn generate_deploy(
@@ -494,20 +443,26 @@ mod tests {
         (*deploy.id(), deploy.take_header())
     }
 
-    fn create_test_buffer() -> (BlockProposer, Effects<Event>) {
-        let registry = Registry::new();
-        let scheduler = utils::leak(Scheduler::<Event>::new(QueueKind::weights()));
-        let event_queue = EventQueueHandle::new(&scheduler);
-        let effect_builder = EffectBuilder::new(event_queue);
-        BlockProposer::new(registry, effect_builder, BlockProposerState::default())
-            .expect("Failure to create a new Block Proposer")
+    fn create_test_proposer() -> BlockProposerReady {
+        BlockProposerReady {
+            sets: Default::default(),
+            deploy_config: Default::default(),
+            state_key: b"block-proposer-test".to_vec(),
+            request_queue: Default::default(),
+        }
     }
 
     impl From<StorageRequest> for Event {
         fn from(_: StorageRequest) -> Self {
             // we never send a storage request in our unit tests, but if this does become
             // meaningful....
-            todo!()
+            unreachable!("no storage requests in block proposer unit tests")
+        }
+    }
+
+    impl From<StateStoreRequest> for Event {
+        fn from(_: StateStoreRequest) -> Self {
+            unreachable!("no state store requests in block proposer unit tests")
         }
     }
 
@@ -520,65 +475,63 @@ mod tests {
         let block_time3 = Timestamp::from(220);
 
         let no_deploys = HashSet::new();
-        let (mut buffer, _effects) = create_test_buffer();
+        let mut proposer = create_test_proposer();
         let mut rng = crate::new_rng();
         let (hash1, deploy1) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
         let (hash2, deploy2) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
         let (hash3, deploy3) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
         let (hash4, deploy4) = generate_deploy(&mut rng, creation_time, ttl, vec![]);
 
-        assert!(buffer
+        assert!(proposer
             .propose_deploys(DeployConfig::default(), block_time2, no_deploys.clone())
             .is_empty());
 
         // add two deploys
-        buffer.add_deploy(block_time2, hash1, deploy1);
-        buffer.add_deploy(block_time2, hash2, deploy2);
+        proposer.add_deploy(block_time2, hash1, deploy1);
+        proposer.add_deploy(block_time2, hash2, deploy2);
 
         // if we try to create a block with a timestamp that is too early, we shouldn't get any
         // deploys
-        assert!(buffer
+        assert!(proposer
             .propose_deploys(DeployConfig::default(), block_time1, no_deploys.clone())
             .is_empty());
 
         // if we try to create a block with a timestamp that is too late, we shouldn't get any
         // deploys, either
-        assert!(buffer
+        assert!(proposer
             .propose_deploys(DeployConfig::default(), block_time3, no_deploys.clone())
             .is_empty());
 
         // take the deploys out
         let deploys =
-            buffer.propose_deploys(DeployConfig::default(), block_time2, no_deploys.clone());
+            proposer.propose_deploys(DeployConfig::default(), block_time2, no_deploys.clone());
 
         assert_eq!(deploys.len(), 2);
         assert!(deploys.contains(&hash1));
         assert!(deploys.contains(&hash2));
 
-        // the deploys should not have been removed
         assert_eq!(
-            buffer
+            proposer
                 .propose_deploys(DeployConfig::default(), block_time2, no_deploys.clone())
                 .len(),
             2
         );
 
         // but they shouldn't be returned if we include it in the past deploys
-        assert!(buffer
+        assert!(proposer
             .propose_deploys(DeployConfig::default(), block_time2, deploys.clone())
             .is_empty());
 
         // finalize the block
-        buffer.finalized_deploys(deploys);
+        proposer.finalized_deploys(deploys);
 
         // add more deploys
-        buffer.add_deploy(block_time2, hash3, deploy3);
-        buffer.add_deploy(block_time2, hash4, deploy4);
+        proposer.add_deploy(block_time2, hash3, deploy3);
+        proposer.add_deploy(block_time2, hash4, deploy4);
 
-        let deploys = buffer.propose_deploys(DeployConfig::default(), block_time2, no_deploys);
+        let deploys = proposer.propose_deploys(DeployConfig::default(), block_time2, no_deploys);
 
-        // since block 1 is now finalized, neither deploy1 nor deploy2 should be among the ones
-        // returned
+        // since block 1 is now finalized, neither deploy1 nor deploy2 should be among the returned
         assert_eq!(deploys.len(), 2);
         assert!(deploys.contains(&hash3));
         assert!(deploys.contains(&hash4));
@@ -601,34 +554,34 @@ mod tests {
             ttl,
             vec![],
         );
-        let (mut buffer, _effects) = create_test_buffer();
+        let mut proposer = create_test_proposer();
 
         // pending
-        buffer.add_deploy(creation_time, hash1, deploy1);
-        buffer.add_deploy(creation_time, hash2, deploy2);
-        buffer.add_deploy(creation_time, hash3, deploy3);
-        buffer.add_deploy(creation_time, hash4, deploy4);
+        proposer.add_deploy(creation_time, hash1, deploy1);
+        proposer.add_deploy(creation_time, hash2, deploy2);
+        proposer.add_deploy(creation_time, hash3, deploy3);
+        proposer.add_deploy(creation_time, hash4, deploy4);
 
         // pending => finalized
-        buffer.finalized_deploys(vec![hash1]);
+        proposer.finalized_deploys(vec![hash1]);
 
-        assert_eq!(buffer.state.pending.len(), 3);
-        assert!(buffer.state.finalized_deploys.contains_key(&hash1));
+        assert_eq!(proposer.sets.pending.len(), 3);
+        assert!(proposer.sets.finalized_deploys.contains_key(&hash1));
 
         // test for retained values
-        let pruned = buffer.prune(test_time);
+        let pruned = proposer.prune(test_time);
         assert_eq!(pruned, 0);
 
-        assert_eq!(buffer.state.pending.len(), 3);
-        assert_eq!(buffer.state.finalized_deploys.len(), 1);
-        assert!(buffer.state.finalized_deploys.contains_key(&hash1));
+        assert_eq!(proposer.sets.pending.len(), 3);
+        assert_eq!(proposer.sets.finalized_deploys.len(), 1);
+        assert!(proposer.sets.finalized_deploys.contains_key(&hash1));
 
         // now move the clock to make some things expire
-        let pruned = buffer.prune(expired_time);
+        let pruned = proposer.prune(expired_time);
         assert_eq!(pruned, 3);
 
-        assert_eq!(buffer.state.pending.len(), 1); // deploy4 is still valid
-        assert_eq!(buffer.state.finalized_deploys.len(), 0);
+        assert_eq!(proposer.sets.pending.len(), 1); // deploy4 is still valid
+        assert_eq!(proposer.sets.finalized_deploys.len(), 0);
     }
 
     #[test]
@@ -643,29 +596,29 @@ mod tests {
         let (hash2, deploy2) = generate_deploy(&mut rng, creation_time, ttl, vec![hash1]);
 
         let no_deploys = HashSet::new();
-        let (mut buffer, _effects) = create_test_buffer();
+        let mut proposer = create_test_proposer();
 
         // add deploy2
-        buffer.add_deploy(creation_time, hash2, deploy2);
+        proposer.add_deploy(creation_time, hash2, deploy2);
 
         // deploy2 has an unsatisfied dependency
-        assert!(buffer
+        assert!(proposer
             .propose_deploys(DeployConfig::default(), block_time, no_deploys.clone())
             .is_empty());
 
         // add deploy1
-        buffer.add_deploy(creation_time, hash1, deploy1);
+        proposer.add_deploy(creation_time, hash1, deploy1);
 
         let deploys =
-            buffer.propose_deploys(DeployConfig::default(), block_time, no_deploys.clone());
+            proposer.propose_deploys(DeployConfig::default(), block_time, no_deploys.clone());
         // only deploy1 should be returned, as it has no dependencies
         assert_eq!(deploys.len(), 1);
         assert!(deploys.contains(&hash1));
 
         // the deploy will be included in block 1
-        buffer.finalized_deploys(deploys);
+        proposer.finalized_deploys(deploys);
 
-        let deploys2 = buffer.propose_deploys(DeployConfig::default(), block_time, no_deploys);
+        let deploys2 = proposer.propose_deploys(DeployConfig::default(), block_time, no_deploys);
         // `blocks` contains a block that contains deploy1 now, so we should get deploy2
         assert_eq!(deploys2.len(), 1);
         assert!(deploys2.contains(&hash2));

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -1,0 +1,65 @@
+use std::fmt::{self, Display, Formatter};
+
+use datasize::DataSize;
+use serde::{Deserialize, Serialize};
+
+use super::{BlockHeight, DeployCollection, FinalizationQueue};
+use crate::{types::Timestamp, Chainspec};
+
+/// Stores the internal state of the BlockProposer.
+#[derive(Clone, DataSize, Debug, Default, Deserialize, Serialize)]
+pub struct BlockProposerDeploySets {
+    /// The collection of deploys pending for inclusion in a block.
+    pub(super) pending: DeployCollection,
+    /// The deploys that have already been included in a finalized block.
+    pub(super) finalized_deploys: DeployCollection,
+    /// The next block height we expect to be finalized.
+    /// If we receive a notification of finalization of a later block, we will store it in
+    /// finalization_queue.
+    /// If we receive a request that contains a later next_finalized, we will store it in
+    /// request_queue.
+    pub(super) next_finalized: BlockHeight,
+    /// The queue of finalized block contents awaiting inclusion in `self.finalized_deploys`.
+    pub(super) finalization_queue: FinalizationQueue,
+}
+
+impl Display for BlockProposerDeploySets {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "(pending:{}, finalized:{})",
+            self.pending.len(),
+            self.finalized_deploys.len()
+        )
+    }
+}
+
+/// Create a state storage key for block proposer deploy sets based on a chainspec.
+///
+/// We namespace based on a chainspec to prevent validators from loading data for a different chain
+/// if they forget to clear their state.
+pub fn create_storage_key(chainspec: &Chainspec) -> Vec<u8> {
+    format!(
+        "block_proposer_deploy_sets:version={},chain_name={}",
+        chainspec.genesis.protocol_version, chainspec.genesis.name
+    )
+    .into()
+}
+
+impl BlockProposerDeploySets {
+    /// Prunes expired deploy information from the BlockProposerState, returns the total deploys
+    /// pruned
+    pub(crate) fn prune(&mut self, current_instant: Timestamp) -> usize {
+        let pending = prune_deploys(&mut self.pending, current_instant);
+        let finalized = prune_deploys(&mut self.finalized_deploys, current_instant);
+        pending + finalized
+    }
+}
+
+/// Prunes expired deploy information from an individual DeployCollection, returns the total
+/// deploys pruned
+pub(super) fn prune_deploys(deploys: &mut DeployCollection, current_instant: Timestamp) -> usize {
+    let initial_len = deploys.len();
+    deploys.retain(|_hash, header| !header.expired(current_instant));
+    initial_len - deploys.len()
+}

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -1,0 +1,66 @@
+use std::{
+    fmt::{self, Formatter},
+    sync::Arc,
+};
+
+use datasize::DataSize;
+use derive_more::From;
+use fmt::Display;
+
+use super::{BlockHeight, BlockProposerDeploySets};
+use crate::{
+    effect::requests::BlockProposerRequest,
+    types::{DeployHash, DeployHeader, ProtoBlock},
+    Chainspec,
+};
+
+/// An event for when using the block proposer as a component.
+#[derive(DataSize, Debug, From)]
+pub enum Event {
+    /// Incoming `BlockProposerRequest`.
+    #[from]
+    Request(BlockProposerRequest),
+    /// The chainspec and previous sets have been successfully loaded from storage.
+    Loaded {
+        /// Loaded chainspec.
+        chainspec: Arc<Chainspec>,
+        /// Loaded previously stored block proposer sets.
+        sets: Option<BlockProposerDeploySets>,
+    },
+    /// A new deploy should be buffered.
+    Buffer {
+        hash: DeployHash,
+        header: Box<DeployHeader>,
+    },
+    /// The deploy-buffer has been asked to prune stale deploys
+    BufferPrune,
+    /// A proto block has been finalized. We should never propose its deploys again.
+    FinalizedProtoBlock {
+        block: ProtoBlock,
+        height: BlockHeight,
+    },
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Event::Request(req) => write!(f, "block-proposer request: {}", req),
+            Event::Loaded {
+                sets: Some(sets), ..
+            } => write!(f, "loaded block-proposer deploy sets: {}", sets),
+            Event::Loaded { sets: None, .. } => write!(
+                f,
+                "loaded block-proposer deploy sets, none found in storage"
+            ),
+            Event::Buffer { hash, .. } => write!(f, "block-proposer add {}", hash),
+            Event::BufferPrune => write!(f, "buffer prune"),
+            Event::FinalizedProtoBlock { block, height } => {
+                write!(
+                    f,
+                    "deploy-buffer finalized proto block {} at height {}",
+                    block, height
+                )
+            }
+        }
+    }
+}

--- a/node/src/components/block_proposer/metrics.rs
+++ b/node/src/components/block_proposer/metrics.rs
@@ -1,0 +1,33 @@
+use datasize::DataSize;
+use prometheus::{self, IntGauge, Registry};
+
+/// Metrics for the block proposer.
+#[derive(DataSize, Debug, Clone)]
+pub struct BlockProposerMetrics {
+    /// Amount of pending deploys
+    #[data_size(skip)]
+    pub(super) pending_deploys: IntGauge,
+    /// Registry stored to allow deregistration later.
+    #[data_size(skip)]
+    registry: Registry,
+}
+
+impl BlockProposerMetrics {
+    /// Creates a new instance of the block proposer metrics.
+    pub fn new(registry: Registry) -> Result<Self, prometheus::Error> {
+        let pending_deploys = IntGauge::new("pending_deploy", "amount of pending deploys")?;
+        registry.register(Box::new(pending_deploys.clone()))?;
+        Ok(BlockProposerMetrics {
+            pending_deploys,
+            registry,
+        })
+    }
+}
+
+impl Drop for BlockProposerMetrics {
+    fn drop(&mut self) {
+        self.registry
+            .unregister(Box::new(self.pending_deploys.clone()))
+            .expect("did not expect deregistering pending_deploys to fail");
+    }
+}

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -52,7 +52,9 @@ use std::{collections::BTreeSet, convert::TryFrom};
 
 use datasize::DataSize;
 use derive_more::From;
-use lmdb::{Cursor, Database, DatabaseFlags, Environment, EnvironmentFlags, Transaction};
+use lmdb::{
+    Cursor, Database, DatabaseFlags, Environment, EnvironmentFlags, Transaction, WriteFlags,
+};
 use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use tempfile::TempDir;
@@ -63,7 +65,10 @@ use super::Component;
 #[cfg(test)]
 use crate::crypto::hash::Digest;
 use crate::{
-    effect::{requests::StorageRequest, EffectBuilder, EffectExt, Effects},
+    effect::{
+        requests::{StateStoreRequest, StorageRequest},
+        EffectBuilder, EffectExt, Effects,
+    },
     fatal,
     types::{Block, BlockHash, Deploy, DeployHash, DeployMetadata},
     utils::WithDir,
@@ -84,6 +89,8 @@ const DEFAULT_MAX_BLOCK_STORE_SIZE: usize = 450 * GIB;
 const DEFAULT_MAX_DEPLOY_STORE_SIZE: usize = 300 * GIB;
 /// Default max deploy metadata store size.
 const DEFAULT_MAX_DEPLOY_METADATA_STORE_SIZE: usize = 300 * GIB;
+/// Default max state store size.
+const DEFAULT_MAX_STATE_STORE_SIZE: usize = 10 * GIB;
 
 /// OS-specific lmdb flags.
 #[cfg(not(target_os = "macos"))]
@@ -100,6 +107,9 @@ pub enum Event {
     /// Incoming storage request.
     #[from]
     StorageRequest(StorageRequest),
+    /// Incoming state storage request.
+    #[from]
+    StateStoreRequest(StateStoreRequest),
 }
 
 /// A storage component initialization error.
@@ -154,6 +164,9 @@ pub struct Storage {
     /// The deploy metadata database.
     #[data_size(skip)]
     deploy_metadata_db: Database,
+    /// The state storage database.
+    #[data_size(skip)]
+    state_store_db: Database,
     /// Block height index.
     block_height_index: BTreeMap<u64, BlockHash>,
     /// Chainspec cache.
@@ -171,7 +184,10 @@ impl<REv> Component<REv> for Storage {
         event: Self::Event,
     ) -> Effects<Self::Event> {
         let result = match event {
-            Event::StorageRequest(req) => self.handle_storage_request::<REv>(effect_builder, req),
+            Event::StorageRequest(req) => self.handle_storage_request::<REv>(req),
+            Event::StateStoreRequest(req) => {
+                self.handle_state_store_request::<REv>(effect_builder, req)
+            }
         };
 
         // Any error is turned into a fatal effect, the component itself does not panic. Note that
@@ -212,13 +228,14 @@ impl Storage {
                     | EnvironmentFlags::NO_TLS,
             )
             .set_max_readers(MAX_TRANSACTIONS)
-            .set_max_dbs(3)
+            .set_max_dbs(4)
             .set_map_size(total_size)
             .open(&root.join("storage.lmdb"))?;
 
         let block_db = env.create_db(Some("blocks"), DatabaseFlags::empty())?;
         let deploy_db = env.create_db(Some("deploys"), DatabaseFlags::empty())?;
         let deploy_metadata_db = env.create_db(Some("deploy_metadata"), DatabaseFlags::empty())?;
+        let state_store_db = env.create_db(Some("state_store"), DatabaseFlags::empty())?;
 
         // We now need to restore the block-height index. Log messages allow timing here.
         info!("reindexing block store");
@@ -256,17 +273,48 @@ impl Storage {
             block_db,
             deploy_db,
             deploy_metadata_db,
+            state_store_db,
             block_height_index,
             chainspec_cache: None,
         })
     }
 
-    /// Handles a storage request.
-    fn handle_storage_request<REv>(
+    /// Handles a state store request.
+    fn handle_state_store_request<REv>(
         &mut self,
         _effect_builder: EffectBuilder<REv>,
-        req: StorageRequest,
+        req: StateStoreRequest,
     ) -> Result<Effects<Event>, Error>
+    where
+        Self: Component<REv>,
+    {
+        // Incoming requests are fairly simple database write. Errors are handled one level above on
+        // the call stack, so all we have to do is load or store a value.
+        match req {
+            StateStoreRequest::Save {
+                key,
+                data,
+                responder,
+            } => {
+                let mut txn = self.env.begin_rw_txn()?;
+                txn.put(self.state_store_db, &key, &data, WriteFlags::default())?;
+                txn.commit()?;
+                Ok(responder.respond(()).ignore())
+            }
+            StateStoreRequest::Load { key, responder } => {
+                let txn = self.env.begin_ro_txn()?;
+                let bytes = match txn.get(self.state_store_db, &key) {
+                    Ok(slice) => Some(slice.to_owned()),
+                    Err(lmdb::Error::NotFound) => None,
+                    Err(err) => return Err(err.into()),
+                };
+                Ok(responder.respond(bytes).ignore())
+            }
+        }
+    }
+
+    /// Handles a storage request.
+    fn handle_storage_request<REv>(&mut self, req: StorageRequest) -> Result<Effects<Event>, Error>
     where
         Self: Component<REv>,
     {
@@ -493,6 +541,10 @@ pub struct Config {
     ///
     /// The size should be a multiple of the OS page size.
     max_deploy_metadata_store_size: usize,
+    /// The maximum size of the database to use for the component state store.
+    ///
+    /// The size should be a multiple of the OS page size.
+    max_state_store_size: usize,
 }
 
 impl Default for Config {
@@ -503,6 +555,7 @@ impl Default for Config {
             max_block_store_size: DEFAULT_MAX_BLOCK_STORE_SIZE,
             max_deploy_store_size: DEFAULT_MAX_DEPLOY_STORE_SIZE,
             max_deploy_metadata_store_size: DEFAULT_MAX_DEPLOY_METADATA_STORE_SIZE,
+            max_state_store_size: DEFAULT_MAX_STATE_STORE_SIZE,
         }
     }
 }
@@ -527,6 +580,7 @@ impl Display for Event {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Event::StorageRequest(req) => req.fmt(f),
+            Event::StateStoreRequest(req) => req.fmt(f),
         }
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -63,6 +63,7 @@ pub mod requests;
 
 use std::{
     any::type_name,
+    borrow::Cow,
     collections::{HashMap, HashSet},
     fmt::{self, Debug, Display, Formatter},
     future::Future,
@@ -74,10 +75,10 @@ use std::{
 use datasize::DataSize;
 use futures::{channel::oneshot, future::BoxFuture, FutureExt};
 use semver::Version;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 use smallvec::{smallvec, SmallVec};
 use tokio::join;
-use tracing::error;
+use tracing::{error, warn};
 
 use casper_execution_engine::{
     core::engine_state::{
@@ -123,7 +124,7 @@ use announcements::{
 use requests::{
     BlockExecutorRequest, BlockProposerRequest, BlockValidationRequest, ChainspecLoaderRequest,
     ConsensusRequest, ContractRuntimeRequest, FetcherRequest, ListForInclusionRequest,
-    MetricsRequest, NetworkInfoRequest, NetworkRequest, StorageRequest,
+    MetricsRequest, NetworkInfoRequest, NetworkRequest, StateStoreRequest, StorageRequest,
 };
 
 /// A pinned, boxed future that produces one or more events.
@@ -382,7 +383,12 @@ impl<REv> EffectBuilder<REv> {
     /// Can be used to trigger events from effects when combined with `.event`. Do not use this do
     /// "do nothing", as it will still cause a task to be spawned.
     #[inline(always)]
-    pub async fn immediately(self) {}
+    #[allow(clippy::manual_async_fn)]
+    pub fn immediately(self) -> impl Future<Output = ()> + Send {
+        // Note: This function is implemented manually without `async` sugar because the `Send`
+        // inference seems to not work in all cases otherwise.
+        async {}
+    }
 
     /// Reports a fatal error.  Normally called via the `crate::fatal!()` macro.
     ///
@@ -965,6 +971,67 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(ChainspecLoaderRequest::GetChainspecInfo, QueueKind::Regular)
             .await
+    }
+
+    /// Loads potentially previously stored state from storage.
+    ///
+    /// Key must be a unique key across the the application, as all keys share a common namespace.
+    ///
+    /// If an error occurs during state loading or no data is found, returns `None`.
+    pub(crate) async fn load_state<T>(self, key: Cow<'static, [u8]>) -> Option<T>
+    where
+        REv: From<StateStoreRequest>,
+        T: DeserializeOwned,
+    {
+        // There is an ugly truth hidden in here: Due to object safety issues, we cannot ship the
+        // actual values around, but only the serialized bytes. For this reason this function
+        // retrieves raw bytes from storage and perform deserialization here.
+        //
+        // Errors are prominently logged but not treated further in any way.
+        self.make_request(
+            move |responder| StateStoreRequest::Load { key, responder },
+            QueueKind::Regular,
+        )
+        .await
+        .map(|data| bincode::deserialize(&data))
+        .transpose()
+        .unwrap_or_else(|err| {
+            let type_name = type_name::<T>();
+            warn!(%type_name, %err, "could not deserialize state from storage");
+            None
+        })
+    }
+
+    /// Save state to storage.
+    ///
+    /// Key must be a unique key across the the application, as all keys share a common namespace.
+    ///
+    /// Returns whether or not storing the state was successful. A component that requires state to
+    /// be successfully stored should check the return value and act accordingly.
+    pub(crate) async fn save_state<T>(self, key: Cow<'static, [u8]>, value: T) -> bool
+    where
+        REv: From<StateStoreRequest>,
+        T: Serialize,
+    {
+        match bincode::serialize(&value) {
+            Ok(data) => {
+                self.make_request(
+                    move |responder| StateStoreRequest::Save {
+                        key,
+                        data,
+                        responder,
+                    },
+                    QueueKind::Regular,
+                )
+                .await;
+                true
+            }
+            Err(err) => {
+                let type_name = type_name::<T>();
+                warn!(%type_name, %err, "Error serializing state");
+                false
+            }
+        }
     }
 
     /// Requests an execution of deploys using Contract Runtime.

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -4,6 +4,7 @@
 //! top-level module documentation for details.
 
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     fmt::{self, Debug, Display, Formatter},
     net::SocketAddr,
@@ -33,6 +34,7 @@ use casper_types::{
     auction::{EraValidators, ValidatorWeights},
     ExecutionResult, Key, ProtocolVersion, URef,
 };
+use hex_fmt::HexFmt;
 
 use super::{Multiple, Responder};
 use crate::{
@@ -321,6 +323,41 @@ impl Display for StorageRequest {
     }
 }
 
+/// State store request.
+#[derive(DataSize, Debug, Serialize)]
+pub enum StateStoreRequest {
+    /// Stores a piece of state to storage.
+    Save {
+        /// Key to store under.
+        key: Cow<'static, [u8]>,
+        /// Value to store, already serialized.
+        #[serde(skip_serializing)]
+        data: Vec<u8>,
+        /// Notification when storing is complete.
+        responder: Responder<()>,
+    },
+    /// Loads a piece of state from storage.
+    Load {
+        /// Key to load from.
+        key: Cow<'static, [u8]>,
+        /// Responder for value, if found, returning the previously passed in serialization form.
+        responder: Responder<Option<Vec<u8>>>,
+    },
+}
+
+impl Display for StateStoreRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            StateStoreRequest::Save { key, data, .. } => {
+                write!(f, "save data under {} ({} bytes)", HexFmt(key), data.len())
+            }
+            StateStoreRequest::Load { key, .. } => {
+                write!(f, "load data from key {}", HexFmt(key))
+            }
+        }
+    }
+}
+
 /// Details of a request for a list of deploys to propose in a new block.
 #[derive(DataSize, Debug)]
 pub struct ListForInclusionRequest {
@@ -338,7 +375,7 @@ pub struct ListForInclusionRequest {
 }
 
 /// A `BlockProposer` request.
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 #[must_use]
 pub enum BlockProposerRequest {
     /// Request a list of deploys to propose in a new block.

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -808,8 +808,6 @@ impl Reactor {
     /// the network, closing all incoming and outgoing connections, and frees up the listening
     /// socket.
     pub async fn into_validator_config(self) -> ValidatorInitConfig {
-        let block_proposer_state = Default::default();
-
         let (network, small_network, rest_server, config) = (
             self.network,
             self.small_network,
@@ -822,7 +820,6 @@ impl Reactor {
                 consensus: self.consensus,
                 init_consensus_effects: self.init_consensus_effects,
                 linear_chain: self.linear_chain.linear_chain().clone(),
-                block_proposer_state,
                 event_stream_server: self.event_stream_server,
             },
         );

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -25,7 +25,7 @@ use crate::testing::network::NetworkedReactor;
 use crate::{
     components::{
         block_executor::{self, BlockExecutor},
-        block_proposer::{self, BlockProposer, BlockProposerState},
+        block_proposer::{self, BlockProposer},
         block_validator::{self, BlockValidator},
         chainspec_loader::{self, ChainspecLoader},
         consensus::{self, EraSupervisor},
@@ -53,7 +53,7 @@ use crate::{
             BlockExecutorRequest, BlockProposerRequest, BlockValidationRequest,
             ChainspecLoaderRequest, ConsensusRequest, ContractRuntimeRequest, FetcherRequest,
             LinearChainRequest, MetricsRequest, NetworkInfoRequest, NetworkRequest, RestRequest,
-            RpcRequest, StorageRequest,
+            RpcRequest, StateStoreRequest, StorageRequest,
         },
         EffectBuilder, EffectExt, Effects,
     },
@@ -151,6 +151,12 @@ pub enum Event {
     /// Chainspec info request
     #[from]
     ChainspecLoaderRequest(#[serde(skip_serializing)] ChainspecLoaderRequest),
+    /// Storage request.
+    #[from]
+    StorageRequest(#[serde(skip_serializing)] StorageRequest),
+    /// Request for state storage.
+    #[from]
+    StateStoreRequest(StateStoreRequest),
 
     // Announcements
     /// Network announcement.
@@ -177,12 +183,6 @@ pub enum Event {
     /// Linear chain announcement.
     #[from]
     LinearChainAnnouncement(#[serde(skip_serializing)] LinearChainAnnouncement),
-}
-
-impl From<StorageRequest> for Event {
-    fn from(request: StorageRequest) -> Self {
-        Event::Storage(request.into())
-    }
 }
 
 impl From<RpcRequest<NodeId>> for Event {
@@ -256,6 +256,8 @@ impl Display for Event {
             Event::NetworkRequest(req) => write!(f, "network request: {}", req),
             Event::NetworkInfoRequest(req) => write!(f, "network info request: {}", req),
             Event::ChainspecLoaderRequest(req) => write!(f, "chainspec loader request: {}", req),
+            Event::StorageRequest(req) => write!(f, "storage request: {}", req),
+            Event::StateStoreRequest(req) => write!(f, "state store request: {}", req),
             Event::DeployFetcherRequest(req) => write!(f, "deploy fetcher request: {}", req),
             Event::BlockProposerRequest(req) => write!(f, "block proposer request: {}", req),
             Event::BlockExecutorRequest(req) => write!(f, "block executor request: {}", req),
@@ -290,7 +292,6 @@ pub struct ValidatorInitConfig {
     pub(super) consensus: EraSupervisor<NodeId>,
     pub(super) init_consensus_effects: Effects<consensus::Event<NodeId>>,
     pub(super) linear_chain: Vec<Block>,
-    pub(super) block_proposer_state: BlockProposerState,
     pub(super) event_stream_server: EventStreamServer,
 }
 
@@ -357,7 +358,6 @@ impl reactor::Reactor for Reactor {
             consensus,
             init_consensus_effects,
             linear_chain,
-            block_proposer_state,
             event_stream_server,
         } = config;
 
@@ -388,7 +388,7 @@ impl reactor::Reactor for Reactor {
             registry,
         )?;
         let (block_proposer, block_proposer_effects) =
-            BlockProposer::new(registry.clone(), effect_builder, block_proposer_state)?;
+            BlockProposer::new(registry.clone(), effect_builder)?;
         let mut effects = reactor::wrap_effects(Event::BlockProposer, block_proposer_effects);
         // Post state hash is expected to be present.
         let genesis_state_root_hash = chainspec_loader
@@ -577,6 +577,12 @@ impl reactor::Reactor for Reactor {
             ),
             Event::ChainspecLoaderRequest(req) => {
                 self.dispatch_event(effect_builder, rng, Event::ChainspecLoader(req.into()))
+            }
+            Event::StorageRequest(req) => {
+                self.dispatch_event(effect_builder, rng, Event::Storage(req.into()))
+            }
+            Event::StateStoreRequest(req) => {
+                self.dispatch_event(effect_builder, rng, Event::Storage(req.into()))
             }
 
             // Announcements:

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -148,6 +148,12 @@ max_deploy_store_size = 12_884_901_888
 # 322_122_547_200 == 12 GiB.
 max_deploy_metadata_store_size = 12_884_901_888
 
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
 
 # ===================================
 # Configuration options for gossiping

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -147,6 +147,12 @@ max_deploy_store_size = 322_122_547_200
 # 322_122_547_200 == 300 GiB.
 max_deploy_metadata_store_size = 322_122_547_200
 
+# Maximum size of the database to use for the state snapshots.
+#
+# The size should be a multiple of the OS page size.
+#
+# 10_737_418_240 == 10 GiB.
+max_state_store_size = 10_737_418_240
 
 # ===================================
 # Configuration options for gossiping


### PR DESCRIPTION
State persistence had been removed during the storage refactoring merged earlier, this PR restores this functionality, albeit slightly different.

Previously no state snapshot was stored by the block proposer, instead the storage component contained custom logic to recalculate the sets of pending deploys, finalized deploys, etc. on demand. This logic was called manually "between reactors", in an `async` function, requiring special-casing and circumventing the component structure. The approach did guarantee that the component was only instantiated once data had been restored.

The new implementation adds a general load/store state logic to the storage component that works within the effect system, to be possibly reused by other components that need to store small state snapshots. For this to work, the block proposer component is turned in a state machine with two states, `Initializing` (and thus waiting for a state snapshot) and `BlockProposerReady`, which is normal operation.

During the `Initializing` state, incoming events are recorded and played back as soon as the state arrives, ensuring no events are lost. **This model can possibly become a blueprint for similar components that require state initialization,** which might ultimately remove the need for the initializer (and possibly joiner) reactor.

This is a slight downgrade in terms of durability, as state snapshots are saved every 10 seconds during pruning, thus intermediate changes can possibly be lost. Startup performance is negligibly better, as the state can be serialized directly instead of having to query the database. Should restoring the previous durability become a priority, I suggest we introduce indices to the storage component instead of special cased logic instead.

Other things to note:

* The chainspec is loaded once in the same fashion, instead of requiring an elaborate cache.
* The `BlockProposer` component has been split up over multiple files, as it grew in size.
* Unit tests for the block propser are largely unchanged, since the `BlockProposerReady` closely resembles the previous version.
* The `BlockProposerState` has been renamed to `BlockProposerDeploySets`, as the former name is better fitting for the state machine state.