### PR TITLE
EE-1118: Replace unbonding era with a creation era

### DIFF
--- a/grpc/tests/src/test/system_contracts/auction/bids.rs
+++ b/grpc/tests/src/test/system_contracts/auction/bids.rs
@@ -213,10 +213,7 @@ fn should_run_add_bid() {
     );
     assert_eq!(unbond_list[0].amount(), &U512::from(WITHDRAW_BID_AMOUNT_2),);
 
-    assert_eq!(
-        unbond_list[0].era_of_withdrawal(),
-        INITIAL_ERA_ID + DEFAULT_UNBONDING_DELAY,
-    );
+    assert_eq!(unbond_list[0].era_of_creation(), INITIAL_ERA_ID,);
 }
 
 #[ignore]
@@ -377,10 +374,7 @@ fn should_run_delegate_and_undelegate() {
     assert_eq!(unbond_list[0].amount(), &U512::from(UNDELEGATE_AMOUNT_1));
     assert!(!unbond_list[0].is_validator());
 
-    assert_eq!(
-        unbond_list[0].era_of_withdrawal() as usize,
-        INITIAL_ERA_ID as usize + DEFAULT_UNBONDING_DELAY as usize
-    );
+    assert_eq!(unbond_list[0].era_of_creation(), INITIAL_ERA_ID);
 }
 
 #[ignore]

--- a/grpc/tests/src/test/system_contracts/auction_bidding.rs
+++ b/grpc/tests/src/test/system_contracts/auction_bidding.rs
@@ -158,11 +158,11 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
     );
 
     assert_eq!(
-        unbond_list[0].era_of_withdrawal() as usize,
-        INITIAL_ERA_ID as usize + DEFAULT_UNBONDING_DELAY as usize
+        unbond_list[0].era_of_creation(),
+        INITIAL_ERA_ID,
     );
 
-    let unbond_era_1 = unbond_list[0].era_of_withdrawal();
+    let unbond_era_1 = unbond_list[0].era_of_creation();
 
     let exec_request_3 = ExecuteRequestBuilder::contract_call_by_hash(
         SYSTEM_ADDR,
@@ -192,7 +192,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
     );
     assert_eq!(unbond_list[0].amount(), &unbond_amount,);
 
-    let unbond_era_2 = unbond_list[0].era_of_withdrawal();
+    let unbond_era_2 = unbond_list[0].era_of_creation();
 
     assert_eq!(unbond_era_2, unbond_era_1);
 
@@ -505,12 +505,9 @@ fn should_run_successful_bond_and_unbond_with_release() {
         U512::zero(),
     );
 
-    assert_eq!(
-        unbond_list[0].era_of_withdrawal() as usize,
-        INITIAL_ERA_ID as usize + 1 + DEFAULT_UNBONDING_DELAY as usize
-    );
+    assert_eq!(unbond_list[0].era_of_creation(), INITIAL_ERA_ID + 1);
 
-    let unbond_era_1 = unbond_list[0].era_of_withdrawal();
+    let unbond_era_1 = unbond_list[0].era_of_creation();
 
     let exec_request_3 = ExecuteRequestBuilder::contract_call_by_hash(
         SYSTEM_ADDR,
@@ -540,7 +537,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
         U512::zero(), // Not paid yet
     );
 
-    let unbond_era_2 = unbond_list[0].era_of_withdrawal();
+    let unbond_era_2 = unbond_list[0].era_of_creation();
 
     assert_eq!(unbond_era_2, unbond_era_1); // era of withdrawal didn't change since first run
 

--- a/grpc/tests/src/test/system_contracts/auction_bidding.rs
+++ b/grpc/tests/src/test/system_contracts/auction_bidding.rs
@@ -157,10 +157,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         U512::zero(),
     );
 
-    assert_eq!(
-        unbond_list[0].era_of_creation(),
-        INITIAL_ERA_ID,
-    );
+    assert_eq!(unbond_list[0].era_of_creation(), INITIAL_ERA_ID,);
 
     let unbond_era_1 = unbond_list[0].era_of_creation();
 

--- a/types/src/auction/detail.rs
+++ b/types/src/auction/detail.rs
@@ -133,10 +133,10 @@ pub(crate) fn process_unbond_requests<P: Auction + ?Sized>(provider: &mut P) -> 
     for unbonding_list in unbonding_purses.values_mut() {
         let mut new_unbonding_list = Vec::new();
         for unbonding_purse in unbonding_list.iter() {
-            // Since `process_unbond_requests` is run before `run_auction`, we should check
-            // if current era id is equal or greater than the `era_of_withdrawal` that was
-            // calculated on `unbond` attempt.
-            if current_era_id >= unbonding_purse.era_of_withdrawal() {
+            // Since `process_unbond_requests` is run before `run_auction`, we should check if
+            // current era id + unbonding deal is equal or greater than the `era_of_creation` that
+            // was calculated on `unbond` attempt.
+            if current_era_id >= unbonding_purse.era_of_creation() + DEFAULT_UNBONDING_DELAY {
                 // Move funds from bid purse to unbonding purse
                 provider
                     .transfer_from_purse_to_purse(
@@ -177,13 +177,13 @@ pub(crate) fn create_unbonding_purse<P: Auction + ?Sized>(
     }
 
     let mut unbonding_purses: UnbondingPurses = get_unbonding_purses(provider)?;
-    let era_of_withdrawal = provider.read_era_id()? + DEFAULT_UNBONDING_DELAY;
+    let era_of_creation = provider.read_era_id()?;
     let new_unbonding_purse = UnbondingPurse::new(
         bonding_purse,
         unbonding_purse,
         validator_public_key,
         unbonder_public_key,
-        era_of_withdrawal,
+        era_of_creation,
         amount,
     );
     unbonding_purses

--- a/types/src/auction/unbonding_purse.rs
+++ b/types/src/auction/unbonding_purse.rs
@@ -18,8 +18,8 @@ pub struct UnbondingPurse {
     validator_public_key: PublicKey,
     /// Unbonders public key.
     unbonder_public_key: PublicKey,
-    /// Unbonding Era.
-    era_of_withdrawal: EraId,
+    /// Era in which this unbonding request was created.
+    era_of_creation: EraId,
     /// Unbonding Amount.
     amount: U512,
 }
@@ -31,7 +31,7 @@ impl UnbondingPurse {
         unbonding_purse: URef,
         validator_public_key: PublicKey,
         unbonder_public_key: PublicKey,
-        era_of_withdrawal: EraId,
+        era_of_creation: EraId,
         amount: U512,
     ) -> Self {
         Self {
@@ -39,7 +39,7 @@ impl UnbondingPurse {
             unbonding_purse,
             validator_public_key,
             unbonder_public_key,
-            era_of_withdrawal,
+            era_of_creation,
             amount,
         }
     }
@@ -74,9 +74,9 @@ impl UnbondingPurse {
         &self.unbonder_public_key
     }
 
-    /// Returns era which will be used to complete this withdrawal request.
-    pub fn era_of_withdrawal(&self) -> EraId {
-        self.era_of_withdrawal
+    /// Returns era which was used to create this unbonding request.
+    pub fn era_of_creation(&self) -> EraId {
+        self.era_of_creation
     }
 
     /// Returns unbonding amount.
@@ -92,7 +92,7 @@ impl ToBytes for UnbondingPurse {
         result.extend(&self.unbonding_purse.to_bytes()?);
         result.extend(&self.validator_public_key.to_bytes()?);
         result.extend(&self.unbonder_public_key.to_bytes()?);
-        result.extend(&self.era_of_withdrawal.to_bytes()?);
+        result.extend(&self.era_of_creation.to_bytes()?);
         result.extend(&self.amount.to_bytes()?);
         Ok(result)
     }
@@ -101,7 +101,7 @@ impl ToBytes for UnbondingPurse {
             + self.unbonding_purse.serialized_length()
             + self.validator_public_key.serialized_length()
             + self.unbonder_public_key.serialized_length()
-            + self.era_of_withdrawal.serialized_length()
+            + self.era_of_creation.serialized_length()
             + self.amount.serialized_length()
     }
 }
@@ -112,7 +112,7 @@ impl FromBytes for UnbondingPurse {
         let (unbonding_purse, bytes) = FromBytes::from_bytes(bytes)?;
         let (validator_public_key, bytes) = FromBytes::from_bytes(bytes)?;
         let (unbonder_public_key, bytes) = FromBytes::from_bytes(bytes)?;
-        let (era_of_withdrawal, bytes) = FromBytes::from_bytes(bytes)?;
+        let (era_of_creation, bytes) = FromBytes::from_bytes(bytes)?;
         let (amount, bytes) = FromBytes::from_bytes(bytes)?;
         Ok((
             UnbondingPurse {
@@ -120,7 +120,7 @@ impl FromBytes for UnbondingPurse {
                 unbonding_purse,
                 validator_public_key,
                 unbonder_public_key,
-                era_of_withdrawal,
+                era_of_creation,
                 amount,
             },
             bytes,
@@ -157,7 +157,7 @@ mod tests {
             unbonding_purse: UNBONDING_PURSE,
             validator_public_key: VALIDATOR_PUBLIC_KEY,
             unbonder_public_key: UNBONDER_PUBLIC_KEY,
-            era_of_withdrawal: ERA_OF_WITHDRAWAL,
+            era_of_creation: ERA_OF_WITHDRAWAL,
             amount: *AMOUNT,
         };
 


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1118

Instead of checking if unbonding era is reached for given unbonding
attempt, we preserve era where the request was made, and then unbonding
delay is calculated at the time when we process unbonding lists.

This is in preparation to put unbonding delay into chainspec and to make
it upgradable.