### PR TITLE
EE-1120: Slash unbonding delegators.

### DIFF
--- a/grpc/tests/src/test/regression/ee_1119.rs
+++ b/grpc/tests/src/test/regression/ee_1119.rs
@@ -237,32 +237,16 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
     builder.exec(slash_request_2).expect_success().commit();
 
     let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
-    assert_eq!(unbond_purses.len(), 1);
+    assert_eq!(unbond_purses.len(), 0);
 
     assert!(
         !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_PUBLIC_KEY),
-        "should not be part of unbonds (noop)"
+        "delegator should not be part of unbond list after slashing validator"
     );
 
     assert!(
-        unbond_purses.contains_key(&VALIDATOR_1),
-        "should still be part of unbonds"
-    );
-
-    let unbond_list = unbond_purses
-        .get(&VALIDATOR_1)
-        .expect("should have validator 1 key");
-    assert_eq!(unbond_list.len(), 1); // only one entry is removed - withdraw bid for VALIDATOR_1's unlocked funds
-
-    let undelegated_unbond_purse = unbond_list[0];
-    assert!(!undelegated_unbond_purse.is_validator()); // only delegated amount is left
-    assert_eq!(
-        undelegated_unbond_purse.validator_public_key(),
-        &VALIDATOR_1
-    );
-    assert_eq!(
-        undelegated_unbond_purse.unbonder_public_key(),
-        &*DEFAULT_ACCOUNT_PUBLIC_KEY
+        !unbond_purses.contains_key(&VALIDATOR_1),
+        "should not be a part of unbond list because delegator was slashed"
     );
 
     let bids: Bids = builder.get_value(auction, BIDS_KEY);
@@ -272,6 +256,6 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         builder.get_value(builder.get_mint_contract_hash(), TOTAL_SUPPLY_KEY);
     assert_eq!(
         total_supply_before_slashing - total_supply_after_slashing,
-        U512::from(VALIDATOR_1_STAKE),
+        U512::from(VALIDATOR_1_STAKE + UNDELEGATE_AMOUNT_1),
     );
 }

--- a/grpc/tests/src/test/regression/ee_1120.rs
+++ b/grpc/tests/src/test/regression/ee_1120.rs
@@ -1,0 +1,311 @@
+use std::{collections::BTreeSet, iter::FromIterator};
+
+use once_cell::sync::Lazy;
+
+use casper_engine_test_support::{
+    internal::{utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS},
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
+};
+use casper_execution_engine::{core::engine_state::genesis::GenesisAccount, shared::motes::Motes};
+use casper_types::{
+    account::AccountHash,
+    auction::{
+        Bids, UnbondingPurses, ARG_DELEGATOR, ARG_UNBOND_PURSE, ARG_VALIDATOR,
+        ARG_VALIDATOR_PUBLIC_KEYS, BIDS_KEY, METHOD_SLASH, UNBONDING_PURSES_KEY,
+    },
+    runtime_args, PublicKey, RuntimeArgs, URef, U512,
+};
+
+const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
+const CONTRACT_DELEGATE: &str = "delegate.wasm";
+const CONTRACT_UNDELEGATE: &str = "undelegate.wasm";
+
+const DELEGATE_AMOUNT_1: u64 = 95_000;
+const DELEGATE_AMOUNT_2: u64 = 42_000;
+const DELEGATE_AMOUNT_3: u64 = 13_000;
+const UNDELEGATE_AMOUNT_1: u64 = 17_000;
+const UNDELEGATE_AMOUNT_2: u64 = 24_500;
+const UNDELEGATE_AMOUNT_3: u64 = 7_500;
+
+const TRANSFER_AMOUNT: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
+
+const ARG_AMOUNT: &str = "amount";
+
+const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
+const VALIDATOR_1: PublicKey = PublicKey::Ed25519([3; 32]);
+const VALIDATOR_2: PublicKey = PublicKey::Ed25519([4; 32]);
+const NONVALIDATOR_1: PublicKey = PublicKey::Ed25519([5; 32]);
+static VALIDATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| VALIDATOR_1.into());
+static VALIDATOR_2_ADDR: Lazy<AccountHash> = Lazy::new(|| VALIDATOR_2.into());
+const VALIDATOR_1_STAKE: u64 = 250_000;
+const VALIDATOR_2_STAKE: u64 = 350_000;
+
+#[ignore]
+#[test]
+fn should_run_ee_1120_slash_delegators() {
+    let accounts = {
+        let validator_1 = GenesisAccount::new(
+            VALIDATOR_1,
+            *VALIDATOR_1_ADDR,
+            Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
+            Motes::new(VALIDATOR_1_STAKE.into()),
+        );
+        let validator_2 = GenesisAccount::new(
+            VALIDATOR_2,
+            *VALIDATOR_2_ADDR,
+            Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
+            Motes::new(VALIDATOR_2_STAKE.into()),
+        );
+
+        let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
+        tmp.push(validator_1);
+        tmp.push(validator_2);
+        tmp
+    };
+    let run_genesis_request = utils::create_run_genesis_request(accounts);
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&run_genesis_request);
+
+    let trasfer_request_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => SYSTEM_ADDR,
+            "amount" => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    builder.exec(trasfer_request_1).expect_success().commit();
+
+    let transfer_request_2 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            "target" => AccountHash::from(NONVALIDATOR_1),
+            "amount" => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    builder.exec(transfer_request_2).expect_success().commit();
+
+    let auction = builder.get_auction_contract_hash();
+
+    //
+    // Validator delegates funds on other genesis validator
+    //
+
+    let delegate_exec_request_1 = ExecuteRequestBuilder::standard(
+        NONVALIDATOR_1.into(),
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => VALIDATOR_2,
+            ARG_DELEGATOR => NONVALIDATOR_1,
+        },
+    )
+    .build();
+
+    let delegate_exec_request_2 = ExecuteRequestBuilder::standard(
+        NONVALIDATOR_1.into(),
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_2),
+            ARG_VALIDATOR => VALIDATOR_1,
+            ARG_DELEGATOR => NONVALIDATOR_1,
+        },
+    )
+    .build();
+
+    let delegate_exec_request_3 = ExecuteRequestBuilder::standard(
+        VALIDATOR_2.into(),
+        CONTRACT_DELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(DELEGATE_AMOUNT_3),
+            ARG_VALIDATOR => VALIDATOR_1,
+            ARG_DELEGATOR => VALIDATOR_2,
+        },
+    )
+    .build();
+
+    builder
+        .exec(delegate_exec_request_1)
+        .expect_success()
+        .commit();
+
+    builder
+        .exec(delegate_exec_request_2)
+        .expect_success()
+        .commit();
+
+    builder
+        .exec(delegate_exec_request_3)
+        .expect_success()
+        .commit();
+
+    // sanity check of the system before undelegating
+    let initial_bids: Bids = builder.get_value(auction, BIDS_KEY);
+    assert_eq!(
+        initial_bids.keys().copied().collect::<BTreeSet<_>>(),
+        BTreeSet::from_iter(vec![VALIDATOR_2, VALIDATOR_1])
+    );
+
+    let initial_unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    assert_eq!(initial_unbond_purses.len(), 0);
+
+    //
+    // Partial unbond through undelegate on other genesis validator
+    //
+    let undelegate_request_1 = ExecuteRequestBuilder::standard(
+        NONVALIDATOR_1.into(),
+        CONTRACT_UNDELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_1),
+            ARG_VALIDATOR => VALIDATOR_1,
+            ARG_DELEGATOR => NONVALIDATOR_1,
+            ARG_UNBOND_PURSE => Option::<URef>::None,
+        },
+    )
+    .build();
+    builder.exec(undelegate_request_1).commit().expect_success();
+
+    let undelegate_request_2 = ExecuteRequestBuilder::standard(
+        NONVALIDATOR_1.into(),
+        CONTRACT_UNDELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_2),
+            ARG_VALIDATOR => VALIDATOR_2,
+            ARG_DELEGATOR => NONVALIDATOR_1,
+            ARG_UNBOND_PURSE => Option::<URef>::None,
+        },
+    )
+    .build();
+    builder.exec(undelegate_request_2).commit().expect_success();
+
+    let undelegate_request_3 = ExecuteRequestBuilder::standard(
+        VALIDATOR_2.into(),
+        CONTRACT_UNDELEGATE,
+        runtime_args! {
+            ARG_AMOUNT => U512::from(UNDELEGATE_AMOUNT_3),
+            ARG_VALIDATOR => VALIDATOR_1,
+            ARG_DELEGATOR => VALIDATOR_2,
+            ARG_UNBOND_PURSE => Option::<URef>::None,
+        },
+    )
+    .build();
+    builder.exec(undelegate_request_3).commit().expect_success();
+
+    // unbonding purses before slashing
+
+    let unbond_purses_before: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    assert_eq!(unbond_purses_before.len(), 2);
+
+    let validator_1_unbond_list_before = unbond_purses_before
+        .get(&VALIDATOR_1)
+        .cloned()
+        .expect("should have unbond");
+    assert_eq!(validator_1_unbond_list_before.len(), 2); // two entries in order: undelegate, and withdraw bid
+
+    let validator_2_unbond_list = unbond_purses_before
+        .get(&VALIDATOR_2)
+        .cloned()
+        .expect("should have unbond");
+    assert_eq!(validator_2_unbond_list.len(), 1); // two entries in order: undelegate, and withdraw bid
+    assert_eq!(
+        validator_2_unbond_list[0].validator_public_key(),
+        &VALIDATOR_2
+    );
+    assert_eq!(
+        validator_2_unbond_list[0].unbonder_public_key(),
+        &NONVALIDATOR_1
+    );
+
+    //
+    // bids before slashing
+    //
+    let bids_before: Bids = builder.get_value(auction, BIDS_KEY);
+    assert_eq!(
+        bids_before.keys().collect::<Vec<_>>(),
+        initial_bids.keys().collect::<Vec<_>>()
+    );
+
+    let slash_request_1 = ExecuteRequestBuilder::contract_call_by_hash(
+        SYSTEM_ADDR,
+        auction,
+        METHOD_SLASH,
+        runtime_args! {
+            ARG_VALIDATOR_PUBLIC_KEYS => vec![
+                VALIDATOR_2
+            ]
+        },
+    )
+    .build();
+
+    builder.exec(slash_request_1).expect_success().commit();
+
+    // compare bids after slashing validator 2
+    let bids_after: Bids = builder.get_value(auction, BIDS_KEY);
+    assert_ne!(bids_before, bids_after);
+    assert_eq!(bids_after.len(), 1);
+    assert!(!bids_after.contains_key(&VALIDATOR_2));
+
+    assert!(bids_after.contains_key(&VALIDATOR_1));
+    assert_eq!(bids_after[&VALIDATOR_1].delegators().len(), 2);
+
+    // NOTE: Validator2's bid on Validator1 wasn't slashed.
+    assert!(bids_after[&VALIDATOR_1]
+        .delegators()
+        .contains_key(&VALIDATOR_2));
+    assert!(bids_after[&VALIDATOR_1]
+        .delegators()
+        .contains_key(&NONVALIDATOR_1));
+
+    let unbond_purses_after: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    assert_ne!(unbond_purses_before, unbond_purses_after);
+
+    let validator_1_unbond_list_after = unbond_purses_after
+        .get(&VALIDATOR_1)
+        .expect("should have validator 1 entry");
+    assert_eq!(validator_1_unbond_list_after.len(), 2);
+    assert_eq!(
+        validator_1_unbond_list_after[0].unbonder_public_key(),
+        &NONVALIDATOR_1
+    );
+
+    // NOTE: As mentioned above Validator2's unbonding purse on Validator1 wasn't slashed
+    assert_eq!(
+        validator_1_unbond_list_after[1].unbonder_public_key(),
+        &VALIDATOR_2
+    );
+
+    // if a delegator gets slashed for one validator's behavior, he isn't also slashed for the other
+    // validators he delegates to
+    assert_eq!(
+        validator_1_unbond_list_after,
+        &validator_1_unbond_list_before
+    );
+
+    //
+    // slash validator1 to clear both bids and unbonding purses
+    //
+    let slash_request_2 = ExecuteRequestBuilder::contract_call_by_hash(
+        SYSTEM_ADDR,
+        auction,
+        METHOD_SLASH,
+        runtime_args! {
+            ARG_VALIDATOR_PUBLIC_KEYS => vec![
+                VALIDATOR_1
+            ]
+        },
+    )
+    .build();
+
+    builder.exec(slash_request_2).expect_success().commit();
+
+    let bids_after: Bids = builder.get_value(auction, BIDS_KEY);
+    assert!(bids_after.is_empty());
+    let unbond_purses_after: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    assert!(unbond_purses_after.is_empty());
+}

--- a/grpc/tests/src/test/regression/mod.rs
+++ b/grpc/tests/src/test/regression/mod.rs
@@ -2,6 +2,7 @@ mod ee_1045;
 mod ee_1071;
 mod ee_1103;
 mod ee_1119;
+mod ee_1120;
 mod ee_221;
 mod ee_401;
 mod ee_441;

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -278,7 +278,7 @@ pub trait Auction:
             let orphaned_delegators = match bids.remove(&validator_public_key) {
                 Some(bid) => {
                     burned_amount += *bid.staked_amount();
-                    modified_validators += 1;
+                    bids_modified = true;
 
                     bid.delegators().keys().copied().collect()
                 }
@@ -322,7 +322,6 @@ pub trait Auction:
             detail::set_bids(self, bids)?;
         }
 
-        // call reduce total supply
         self.reduce_total_supply(burned_amount)?;
 
         Ok(())

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -273,7 +273,6 @@ pub trait Auction:
 
         let mut unbonding_purses: UnbondingPurses = detail::get_unbonding_purses(self)?;
         let mut unbonding_purses_modified = false;
-
         for validator_public_key in validator_public_keys {
             // Clean up bids for given validator and save up assigned delegators
             let orphaned_delegators = match bids.remove(&validator_public_key) {

--- a/types/src/auction/detail.rs
+++ b/types/src/auction/detail.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::vec::Vec;
 use core::convert::TryInto;
 
 use num_rational::Ratio;
@@ -263,36 +263,4 @@ where
     set_bids(provider, bids)?;
 
     Ok(amount)
-}
-
-/// Removes bids of specified public keys.
-///
-/// Returns the amount of stake burned by removing the bids.
-pub(crate) fn quash_bid<P: StorageProvider + RuntimeProvider + ?Sized>(
-    provider: &mut P,
-    validator_public_keys: &[PublicKey],
-) -> Result<(U512, BTreeSet<PublicKey>)> {
-    // Clean up inside `bids`
-    let mut validators = get_bids(provider)?;
-
-    let mut modified_validators = 0usize;
-
-    let mut burned_amount: U512 = U512::zero();
-
-    let mut delegators = BTreeSet::new();
-
-    for validator_public_key in validator_public_keys {
-        if let Some(bid) = validators.remove(validator_public_key) {
-            burned_amount += *bid.staked_amount();
-            modified_validators += 1;
-
-            delegators.extend(bid.delegators().keys());
-        }
-    }
-
-    if modified_validators > 0 {
-        set_bids(provider, validators)?;
-    }
-
-    Ok((burned_amount, delegators))
 }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1120

Adds a clause to the slashing logic so delegators present in bids entry for given slashed validator are collected, and then also removed from unbonding purses for given slashed validator.

This also inlines `detail::quash_bid` to get the benefit of removing validator's delegators as part of single step per validator to be slashed.