### PR TITLE
NDRS-424: Do not execute block when it had been executed in the past.

### DIFF
--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -422,7 +422,7 @@ impl<REv: ReactorEventT> Component<REv> for BlockExecutor {
                     // joining), do it now.
                     self.get_deploys(effect_builder, finalized_block)
                 } else {
-                    return Effects::new();
+                    Effects::new()
                 }
             }
             Event::GetDeploysResult {

--- a/node/src/components/block_executor/event.rs
+++ b/node/src/components/block_executor/event.rs
@@ -23,6 +23,8 @@ use crate::{
 /// Block executor component event.
 #[derive(Debug, From)]
 pub enum Event {
+    /// Indicates whether block has already been finalized and executed in the past.
+    BlockAlreadyExists(bool, FinalizedBlock),
     /// A request made of the Block executor component.
     #[from]
     Request(BlockExecutorRequest),
@@ -148,6 +150,9 @@ impl Display for Event {
                 state.state_root_hash,
                 result
             ),
+            Event::BlockAlreadyExists(flag, fb) => {
+                write!(f, "Block at height: {} was executed before: {}", fb.height(), flag)
+            }
         }
     }
 }

--- a/node/src/components/block_executor/event.rs
+++ b/node/src/components/block_executor/event.rs
@@ -151,7 +151,12 @@ impl Display for Event {
                 result
             ),
             Event::BlockAlreadyExists(flag, fb) => {
-                write!(f, "Block at height: {} was executed before: {}", fb.height(), flag)
+                write!(
+                    f,
+                    "Block at height: {} was executed before: {}",
+                    fb.height(),
+                    flag
+                )
             }
         }
     }


### PR DESCRIPTION
## Introduction ##

When in validator mode, node may end up finalizing (and requesting execution) blocks that have been executed when in joining mode. This PR proposes a solution where double execution does not happen.

JIRA ticket: https://casperlabs.atlassian.net/browse/NDRS-424

### Validator mode ###
The flow for finalized blocks when node is in _validator mode_:

1. Consensus finalizes a proposal and sends an `ExecuteBlock(finalized_block)` to the `BlockExecutor`.
2. `BlockExecutor` executes the `finalized_block` and announces `LinearChainBlock`.
3. Announcement creates two events:
    * Sends an event to the event stream about new block being added.
    * Sends a `LinearChainBlock` to the `LinearChain` component.
4. `LinearChain` component stores the block and sends an event to the `Consensus` component.
5. `Consensus` component acts on the new linear chain block: creates a signature if necessary and instantiates new era if that was the last block of the previous era.

### Joining mode ### 

When node runs in _joining mode_, the steps are:

1. `LinearChainSync` component downloads a new linear chain block asks `BlockExecutor` to execute it.
2. `BlockExecutor` executes the `finalized_block` and announces `LinearChainBlock`.
3. Announcement creates two events:
    * Sends an event to the event stream about new block being added.
    * Sends a `LinearChainBlock` to the `LinearChain` component.
4. `LinearChain` component stores the block and sends an event to the `Consensus` component.
5. `Consensus` component acts on the new linear chain block: creates a signature if necessary and instantiates new era if that was the last block of the previous era and notifies the `LinearChainSync` component.
6. `LinearChainSync` downloads next block in the chain.

As you can see above, all steps are the same except for the first one. 

The problem was that once node transitioned from _joining_ to the _validator_ mode, it might download all the consensus message from the active era which would make the `Consensus` component send `ExecuteBlock(finalized_block)` event to the `BlockExecutor` (and repeat steps 2-5).

### Solution ###

Prior to executing a block, check if the block at this height has been executed before. If it was, skip the next steps. All the effects that happen because of block execution:
* send and event to the event stream (events created when in _joining mode_ should also be sent to the event stream – needs a ticket)
* store the block in the persistent storage
* create (and gossip) finality signature
* create a new era (if necessary)

were already executed when the block was downloaded and executed in the _joining mode_. Participating in the consensus also requires knowledge of the whole protocol state (all past consensus messages) so downloading the DAG, when the first consensus message is received, is not only OK but necessary.