### PR TITLE
HWY-205: Some cleanups related to LNC.

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -134,7 +134,7 @@ impl<C: Context> ActiveValidator<C> {
     /// Returns actions a validator needs to take upon receiving a new unit.
     pub(crate) fn on_new_unit(
         &mut self,
-        vhash: &C::Hash,
+        uhash: &C::Hash,
         now: Timestamp,
         state: &State<C>,
         instance_id: C::InstanceId,
@@ -144,16 +144,16 @@ impl<C: Context> ActiveValidator<C> {
             return vec![Effect::WeEquivocated(evidence.clone())];
         }
         let mut effects = vec![];
-        if self.should_send_confirmation(vhash, now, state) {
-            let panorama = state.confirmation_panorama(self.vidx, vhash);
+        if self.should_send_confirmation(uhash, now, state) {
+            let panorama = state.confirmation_panorama(self.vidx, uhash);
             if panorama.has_correct() {
                 let confirmation_unit = self.new_unit(panorama, now, None, state, instance_id, rng);
                 let vv = ValidVertex(Vertex::Unit(confirmation_unit));
                 effects.extend(vec![Effect::NewVertex(vv)])
             }
         };
-        if self.should_endorse(vhash, state) {
-            let endorsement = self.endorse(vhash, rng);
+        if self.should_endorse(uhash, state) {
+            let endorsement = self.endorse(uhash, rng);
             effects.extend(vec![Effect::NewVertex(ValidVertex(endorsement))]);
         }
         effects
@@ -276,7 +276,7 @@ impl<C: Context> ActiveValidator<C> {
             return false;
         }
         if let Some(unit) = self.latest_unit(state) {
-            if unit.panorama._sees_correct(state, vhash) {
+            if unit.panorama.sees_correct(state, vhash) {
                 error!(%vhash, "called on_new_unit with already confirmed proposal");
                 return false; // We already sent a confirmation.
             }

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -121,7 +121,7 @@ impl<C: Context> ActiveValidator<C> {
         if timestamp == r_id && state.leader(r_id) == self.vidx {
             effects.extend(self.request_new_block(state, instance_id, timestamp, rng))
         } else if timestamp == r_id + self.witness_offset(r_len) {
-            let panorama = state.citable_panorama().cutoff(state, timestamp);
+            let panorama = state.panorama().cutoff(state, timestamp);
             if panorama.has_correct() {
                 let witness_unit =
                     self.new_unit(panorama, timestamp, None, state, instance_id, rng);
@@ -199,7 +199,7 @@ impl<C: Context> ActiveValidator<C> {
             );
             return None;
         }
-        let panorama = state.citable_panorama().cutoff(state, timestamp);
+        let panorama = state.panorama().cutoff(state, timestamp);
         let opt_parent_hash = state.fork_choice(&panorama);
         if opt_parent_hash.map_or(false, |hash| state.is_terminal_block(hash)) {
             let proposal_unit = self.new_unit(panorama, timestamp, None, state, instance_id, rng);
@@ -310,7 +310,7 @@ impl<C: Context> ActiveValidator<C> {
         }
         if panorama[self.vidx] != state.panorama()[self.vidx] {
             error!("replacing unit panorama to avoid equivocation");
-            panorama = state.citable_panorama().clone();
+            panorama = state.panorama().clone();
         }
         let seq_number = panorama.next_seq_num(state, self.vidx);
         let endorsed = state.seen_endorsed(&panorama);

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -68,14 +68,13 @@ impl<C: Context> FinalityDetector<C> {
             } else {
                 None
             };
-            let faulty_iter = unit.panorama.enumerate().filter(|(_, obs)| obs.is_faulty());
 
             Some(FinalizedBlock {
                 value: block.value.clone(),
                 timestamp: unit.timestamp,
                 height: block.height,
                 rewards,
-                equivocators: faulty_iter.map(|(vidx, _)| to_id(vidx)).collect(),
+                equivocators: unit.panorama.iter_faulty().map(to_id).collect(),
                 proposer: to_id(unit.creator),
             })
         }))

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -72,12 +72,7 @@ fn compute_rewards_for<C: Context>(
         }
     }
 
-    let faulty_w: Weight = panorama
-        .iter()
-        .zip(state.weights())
-        .filter(|(obs, _)| obs.is_faulty())
-        .map(|(_, w)| w)
-        .sum();
+    let faulty_w: Weight = panorama.iter_faulty().map(|vidx| state.weight(vidx)).sum();
 
     // Collect the block rewards for each validator who is a member of at least one summit.
     max_quorum

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -121,61 +121,6 @@ impl<C: Context> Fault<C> {
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct Panoramas<C: Context> {
-    /// The full panorama, corresponding to the complete protocol state.
-    panorama: Panorama<C>,
-    /// Panorama used when creating new units.
-    /// In the presence of faults may lag behind `panorama`.
-    /// Units, that if cited by a new unit would make that unit violate the LNC, are not added to
-    /// `citable_panorama`.
-    citable_panorama: Panorama<C>,
-}
-
-impl<C: Context> Panoramas<C> {
-    fn new(panorama: Panorama<C>, citable_panorama: Panorama<C>) -> Self {
-        Panoramas {
-            panorama,
-            citable_panorama,
-        }
-    }
-
-    /// Returns the complete protocol state's latest panorama.
-    pub(crate) fn panorama(&self) -> &Panorama<C> {
-        &self.panorama
-    }
-
-    /// Returns the citable panorama.
-    pub(crate) fn citable_panorama(&self) -> &Panorama<C> {
-        &self.citable_panorama
-    }
-
-    /// Marks validator at `idx` as faulty.
-    pub(crate) fn mark_faulty(&mut self, idx: ValidatorIndex) {
-        self.panorama[idx] = Observation::Faulty;
-        self.citable_panorama[idx] = Observation::Faulty;
-    }
-
-    /// Updates latest observation of `creator` as `Correct(unit)`.
-    /// Once a unit is a endorsed it is safe to cite it.
-    pub(crate) fn endorsed(&mut self, _creator: ValidatorIndex, _unit: C::Hash) {
-        //TODO
-    }
-
-    /// Updates panoramas with the new observation.
-    /// `citable_panorama` will be updated only if it won't violate the LNC.
-    pub(crate) fn update_panorama(&mut self, creator: ValidatorIndex, new_obs: Observation<C>) {
-        // TODO(HWY-167): Decide whether new unit should be accepted to the `citable_panorama`.
-        self.citable_panorama[creator] = new_obs.clone();
-        self.panorama[creator] = new_obs;
-    }
-
-    /// Returns the latest observation of `validator`.
-    pub(crate) fn get(&self, validator: ValidatorIndex) -> &Observation<C> {
-        self.panorama.get(validator)
-    }
-}
-
 /// A passive instance of the Highway protocol, containing its local state.
 ///
 /// Both observers and active validators must instantiate this, pass in all incoming vertices from
@@ -197,8 +142,8 @@ pub(crate) struct State<C: Context> {
     blocks: HashMap<C::Hash, Block<C>>,
     /// List of faulty validators and their type of fault.
     faults: HashMap<ValidatorIndex, Fault<C>>,
-    /// Panoramas that the protocol observed.
-    panoramas: Panoramas<C>,
+    /// The full panorama, corresponding to the complete protocol state.
+    panorama: Panorama<C>,
     /// All currently endorsed units, by hash.
     endorsements: HashMap<C::Hash, ValidatorMap<Option<C::Signature>>>,
     /// Units that don't yet have 2/3 of stake endorsing them.
@@ -237,7 +182,6 @@ impl<C: Context> State<C> {
             );
             panorama[*idx] = Observation::Faulty;
         }
-        let panoramas = Panoramas::new(panorama.clone(), panorama);
         State {
             params,
             weights,
@@ -245,7 +189,7 @@ impl<C: Context> State<C> {
             units: HashMap::new(),
             blocks: HashMap::new(),
             faults,
-            panoramas,
+            panorama,
             endorsements: HashMap::new(),
             incomplete_endorsements: HashMap::new(),
             clock: Clock::new(),
@@ -349,7 +293,7 @@ impl<C: Context> State<C> {
 
     /// Marks the given validator as faulty, unless it is already banned or we have direct evidence.
     pub(crate) fn mark_faulty(&mut self, idx: ValidatorIndex) {
-        self.panoramas.mark_faulty(idx);
+        self.panorama[idx] = Observation::Faulty;
         self.faults.entry(idx).or_insert(Fault::Indirect);
     }
 
@@ -370,7 +314,7 @@ impl<C: Context> State<C> {
 
     /// Returns an iterator over latest unit hashes from honest validators.
     pub(crate) fn iter_correct_hashes(&self) -> impl Iterator<Item = &C::Hash> {
-        self.panorama().iter_correct_hashes()
+        self.panorama.iter_correct_hashes()
     }
 
     /// Returns the unit with the given hash, if present.
@@ -400,12 +344,7 @@ impl<C: Context> State<C> {
 
     /// Returns the complete protocol state's latest panorama.
     pub(crate) fn panorama(&self) -> &Panorama<C> {
-        &self.panoramas.panorama()
-    }
-
-    /// Returns the "safe" panorama, that can be used when creating new units.
-    pub(crate) fn citable_panorama(&self) -> &Panorama<C> {
-        &self.panoramas.citable_panorama()
+        &self.panorama
     }
 
     /// Returns the leader in the specified time slot.
@@ -425,8 +364,8 @@ impl<C: Context> State<C> {
     /// The unit must be valid, and its dependencies satisfied.
     pub(crate) fn add_valid_unit(&mut self, swunit: SignedWireUnit<C>) {
         let wunit = &swunit.wire_unit;
-        self.update_panorama(&swunit);
         let hash = wunit.hash();
+        let instance_id = wunit.instance_id;
         let fork_choice = self.fork_choice(&wunit.panorama).cloned();
         let (unit, opt_value) = Unit::new(swunit, fork_choice.as_ref(), self);
         if let Some(value) = opt_value {
@@ -434,6 +373,7 @@ impl<C: Context> State<C> {
             self.blocks.insert(hash, block);
         }
         self.units.insert(hash, unit);
+        self.update_panorama(hash, instance_id);
     }
 
     /// Adds direct evidence proving a validator to be faulty, unless that validators is already
@@ -447,7 +387,7 @@ impl<C: Context> State<C> {
         // TODO: Should use Display, not Debug!
         trace!(?evidence, "marking validator #{} as faulty", idx.0);
         self.faults.insert(idx, Fault::Direct(evidence));
-        self.panoramas.mark_faulty(idx);
+        self.panorama[idx] = Observation::Faulty;
         true
     }
 
@@ -479,9 +419,6 @@ impl<C: Context> State<C> {
                 .map(|vidx| fully_endorsed.remove(&vidx))
                 .collect();
             self.endorsements.insert(unit, endorsed_map);
-            // When unit gets endorsed, it becomes safe to cite.
-            let creator = self.unit(&unit).creator;
-            self.panoramas.endorsed(creator, unit);
         }
     }
 
@@ -672,29 +609,30 @@ impl<C: Context> State<C> {
 
     /// Updates `self.panorama` with an incoming unit. Panics if dependencies are missing.
     ///
-    /// If the new unit is valid, it will just add `Observation::Correct(wunit.hash())` to the
+    /// If the new unit is valid, it will just add `Observation::Correct(uhash)` to the
     /// panorama. If it represents an equivocation, it adds `Observation::Faulty` and updates
     /// `self.faults`.
     ///
-    /// Panics unless all dependencies of `wunit` have already been added to `self`.
-    fn update_panorama(&mut self, swunit: &SignedWireUnit<C>) {
-        let wunit = &swunit.wire_unit;
-        let creator = wunit.creator;
-        let new_obs = match (self.panoramas.get(creator), wunit.panorama.get(creator)) {
+    /// Panics unless the unit has already been added to `self`.
+    fn update_panorama(&mut self, uhash: C::Hash, instance_id: C::InstanceId) {
+        let unit = self.unit(&uhash);
+        let creator = unit.creator;
+        let new_obs = match (self.panorama.get(creator), unit.panorama.get(creator)) {
             (Observation::Faulty, _) => Observation::Faulty,
-            (obs0, obs1) if obs0 == obs1 => Observation::Correct(wunit.hash()),
+            (obs0, obs1) if obs0 == obs1 => Observation::Correct(uhash),
             (Observation::None, _) => panic!("missing creator's previous unit"),
             (Observation::Correct(hash0), _) => {
                 // If we have all dependencies of wunit and still see the sender as correct, the
                 // predecessor of wunit must be a predecessor of hash0. So we already have a
                 // conflicting unit with the same sequence number:
-                let prev0 = self.find_in_swimlane(hash0, wunit.seq_number).unwrap();
-                let wunit0 = self.wire_unit(prev0, wunit.instance_id).unwrap();
-                self.add_evidence(Evidence::Equivocation(wunit0, swunit.clone()));
+                let prev0 = self.find_in_swimlane(hash0, unit.seq_number).unwrap();
+                let wunit0 = self.wire_unit(prev0, instance_id).unwrap();
+                let wunit1 = self.wire_unit(&uhash, instance_id).unwrap();
+                self.add_evidence(Evidence::Equivocation(wunit0, wunit1));
                 Observation::Faulty
             }
         };
-        self.panoramas.update_panorama(wunit.creator, new_obs);
+        self.panorama[creator] = new_obs;
     }
 
     /// Returns `true` if this is a proposal and the creator is not faulty.
@@ -755,7 +693,7 @@ impl<C: Context> State<C> {
     /// Returns `None` if there are no correct validators in the panorama.
     pub(crate) fn median_round_exp(&self) -> Option<u8> {
         weighted_median(
-            self.panorama()
+            self.panorama
                 .iter_correct(self)
                 .map(|unit| (unit.round_exp, self.weight(unit.creator))),
         )

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -787,12 +787,8 @@ impl<C: Context> State<C> {
     /// Returns index of the first equivocator that was cited naively in violation of the LNC, or
     /// `None` if the LNC is satisfied.
     fn validate_lnc(&self, wunit: &WireUnit<C>) -> Option<ValidatorIndex> {
-        wunit
-            .panorama
-            .enumerate()
-            .filter(|(_, obs)| obs.is_faulty())
-            .map(|(i, _)| i)
-            .find(|eq_idx| !self.satisfies_lnc_for(wunit, *eq_idx))
+        let violates_lnc = |eq_idx: &ValidatorIndex| !self.satisfies_lnc_for(wunit, *eq_idx);
+        wunit.panorama.iter_faulty().find(violates_lnc)
     }
 
     // Stub, replace with `_satisfies_lnc_for`

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -586,7 +586,7 @@ impl<C: Context> State<C> {
             }
         }
         for hash in &wunit.endorsed {
-            if !wunit.panorama._sees(self, hash) {
+            if !wunit.panorama.sees(self, hash) {
                 return Err(UnitError::EndorsedButUnseen {
                     hash: format!("{:?}", hash),
                     wire_unit: format!("{:?}", wunit),
@@ -714,7 +714,7 @@ impl<C: Context> State<C> {
         // Now add all remaining endorsed units. Since the pan.sees check is expensive, do it only
         // for the ones that are actually new.
         for hash in self.endorsements.keys() {
-            if !result.contains(hash) && pan._sees(self, hash) {
+            if !result.contains(hash) && pan.sees(self, hash) {
                 result.insert(*hash);
             }
         }
@@ -850,19 +850,19 @@ impl<C: Context> State<C> {
     /// Returns whether the unit with `hash0` sees the one with `hash1` (i.e. `hash0 ≥ hash1`),
     /// and sees `hash1`'s creator as correct.
     fn _sees_correct(&self, hash0: &C::Hash, hash1: &C::Hash) -> bool {
-        hash0 == hash1 || self.unit(hash0).panorama._sees_correct(self, hash1)
+        hash0 == hash1 || self.unit(hash0).panorama.sees_correct(self, hash1)
     }
 
     /// Returns whether the unit with `hash0` sees the one with `hash1` (i.e. `hash0 ≥ hash1`).
     fn _sees(&self, hash0: &C::Hash, hash1: &C::Hash) -> bool {
-        hash0 == hash1 || self.unit(hash0).panorama._sees(self, hash1)
+        hash0 == hash1 || self.unit(hash0).panorama.sees(self, hash1)
     }
 
     // Returns whether the units with `hash0` and `hash1` see each other or are equal.
     fn _is_compatible(&self, hash0: &C::Hash, hash1: &C::Hash) -> bool {
         hash0 == hash1
-            || self.unit(hash0).panorama._sees(self, hash1)
-            || self.unit(hash1).panorama._sees(self, hash0)
+            || self.unit(hash0).panorama.sees(self, hash1)
+            || self.unit(hash1).panorama.sees(self, hash0)
     }
 
     /// Returns the panorama of the confirmation for the leader unit `vhash`.

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -622,8 +622,8 @@ impl<C: Context> State<C> {
             (obs0, obs1) if obs0 == obs1 => Observation::Correct(uhash),
             (Observation::None, _) => panic!("missing creator's previous unit"),
             (Observation::Correct(hash0), _) => {
-                // If we have all dependencies of wunit and still see the sender as correct, the
-                // predecessor of wunit must be a predecessor of hash0. So we already have a
+                // If we have all dependencies of unit and still see the sender as correct, the
+                // predecessor of unit must be a predecessor of hash0. So we already have a
                 // conflicting unit with the same sequence number:
                 let prev0 = self.find_in_swimlane(hash0, unit.seq_number).unwrap();
                 let wunit0 = self.wire_unit(prev0, instance_id).unwrap();

--- a/node/src/components/consensus/highway_core/state/panorama.rs
+++ b/node/src/components/consensus/highway_core/state/panorama.rs
@@ -71,7 +71,7 @@ impl<C: Context> Observation<C> {
         match (self, other) {
             (Observation::Faulty, _) | (_, Observation::None) => true,
             (Observation::Correct(hash0), Observation::Correct(hash1)) => {
-                hash0 == hash1 || state.unit(hash0).panorama._sees_correct(state, hash1)
+                hash0 == hash1 || state.unit(hash0).panorama.sees_correct(state, hash1)
             }
             (_, _) => false,
         }
@@ -129,7 +129,7 @@ impl<C: Context> Panorama<C> {
     }
 
     /// Returns `true` if `self` sees the creator of `hash` as correct, and sees that unit.
-    pub(crate) fn _sees_correct(&self, state: &State<C>, hash: &C::Hash) -> bool {
+    pub(crate) fn sees_correct(&self, state: &State<C>, hash: &C::Hash) -> bool {
         let unit = state.unit(hash);
         let can_see = |latest_hash: &C::Hash| {
             Some(hash) == state.find_in_swimlane(latest_hash, unit.seq_number)
@@ -138,7 +138,7 @@ impl<C: Context> Panorama<C> {
     }
 
     /// Returns `true` if `self` sees the unit with the specified `hash`.
-    pub(crate) fn _sees(&self, state: &State<C>, hash_to_be_found: &C::Hash) -> bool {
+    pub(crate) fn sees(&self, state: &State<C>, hash_to_be_found: &C::Hash) -> bool {
         // TODO: Optimize this!
         let mut visited = HashSet::new();
         let mut to_visit: Vec<_> = self.iter_correct_hashes().collect();
@@ -158,8 +158,8 @@ impl<C: Context> Panorama<C> {
         let merge_obs = |observations: (&Observation<C>, &Observation<C>)| match observations {
             (Observation::Faulty, _) | (_, Observation::Faulty) => Observation::Faulty,
             (Observation::None, obs) | (obs, Observation::None) => obs.clone(),
-            (obs0, Observation::Correct(vh1)) if self._sees_correct(state, vh1) => obs0.clone(),
-            (Observation::Correct(vh0), obs1) if other._sees_correct(state, vh0) => obs1.clone(),
+            (obs0, Observation::Correct(vh1)) if self.sees_correct(state, vh1) => obs0.clone(),
+            (Observation::Correct(vh0), obs1) if other.sees_correct(state, vh0) => obs1.clone(),
             (Observation::Correct(_), Observation::Correct(_)) => Observation::Faulty,
         };
         let observations = self.iter().zip(other).map(merge_obs).collect_vec();

--- a/node/src/components/consensus/highway_core/state/panorama.rs
+++ b/node/src/components/consensus/highway_core/state/panorama.rs
@@ -115,6 +115,13 @@ impl<C: Context> Panorama<C> {
         self.iter().filter_map(Observation::correct)
     }
 
+    /// Returns an iterator over all faulty validators' indices.
+    pub(crate) fn iter_faulty(&self) -> impl Iterator<Item = ValidatorIndex> + '_ {
+        self.enumerate()
+            .filter(|(_, obs)| obs.is_faulty())
+            .map(|(i, _)| i)
+    }
+
     /// Returns the correct sequence number for a new unit by `vidx` with this panorama.
     pub(crate) fn next_seq_num(&self, state: &State<C>, vidx: ValidatorIndex) -> u64 {
         let add1 = |vh: &C::Hash| state.unit(vh).seq_number + 1;


### PR DESCRIPTION
This will make the diff smaller when we merge LNC-compliant unit creation.
* Add a `Panorama::iter_faulty` to deduplicate some code.
* `citable_panorama` will be replaced with something simpler, so I remove it here.
* Rename a few identifiers that were overlooked or renamed by mistake.

https://casperlabs.atlassian.net/browse/HWY-205