### PR TITLE
EE-1115: persist seigniorage metadata

### DIFF
--- a/execution_engine/src/core/resolvers/v1_function_index.rs
+++ b/execution_engine/src/core/resolvers/v1_function_index.rs
@@ -51,6 +51,7 @@ pub enum FunctionIndex {
     RemoveContractUserGroupURefsIndex,
     Blake2b,
     RecordTransfer,
+    RecordAuctionInfo,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution_engine/src/core/resolvers/v1_resolver.rs
+++ b/execution_engine/src/core/resolvers/v1_resolver.rs
@@ -212,6 +212,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 8][..], Some(ValueType::I32)),
                 FunctionIndex::RecordTransfer.into(),
             ),
+            "casper_record_auction_info" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
+                FunctionIndex::RecordAuctionInfo.into(),
+            ),
             #[cfg(feature = "test-support")]
             "casper_print" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], None),

--- a/execution_engine/src/core/runtime/auction_internal.rs
+++ b/execution_engine/src/core/runtime/auction_internal.rs
@@ -1,7 +1,9 @@
 use casper_types::{
     account,
     account::AccountHash,
-    auction::{Auction, MintProvider, RuntimeProvider, StorageProvider, SystemProvider},
+    auction::{
+        Auction, AuctionInfo, MintProvider, RuntimeProvider, StorageProvider, SystemProvider,
+    },
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::auction::Error,
     ApiError, CLTyped, CLValue, Key, TransferredTo, URef, BLAKE2B_DIGEST_LENGTH, U512,
@@ -62,6 +64,11 @@ where
             Ok(Err(api_error)) => Err(api_error),
             Err(_) => Err(ApiError::Transfer),
         }
+    }
+
+    fn record_auction_info(&mut self, era_id: u64, auction_info: AuctionInfo) -> Result<(), Error> {
+        Runtime::record_auction_info(self, era_id, auction_info)
+            .map_err(|_| Error::RecordAuctionInfo)
     }
 }
 

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -6,6 +6,7 @@ use casper_types::{
     account,
     account::AccountHash,
     api_error,
+    auction::{AuctionInfo, EraId},
     bytesrepr::{self, ToBytes},
     contracts::{EntryPoints, NamedKeys},
     ContractHash, ContractPackageHash, ContractVersion, Group, Key, URef, U512,
@@ -973,6 +974,26 @@ where
                 let amount: U512 = self.t_from_mem(amount_ptr, amount_size)?;
                 let id: Option<u64> = self.t_from_mem(id_ptr, id_size)?;
                 self.record_transfer(source, target, amount, id)?;
+                Ok(Some(RuntimeValue::I32(0)))
+            }
+
+            FunctionIndex::RecordAuctionInfo => {
+                // RecordAuctionInfo is a special cased internal host function only callable by the
+                // auction contract and for accounting purposes it isn't represented in protocol
+                // data.
+                let (era_id_ptr, era_id_size, auction_info_ptr, auction_info_size): (
+                    u32,
+                    u32,
+                    u32,
+                    u32,
+                ) = Args::parse(args)?;
+                scoped_instrumenter.add_property("era_id_size", era_id_size.to_string());
+                scoped_instrumenter
+                    .add_property("auction_info_size", auction_info_size.to_string());
+                let era_id: EraId = self.t_from_mem(era_id_ptr, era_id_size)?;
+                let auction_info: AuctionInfo =
+                    self.t_from_mem(auction_info_ptr, auction_info_size)?;
+                self.record_auction_info(era_id, auction_info)?;
                 Ok(Some(RuntimeValue::I32(0)))
             }
         }

--- a/execution_engine/src/core/runtime/scoped_instrumenter.rs
+++ b/execution_engine/src/core/runtime/scoped_instrumenter.rs
@@ -141,6 +141,7 @@ impl Drop for ScopedInstrumenter {
             }
             FunctionIndex::Blake2b => "host_blake2b",
             FunctionIndex::RecordTransfer => "host_record_transfer",
+            FunctionIndex::RecordAuctionInfo => "host_record_auction",
         };
 
         let mut properties = mem::take(&mut self.properties);

--- a/execution_engine/src/core/tracking_copy/byte_size.rs
+++ b/execution_engine/src/core/tracking_copy/byte_size.rs
@@ -42,6 +42,7 @@ impl ByteSize for StoredValue {
                 }
                 StoredValue::DeployInfo(deploy_info) => deploy_info.serialized_length(),
                 StoredValue::Transfer(transfer) => transfer.serialized_length(),
+                StoredValue::AuctionInfo(auction_info) => auction_info.serialized_length(),
             }
     }
 }

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -424,6 +424,9 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
                 StoredValue::DeployInfo(_) => {
                     return Ok(query.into_not_found_result(&"DeployInfo value found."));
                 }
+                StoredValue::AuctionInfo(_) => {
+                    return Ok(query.into_not_found_result(&"AuctionInfo value found."));
+                }
             }
         }
     }

--- a/execution_engine/src/shared/transform.rs
+++ b/execution_engine/src/shared/transform.rs
@@ -189,6 +189,11 @@ impl Transform {
                     let found = "DeployInfo".to_string();
                     Err(TypeMismatch::new(expected, found).into())
                 }
+                StoredValue::AuctionInfo(_) => {
+                    let expected = "Contract or Account".to_string();
+                    let found = "AuctionInfo".to_string();
+                    Err(TypeMismatch::new(expected, found).into())
+                }
             },
             Transform::Failure(error) => Err(error),
         }
@@ -320,6 +325,9 @@ impl From<&Transform> for casper_types::Transform {
             }
             Transform::Write(StoredValue::DeployInfo(deploy_info)) => {
                 casper_types::Transform::WriteDeployInfo(deploy_info.clone())
+            }
+            Transform::Write(StoredValue::AuctionInfo(auction_info)) => {
+                casper_types::Transform::WriteAuctionInfo(auction_info.clone())
             }
             Transform::AddInt32(value) => casper_types::Transform::AddInt32(*value),
             Transform::AddUInt64(value) => casper_types::Transform::AddUInt64(*value),

--- a/grpc/server/protobuf/casper/state.proto
+++ b/grpc/server/protobuf/casper/state.proto
@@ -261,6 +261,28 @@ message DeployInfo {
     BigInt gas = 5;
 }
 
+message SeigniorageAllocation {
+    message Validator {
+        bytes validator_public_key = 1;
+        BigInt amount = 2;
+    }
+
+    message Delegator {
+        bytes delegator_public_key = 1;
+        bytes validator_public_key = 2;
+        BigInt amount = 3;
+    }
+
+    oneof variants {
+        Validator validator = 1;
+        Delegator delegator = 2;
+    }
+}
+
+message AuctionInfo {
+    repeated SeigniorageAllocation seigniorage_allocations = 1;
+}
+
 // Value stored under a key in global state.
 message StoredValue {
     oneof variants {
@@ -271,6 +293,7 @@ message StoredValue {
         ContractWasm contract_wasm = 5;
         Transfer transfer = 6;
         DeployInfo deploy_info = 7;
+        AuctionInfo auction_info = 8;
     }
 }
 
@@ -309,6 +332,7 @@ message Key {
 		URef uref = 3;
 		TransferAddr transfer = 4;
 		DeployHash deploy_info = 5;
+		uint64 auction_info = 6;
 	}
 
 	message Address {

--- a/grpc/server/src/engine_server/mappings/state/auction_info.rs
+++ b/grpc/server/src/engine_server/mappings/state/auction_info.rs
@@ -1,0 +1,107 @@
+use std::convert::{TryFrom, TryInto};
+
+use crate::engine_server::{
+    mappings::ParsingError, state, state::SeigniorageAllocation_oneof_variants,
+};
+
+use casper_types::{
+    auction::{AuctionInfo, SeigniorageAllocation},
+    bytesrepr::{self, ToBytes},
+    U512,
+};
+
+impl From<SeigniorageAllocation> for state::SeigniorageAllocation {
+    fn from(allocation: SeigniorageAllocation) -> Self {
+        let mut ret = state::SeigniorageAllocation::new();
+        match allocation {
+            SeigniorageAllocation::Validator {
+                validator_public_key,
+                amount,
+            } => {
+                let validator_public_key_bytes = validator_public_key.to_bytes().unwrap();
+                let amount = amount.into();
+                let mut validator = state::SeigniorageAllocation_Validator::new();
+                validator.set_validator_public_key(validator_public_key_bytes);
+                validator.set_amount(amount);
+                ret.set_validator(validator)
+            }
+            SeigniorageAllocation::Delegator {
+                delegator_public_key,
+                validator_public_key,
+                amount,
+            } => {
+                let delegator_public_key_bytes = delegator_public_key.to_bytes().unwrap();
+                let validator_public_key_bytes = validator_public_key.to_bytes().unwrap();
+                let amount = amount.into();
+                let mut delegator = state::SeigniorageAllocation_Delegator::new();
+                delegator.set_delegator_public_key(delegator_public_key_bytes);
+                delegator.set_validator_public_key(validator_public_key_bytes);
+                delegator.set_amount(amount);
+                ret.set_delegator(delegator)
+            }
+        }
+        ret
+    }
+}
+
+impl TryFrom<state::SeigniorageAllocation> for SeigniorageAllocation {
+    type Error = ParsingError;
+
+    fn try_from(
+        pb_seigniorage_allocation: state::SeigniorageAllocation,
+    ) -> Result<Self, Self::Error> {
+        let pb_variants = pb_seigniorage_allocation.variants.as_ref().ok_or_else(|| {
+            ParsingError("Unable to parse Protobuf SeigniorageAllocation".to_string())
+        })?;
+
+        match pb_variants {
+            SeigniorageAllocation_oneof_variants::validator(pb_validator) => {
+                let validator_public_key =
+                    bytesrepr::deserialize(pb_validator.get_validator_public_key().to_vec())?;
+                let amount = U512::try_from(pb_validator.get_amount().to_owned())?;
+                Ok(SeigniorageAllocation::validator(
+                    validator_public_key,
+                    amount,
+                ))
+            }
+            SeigniorageAllocation_oneof_variants::delegator(pb_delegator) => {
+                let delegator_public_key =
+                    bytesrepr::deserialize(pb_delegator.get_delegator_public_key().to_vec())?;
+                let validator_public_key =
+                    bytesrepr::deserialize(pb_delegator.get_validator_public_key().to_vec())?;
+                let amount = U512::try_from(pb_delegator.get_amount().to_owned())?;
+                Ok(SeigniorageAllocation::delegator(
+                    delegator_public_key,
+                    validator_public_key,
+                    amount,
+                ))
+            }
+        }
+    }
+}
+
+impl From<AuctionInfo> for state::AuctionInfo {
+    fn from(auction_info: AuctionInfo) -> Self {
+        let mut ret = state::AuctionInfo::new();
+        let mut pb_vec_seigniorage_allocations = Vec::new();
+        for allocation in auction_info.seigniorage_allocations().iter() {
+            pb_vec_seigniorage_allocations.push(allocation.to_owned().into());
+        }
+        ret.set_seigniorage_allocations(pb_vec_seigniorage_allocations.into());
+        ret
+    }
+}
+
+impl TryFrom<state::AuctionInfo> for AuctionInfo {
+    type Error = ParsingError;
+
+    fn try_from(pb_auction_info: state::AuctionInfo) -> Result<Self, Self::Error> {
+        let mut seigniorage_allocations = Vec::new();
+        for pb_seigniorage_allocation in pb_auction_info.get_seigniorage_allocations().iter() {
+            seigniorage_allocations.push(pb_seigniorage_allocation.to_owned().try_into()?);
+        }
+        let mut ret = AuctionInfo::new();
+        *ret.seigniorage_allocations_mut() = seigniorage_allocations;
+        Ok(ret)
+    }
+}

--- a/grpc/server/src/engine_server/mappings/state/key.rs
+++ b/grpc/server/src/engine_server/mappings/state/key.rs
@@ -34,6 +34,7 @@ impl From<Key> for state::Key {
                 pb_transfer_addr.set_transfer_addr(transfer_addr.value().to_vec());
                 pb_key.set_transfer(pb_transfer_addr)
             }
+            Key::AuctionInfo(era_id) => pb_key.set_auction_info(era_id),
         }
         pb_key
     }
@@ -74,6 +75,7 @@ impl TryFrom<state::Key> for Key {
                 )?);
                 Key::DeployInfo(deploy_hash)
             }
+            Key_oneof_value::auction_info(era_id) => Key::AuctionInfo(era_id),
         };
         Ok(key)
     }

--- a/grpc/server/src/engine_server/mappings/state/mod.rs
+++ b/grpc/server/src/engine_server/mappings/state/mod.rs
@@ -2,6 +2,7 @@
 //! defined in protobuf/io/casperlabs/casper/consensus/state.proto
 
 mod account;
+mod auction_info;
 pub(crate) mod big_int;
 mod cl_type;
 mod cl_value;

--- a/grpc/server/src/engine_server/mappings/state/stored_value.rs
+++ b/grpc/server/src/engine_server/mappings/state/stored_value.rs
@@ -25,6 +25,9 @@ impl From<StoredValue> for state::StoredValue {
             }
             StoredValue::Transfer(transfer) => pb_value.set_transfer(transfer.into()),
             StoredValue::DeployInfo(deploy_info) => pb_value.set_deploy_info(deploy_info.into()),
+            StoredValue::AuctionInfo(auction_info) => {
+                pb_value.set_auction_info(auction_info.into())
+            }
         }
 
         pb_value
@@ -60,6 +63,9 @@ impl TryFrom<state::StoredValue> for StoredValue {
             }
             StoredValue_oneof_variants::deploy_info(pb_deploy_info) => {
                 StoredValue::DeployInfo(pb_deploy_info.try_into()?)
+            }
+            StoredValue_oneof_variants::auction_info(pb_auction_info) => {
+                StoredValue::AuctionInfo(pb_auction_info.try_into()?)
             }
         };
 

--- a/grpc/tests/src/test/system_contracts/auction/distribute.rs
+++ b/grpc/tests/src/test/system_contracts/auction/distribute.rs
@@ -14,12 +14,12 @@ use casper_types::{
     self,
     account::AccountHash,
     auction::{
-        DelegationRate, ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_DELEGATOR_PUBLIC_KEY,
-        ARG_PUBLIC_KEY, ARG_REWARD_FACTORS, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY, BLOCK_REWARD,
-        DELEGATION_RATE_DENOMINATOR, METHOD_DISTRIBUTE, METHOD_WITHDRAW_DELEGATOR_REWARD,
-        METHOD_WITHDRAW_VALIDATOR_REWARD,
+        DelegationRate, SeigniorageAllocation, ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR,
+        ARG_DELEGATOR_PUBLIC_KEY, ARG_PUBLIC_KEY, ARG_REWARD_FACTORS, ARG_VALIDATOR,
+        ARG_VALIDATOR_PUBLIC_KEY, BLOCK_REWARD, DELEGATION_RATE_DENOMINATOR, METHOD_DISTRIBUTE,
+        METHOD_WITHDRAW_DELEGATOR_REWARD, METHOD_WITHDRAW_VALIDATOR_REWARD,
     },
-    runtime_args, ProtocolVersion, PublicKey, RuntimeArgs, U512,
+    runtime_args, Key, ProtocolVersion, PublicKey, RuntimeArgs, U512,
 };
 
 const ARG_ENTRY_POINT: &str = "entry_point";
@@ -316,6 +316,37 @@ fn should_distribute_delegation_rate_zero() {
         None,
     );
     assert!(delegator_2_balance.is_zero());
+
+    let auction_info = {
+        let era = builder.get_era();
+
+        let auction_info_value = builder
+            .query(None, Key::AuctionInfo(era), &[])
+            .expect("should have value");
+
+        auction_info_value
+            .as_auction_info()
+            .cloned()
+            .expect("should be auction info")
+    };
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_1).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_1).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_1 && *amount == expected_delegator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_2).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_2 && *amount == expected_delegator_1_balance
+    ));
 }
 
 #[ignore]
@@ -482,6 +513,37 @@ fn should_distribute_delegation_rate_half() {
 
     let total_payout = validator_1_balance + delegator_1_balance + delegator_2_balance;
     assert_eq!(total_payout, expected_total_reward_integer);
+
+    let auction_info = {
+        let era = builder.get_era();
+
+        let auction_info_value = builder
+            .query(None, Key::AuctionInfo(era), &[])
+            .expect("should have value");
+
+        auction_info_value
+            .as_auction_info()
+            .cloned()
+            .expect("should be auction info")
+    };
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_1).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_1).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_1 && *amount == expected_delegator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_2).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_2 && *amount == expected_delegator_1_balance
+    ));
 }
 
 #[ignore]
@@ -639,6 +701,37 @@ fn should_distribute_delegation_rate_full() {
 
     let total_payout = validator_1_balance + delegator_1_balance + delegator_2_balance;
     assert_eq!(total_payout, expected_total_reward_integer);
+
+    let auction_info = {
+        let era = builder.get_era();
+
+        let auction_info_value = builder
+            .query(None, Key::AuctionInfo(era), &[])
+            .expect("should have value");
+
+        auction_info_value
+            .as_auction_info()
+            .cloned()
+            .expect("should be auction info")
+    };
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_1).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_1).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_1 && *amount == expected_delegator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_2).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_2 && *amount == expected_delegator_1_balance
+    ));
 }
 
 #[ignore]
@@ -802,6 +895,37 @@ fn should_distribute_uneven_delegation_rate_zero() {
 
     let total_payout = validator_1_balance + delegator_1_balance + delegator_2_balance;
     assert_eq!(total_payout, expected_total_reward_integer);
+
+    let auction_info = {
+        let era = builder.get_era();
+
+        let auction_info_value = builder
+            .query(None, Key::AuctionInfo(era), &[])
+            .expect("should have value");
+
+        auction_info_value
+            .as_auction_info()
+            .cloned()
+            .expect("should be auction info")
+    };
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_1).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_1).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_1 && *amount == expected_delegator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_2).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_2 && *amount == expected_delegator_2_balance
+    ));
 }
 
 #[ignore]
@@ -962,6 +1086,37 @@ fn should_distribute_by_factor() {
     let total_payout = validator_1_balance + validator_2_balance + validator_3_balance;
     let rounded_amount = U512::from(2);
     assert_eq!(total_payout, expected_total_reward_integer - rounded_amount);
+
+    let auction_info = {
+        let era = builder.get_era();
+
+        let auction_info_value = builder
+            .query(None, Key::AuctionInfo(era), &[])
+            .expect("should have value");
+
+        auction_info_value
+            .as_auction_info()
+            .cloned()
+            .expect("should be auction info")
+    };
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_1).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_2).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_2 && *amount == expected_validator_2_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_3).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_3 && *amount == expected_validator_3_balance
+    ));
 }
 
 #[ignore]
@@ -1121,6 +1276,37 @@ fn should_distribute_by_factor_regardless_of_stake() {
     let total_payout = validator_1_balance + validator_2_balance + validator_3_balance;
     let rounded_amount = U512::from(2);
     assert_eq!(total_payout, expected_total_reward_integer - rounded_amount);
+
+    let auction_info = {
+        let era = builder.get_era();
+
+        let auction_info_value = builder
+            .query(None, Key::AuctionInfo(era), &[])
+            .expect("should have value");
+
+        auction_info_value
+            .as_auction_info()
+            .cloned()
+            .expect("should be auction info")
+    };
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_1).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_2).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_2 && *amount == expected_validator_2_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_3).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_3 && *amount == expected_validator_3_balance
+    ));
 }
 
 #[ignore]
@@ -1278,6 +1464,37 @@ fn should_distribute_by_factor_uneven() {
     let total_payout = validator_1_balance + validator_2_balance + validator_3_balance;
     let rounded_amount = U512::one();
     assert_eq!(total_payout, expected_total_reward_integer - rounded_amount);
+
+    let auction_info = {
+        let era = builder.get_era();
+
+        let auction_info_value = builder
+            .query(None, Key::AuctionInfo(era), &[])
+            .expect("should have value");
+
+        auction_info_value
+            .as_auction_info()
+            .cloned()
+            .expect("should be auction info")
+    };
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_1).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_2).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_2 && *amount == expected_validator_2_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_3).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_3 && *amount == expected_validator_3_balance
+    ));
 }
 
 #[ignore]
@@ -1536,6 +1753,55 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     .sum();
 
     assert_eq!(total_payout, expected_total_reward_integer - remainder);
+
+    let auction_info = {
+        let era = builder.get_era();
+
+        let auction_info_value = builder
+            .query(None, Key::AuctionInfo(era), &[])
+            .expect("should have value");
+
+        auction_info_value
+            .as_auction_info()
+            .cloned()
+            .expect("should be auction info")
+    };
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_1).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_1 && *amount == validator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_2).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_2 && *amount == validator_2_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_3).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_3 && *amount == validator_3_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_1).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_1 && *amount == delegator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_2).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_2 && *amount == delegator_2_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(DELEGATOR_3).next(),
+        Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
+        if *delegator_public_key == DELEGATOR_3 && *amount == delegator_3_balance
+    ));
 }
 
 #[ignore]
@@ -1822,6 +2088,66 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     .sum();
 
     assert_eq!(total_payout, expected_total_reward_integer - remainder);
+
+    let auction_info = {
+        let era = builder.get_era();
+
+        let auction_info_value = builder
+            .query(None, Key::AuctionInfo(era), &[])
+            .expect("should have value");
+
+        auction_info_value
+            .as_auction_info()
+            .cloned()
+            .expect("should be auction info")
+    };
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_1).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_2).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_2 && *amount == expected_validator_2_balance
+    ));
+
+    assert!(matches!(
+        auction_info.select(VALIDATOR_3).next(),
+        Some(SeigniorageAllocation::Validator { validator_public_key, amount })
+        if *validator_public_key == VALIDATOR_3 && *amount == expected_validator_3_balance
+    ));
+
+    let delegator_1_allocations: Vec<SeigniorageAllocation> =
+        auction_info.select(DELEGATOR_1).cloned().collect();
+
+    assert_eq!(delegator_1_allocations.len(), 3);
+
+    assert!(
+        delegator_1_allocations.contains(&SeigniorageAllocation::delegator(
+            DELEGATOR_1,
+            VALIDATOR_1,
+            expected_delegator_1_validator_1_balance,
+        ))
+    );
+
+    assert!(
+        delegator_1_allocations.contains(&SeigniorageAllocation::delegator(
+            DELEGATOR_1,
+            VALIDATOR_2,
+            expected_delegator_1_validator_2_balance,
+        ))
+    );
+
+    assert!(
+        delegator_1_allocations.contains(&SeigniorageAllocation::delegator(
+            DELEGATOR_1,
+            VALIDATOR_3,
+            expected_delegator_1_validator_3_balance,
+        ))
+    );
 }
 
 #[ignore]

--- a/grpc/tests/src/test/system_contracts/auction_install.rs
+++ b/grpc/tests/src/test/system_contracts/auction_install.rs
@@ -25,8 +25,6 @@ const TRANSFER_AMOUNT: u64 = 250_000_000 + 1000;
 const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 const DEPLOY_HASH_2: DeployHash = DeployHash::new([2u8; 32]);
 
-// one named_key for each validator and three for the purses, one for validator slots, one for
-// auction_delay, one for locked_funds_period.
 const EXPECTED_KNOWN_KEYS_LEN: usize = 9;
 
 #[ignore]

--- a/node/src/types/json_compatibility/stored_value.rs
+++ b/node/src/types/json_compatibility/stored_value.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use casper_execution_engine::shared::stored_value::StoredValue as ExecutionEngineStoredValue;
 use casper_types::{
+    auction::AuctionInfo,
     bytesrepr::{self, ToBytes},
     CLValue, DeployInfo, Transfer,
 };
@@ -40,6 +41,8 @@ pub enum StoredValue {
     Transfer(Transfer),
     /// A record of a deploy
     DeployInfo(DeployInfo),
+    /// Auction metadata
+    AuctionInfo(AuctionInfo),
 }
 
 impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
@@ -61,6 +64,9 @@ impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
             ExecutionEngineStoredValue::Transfer(transfer) => StoredValue::Transfer(*transfer),
             ExecutionEngineStoredValue::DeployInfo(deploy_info) => {
                 StoredValue::DeployInfo(deploy_info.clone())
+            }
+            ExecutionEngineStoredValue::AuctionInfo(auction_info) => {
+                StoredValue::AuctionInfo(auction_info.clone())
             }
         };
 

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -421,6 +421,21 @@ extern "C" {
         id_ptr: *const u8,
         id_size: usize,
     ) -> i32;
+    /// Records auction info.  Can only be called from within the auction contract.
+    /// Needed to support system contract-based execution.
+    ///
+    /// # Arguments
+    ///
+    /// * `era_id_ptr` - pointer in wasm memory to bytes representing the `EraId`
+    /// * `era_id_size` - size of the `EraId` (in bytes)
+    /// * `auction_info_ptr` - pointer in wasm memory to bytes representing the `AuctionInfo`
+    /// * `auction_info_size` - size of the `AuctionInfo` (in bytes)
+    pub fn casper_record_auction_info(
+        era_id_ptr: *const u8,
+        era_id_size: usize,
+        auction_info_ptr: *const u8,
+        auction_info_size: usize,
+    ) -> i32;
     /// This function uses the mint contract's balance function to get the balance
     /// of the specified purse. It causes a `Trap` if the bytes in wasm memory
     /// from `purse_ptr` to `purse_ptr + purse_size` cannot be

--- a/smart_contracts/contracts/system/auction/src/lib.rs
+++ b/smart_contracts/contracts/system/auction/src/lib.rs
@@ -13,10 +13,10 @@ use casper_contract::{
 use casper_types::{
     account::AccountHash,
     auction::{
-        Auction, DelegationRate, MintProvider, RuntimeProvider, SeigniorageRecipients,
-        StorageProvider, SystemProvider, ValidatorWeights, ARG_AMOUNT, ARG_DELEGATION_RATE,
-        ARG_DELEGATOR, ARG_DELEGATOR_PUBLIC_KEY, ARG_PUBLIC_KEY, ARG_REWARD_FACTORS,
-        ARG_SOURCE_PURSE, ARG_TARGET_PURSE, ARG_UNBOND_PURSE, ARG_VALIDATOR,
+        Auction, AuctionInfo, DelegationRate, EraId, MintProvider, RuntimeProvider,
+        SeigniorageRecipients, StorageProvider, SystemProvider, ValidatorWeights, ARG_AMOUNT,
+        ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_DELEGATOR_PUBLIC_KEY, ARG_PUBLIC_KEY,
+        ARG_REWARD_FACTORS, ARG_SOURCE_PURSE, ARG_TARGET_PURSE, ARG_UNBOND_PURSE, ARG_VALIDATOR,
         ARG_VALIDATOR_PUBLIC_KEY, ARG_VALIDATOR_PUBLIC_KEYS, METHOD_ADD_BID, METHOD_DELEGATE,
         METHOD_DISTRIBUTE, METHOD_GET_ERA_VALIDATORS, METHOD_READ_ERA_ID,
         METHOD_READ_SEIGNIORAGE_RECIPIENTS, METHOD_RUN_AUCTION, METHOD_SLASH, METHOD_UNDELEGATE,
@@ -59,6 +59,14 @@ impl SystemProvider for AuctionContract {
         amount: U512,
     ) -> StdResult<(), ApiError> {
         system::transfer_from_purse_to_purse(source, target, amount, None)
+    }
+
+    fn record_auction_info(
+        &mut self,
+        era_id: EraId,
+        auction_info: AuctionInfo,
+    ) -> Result<(), Error> {
+        system::record_auction_info(era_id, auction_info).map_err(|_| Error::RecordAuctionInfo)
     }
 }
 

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -1,4 +1,5 @@
 //! Contains implementation of a Auction contract functionality.
+mod auction_info;
 mod bid;
 mod constants;
 mod delegator;
@@ -18,6 +19,7 @@ use crate::{
     PublicKey, URef, U512,
 };
 
+pub use auction_info::*;
 pub use bid::Bid;
 pub use constants::*;
 pub use delegator::Delegator;
@@ -392,11 +394,15 @@ pub trait Auction:
 
         let seigniorage_recipients = self.read_seigniorage_recipients()?;
         let base_round_reward = self.read_base_round_reward()?;
+        let era_id = detail::get_era_id(self)?;
 
         // // TODO: fix consensus?
         // if reward_factors.keys().ne(seigniorage_recipients.keys()) {
         //     return Err(Error::MismatchedEraValidators);
         // }
+
+        let mut auction_info = AuctionInfo::new();
+        let mut seigniorage_allocations = auction_info.seigniorage_allocations_mut();
 
         for (public_key, reward_factor) in reward_factors {
             let recipient = match seigniorage_recipients.get(&public_key) {
@@ -438,13 +444,21 @@ pub trait Auction:
                         let reward = delegators_part * reward_multiplier;
                         (*delegator_key, reward)
                     });
-            let total_delegator_payout: U512 =
-                detail::update_delegator_rewards(self, public_key, delegator_rewards)?;
+            let total_delegator_payout: U512 = detail::update_delegator_rewards(
+                self,
+                &mut seigniorage_allocations,
+                public_key,
+                delegator_rewards,
+            )?;
 
             let validators_part: Ratio<U512> = total_reward - Ratio::from(total_delegator_payout);
             let validator_reward = validators_part.to_integer();
-            let validator_payout =
-                detail::update_validator_reward(self, public_key, validator_reward)?;
+            let validator_payout = detail::update_validator_reward(
+                self,
+                &mut seigniorage_allocations,
+                public_key,
+                validator_reward,
+            )?;
 
             // TODO: add "mint into existing purse" facility
             let validator_reward_purse = self
@@ -477,6 +491,9 @@ pub trait Auction:
             )
             .map_err(|_| Error::DelegatorRewardTransfer)?;
         }
+
+        self.record_auction_info(era_id, auction_info)?;
+
         Ok(())
     }
 

--- a/types/src/auction/auction_info.rs
+++ b/types/src/auction/auction_info.rs
@@ -1,0 +1,295 @@
+// TODO - remove once schemars stops causing warning.
+#![allow(clippy::field_reassign_with_default)]
+
+use alloc::{boxed::Box, vec::Vec};
+
+#[cfg(feature = "std")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    CLType, CLTyped, PublicKey, U512,
+};
+
+const SEIGNIORAGE_ALLOCATION_VALIDATOR_TAG: u8 = 0;
+const SEIGNIORAGE_ALLOCATION_DELEGATOR_TAG: u8 = 1;
+
+/// Information about a seigniorage allocation
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub enum SeigniorageAllocation {
+    /// Info about a seigniorage allocation for a validator
+    Validator {
+        /// Validator's public key
+        validator_public_key: PublicKey,
+        /// Allocated amount
+        amount: U512,
+    },
+    /// Info about a seigniorage allocation for a delegator
+    Delegator {
+        /// Delegator's public key
+        delegator_public_key: PublicKey,
+        /// Validator's public key
+        validator_public_key: PublicKey,
+        /// Allocated amount
+        amount: U512,
+    },
+}
+
+impl SeigniorageAllocation {
+    /// Constructs a [`SeigniorageAllocation::Validator`]
+    pub const fn validator(validator_public_key: PublicKey, amount: U512) -> Self {
+        SeigniorageAllocation::Validator {
+            validator_public_key,
+            amount,
+        }
+    }
+
+    /// Constructs a [`SeigniorageAllocation::Delegator`]
+    pub const fn delegator(
+        delegator_public_key: PublicKey,
+        validator_public_key: PublicKey,
+        amount: U512,
+    ) -> Self {
+        SeigniorageAllocation::Delegator {
+            delegator_public_key,
+            validator_public_key,
+            amount,
+        }
+    }
+
+    /// Returns the amount for a given seigniorage allocation
+    pub fn amount(&self) -> &U512 {
+        match self {
+            SeigniorageAllocation::Validator { amount, .. } => amount,
+            SeigniorageAllocation::Delegator { amount, .. } => amount,
+        }
+    }
+
+    fn tag(&self) -> u8 {
+        match self {
+            SeigniorageAllocation::Validator { .. } => SEIGNIORAGE_ALLOCATION_VALIDATOR_TAG,
+            SeigniorageAllocation::Delegator { .. } => SEIGNIORAGE_ALLOCATION_DELEGATOR_TAG,
+        }
+    }
+}
+
+impl ToBytes for SeigniorageAllocation {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.append(&mut self.tag().to_bytes()?);
+        match self {
+            SeigniorageAllocation::Validator {
+                validator_public_key,
+                amount,
+            } => {
+                buffer.append(&mut validator_public_key.to_bytes()?);
+                buffer.append(&mut amount.to_bytes()?);
+            }
+            SeigniorageAllocation::Delegator {
+                delegator_public_key,
+                validator_public_key,
+                amount,
+            } => {
+                buffer.append(&mut delegator_public_key.to_bytes()?);
+                buffer.append(&mut validator_public_key.to_bytes()?);
+                buffer.append(&mut amount.to_bytes()?);
+            }
+        }
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.tag().serialized_length()
+            + match self {
+                SeigniorageAllocation::Validator {
+                    validator_public_key,
+                    amount,
+                } => validator_public_key.serialized_length() + amount.serialized_length(),
+                SeigniorageAllocation::Delegator {
+                    delegator_public_key,
+                    validator_public_key,
+                    amount,
+                } => {
+                    delegator_public_key.serialized_length()
+                        + validator_public_key.serialized_length()
+                        + amount.serialized_length()
+                }
+            }
+    }
+}
+
+impl FromBytes for SeigniorageAllocation {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, rem) = <u8>::from_bytes(bytes)?;
+        match tag {
+            SEIGNIORAGE_ALLOCATION_VALIDATOR_TAG => {
+                let (validator_public_key, rem) = PublicKey::from_bytes(rem)?;
+                let (amount, rem) = U512::from_bytes(rem)?;
+                Ok((
+                    SeigniorageAllocation::validator(validator_public_key, amount),
+                    rem,
+                ))
+            }
+            SEIGNIORAGE_ALLOCATION_DELEGATOR_TAG => {
+                let (delegator_public_key, rem) = PublicKey::from_bytes(rem)?;
+                let (validator_public_key, rem) = PublicKey::from_bytes(rem)?;
+                let (amount, rem) = U512::from_bytes(rem)?;
+                Ok((
+                    SeigniorageAllocation::delegator(
+                        delegator_public_key,
+                        validator_public_key,
+                        amount,
+                    ),
+                    rem,
+                ))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+impl CLTyped for SeigniorageAllocation {
+    fn cl_type() -> CLType {
+        CLType::Any
+    }
+}
+
+/// Auction metdata.  Intended to be recorded at each era.
+#[derive(Debug, Default, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct AuctionInfo {
+    seigniorage_allocations: Vec<SeigniorageAllocation>,
+}
+
+impl AuctionInfo {
+    /// Constructs a [`AuctionInfo`].
+    pub fn new() -> Self {
+        let seigniorage_allocations = Vec::new();
+        AuctionInfo {
+            seigniorage_allocations,
+        }
+    }
+
+    /// Returns a reference to the seigniorage allocations collection
+    pub fn seigniorage_allocations(&self) -> &Vec<SeigniorageAllocation> {
+        &self.seigniorage_allocations
+    }
+
+    /// Returns a mutable reference to the seigniorage allocations collection
+    pub fn seigniorage_allocations_mut(&mut self) -> &mut Vec<SeigniorageAllocation> {
+        &mut self.seigniorage_allocations
+    }
+
+    /// Returns all seigniorage allocations that match the provided public key
+    /// using the following criteria:
+    /// * If the match candidate is a validator allocation, the provided public key is matched
+    ///   against the validator public key.
+    /// * If the match candidate is a delegator allocation, the provided public key is matched
+    ///   against the delegator public key.
+    pub fn select(&self, public_key: PublicKey) -> impl Iterator<Item = &SeigniorageAllocation> {
+        self.seigniorage_allocations
+            .iter()
+            .filter(move |allocation| match allocation {
+                SeigniorageAllocation::Validator {
+                    validator_public_key,
+                    ..
+                } => public_key == *validator_public_key,
+                SeigniorageAllocation::Delegator {
+                    delegator_public_key,
+                    ..
+                } => public_key == *delegator_public_key,
+            })
+    }
+}
+
+impl ToBytes for AuctionInfo {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        self.seigniorage_allocations.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.seigniorage_allocations.serialized_length()
+    }
+}
+
+impl FromBytes for AuctionInfo {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (seigniorage_allocations, rem) = Vec::<SeigniorageAllocation>::from_bytes(bytes)?;
+        Ok((
+            AuctionInfo {
+                seigniorage_allocations,
+            },
+            rem,
+        ))
+    }
+}
+
+impl CLTyped for AuctionInfo {
+    fn cl_type() -> CLType {
+        CLType::List(Box::new(SeigniorageAllocation::cl_type()))
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod gens {
+    use proptest::{
+        collection::{self, SizeRange},
+        prelude::Strategy,
+        prop_oneof,
+    };
+
+    use crate::{
+        auction::{AuctionInfo, SeigniorageAllocation},
+        gens::u512_arb,
+        public_key::gens::public_key_arb,
+    };
+
+    fn seigniorage_allocation_validator_arb() -> impl Strategy<Value = SeigniorageAllocation> {
+        (public_key_arb(), u512_arb()).prop_map(|(validator_public_key, amount)| {
+            SeigniorageAllocation::validator(validator_public_key, amount)
+        })
+    }
+
+    fn seigniorage_allocation_delegator_arb() -> impl Strategy<Value = SeigniorageAllocation> {
+        (public_key_arb(), public_key_arb(), u512_arb()).prop_map(
+            |(delegator_public_key, validator_public_key, amount)| {
+                SeigniorageAllocation::delegator(delegator_public_key, validator_public_key, amount)
+            },
+        )
+    }
+
+    pub fn seigniorage_allocation_arb() -> impl Strategy<Value = SeigniorageAllocation> {
+        prop_oneof![
+            seigniorage_allocation_validator_arb(),
+            seigniorage_allocation_delegator_arb()
+        ]
+    }
+
+    pub fn auction_info_arb(size: impl Into<SizeRange>) -> impl Strategy<Value = AuctionInfo> {
+        collection::vec(seigniorage_allocation_arb(), size).prop_map(|allocations| {
+            let mut auction_info = AuctionInfo::new();
+            *auction_info.seigniorage_allocations_mut() = allocations;
+            auction_info
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use crate::bytesrepr;
+
+    use super::gens;
+
+    proptest! {
+        #[test]
+        fn test_serialization_roundtrip(auction_info in gens::auction_info_arb(0..32)) {
+            bytesrepr::test_serialization_roundtrip(&auction_info)
+        }
+    }
+}

--- a/types/src/auction/providers.rs
+++ b/types/src/auction/providers.rs
@@ -1,5 +1,6 @@
 use crate::{
     account::AccountHash,
+    auction::{AuctionInfo, EraId},
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::auction::Error,
     ApiError, CLTyped, Key, TransferResult, URef, BLAKE2B_DIGEST_LENGTH, U512,
@@ -44,6 +45,13 @@ pub trait SystemProvider {
         target: URef,
         amount: U512,
     ) -> Result<(), ApiError>;
+
+    /// Records auction info at the given era id.
+    fn record_auction_info(
+        &mut self,
+        era_id: EraId,
+        auction_info: AuctionInfo,
+    ) -> Result<(), Error>;
 }
 
 /// Provides an access to mint.

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -29,6 +29,7 @@ use serde::{Deserialize, Serialize};
 use crate::KEY_HASH_LENGTH;
 use crate::{
     account::AccountHash,
+    auction::AuctionInfo,
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     CLValue, DeployInfo, NamedKey, Transfer, TransferAddr, U128, U256, U512,
 };
@@ -52,13 +53,14 @@ const TRANSFORM_WRITE_CONTRACT_TAG: u8 = 4;
 const TRANSFORM_WRITE_CONTRACT_PACKAGE_TAG: u8 = 5;
 const TRANSFORM_WRITE_DEPLOY_INFO_TAG: u8 = 6;
 const TRANSFORM_WRITE_TRANSFER_TAG: u8 = 7;
-const TRANSFORM_ADD_INT32_TAG: u8 = 8;
-const TRANSFORM_ADD_UINT64_TAG: u8 = 9;
-const TRANSFORM_ADD_UINT128_TAG: u8 = 10;
-const TRANSFORM_ADD_UINT256_TAG: u8 = 11;
-const TRANSFORM_ADD_UINT512_TAG: u8 = 12;
-const TRANSFORM_ADD_KEYS_TAG: u8 = 13;
-const TRANSFORM_FAILURE_TAG: u8 = 14;
+const TRANSFORM_WRITE_AUCTION_INFO_TAG: u8 = 8;
+const TRANSFORM_ADD_INT32_TAG: u8 = 9;
+const TRANSFORM_ADD_UINT64_TAG: u8 = 10;
+const TRANSFORM_ADD_UINT128_TAG: u8 = 11;
+const TRANSFORM_ADD_UINT256_TAG: u8 = 12;
+const TRANSFORM_ADD_UINT512_TAG: u8 = 13;
+const TRANSFORM_ADD_KEYS_TAG: u8 = 14;
+const TRANSFORM_FAILURE_TAG: u8 = 15;
 
 #[cfg(feature = "std")]
 static EXECUTION_RESULT: Lazy<ExecutionResult> = Lazy::new(|| {
@@ -440,8 +442,10 @@ pub enum Transform {
     WriteContract,
     /// Writes a smart contract package to global state.
     WriteContractPackage,
-    /// Writes the given Deploy to global state.
+    /// Writes the given DeployInfo to global state.
     WriteDeployInfo(DeployInfo),
+    /// Writes the given AuctionInfo to global state.
+    WriteAuctionInfo(AuctionInfo),
     /// Writes the given Transfer to global state.
     WriteTransfer(Transfer),
     /// Adds the given `i32`.
@@ -481,6 +485,10 @@ impl ToBytes for Transform {
             Transform::WriteDeployInfo(deploy_info) => {
                 buffer.insert(0, TRANSFORM_WRITE_DEPLOY_INFO_TAG);
                 buffer.extend(deploy_info.to_bytes()?);
+            }
+            Transform::WriteAuctionInfo(auction_info) => {
+                buffer.insert(0, TRANSFORM_WRITE_AUCTION_INFO_TAG);
+                buffer.extend(auction_info.to_bytes()?);
             }
             Transform::WriteTransfer(transfer) => {
                 buffer.insert(0, TRANSFORM_WRITE_TRANSFER_TAG);

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -257,9 +257,7 @@ impl Key {
                 let era_id_bytes = era_id.to_le_bytes();
                 let era_id_bytes_len = era_id_bytes.len();
                 assert!(era_id_bytes_len < BLAKE2B_DIGEST_LENGTH);
-                for i in 0..era_id_bytes_len {
-                    ret[i] = era_id_bytes[i]
-                }
+                ret[..era_id_bytes_len].clone_from_slice(&era_id_bytes);
                 ret
             }
         }

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -254,7 +254,12 @@ impl Key {
             Key::AuctionInfo(era_id) => {
                 // stop-gap measure until this method is removed
                 let mut ret = [0u8; BLAKE2B_DIGEST_LENGTH];
-                ret.clone_from_slice(&era_id.to_le_bytes());
+                let era_id_bytes = era_id.to_le_bytes();
+                let era_id_bytes_len = era_id_bytes.len();
+                assert!(era_id_bytes_len < BLAKE2B_DIGEST_LENGTH);
+                for i in 0..era_id_bytes_len {
+                    ret[i] = era_id_bytes[i]
+                }
                 ret
             }
         }

--- a/types/src/public_key.rs
+++ b/types/src/public_key.rs
@@ -317,6 +317,29 @@ impl CLTyped for PublicKey {
 }
 
 #[cfg(test)]
+pub(crate) mod gens {
+    use std::convert::TryInto;
+
+    use proptest::{
+        array, collection,
+        prelude::{Arbitrary, Strategy},
+        prop_oneof,
+    };
+
+    use crate::{public_key::SECP256K1_PUBLIC_KEY_LENGTH, PublicKey};
+
+    pub fn public_key_arb() -> impl Strategy<Value = PublicKey> {
+        prop_oneof![
+            array::uniform32(<u8>::arbitrary()).prop_map(PublicKey::Ed25519),
+            collection::vec(<u8>::arbitrary(), SECP256K1_PUBLIC_KEY_LENGTH).prop_map(|bytes| {
+                let bytes_array: [u8; SECP256K1_PUBLIC_KEY_LENGTH] = bytes.try_into().unwrap();
+                PublicKey::Secp256k1(bytes_array.into())
+            })
+        ]
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::PublicKey;
     use crate::{bytesrepr, CLValue};

--- a/types/src/system_contract_errors/auction.rs
+++ b/types/src/system_contract_errors/auction.rs
@@ -119,6 +119,9 @@ pub enum Error {
     /// Failed to transfer desired amount into unbonding purse.
     #[fail(display = "Transfer to unbonding purse error")]
     TransferToUnbondingPurse = 32,
+    /// Failed to record auction info.
+    #[fail(display = "Record auction info error")]
+    RecordAuctionInfo = 33,
 
     #[cfg(test)]
     #[doc(hidden)]
@@ -183,6 +186,7 @@ impl TryFrom<u8> for Error {
             d if d == Error::WithdrawDelegatorReward as u8 => Ok(Error::WithdrawDelegatorReward),
             d if d == Error::WithdrawValidatorReward as u8 => Ok(Error::WithdrawValidatorReward),
             d if d == Error::TransferToUnbondingPurse as u8 => Ok(Error::TransferToUnbondingPurse),
+            d if d == Error::RecordAuctionInfo as u8 => Ok(Error::RecordAuctionInfo),
             _ => Err(TryFromU8ForError(())),
         }
     }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1115

This PR:
- introduces an `AuctionInfo` type, a `Key::AuctionInfo(EraId)` variant, and a `StoredValue::AuctionInfo(AuctionInfo)` value.
- updates `Auction::distribute` to store seigniorage metadata as `AuctionInfo` at these keys.