### PR TITLE
Adding contract building step to `nctl` prerequisites documentation

### DIFF
--- a/utils/nctl/docs/setup.md
+++ b/utils/nctl/docs/setup.md
@@ -11,9 +11,10 @@
 # Supervisor - cross-platform process manager.
 python3 -m pip install supervisor
 
-# Rust toolchain - required by casper-node software.
+# Rust toolchain and smart contracts - required by casper-node software.
 cd YOUR_WORKING_DIRECTORY/casper-node
 make setup-rs
+make build-contracts-rs
 ```
 
 ### Step 2 - extend bashrc file to make NCTL commands available from terminal session.


### PR DESCRIPTION
Resolves STS-64. Just a simple documentation update.