### PR TITLE
NO-TICKET: Simplify impl Ord for HighwayMessage.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{components::consensus::traits::Context, types::Timestamp, NodeRng};
 
 /// Information about the context in which a new block is created.
-#[derive(Clone, DataSize, Eq, PartialEq, Debug, Ord, PartialOrd)]
+#[derive(Clone, DataSize, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
 pub struct BlockContext {
     timestamp: Timestamp,
     height: u64,

--- a/node/src/components/consensus/highway_core/endorsement.rs
+++ b/node/src/components/consensus/highway_core/endorsement.rs
@@ -17,7 +17,7 @@ pub(crate) enum EndorsementError {
 
 /// Testimony that creator of `unit` was seen honest
 /// by `endorser` at the moment of creating this endorsement.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) struct Endorsement<C: Context> {
     /// Unit being endorsed.
     unit: C::Hash,
@@ -42,7 +42,7 @@ impl<C: Context> Endorsement<C> {
 
 /// Testimony that creator of `unit` was seen honest
 /// by `endorser` at the moment of creating this endorsement.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) struct SignedEndorsement<C: Context> {
     /// Original endorsement,
     endorsement: Endorsement<C>,

--- a/node/src/components/consensus/highway_core/evidence.rs
+++ b/node/src/components/consensus/highway_core/evidence.rs
@@ -22,7 +22,7 @@ pub(crate) enum EvidenceError {
 }
 
 /// Evidence that a validator is faulty.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(bound(
     serialize = "C::Hash: Serialize",
     deserialize = "C::Hash: Deserialize<'de>",

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -38,7 +38,7 @@ impl<C: Context> Dependency<C> {
 /// An element of the protocol state, that might depend on other elements.
 ///
 /// It is the vertex in a directed acyclic graph, whose edges are dependencies.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(bound(
     serialize = "C::Hash: Serialize",
     deserialize = "C::Hash: Deserialize<'de>",
@@ -104,7 +104,7 @@ impl<C: Context> Vertex<C> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(bound(
     serialize = "C::Hash: Serialize",
     deserialize = "C::Hash: Deserialize<'de>",
@@ -133,7 +133,7 @@ impl<C: Context> SignedWireUnit<C> {
 }
 
 /// A unit as it is sent over the wire, possibly containing a new block.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(bound(
     serialize = "C::Hash: Serialize",
     deserialize = "C::Hash: Deserialize<'de>",
@@ -189,7 +189,7 @@ impl<C: Context> WireUnit<C> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(bound(
     serialize = "C::Hash: Serialize",
     deserialize = "C::Hash: Deserialize<'de>",

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{hash_map::DefaultHasher, HashMap, VecDeque},
     fmt::{self, Debug, Display, Formatter},
-    hash::Hasher,
+    hash::{Hash, Hasher},
     iter::FromIterator,
 };
 
@@ -13,11 +13,10 @@ use tracing::{trace, warn};
 
 use super::{
     active_validator::Effect,
-    evidence::Evidence,
     finality_detector::{FinalityDetector, FttExceeded},
     highway::{
-        Dependency, Endorsements, GetDepOutcome, Highway, Params, PreValidatedVertex,
-        SignedWireUnit, ValidVertex, Vertex, VertexError,
+        Dependency, GetDepOutcome, Highway, Params, PreValidatedVertex, SignedWireUnit,
+        ValidVertex, Vertex, VertexError,
     },
     state::Fault,
     validators::Validators,
@@ -48,7 +47,7 @@ const TEST_END_HEIGHT: u64 = 100000;
 pub(crate) const TEST_BLOCK_REWARD: u64 = 1_000_000_000_000;
 pub(crate) const TEST_REDUCED_BLOCK_REWARD: u64 = 200_000_000_000;
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 enum HighwayMessage {
     Timer(Timestamp),
     NewVertex(Box<Vertex<TestContext>>),
@@ -114,57 +113,11 @@ impl PartialOrd for HighwayMessage {
 
 impl Ord for HighwayMessage {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if self == other {
-            return std::cmp::Ordering::Equal;
-        }
-        match (self, other) {
-            (HighwayMessage::Timer(t1), HighwayMessage::Timer(t2)) => t1.cmp(&t2),
-            (HighwayMessage::NewVertex(v1), HighwayMessage::NewVertex(v2)) => {
-                match (&**v1, &**v2) {
-                    (Vertex::Unit(swv1), Vertex::Unit(swv2)) => swv1.hash().cmp(&swv2.hash()),
-                    (Vertex::Unit(_), _) => std::cmp::Ordering::Less,
-                    (
-                        Vertex::Evidence(Evidence::Equivocation(ev1_a, ev1_b)),
-                        Vertex::Evidence(Evidence::Equivocation(ev2_a, ev2_b)),
-                    ) => ev1_a
-                        .hash()
-                        .cmp(&ev2_a.hash())
-                        .then_with(|| ev1_b.hash().cmp(&ev2_b.hash())),
-                    (Vertex::Evidence(_), _) => std::cmp::Ordering::Less,
-                    (
-                        Vertex::Endorsements(Endorsements {
-                            unit: l_hash,
-                            endorsers: l_vid,
-                        }),
-                        Vertex::Endorsements(Endorsements {
-                            unit: r_hash,
-                            endorsers: r_vid,
-                        }),
-                    ) => l_hash.cmp(r_hash).then_with(|| l_vid.cmp(r_vid)),
-                    (Vertex::Endorsements(_), _) => std::cmp::Ordering::Less,
-                }
-            }
-            (HighwayMessage::RequestBlock(bc1), HighwayMessage::RequestBlock(bc2)) => bc1.cmp(&bc2),
-            (HighwayMessage::WeAreFaulty(ev1), HighwayMessage::WeAreFaulty(ev2)) => {
-                match (&**ev1, &**ev2) {
-                    (Fault::Banned, _) => std::cmp::Ordering::Greater,
-                    (Fault::Indirect, _) => std::cmp::Ordering::Greater,
-                    (Fault::Direct(ev1), Fault::Direct(ev2)) => {
-                        let Evidence::Equivocation(ev1_a, ev1_b) = ev1;
-                        let Evidence::Equivocation(ev2_a, ev2_b) = ev2;
-                        ev1_a
-                            .hash()
-                            .cmp(&ev2_a.hash())
-                            .then_with(|| ev1_b.hash().cmp(&ev2_b.hash()))
-                    }
-                    (_, _) => std::cmp::Ordering::Less,
-                }
-            }
-            (HighwayMessage::Timer(_), _) => std::cmp::Ordering::Less,
-            (HighwayMessage::NewVertex(_), _) => std::cmp::Ordering::Less,
-            (HighwayMessage::RequestBlock(_), _) => std::cmp::Ordering::Less,
-            (HighwayMessage::WeAreFaulty(_), _) => std::cmp::Ordering::Greater,
-        }
+        let mut hasher0 = DefaultHasher::new();
+        let mut hasher1 = DefaultHasher::new();
+        self.hash(&mut hasher0);
+        other.hash(&mut hasher1);
+        hasher0.finish().cmp(&hasher1.finish())
     }
 }
 

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -101,7 +101,7 @@ pub(crate) enum UnitError {
 /// The `Banned` state is fixed from the beginning and can't be replaced. However, `Indirect` can
 /// be replaced with `Direct` evidence, which has the same effect but doesn't rely on information
 /// from other consensus protocol instances.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) enum Fault<C: Context> {
     /// The validator was known to be faulty from the beginning. All their messages are considered
     /// invalid in this Highway instance.

--- a/node/src/components/consensus/highway_core/state/panorama.rs
+++ b/node/src/components/consensus/highway_core/state/panorama.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// The observed behavior of a validator at some point in time.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(bound(
     serialize = "C::Hash: Serialize",
     deserialize = "C::Hash: Deserialize<'de>",

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -122,7 +122,7 @@ impl<VID: Ord + Hash + fmt::Debug> fmt::Display for Validators<VID> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRef, From)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRef, From, Hash)]
 pub(crate) struct ValidatorMap<T>(Vec<T>);
 
 impl<T> ValidatorMap<T> {


### PR DESCRIPTION
This uses hashes to order messages in the Highway Core DES tests, so that e.g. updates to the vertex structure don't require complicated extensions of this trait implementation.

(In preparation for [HWY-168](https://casperlabs.atlassian.net/browse/HWY-168).)