### PR TITLE
NO-TICKET: fix gossiper bug

### DIFF
--- a/node/src/components/gossiper/event.rs
+++ b/node/src/components/gossiper/event.rs
@@ -22,6 +22,7 @@ pub enum Event<T: Item> {
     /// The network component gossiped to the included peers.
     GossipedTo {
         item_id: T::Id,
+        requested_count: usize,
         peers: HashSet<NodeId>,
     },
     /// The timeout for waiting for a gossip response has elapsed and we should check the response
@@ -47,7 +48,7 @@ impl<T: Item> Display for Event<T> {
             Event::ItemReceived { item_id, source } => {
                 write!(formatter, "new item {} received from {}", item_id, source)
             }
-            Event::GossipedTo { item_id, peers } => write!(
+            Event::GossipedTo { item_id, peers, .. } => write!(
                 formatter,
                 "gossiped {} to {}",
                 item_id,

--- a/node/src/components/gossiper/gossip_table.rs
+++ b/node/src/components/gossiper/gossip_table.rs
@@ -365,6 +365,18 @@ impl<T: Copy + Eq + Hash + Display> GossipTable<T> {
         GossipAction::Noop
     }
 
+    /// Directly reduces the in-flight count of gossip requests for the given item by the given
+    /// amount.
+    ///
+    /// This should be called if, after trying to gossip to a given number of peers, we find that
+    /// we've not been able to select enough peers.  Without this reduction, the given gossip item
+    /// would never move from `current` to `finished` or `paused`, and hence would never be purged.
+    pub(crate) fn reduce_in_flight_count(&mut self, data_id: &T, reduce_by: usize) {
+        if let Some(state) = self.current.get_mut(data_id) {
+            state.in_flight_count = state.in_flight_count.saturating_sub(reduce_by);
+        }
+    }
+
     /// Checks if gossip request we sent timed out.
     ///
     /// If the peer is already counted as a holder, it has previously responded and this method

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -175,7 +175,7 @@ saturation_limit_percent = 80
 #
 # The longer they are retained, the lower the likelihood of re-gossiping a piece of data.  However,
 # the longer they are retained, the larger the list of finished entries can grow.
-finished_entry_duration_secs = 3600
+finished_entry_duration_secs = 60
 
 # The timeout duration in seconds for a single gossip request, i.e. for a single gossip message
 # sent from this node, it will be considered timed out if the expected response from that peer is


### PR DESCRIPTION
This PR fixes a bug which only has an effect if a peer is connected to less than or equal to the `gossip.infection_target` config value (currently 3 by default).

The problem is that when the gossiper calls its internal gossip table to inform it of a new item to gossip, it returns how many peers to gossip to.  The table tracks the state of gossiping this item, including an in-flight count of gossip messages sent, expecting a response or timeout for each.

Neither the gossiper nor the gossip table are aware of how many peers we're actually connected to, so upon sending a gossip event to the network component, it responds with a list of the peers which were actually attempted.  When the gossiper handles this response, it performs the following steps:
* if we didn't gossip to any peers, it pauses gossiping this item
* for each peer we did attempt to gossip to, it sets a timeout in case the peer doesn't respond

For the gossiped item to be deemed finished in the table, we need to receive responses or a timeout for each in-flight message.  However, if we weren't able to actually send the requested amount of gossip requests, there is a mismatch between the table's in-flight count and the actual in-flight messages.  This results in the item being marooned in a `current` state and hence never being purged.

The fix is to reduce the table's in-flight count when the gossiper handles the response from the network component and becomes aware of the shortfall.