### PR TITLE
NO-TICKET: Sign linear chain block only if validator bonded in that era.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -150,6 +150,9 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
     /// Returns the list of all validators that were observed as faulty in this consensus instance.
     fn validators_with_evidence(&self) -> Vec<&C::ValidatorId>;
 
+    /// Returns whether validator is bonded in that instance of the consensus protocol.
+    fn is_bonded_validator(&self, vid: &C::ValidatorId) -> bool;
+
     /// Returns true if the protocol has received some messages since initialization.
     fn has_received_messages(&self) -> bool;
 }

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -94,6 +94,11 @@ impl<VID: Eq + Hash> Validators<VID> {
             .filter(|(_, v)| v.banned)
             .map(|(idx, _)| ValidatorIndex::from(idx as u32))
     }
+
+    /// Return whether the validator exists in this validator map.
+    pub(crate) fn has_validator(&self, validator: &VID) -> bool {
+        self.index_by_id.contains_key(validator)
+    }
 }
 
 impl<VID: Ord + Hash + Clone, W: Into<Weight>> FromIterator<(VID, W)> for Validators<VID> {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -622,4 +622,8 @@ where
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn is_bonded_validator(&self, vid: &C::ValidatorId) -> bool {
+        self.highway.validators().has_validator(vid)
+    }
 }

--- a/node/src/components/consensus/tests/mock_proto.rs
+++ b/node/src/components/consensus/tests/mock_proto.rs
@@ -101,6 +101,7 @@ where
     start_time: Timestamp,
     pending_blocks: VecDeque<PendingBlock<C>>,
     finalized_blocks: Vec<FinalizedBlock<C>>,
+    validators: Vec<C::ValidatorId>,
 }
 
 impl<C: Context + 'static> MockProto<C>
@@ -110,7 +111,7 @@ where
     /// Creates a new boxed `MockProto` instance.
     pub(crate) fn new_boxed(
         instance_id: C::InstanceId,
-        _validator_stakes: Vec<(C::ValidatorId, Motes)>,
+        validator_stakes: Vec<(C::ValidatorId, Motes)>,
         slashed: &HashSet<C::ValidatorId>,
         chainspec: &Chainspec,
         _prev_cp: Option<&dyn ConsensusProtocol<NodeId, C>>,
@@ -127,6 +128,7 @@ where
             start_time,
             pending_blocks: Default::default(),
             finalized_blocks: Default::default(),
+            validators: validator_stakes.into_iter().map(|(vid, _)| vid).collect(),
         })
     }
 }
@@ -295,5 +297,9 @@ where
 
     fn has_received_messages(&self) -> bool {
         !self.pending_blocks.is_empty() || !self.finalized_blocks.is_empty()
+    }
+
+    fn is_bonded_validator(&self, vid: &C::ValidatorId) -> bool {
+        self.validators.iter().any(|id| id == vid)
     }
 }


### PR DESCRIPTION
Creates the finality signature only if a validator is bonded in an era when the block was created.