### PR TITLE
NO-TICKET: drop connections to peers which don't have an identical genesis config hash

### DIFF
--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -35,7 +35,6 @@ use casper_types::{auction::ValidatorWeights, ProtocolVersion};
 
 use crate::{
     components::Component,
-    crypto::hash,
     effect::{requests::ContractRuntimeRequest, EffectBuilder, EffectExt, Effects},
     utils::WithDir,
     Chainspec, NodeRng, StorageConfig,
@@ -429,9 +428,7 @@ impl ContractRuntime {
     /// Commits a genesis using a chainspec
     fn commit_genesis(&self, chainspec: Box<Chainspec>) -> Result<GenesisResult, Error> {
         let correlation_id = CorrelationId::new();
-        let serialized_chainspec =
-            bincode::serialize(&chainspec).map_err(|error| Error::from_serialization(*error))?;
-        let genesis_config_hash = hash::hash(&serialized_chainspec);
+        let genesis_config_hash = chainspec.hash();
         let protocol_version = ProtocolVersion::from_parts(
             chainspec.genesis.protocol_version.major as u32,
             chainspec.genesis.protocol_version.minor as u32,

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -390,8 +390,15 @@ where
                 }
 
                 debug!(%peer_id, %peer_address, "{}: established incoming connection", self.our_id);
-                // The sink is never used, as we only read data from incoming connections.
-                let (_sink, stream) = framed::<P>(transport).split();
+                // The sink is only used to send a single handshake message, then dropped.
+                let (mut sink, stream) = framed::<P>(transport).split();
+                let handshake = Message::Handshake {
+                    genesis_config_hash: self.genesis_config_hash,
+                };
+                let mut effects = async move {
+                    let _ = sink.send(handshake).await;
+                }
+                .ignore::<Event<P>>();
 
                 let _ = self.incoming.insert(
                     peer_id.clone(),
@@ -402,7 +409,7 @@ where
                 );
 
                 // If the connection is now complete, announce the new peer before starting reader.
-                let mut effects = self.check_connection_complete(effect_builder, peer_id.clone());
+                effects.extend(self.check_connection_complete(effect_builder, peer_id.clone()));
 
                 effects.extend(
                     message_reader(
@@ -462,7 +469,8 @@ where
             return Effects::new();
         }
 
-        let (sink, _stream) = framed::<P>(transport).split();
+        // The stream is only used to receive a single handshake message and then dropped.
+        let (sink, stream) = framed::<P>(transport).split();
         debug!(%peer_id, %peer_address, "{}: established outgoing connection", self.our_id);
 
         let (sender, receiver) = mpsc::unbounded_channel();
@@ -483,12 +491,23 @@ where
         let handshake = Message::Handshake {
             genesis_config_hash: self.genesis_config_hash,
         };
+        let peer_id_cloned = peer_id.clone();
         effects.extend(
             message_sender(receiver, sink, handshake).event(move |result| Event::OutgoingFailed {
                 peer_id: Some(peer_id),
                 peer_address,
                 error: result.err().map(Into::into),
             }),
+        );
+        effects.extend(
+            handshake_reader(
+                self.event_queue,
+                stream,
+                self.our_id.clone(),
+                peer_id_cloned,
+                peer_address,
+            )
+            .ignore::<Event<P>>(),
         );
 
         effects
@@ -613,7 +632,7 @@ where
                         self.our_id,
                         peer_id
                     );
-                    return self.remove(effect_builder, &peer_id, true);
+                    return self.remove(effect_builder, &peer_id, false);
                 }
                 Effects::new()
             }
@@ -950,6 +969,41 @@ async fn setup_tls(
         NodeId::from(tls::validate_cert(peer_cert)?.public_key_fingerprint()),
         tls_stream,
     ))
+}
+
+/// Network handshake reader for single handshake message received by outgoing connection.
+async fn handshake_reader<REv, P>(
+    event_queue: EventQueueHandle<REv>,
+    mut stream: SplitStream<FramedTransport<P>>,
+    our_id: NodeId,
+    peer_id: NodeId,
+    peer_address: SocketAddr,
+) where
+    P: DeserializeOwned + Send + Display,
+    REv: From<Event<P>>,
+{
+    if let Some(incoming_handshake_msg) = stream.next().await {
+        if let Ok(msg @ Message::Handshake { .. }) = incoming_handshake_msg {
+            debug!(%msg, %peer_id, "{}: handshake received", our_id);
+            return event_queue
+                .schedule(
+                    Event::IncomingMessage { peer_id, msg },
+                    QueueKind::NetworkIncoming,
+                )
+                .await;
+        }
+    }
+    warn!(%peer_id, "{}: receiving handshake failed, closing connection", our_id);
+    event_queue
+        .schedule(
+            Event::OutgoingFailed {
+                peer_id: Some(peer_id),
+                peer_address,
+                error: None,
+            },
+            QueueKind::Network,
+        )
+        .await
 }
 
 /// Network message reader.

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -2,11 +2,21 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
+use crate::crypto::hash::Digest;
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Message<P>(pub(super) P);
+pub enum Message<P> {
+    Handshake { genesis_config_hash: Digest },
+    Payload(P),
+}
 
 impl<P: Display> Display for Message<P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "payload: {}", self.0)
+        match self {
+            Message::Handshake {
+                genesis_config_hash,
+            } => write!(f, "handshake: {}", genesis_config_hash),
+            Message::Payload(payload) => write!(f, "payload: {}", payload),
+        }
     }
 }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -367,8 +367,13 @@ impl reactor::Reactor for Reactor {
 
         let network_config = network::Config::from(&config.network);
         let (network, network_effects) = Network::new(event_queue, network_config, false)?;
-        let (small_network, small_network_effects) =
-            SmallNetwork::new(event_queue, config.network.clone(), false)?;
+        let genesis_config_hash = chainspec_loader.chainspec().hash();
+        let (small_network, small_network_effects) = SmallNetwork::new(
+            event_queue,
+            config.network.clone(),
+            genesis_config_hash,
+            false,
+        )?;
 
         let linear_chain_fetcher = Fetcher::new(config.fetcher);
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -370,8 +370,9 @@ impl reactor::Reactor for Reactor {
         let effect_builder = EffectBuilder::new(event_queue);
         let network_config = network::Config::from(&config.network);
         let (network, network_effects) = Network::new(event_queue, network_config, true)?;
+        let genesis_config_hash = chainspec_loader.chainspec().hash();
         let (small_network, small_network_effects) =
-            SmallNetwork::new(event_queue, config.network, true)?;
+            SmallNetwork::new(event_queue, config.network, genesis_config_hash, true)?;
 
         let address_gossiper =
             Gossiper::new_for_complete_items("address_gossiper", config.gossip, registry)?;


### PR DESCRIPTION
This PR adds a handshake once a new connection is established between peers whereby the genesis config hashes are exchanged and the connection dropped in the case of a mismatch.

On establishing an outgoing connection, the peer immediately sends the handshake as the first message.  On the receiving side, the handshake is compared to the local genesis config hash, and if different, the connection is dropped.  For simplicity, after dropping any connection, the peer checks to see if it's isolated and terminates if so.  This check was previously only done upon a bootstrap connection failing.  However, now the bootstrap connection can succeed only to be dropped shortly afterwards due to a handshake failure, by which time the isolation check was already completed.

The implementation could be improved somewhat if the small network component is to be retained long-term.  However, this approach seems to be the simplest for now.  It has necessitated a test removal - since the fatal error generated by a single isolated node causes the small network's unit test to fail.

I have tested the behaviour with a local testnet where 4 peers share a chainspec, and a 5th peer using the same chainspec with only the timestamps changed fails to remain connected to the bootstrap node and terminates.