### PR TITLE
HWY-199: Fix era height off-by-one error.

### DIFF
--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -665,7 +665,7 @@ impl<C: Context> State<C> {
     /// Returns `true` if the `bhash` is a block that can have no children.
     pub(crate) fn is_terminal_block(&self, bhash: &C::Hash) -> bool {
         self.blocks.get(bhash).map_or(false, |block| {
-            block.height >= self.params.end_height()
+            block.height + 1 >= self.params.end_height()
                 && self.unit(bhash).timestamp >= self.params.end_timestamp()
         })
     }

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -30,6 +30,11 @@ pub(crate) const HANNA: ValidatorIndex = ValidatorIndex(7);
 pub(crate) const N: Observation<TestContext> = Observation::None;
 pub(crate) const F: Observation<TestContext> = Observation::Faulty;
 
+const TEST_MIN_ROUND_EXP: u8 = 4;
+const TEST_MAX_ROUND_EXP: u8 = 19;
+const TEST_INIT_ROUND_EXP: u8 = 4;
+const TEST_ERA_HEIGHT: u64 = 5;
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct TestContext;
 
@@ -111,12 +116,12 @@ impl State<TestContext> {
             seed,
             TEST_BLOCK_REWARD,
             TEST_BLOCK_REWARD / 5,
-            4,
-            19,
-            4,
-            u64::MAX,
-            Timestamp::from(u64::MAX),
-            Timestamp::from(u64::MAX),
+            TEST_MIN_ROUND_EXP,
+            TEST_MAX_ROUND_EXP,
+            TEST_INIT_ROUND_EXP,
+            TEST_ERA_HEIGHT,
+            Timestamp::from(0),
+            Timestamp::from(0),
         );
         State::new(weights, params, vec![])
     }
@@ -720,6 +725,29 @@ fn validate_lnc_four_forks() -> Result<(), AddUnitError<TestContext>> {
     // And it should still work if both were endorsed.
     endorse!(pre_endorse_state, rng, h0; ALICE, BOB, CAROL, DAN, GINA, HANNA);
     add_unit!(pre_endorse_state, rng, DAN, None; a0, b0, c0, d0, F, f0, g0, h0; a0, g0, b0, h0)?;
+    Ok(())
+}
+
+#[test]
+fn is_terminal_block() -> Result<(), AddUnitError<TestContext>> {
+    let mut state = State::new_test(WEIGHTS, 0);
+    let mut rng = crate::new_rng();
+
+    let a0 = add_unit!(state, rng, ALICE, 0x00; N, N, N)?;
+    assert!(!state.is_terminal_block(&a0)); // height 0
+    let b0 = add_unit!(state, rng, BOB, 0x01; a0, N, N)?;
+    assert!(!state.is_terminal_block(&b0)); // height 1
+    let c0 = add_unit!(state, rng, CAROL, 0x02; a0, b0, N)?;
+    assert!(!state.is_terminal_block(&c0)); // height 2
+    let a1 = add_unit!(state, rng, ALICE, 0x03; a0, b0, c0)?;
+    assert!(!state.is_terminal_block(&a1)); // height 3
+    let a2 = add_unit!(state, rng, ALICE, None; a1, b0, c0)?;
+    assert!(!state.is_terminal_block(&a2)); // not a block
+    let a3 = add_unit!(state, rng, ALICE, 0x04; a2, b0, c0)?;
+    assert!(state.is_terminal_block(&a3)); // height 4, i.e. the fifth block and thus the last one
+    assert_eq!(TEST_ERA_HEIGHT - 1, state.block(&a3).height);
+    let a4 = add_unit!(state, rng, ALICE, None; a3, b0, c0)?;
+    assert!(!state.is_terminal_block(&a4)); // not a block
     Ok(())
 }
 


### PR DESCRIPTION
If the era height is 5, the last block is block 4, not 5, since we start counting at 0.

https://casperlabs.atlassian.net/browse/HWY-199