### PR TITLE
EE-1117: Extend UnbondingPurse structure.

### DIFF
--- a/grpc/tests/src/test/system_contracts/auction/bids.rs
+++ b/grpc/tests/src/test/system_contracts/auction/bids.rs
@@ -203,17 +203,18 @@ fn should_run_add_bid() {
         .get(&BID_ACCOUNT_1_PK)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
-    assert_eq!(unbond_list[0].public_key, BID_ACCOUNT_1_PK);
+    assert_eq!(unbond_list[0].validator_public_key(), &BID_ACCOUNT_1_PK);
     // `WITHDRAW_BID_AMOUNT_2` is in unbonding list
 
     assert_eq!(
-        unbonding_purse, unbond_list[0].unbonding_purse,
+        &unbonding_purse,
+        unbond_list[0].unbonding_purse(),
         "unbonding queue should have account's unbonding purse"
     );
-    assert_eq!(unbond_list[0].amount, U512::from(WITHDRAW_BID_AMOUNT_2),);
+    assert_eq!(unbond_list[0].amount(), &U512::from(WITHDRAW_BID_AMOUNT_2),);
 
     assert_eq!(
-        unbond_list[0].era_of_withdrawal,
+        unbond_list[0].era_of_withdrawal(),
         INITIAL_ERA_ID + DEFAULT_UNBONDING_DELAY,
     );
 }
@@ -359,6 +360,26 @@ fn should_run_delegate_and_undelegate() {
     assert_eq!(
         delegated_amount_1,
         U512::from(DELEGATE_AMOUNT_1 + DELEGATE_AMOUNT_2 - UNDELEGATE_AMOUNT_1)
+    );
+
+    let unbonding_purses: UnbondingPurses = builder.get_value(auction_hash, UNBONDING_PURSES_KEY);
+    assert_eq!(unbonding_purses.len(), 1);
+
+    let unbond_list = unbonding_purses
+        .get(&NON_FOUNDER_VALIDATOR_1_PK)
+        .expect("should have unbonding purse for non founder validator");
+    assert_eq!(unbond_list.len(), 1);
+    assert_eq!(
+        unbond_list[0].validator_public_key(),
+        &NON_FOUNDER_VALIDATOR_1_PK
+    );
+    assert_eq!(unbond_list[0].unbonder_public_key(), &BID_ACCOUNT_1_PK);
+    assert_eq!(unbond_list[0].amount(), &U512::from(UNDELEGATE_AMOUNT_1));
+    assert!(!unbond_list[0].is_validator());
+
+    assert_eq!(
+        unbond_list[0].era_of_withdrawal() as usize,
+        INITIAL_ERA_ID as usize + DEFAULT_UNBONDING_DELAY as usize
     );
 }
 
@@ -841,18 +862,18 @@ fn should_release_founder_stake() {
         .get(&ACCOUNT_1_PK)
         .expect("should have unbond");
     assert_eq!(pre_unbond_list.len(), 2);
-    assert_eq!(pre_unbond_list[0].public_key, ACCOUNT_1_PK);
-    assert_eq!(pre_unbond_list[0].amount, ACCOUNT_1_WITHDRAW_1.into());
-    assert_eq!(pre_unbond_list[1].public_key, ACCOUNT_1_PK);
-    assert_eq!(pre_unbond_list[1].amount, ACCOUNT_1_WITHDRAW_2.into());
+    assert_eq!(pre_unbond_list[0].validator_public_key(), &ACCOUNT_1_PK);
+    assert_eq!(pre_unbond_list[0].amount(), &ACCOUNT_1_WITHDRAW_1.into());
+    assert_eq!(pre_unbond_list[1].validator_public_key(), &ACCOUNT_1_PK);
+    assert_eq!(pre_unbond_list[1].amount(), &ACCOUNT_1_WITHDRAW_2.into());
 
     // Funds are not transferred yet from the original bonding purse
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[0].unbonding_purse),
+        builder.get_purse_balance(*pre_unbond_list[0].unbonding_purse()),
         U512::zero(),
     );
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[1].unbonding_purse),
+        builder.get_purse_balance(*pre_unbond_list[1].unbonding_purse()),
         U512::zero(),
     );
     // check that bids are updated for given validator
@@ -879,11 +900,11 @@ fn should_release_founder_stake() {
     // Funds are transferred from the original bonding purse to the unbonding purses
     //
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[0].unbonding_purse), // still valid
+        builder.get_purse_balance(*pre_unbond_list[0].unbonding_purse()), // still valid
         ACCOUNT_1_WITHDRAW_1.into(),
     );
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[1].unbonding_purse), // still valid
+        builder.get_purse_balance(*pre_unbond_list[1].unbonding_purse()), // still valid
         U512::zero(),
     );
 
@@ -901,11 +922,11 @@ fn should_release_founder_stake() {
     builder.exec(exec_request_4).expect_success().commit();
 
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[0].unbonding_purse), // still valid ref
+        builder.get_purse_balance(*pre_unbond_list[0].unbonding_purse()), // still valid ref
         ACCOUNT_1_WITHDRAW_1.into(),
     );
     assert_eq!(
-        builder.get_purse_balance(pre_unbond_list[1].unbonding_purse), // still valid ref
+        builder.get_purse_balance(*pre_unbond_list[1].unbonding_purse()), // still valid ref
         ACCOUNT_1_WITHDRAW_2.into(),
     );
 

--- a/grpc/tests/src/test/system_contracts/auction_bidding.rs
+++ b/grpc/tests/src/test/system_contracts/auction_bidding.rs
@@ -147,18 +147,22 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
-    assert_eq!(unbond_list[0].public_key, default_public_key_arg,);
     assert_eq!(
-        builder.get_purse_balance(unbond_list[0].unbonding_purse),
+        unbond_list[0].validator_public_key(),
+        &default_public_key_arg,
+    );
+    assert!(unbond_list[0].is_validator());
+    assert_eq!(
+        builder.get_purse_balance(*unbond_list[0].unbonding_purse()),
         U512::zero(),
     );
 
     assert_eq!(
-        unbond_list[0].era_of_withdrawal as usize,
+        unbond_list[0].era_of_withdrawal() as usize,
         INITIAL_ERA_ID as usize + DEFAULT_UNBONDING_DELAY as usize
     );
 
-    let unbond_era_1 = unbond_list[0].era_of_withdrawal;
+    let unbond_era_1 = unbond_list[0].era_of_withdrawal();
 
     let exec_request_3 = ExecuteRequestBuilder::contract_call_by_hash(
         SYSTEM_ADDR,
@@ -177,14 +181,18 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
-    assert_eq!(unbond_list[0].public_key, default_public_key_arg,);
     assert_eq!(
-        builder.get_purse_balance(unbond_list[0].unbonding_purse),
+        unbond_list[0].validator_public_key(),
+        &default_public_key_arg,
+    );
+    assert!(unbond_list[0].is_validator());
+    assert_eq!(
+        builder.get_purse_balance(*unbond_list[0].unbonding_purse()),
         U512::zero(),
     );
-    assert_eq!(unbond_list[0].amount, unbond_amount,);
+    assert_eq!(unbond_list[0].amount(), &unbond_amount,);
 
-    let unbond_era_2 = unbond_list[0].era_of_withdrawal;
+    let unbond_era_2 = unbond_list[0].era_of_withdrawal();
 
     assert_eq!(unbond_era_2, unbond_era_1);
 
@@ -487,18 +495,22 @@ fn should_run_successful_bond_and_unbond_with_release() {
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
-    assert_eq!(unbond_list[0].public_key, default_public_key_arg,);
     assert_eq!(
-        builder.get_purse_balance(unbond_list[0].unbonding_purse),
+        unbond_list[0].validator_public_key(),
+        &default_public_key_arg,
+    );
+    assert!(unbond_list[0].is_validator());
+    assert_eq!(
+        builder.get_purse_balance(*unbond_list[0].unbonding_purse()),
         U512::zero(),
     );
 
     assert_eq!(
-        unbond_list[0].era_of_withdrawal as usize,
+        unbond_list[0].era_of_withdrawal() as usize,
         INITIAL_ERA_ID as usize + 1 + DEFAULT_UNBONDING_DELAY as usize
     );
 
-    let unbond_era_1 = unbond_list[0].era_of_withdrawal;
+    let unbond_era_1 = unbond_list[0].era_of_withdrawal();
 
     let exec_request_3 = ExecuteRequestBuilder::contract_call_by_hash(
         SYSTEM_ADDR,
@@ -517,14 +529,18 @@ fn should_run_successful_bond_and_unbond_with_release() {
         .get(&default_public_key_arg)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
-    assert_eq!(unbond_list[0].public_key, default_public_key_arg,);
-    assert_eq!(unbond_list[0].unbonding_purse, unbonding_purse,);
+    assert_eq!(
+        unbond_list[0].validator_public_key(),
+        &default_public_key_arg,
+    );
+    assert!(unbond_list[0].is_validator());
+    assert_eq!(unbond_list[0].unbonding_purse(), &unbonding_purse,);
     assert_eq!(
         builder.get_purse_balance(unbonding_purse),
         U512::zero(), // Not paid yet
     );
 
-    let unbond_era_2 = unbond_list[0].era_of_withdrawal;
+    let unbond_era_2 = unbond_list[0].era_of_withdrawal();
 
     assert_eq!(unbond_era_2, unbond_era_1); // era of withdrawal didn't change since first run
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,7 +18,6 @@ blake2 = { version = "0.9.0", default-features = false }
 datasize = { version = "0.2.0", default-features = false }
 failure = { version = "0.1.8", default-features = false, features = ["failure_derive"] }
 hex_fmt = "0.3.0"
-once_cell = { version = "1.5.2", optional = true }
 num-derive = { version = "0.3.0", default-features = false }
 num-integer = { version = "0.1.42", default-features = false }
 num-rational = { version = "0.3.0", default-features = false }
@@ -29,6 +28,7 @@ schemars = { version = "0.8.0", features = ["preserve_order"], optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.59", default-features = false }
 uint = { version = "0.8.3", default-features = false }
+once_cell = "1.5.2"
 
 [dev-dependencies]
 bincode = "1.3.1"
@@ -41,7 +41,7 @@ serde_test = "1.0.117"
 
 [features]
 default = ["base16/alloc", "serde/alloc", "serde_json/alloc"]
-std = ["base16/std", "serde/std", "serde_json/std","once_cell","schemars"]
+std = ["base16/std", "serde/std", "serde_json/std", "schemars"]
 gens = ["std", "proptest/std"]
 no-unstable-features = []
 

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -133,6 +133,7 @@ pub trait Auction:
         detail::create_unbonding_purse(
             self,
             public_key,
+            public_key, // validator is the unbonder
             *bid.bonding_purse(),
             unbonding_purse,
             amount,
@@ -234,6 +235,7 @@ pub trait Auction:
             Some(delegator) => {
                 detail::create_unbonding_purse(
                     self,
+                    validator_public_key,
                     delegator_public_key,
                     *delegator.bonding_purse(),
                     unbonding_purse,
@@ -269,7 +271,7 @@ pub trait Auction:
         for validator_public_key in validator_public_keys {
             // TODO: slash delegators properly
             if let Some(unbonding_list) = unbonding_purses.remove(&validator_public_key) {
-                burned_amount += unbonding_list.iter().map(|x| x.amount).sum();
+                burned_amount += unbonding_list.iter().map(|x| *x.amount()).sum();
                 unbonding_purses_modified = true;
             }
         }

--- a/types/src/auction/unbonding_purse.rs
+++ b/types/src/auction/unbonding_purse.rs
@@ -25,7 +25,7 @@ pub struct UnbondingPurse {
 }
 
 impl UnbondingPurse {
-    /// Creates [`UnbondingPurse`] instance for a withdraw bid request made by a delegator.
+    /// Creates [`UnbondingPurse`] instance for an unbonding request.
     pub fn new(
         bonding_purse: URef,
         unbonding_purse: URef,

--- a/types/src/auction/unbonding_purse.rs
+++ b/types/src/auction/unbonding_purse.rs
@@ -26,7 +26,7 @@ pub struct UnbondingPurse {
 
 impl UnbondingPurse {
     /// Creates [`UnbondingPurse`] instance for an unbonding request.
-    pub fn new(
+    pub const fn new(
         bonding_purse: URef,
         unbonding_purse: URef,
         validator_public_key: PublicKey,

--- a/types/src/auction/unbonding_purse.rs
+++ b/types/src/auction/unbonding_purse.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 
 use crate::{
+    auction::EraId,
     bytesrepr::{self, FromBytes, ToBytes},
     CLType, CLTyped, PublicKey, URef, U512,
 };
@@ -10,15 +11,78 @@ use crate::{
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct UnbondingPurse {
     /// Bonding Purse
-    pub bonding_purse: URef,
+    bonding_purse: URef,
     /// Unbonding Purse.
-    pub unbonding_purse: URef,
-    /// Unbonding Origin.
-    pub public_key: PublicKey,
+    unbonding_purse: URef,
+    /// Validators public key.
+    validator_public_key: PublicKey,
+    /// Unbonders public key.
+    unbonder_public_key: PublicKey,
     /// Unbonding Era.
-    pub era_of_withdrawal: u64,
+    era_of_withdrawal: EraId,
     /// Unbonding Amount.
-    pub amount: U512,
+    amount: U512,
+}
+
+impl UnbondingPurse {
+    /// Creates [`UnbondingPurse`] instance for a withdraw bid request made by a delegator.
+    pub fn new(
+        bonding_purse: URef,
+        unbonding_purse: URef,
+        validator_public_key: PublicKey,
+        unbonder_public_key: PublicKey,
+        era_of_withdrawal: EraId,
+        amount: U512,
+    ) -> Self {
+        Self {
+            bonding_purse,
+            unbonding_purse,
+            validator_public_key,
+            unbonder_public_key,
+            era_of_withdrawal,
+            amount,
+        }
+    }
+
+    /// Checks if given request is made by a validator by checking if public key of unbonder is same
+    /// as a key owned by validator.
+    pub fn is_validator(&self) -> bool {
+        self.validator_public_key == self.unbonder_public_key
+    }
+
+    /// Returns bonding purse used to make this unbonding request.
+    pub fn bonding_purse(&self) -> &URef {
+        &self.bonding_purse
+    }
+
+    /// Returns unbonding purse which will be used to deliver funds.
+    pub fn unbonding_purse(&self) -> &URef {
+        &self.unbonding_purse
+    }
+
+    /// Returns public key of validator.
+    pub fn validator_public_key(&self) -> &PublicKey {
+        &self.validator_public_key
+    }
+
+    /// Returns public key of unbonder.
+    ///
+    /// For withdrawal requests that originated from validator's public key through
+    /// [`crate::auction::Auction::withdraw_bid`] entrypoint this is equal to
+    /// [`UnbondingPurse::validator_public_key`] and [`UnbondingPurse::is_validator`] is `true`.
+    pub fn unbonder_public_key(&self) -> &PublicKey {
+        &self.unbonder_public_key
+    }
+
+    /// Returns era which will be used to complete this withdrawal request.
+    pub fn era_of_withdrawal(&self) -> EraId {
+        self.era_of_withdrawal
+    }
+
+    /// Returns unbonding amount.
+    pub fn amount(&self) -> &U512 {
+        &self.amount
+    }
 }
 
 impl ToBytes for UnbondingPurse {
@@ -26,7 +90,8 @@ impl ToBytes for UnbondingPurse {
         let mut result = bytesrepr::allocate_buffer(self)?;
         result.extend(&self.bonding_purse.to_bytes()?);
         result.extend(&self.unbonding_purse.to_bytes()?);
-        result.extend(&self.public_key.to_bytes()?);
+        result.extend(&self.validator_public_key.to_bytes()?);
+        result.extend(&self.unbonder_public_key.to_bytes()?);
         result.extend(&self.era_of_withdrawal.to_bytes()?);
         result.extend(&self.amount.to_bytes()?);
         Ok(result)
@@ -34,7 +99,8 @@ impl ToBytes for UnbondingPurse {
     fn serialized_length(&self) -> usize {
         self.bonding_purse.serialized_length()
             + self.unbonding_purse.serialized_length()
-            + self.public_key.serialized_length()
+            + self.validator_public_key.serialized_length()
+            + self.unbonder_public_key.serialized_length()
             + self.era_of_withdrawal.serialized_length()
             + self.amount.serialized_length()
     }
@@ -44,14 +110,16 @@ impl FromBytes for UnbondingPurse {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (bonding_purse, bytes) = FromBytes::from_bytes(bytes)?;
         let (unbonding_purse, bytes) = FromBytes::from_bytes(bytes)?;
-        let (public_key, bytes) = FromBytes::from_bytes(bytes)?;
+        let (validator_public_key, bytes) = FromBytes::from_bytes(bytes)?;
+        let (unbonder_public_key, bytes) = FromBytes::from_bytes(bytes)?;
         let (era_of_withdrawal, bytes) = FromBytes::from_bytes(bytes)?;
         let (amount, bytes) = FromBytes::from_bytes(bytes)?;
         Ok((
             UnbondingPurse {
                 bonding_purse,
                 unbonding_purse,
-                public_key,
+                validator_public_key,
+                unbonder_public_key,
                 era_of_withdrawal,
                 amount,
             },
@@ -68,17 +136,56 @@ impl CLTyped for UnbondingPurse {
 
 #[cfg(test)]
 mod tests {
-    use crate::{auction::UnbondingPurse, bytesrepr, AccessRights, PublicKey, URef, U512};
+    use once_cell::sync::Lazy;
+
+    use crate::{
+        auction::{EraId, UnbondingPurse},
+        bytesrepr, AccessRights, PublicKey, URef, U512,
+    };
+
+    const BONDING_PURSE: URef = URef::new([41; 32], AccessRights::READ_ADD_WRITE);
+    const UNBONDING_PURSE: URef = URef::new([42; 32], AccessRights::READ_ADD_WRITE);
+    const VALIDATOR_PUBLIC_KEY: PublicKey = PublicKey::Ed25519([42; 32]);
+    const UNBONDER_PUBLIC_KEY: PublicKey = PublicKey::Ed25519([43; 32]);
+    const ERA_OF_WITHDRAWAL: EraId = EraId::max_value();
+    static AMOUNT: Lazy<U512> = Lazy::new(|| U512::max_value() - 1);
 
     #[test]
     fn serialization_roundtrip() {
         let unbonding_purse = UnbondingPurse {
-            bonding_purse: URef::new([41; 32], AccessRights::READ_ADD_WRITE),
-            unbonding_purse: URef::new([42; 32], AccessRights::READ_ADD_WRITE),
-            public_key: PublicKey::Ed25519([42; 32]),
-            era_of_withdrawal: u64::max_value(),
-            amount: U512::max_value() - 1,
+            bonding_purse: BONDING_PURSE,
+            unbonding_purse: UNBONDING_PURSE,
+            validator_public_key: VALIDATOR_PUBLIC_KEY,
+            unbonder_public_key: UNBONDER_PUBLIC_KEY,
+            era_of_withdrawal: ERA_OF_WITHDRAWAL,
+            amount: *AMOUNT,
         };
+
         bytesrepr::test_serialization_roundtrip(&unbonding_purse);
+    }
+    #[test]
+    fn should_be_validator_condition() {
+        let validator_unbonding_purse = UnbondingPurse::new(
+            BONDING_PURSE,
+            UNBONDING_PURSE,
+            VALIDATOR_PUBLIC_KEY,
+            VALIDATOR_PUBLIC_KEY,
+            ERA_OF_WITHDRAWAL,
+            *AMOUNT,
+        );
+        assert!(validator_unbonding_purse.is_validator());
+    }
+
+    #[test]
+    fn should_be_delegator_condition() {
+        let delegator_unbonding_purse = UnbondingPurse::new(
+            BONDING_PURSE,
+            UNBONDING_PURSE,
+            VALIDATOR_PUBLIC_KEY,
+            UNBONDER_PUBLIC_KEY,
+            ERA_OF_WITHDRAWAL,
+            *AMOUNT,
+        );
+        assert!(!delegator_unbonding_purse.is_validator());
     }
 }

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -92,7 +92,7 @@ pub struct URef(URefAddr, AccessRights);
 
 impl URef {
     /// Constructs a [`URef`] from an address and access rights.
-    pub fn new(address: URefAddr, access_rights: AccessRights) -> Self {
+    pub const fn new(address: URefAddr, access_rights: AccessRights) -> Self {
         URef(address, access_rights)
     }
 


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1117

Adds two additional fields for each unbonding request 

```rust
/// Validator Public Key
pub validator_public_key: Public Key, 
/// Unbonder Public Key
pub unbonder_public_key: Public Key,
```