### PR TITLE
NDRS-294: Pass the list of ancestors to the block proposer

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -71,6 +71,7 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     /// TODO: Add more details that are necessary for block creation.
     CreateNewBlock {
         block_context: BlockContext,
+        past_values: Vec<C::ConsensusValue>,
     },
     /// A block was finalized.
     FinalizedBlock(FinalizedBlock<C>),
@@ -152,8 +153,4 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
 
     /// Returns true if the protocol has received some messages since initialization.
     fn has_received_messages(&self) -> bool;
-
-    /// Returns an iterator over all the values that are expected to become finalized, but are not
-    /// finalized yet.
-    fn non_finalized_values<'a>(&'a self) -> Box<dyn Iterator<Item = &'a C::ConsensusValue> + 'a>;
 }

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -67,8 +67,7 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     CreatedTargetedMessage(Vec<u8>, I),
     InvalidIncomingMessage(Vec<u8>, I, Error),
     ScheduleTimer(Timestamp),
-    /// Request deploys for a new block, whose timestamp will be the given `u64`.
-    /// TODO: Add more details that are necessary for block creation.
+    /// Request deploys for a new block, providing the necessary context.
     CreateNewBlock {
         block_context: BlockContext,
         past_values: Vec<C::ConsensusValue>,

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -152,4 +152,8 @@ pub(crate) trait ConsensusProtocol<I, C: Context> {
 
     /// Returns true if the protocol has received some messages since initialization.
     fn has_received_messages(&self) -> bool;
+
+    /// Returns an iterator over all the values that are expected to become finalized, but are not
+    /// finalized yet.
+    fn non_finalized_values<'a>(&'a self) -> Box<dyn Iterator<Item = &'a C::ConsensusValue> + 'a>;
 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -616,11 +616,12 @@ where
                     .set_timeout(timediff.into())
                     .event(move |_| Event::Timer { era_id, timestamp })
             }
-            ProtocolOutcome::CreateNewBlock { block_context } => {
-                let past_deploys = self
-                    .era(era_id)
-                    .consensus
-                    .non_finalized_values()
+            ProtocolOutcome::CreateNewBlock {
+                block_context,
+                past_values,
+            } => {
+                let past_deploys = past_values
+                    .iter()
                     .flat_map(|candidate| candidate.proto_block().deploys())
                     .cloned()
                     .collect();

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -151,6 +151,11 @@ impl<C: Context> FinalityDetector<C> {
         let height_plus_1 = |bhash| state.block(bhash).height + 1;
         self.last_finalized.as_ref().map_or(0, height_plus_1)
     }
+
+    /// Returns the hash of the last finalized block (if any).
+    pub(crate) fn last_finalized(&self) -> Option<&C::Hash> {
+        self.last_finalized.as_ref()
+    }
 }
 
 #[allow(unused_qualifications)] // This is to suppress warnings originating in the test macros.

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -473,7 +473,7 @@ impl<C: Context> Highway<C> {
                     result.extend(self.add_valid_vertex(vv.clone(), rng, timestamp))
                 }
                 Effect::WeAreFaulty(_) => self.deactivate_validator(),
-                Effect::ScheduleTimer(_) | Effect::RequestNewBlock(_) => (),
+                Effect::ScheduleTimer(_) | Effect::RequestNewBlock { .. } => (),
             }
         }
         result.extend(effects);

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -99,7 +99,9 @@ impl From<Effect<TestContext>> for HighwayMessage {
             // validators so for them it's just `Vertex` that needs to be validated.
             Effect::NewVertex(ValidVertex(v)) => HighwayMessage::NewVertex(Box::new(v)),
             Effect::ScheduleTimer(t) => HighwayMessage::Timer(t),
-            Effect::RequestNewBlock(block_context) => HighwayMessage::RequestBlock(block_context),
+            Effect::RequestNewBlock { block_context, .. } => {
+                HighwayMessage::RequestBlock(block_context)
+            }
             Effect::WeAreFaulty(fault) => HighwayMessage::WeAreFaulty(Box::new(fault)),
         }
     }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -153,7 +153,11 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             }
             AvEffect::ScheduleTimer(timestamp) => vec![ProtocolOutcome::ScheduleTimer(timestamp)],
             AvEffect::RequestNewBlock(block_context) => {
-                vec![ProtocolOutcome::CreateNewBlock { block_context }]
+                let past_values = self.non_finalized_values().cloned().collect();
+                vec![ProtocolOutcome::CreateNewBlock {
+                    block_context,
+                    past_values,
+                }]
             }
             AvEffect::WeAreFaulty(fault) => panic!("this validator is faulty: {:?}", fault),
         }
@@ -405,6 +409,41 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         }
         dropped_vertices
     }
+
+    /// Returns an iterator over all the values that are expected to become finalized, but are not
+    /// finalized yet.
+    pub(crate) fn non_finalized_values<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = &'a C::ConsensusValue> + 'a> {
+        let next_finalized_height = self
+            .finality_detector
+            .last_finalized()
+            .map_or(0, |bhash| self.highway.state().block(bhash).height + 1);
+        // early return if there is no fork choice
+        let fork_choice = match self
+            .highway
+            .state()
+            .fork_choice(self.highway.state().panorama())
+        {
+            Some(bhash) => bhash,
+            None => {
+                return Box::new(iter::empty());
+            }
+        };
+        Box::new(
+            // start at the next finalized height
+            (next_finalized_height..)
+                // take the ancestor of the fork choice at this height
+                .map(move |height| self.highway.state().find_ancestor(fork_choice, height))
+                // only take values while there actually exists such an ancestor
+                .take_while(Option::is_some)
+                // flatten the `Option` returned by the iterator
+                .flatten()
+                // the ancestor is expressed as a block hash - return the value contained in the
+                // block
+                .map(move |bhash| &self.highway.state().block(bhash).value),
+        )
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -618,37 +657,6 @@ where
 
     fn has_received_messages(&self) -> bool {
         self.highway.state().is_empty()
-    }
-
-    fn non_finalized_values<'a>(&'a self) -> Box<dyn Iterator<Item = &'a C::ConsensusValue> + 'a> {
-        let next_finalized_height = self
-            .finality_detector
-            .last_finalized()
-            .map_or(0, |bhash| self.highway.state().block(bhash).height + 1);
-        // early return if there is no fork choice
-        let fork_choice = match self
-            .highway
-            .state()
-            .fork_choice(self.highway.state().panorama())
-        {
-            Some(bhash) => bhash,
-            None => {
-                return Box::new(iter::empty());
-            }
-        };
-        Box::new(
-            // start at the next finalized height
-            (next_finalized_height..)
-                // take the ancestor of the fork choice at this height
-                .map(move |height| self.highway.state().find_ancestor(fork_choice, height))
-                // only take values while there actually exists such an ancestor
-                .take_while(Option::is_some)
-                // flatten the `Option` returned by the iterator
-                .flatten()
-                // the ancestor is expressed as a block hash - return the value contained in the
-                // block
-                .map(move |bhash| &self.highway.state().block(bhash).value),
-        )
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -426,7 +426,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             }
             let opt_block = fork_choice.map(|bhash| self.highway.state().block(&bhash));
             let value = opt_block.map(|block| &block.value);
-            fork_choice = opt_block.map(|block| block.skip_idx[0]);
+            fork_choice = opt_block.and_then(|block| block.parent().cloned());
             value
         })
     }

--- a/node/src/components/consensus/tests/mock_proto.rs
+++ b/node/src/components/consensus/tests/mock_proto.rs
@@ -296,4 +296,8 @@ where
     fn has_received_messages(&self) -> bool {
         !self.pending_blocks.is_empty() || !self.finalized_blocks.is_empty()
     }
+
+    fn non_finalized_values<'a>(&'a self) -> Box<dyn Iterator<Item = &'a C::ConsensusValue> + 'a> {
+        todo!("implement non_finalized_values")
+    }
 }

--- a/node/src/components/consensus/tests/mock_proto.rs
+++ b/node/src/components/consensus/tests/mock_proto.rs
@@ -296,8 +296,4 @@ where
     fn has_received_messages(&self) -> bool {
         !self.pending_blocks.is_empty() || !self.finalized_blocks.is_empty()
     }
-
-    fn non_finalized_values<'a>(&'a self) -> Box<dyn Iterator<Item = &'a C::ConsensusValue> + 'a> {
-        todo!("implement non_finalized_values")
-    }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -815,6 +815,7 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn request_proto_block(
         self,
         block_context: BlockContext,
+        past_deploys: HashSet<DeployHash>,
         next_finalized: u64,
         random_bit: bool,
     ) -> (ProtoBlock, BlockContext)
@@ -826,7 +827,7 @@ impl<REv> EffectBuilder<REv> {
                 |responder| {
                     BlockProposerRequest::ListForInclusion(ListForInclusionRequest {
                         current_instant: block_context.timestamp(),
-                        past_deploys: Default::default(), // TODO
+                        past_deploys,
                         next_finalized,
                         responder,
                     })


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-294

Only now the block proposer (formerly the deploy buffer) needs the set of deploys from the non-finalized ancestors instead of the ancestors themselves, so we pass that.