### PR TITLE
EE-1119: update Auction::slash to handle cases where a validator has delegated using its validator key

### DIFF
--- a/grpc/test_support/src/internal/wasm_test_builder.rs
+++ b/grpc/test_support/src/internal/wasm_test_builder.rs
@@ -866,7 +866,10 @@ where
         let contract = self
             .get_contract(contract_hash)
             .expect("should have contract");
-        let key = contract.named_keys().get(name).expect("should have purse");
+        let key = contract
+            .named_keys()
+            .get(name)
+            .expect("should have named key");
         let stored_value = self.query(None, *key, &[]).expect("should query");
         let cl_value = stored_value
             .as_cl_value()

--- a/grpc/tests/src/test/regression/ee_1119.rs
+++ b/grpc/tests/src/test/regression/ee_1119.rs
@@ -265,6 +265,6 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         builder.get_value(builder.get_mint_contract_hash(), TOTAL_SUPPLY_KEY);
     assert_eq!(
         total_supply_before_slashing - total_supply_after_slashing,
-        U512::from(VALIDATOR_1_STAKE) - unbond_amount + U512::from(UNDELEGATE_AMOUNT_1)
+        U512::from(VALIDATOR_1_STAKE),
     );
 }

--- a/grpc/tests/src/test/regression/ee_1119.rs
+++ b/grpc/tests/src/test/regression/ee_1119.rs
@@ -1,0 +1,270 @@
+use casper_engine_test_support::{
+    internal::{
+        utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS,
+        DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_LOCKED_FUNDS_PERIOD,
+    },
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
+};
+use casper_execution_engine::{core::engine_state::genesis::GenesisAccount, shared::motes::Motes};
+use casper_types::{
+    account::AccountHash,
+    auction::{
+        Bids, UnbondingPurses, ARG_DELEGATOR, ARG_UNBOND_PURSE, ARG_VALIDATOR,
+        ARG_VALIDATOR_PUBLIC_KEYS, BIDS_KEY, METHOD_RUN_AUCTION, METHOD_SLASH,
+        UNBONDING_PURSES_KEY,
+    },
+    mint::TOTAL_SUPPLY_KEY,
+    runtime_args, PublicKey, RuntimeArgs, URef, U512,
+};
+use once_cell::sync::Lazy;
+
+const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
+const CONTRACT_WITHDRAW_BID: &str = "withdraw_bid.wasm";
+const CONTRACT_DELEGATE: &str = "delegate.wasm";
+const CONTRACT_UNDELEGATE: &str = "undelegate.wasm";
+
+const DELEGATE_AMOUNT_1: u64 = 95_000;
+const UNDELEGATE_AMOUNT_1: u64 = 17_000;
+
+const TRANSFER_AMOUNT: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
+
+const ARG_AMOUNT: &str = "amount";
+const ARG_PUBLIC_KEY: &str = "public_key";
+
+const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
+const VALIDATOR_1: PublicKey = PublicKey::Ed25519([3; 32]);
+static VALIDATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| VALIDATOR_1.into());
+const VALIDATOR_1_STAKE: u64 = 250_000;
+
+#[ignore]
+#[test]
+fn should_run_ee_1119_dont_slash_delegated_validators() {
+    let accounts = {
+        let validator_1 = GenesisAccount::new(
+            VALIDATOR_1,
+            *VALIDATOR_1_ADDR,
+            Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
+            Motes::new(VALIDATOR_1_STAKE.into()),
+        );
+
+        let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
+        tmp.push(validator_1);
+        tmp
+    };
+    let run_genesis_request = utils::create_run_genesis_request(accounts);
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&run_genesis_request);
+
+    let exec_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => SYSTEM_ADDR,
+            "amount" => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    builder.exec(exec_request).expect_success().commit();
+
+    let auction = builder.get_auction_contract_hash();
+
+    //
+    // Validator delegates funds on other genesis validator
+    //
+
+    let delegate_exec_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => VALIDATOR_1,
+            ARG_DELEGATOR => *DEFAULT_ACCOUNT_PUBLIC_KEY,
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegate_exec_request)
+        .expect_success()
+        .commit();
+
+    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let validator_1_bid = bids.get(&VALIDATOR_1).expect("should have bid");
+    let bid_purse = validator_1_bid.bonding_purse();
+    assert_eq!(
+        builder.get_purse_balance(*bid_purse),
+        U512::from(VALIDATOR_1_STAKE),
+    );
+
+    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    assert_eq!(unbond_purses.len(), 0);
+
+    //
+    // Unlock funds of genesis validators
+    //
+
+    for _ in 0..=DEFAULT_LOCKED_FUNDS_PERIOD {
+        let run_auction_request = ExecuteRequestBuilder::contract_call_by_hash(
+            SYSTEM_ADDR,
+            auction,
+            METHOD_RUN_AUCTION,
+            runtime_args! {},
+        )
+        .build();
+
+        builder.exec(run_auction_request).expect_success().commit();
+    }
+
+    //
+    // Partial unbond through undelegate on other genesis validator
+    //
+
+    let unbond_amount = U512::from(VALIDATOR_1_STAKE) - 1;
+
+    let exec_request_3 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_UNDELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => VALIDATOR_1,
+            ARG_DELEGATOR => *DEFAULT_ACCOUNT_PUBLIC_KEY,
+            ARG_UNBOND_PURSE => Option::<URef>::None,
+        },
+    )
+    .build();
+    builder.exec(exec_request_3).commit().expect_success();
+
+    //
+    // Other genesis validator withdraws withdraws his bid
+    //
+
+    let withdraw_bid_request = ExecuteRequestBuilder::standard(
+        *VALIDATOR_1_ADDR,
+        CONTRACT_WITHDRAW_BID,
+        runtime_args! {
+            ARG_AMOUNT => unbond_amount,
+            ARG_PUBLIC_KEY => VALIDATOR_1,
+            ARG_UNBOND_PURSE => Option::<URef>::None,
+        },
+    )
+    .build();
+
+    builder.exec(withdraw_bid_request).expect_success().commit();
+
+    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    assert_eq!(unbond_purses.len(), 1);
+
+    let unbond_list = unbond_purses
+        .get(&VALIDATOR_1)
+        .cloned()
+        .expect("should have unbond");
+    assert_eq!(unbond_list.len(), 2); // two entries in order: undelegate, and withdraw bid
+
+    // undelegate entry
+
+    assert_eq!(unbond_list[0].validator_public_key(), &VALIDATOR_1,);
+    assert_eq!(
+        unbond_list[0].unbonder_public_key(),
+        &*DEFAULT_ACCOUNT_PUBLIC_KEY,
+    );
+    assert!(!unbond_list[0].is_validator());
+
+    //
+    // withdraw_bid entry
+    //
+
+    assert_eq!(unbond_list[1].validator_public_key(), &VALIDATOR_1,);
+    assert_eq!(unbond_list[1].unbonder_public_key(), &VALIDATOR_1,);
+    assert!(unbond_list[1].is_validator());
+    assert_eq!(unbond_list[1].amount(), &unbond_amount);
+
+    assert!(
+        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_PUBLIC_KEY),
+        "should not be part of unbonds"
+    );
+
+    let exec_request_4 = ExecuteRequestBuilder::contract_call_by_hash(
+        SYSTEM_ADDR,
+        auction,
+        METHOD_SLASH,
+        runtime_args! {
+            ARG_VALIDATOR_PUBLIC_KEYS => vec![
+               *DEFAULT_ACCOUNT_PUBLIC_KEY,
+            ]
+        },
+    )
+    .build();
+
+    builder.exec(exec_request_4).expect_success().commit();
+
+    let unbond_purses_noop: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    assert_eq!(
+        unbond_purses, unbond_purses_noop,
+        "slashing default validator should be noop because no unbonding was done"
+    );
+
+    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    assert!(!bids.is_empty());
+    assert!(bids.contains_key(&VALIDATOR_1)); // still bid upon
+
+    //
+    // Slash - only `withdraw_bid` amount is slashed
+    //
+    let total_supply_before_slashing: U512 =
+        builder.get_value(builder.get_mint_contract_hash(), TOTAL_SUPPLY_KEY);
+
+    let exec_request_5 = ExecuteRequestBuilder::contract_call_by_hash(
+        SYSTEM_ADDR,
+        auction,
+        METHOD_SLASH,
+        runtime_args! {
+            ARG_VALIDATOR_PUBLIC_KEYS => vec![
+               VALIDATOR_1
+            ]
+        },
+    )
+    .build();
+
+    builder.exec(exec_request_5).expect_success().commit();
+
+    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    assert_eq!(unbond_purses.len(), 1);
+
+    assert!(
+        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_PUBLIC_KEY),
+        "should not be part of unbonds (noop)"
+    );
+
+    assert!(
+        unbond_purses.contains_key(&VALIDATOR_1),
+        "should still be part of unbonds"
+    );
+
+    let unbond_list = unbond_purses
+        .get(&VALIDATOR_1)
+        .expect("should have validator 1 key");
+    assert_eq!(unbond_list.len(), 1); // only one entry is removed - withdraw bid for VALIDATOR_1's unlocked funds
+
+    let undelegated_unbond_purse = unbond_list[0];
+    assert!(!undelegated_unbond_purse.is_validator()); // only delegated amount is left
+    assert_eq!(
+        undelegated_unbond_purse.validator_public_key(),
+        &VALIDATOR_1
+    );
+    assert_eq!(
+        undelegated_unbond_purse.unbonder_public_key(),
+        &*DEFAULT_ACCOUNT_PUBLIC_KEY
+    );
+
+    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    assert!(!bids.contains_key(&VALIDATOR_1)); // still bid upon
+
+    let total_supply_after_slashing: U512 =
+        builder.get_value(builder.get_mint_contract_hash(), TOTAL_SUPPLY_KEY);
+    assert_eq!(
+        total_supply_before_slashing - total_supply_after_slashing,
+        U512::from(VALIDATOR_1_STAKE) - unbond_amount + U512::from(UNDELEGATE_AMOUNT_1)
+    );
+}

--- a/grpc/tests/src/test/regression/mod.rs
+++ b/grpc/tests/src/test/regression/mod.rs
@@ -1,6 +1,7 @@
 mod ee_1045;
 mod ee_1071;
 mod ee_1103;
+mod ee_1119;
 mod ee_221;
 mod ee_401;
 mod ee_441;

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -269,8 +269,6 @@ pub trait Auction:
 
         let mut unbonding_purses_modified = false;
         for validator_public_key in validator_public_keys {
-            // let mut cleanup_required = false;
-
             if let Some(unbonding_list) = unbonding_purses.get_mut(&validator_public_key) {
                 let length_before = unbonding_list.len();
 

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -270,21 +270,21 @@ pub trait Auction:
         let mut unbonding_purses_modified = false;
         for validator_public_key in validator_public_keys {
             if let Some(unbonding_list) = unbonding_purses.get_mut(&validator_public_key) {
-                let length_before = unbonding_list.len();
+                let initial_length = unbonding_list.len();
 
                 unbonding_list.retain(|unbonding_purse| {
                     // Only entries created by non-validators are retained
-                    let retain = !unbonding_purse.is_validator();
+                    let should_retain = !unbonding_purse.is_validator();
 
-                    if !retain {
+                    if !should_retain {
                         // Amounts inside removed entries are burned only.
                         burned_amount += *unbonding_purse.amount()
                     }
 
-                    retain
+                    should_retain
                 });
 
-                if unbonding_list.len() != length_before {
+                if unbonding_list.len() != initial_length {
                     unbonding_purses_modified = true;
                 }
 

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -269,10 +269,32 @@ pub trait Auction:
 
         let mut unbonding_purses_modified = false;
         for validator_public_key in validator_public_keys {
-            // TODO: slash delegators properly
-            if let Some(unbonding_list) = unbonding_purses.remove(&validator_public_key) {
-                burned_amount += unbonding_list.iter().map(|x| *x.amount()).sum();
-                unbonding_purses_modified = true;
+            // let mut cleanup_required = false;
+
+            if let Some(unbonding_list) = unbonding_purses.get_mut(&validator_public_key) {
+                let length_before = unbonding_list.len();
+
+                unbonding_list.retain(|unbonding_purse| {
+                    // Only entries created by non-validators are retained
+                    let retain = !unbonding_purse.is_validator();
+
+                    if !retain {
+                        // Amounts inside removed entries are burned only.
+                        burned_amount += *unbonding_purse.amount()
+                    }
+
+                    retain
+                });
+
+                if unbonding_list.len() != length_before {
+                    unbonding_purses_modified = true;
+                }
+
+                if unbonding_list.is_empty() {
+                    // Cleans up empty map entries to preserve global state.
+                    unbonding_purses.remove(&validator_public_key).unwrap();
+                    unbonding_purses_modified = true;
+                }
             }
         }
 

--- a/types/src/auction/unbonding_purse.rs
+++ b/types/src/auction/unbonding_purse.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 
 /// Unbonding purse.
-#[cfg_attr(test, derive(Debug))]
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct UnbondingPurse {
     /// Bonding Purse
     bonding_purse: URef,


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1119

Regression test scenario:

- validator X delegates funds on genesis validator Y
- validator Y will do `withdraw_bid` on himself after unlock period is hit
- validator X would `undelegate` funds on Y
- (at this point `unbonding_purses` contains two entries for validator Y: one with `is_validator()` other one with `!is_validator()`)
- slash validator Y
- now only element in the `unbonding_purses` for Y is the `!is_validator()` entry that X originated with `undelegate`
