### PR TITLE
NO-TICKET: Stop voting on own fault, not just equivocation.

### DIFF
--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -472,7 +472,7 @@ impl<C: Context> Highway<C> {
                 Effect::NewVertex(vv) => {
                     result.extend(self.add_valid_vertex(vv.clone(), rng, timestamp))
                 }
-                Effect::WeEquivocated(_) => self.deactivate_validator(),
+                Effect::WeAreFaulty(_) => self.deactivate_validator(),
                 Effect::ScheduleTimer(_) | Effect::RequestNewBlock(_) => (),
             }
         }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -154,9 +154,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             AvEffect::RequestNewBlock(block_context) => {
                 vec![ProtocolOutcome::CreateNewBlock { block_context }]
             }
-            AvEffect::WeEquivocated(evidence) => {
-                panic!("this validator equivocated: {:?}", evidence);
-            }
+            AvEffect::WeAreFaulty(fault) => panic!("this validator is faulty: {:?}", fault),
         }
     }
 


### PR DESCRIPTION
With cross-era slashing there are now faults other than equivocations. If we are a faulty node we should not produce new units.