### PR TITLE
NDRS-625: get-block-transfers rpc endpoint

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -36,6 +36,7 @@ SUBCOMMANDS:
     transfer               Transfers funds between purses
     get-deploy             Retrieves a deploy from the network
     get-block              Retrieves a block from the network
+    get-block-transfers    Retrieves all transfers for a block from the network
     list-deploys           Retrieves the list of all deploy hashes in a given block
     get-state-root-hash    Retrieves a state root hash at a given block
     query-state            Retrieves a stored value from the network
@@ -299,6 +300,39 @@ cargo run --release -- get-block --block-hash=80a09df67f45bfb290c8f36021daf2fb89
 
 The `state_root_hash` in the response's `header` is worth noting, as it can be used to identify the state root hash
 for the purposes of querying the global state.
+
+### Get all `Transfers` contained in a `Block`
+
+To retrieve all `Transfer` transactions processed in a `Block` created by the network, you can use `get-block-transfers`. For example:
+
+```
+cargo run --release -- get-block-transfers --block-hash=80a09df67f45bfb290c8f36021daf2fb898587a48fa0e4f7c506202ae8f791b8
+```
+
+<details><summary>example output</summary>
+
+```commandline
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.0.0",
+    "block_hash": "80a09df67f45bfb290c8f36021daf2fb898587a48fa0e4f7c506202ae8f791b8",
+    "transfers": [
+      {
+        "amount": "100000000",
+        "deploy_hash": "ab87c5f2c0f6f331bf488703676fb0c68f897282dfbb8e085752f220a3dfc25e",
+        "from": "account-hash-1ace33e66142d5a0679ba5507ef75b9c09888d1567e86100d1db535fa819a962",
+        "gas": "0",
+        "id": null,
+        "source": "uref-21f7316e72d1baa7b706a9083077d643665ad3a56673c594db9762ceac4f3788-007",
+        "target": "uref-c5eb9788156b53c9a599dfb5e591c6399580b491c72086a6bc028dd18fdfcb2d-004"
+      }
+    ]
+  },
+  "id": 7229488934468542904
+}
+```
+</details>
 
 
 ### Query the global state

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -248,6 +248,25 @@ pub fn get_block(
     RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_block(maybe_block_id)
 }
 
+/// Retrieves all `Transfer` items for a `Block` from the network.
+///
+/// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the
+///   response. If it can be parsed as an `i64` it will be used as a JSON integer. If empty, a
+///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
+/// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
+///   running, e.g. `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the
+///   `Block` height or empty. If empty, the latest `Block` transfers will be retrieved.
+pub fn get_block_transfers(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    maybe_block_id: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_block_transfers(maybe_block_id)
+}
+
 /// Retrieves a state root hash at a given `Block`.
 ///
 /// * `maybe_rpc_id` is the JSON-RPC identifier, applied to the request and returned in the

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -13,7 +13,8 @@ use casper_node::{
     rpcs::{
         account::{PutDeploy, PutDeployParams},
         chain::{
-            BlockIdentifier, GetBlock, GetBlockParams, GetStateRootHash, GetStateRootHashParams,
+            BlockIdentifier, GetBlock, GetBlockParams, GetBlockTransfers, GetBlockTransfersParams,
+            GetStateRootHash, GetStateRootHashParams,
         },
         docs::ListRpcs,
         info::{GetDeploy, GetDeployParams},
@@ -219,6 +220,18 @@ impl RpcCall {
         Ok(response)
     }
 
+    pub(crate) fn get_block_transfers(self, maybe_block_identifier: &str) -> Result<JsonRpc> {
+        let maybe_block_identifier = Self::block_identifier(maybe_block_identifier)?;
+        let response = match maybe_block_identifier {
+            Some(block_identifier) => {
+                let params = GetBlockTransfersParams { block_identifier };
+                GetBlockTransfers::request_with_map_params(self, params)
+            }
+            None => GetBlockTransfers::request(self),
+        }?;
+        Ok(response)
+    }
+
     fn block_identifier(maybe_block_identifier: &str) -> Result<Option<BlockIdentifier>> {
         if maybe_block_identifier.is_empty() {
             return Ok(None);
@@ -324,6 +337,10 @@ impl RpcClient for GetBlock {
     const RPC_METHOD: &'static str = Self::METHOD;
 }
 
+impl RpcClient for GetBlockTransfers {
+    const RPC_METHOD: &'static str = Self::METHOD;
+}
+
 impl RpcClient for GetStateRootHash {
     const RPC_METHOD: &'static str = Self::METHOD;
 }
@@ -354,6 +371,7 @@ pub(crate) trait IntoJsonMap: Serialize {
 
 impl IntoJsonMap for PutDeployParams {}
 impl IntoJsonMap for GetBlockParams {}
+impl IntoJsonMap for GetBlockTransfersParams {}
 impl IntoJsonMap for GetStateRootHashParams {}
 impl IntoJsonMap for GetDeployParams {}
 impl IntoJsonMap for GetBalanceParams {}

--- a/client/src/block.rs
+++ b/client/src/block.rs
@@ -1,1 +1,2 @@
 mod get;
+mod transfers;

--- a/client/src/block/transfers.rs
+++ b/client/src/block/transfers.rs
@@ -1,0 +1,49 @@
+use std::str;
+
+use clap::{App, ArgMatches, SubCommand};
+
+use casper_node::rpcs::chain::GetBlockTransfers;
+
+use crate::{command::ClientCommand, common};
+
+/// This struct defines the order in which the args are shown for this subcommand.
+enum DisplayOrder {
+    Verbose,
+    NodeAddress,
+    RpcId,
+    BlockIdentifier,
+}
+
+impl<'a, 'b> ClientCommand<'a, 'b> for GetBlockTransfers {
+    const NAME: &'static str = "get-block-transfers";
+    const ABOUT: &'static str = "Retrieves all transfers for a block from the network";
+
+    fn build(display_order: usize) -> App<'a, 'b> {
+        SubCommand::with_name(Self::NAME)
+            .about(Self::ABOUT)
+            .display_order(display_order)
+            .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
+            .arg(common::node_address::arg(
+                DisplayOrder::NodeAddress as usize,
+            ))
+            .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
+            .arg(common::block_identifier::arg(
+                DisplayOrder::BlockIdentifier as usize,
+            ))
+    }
+
+    fn run(matches: &ArgMatches<'_>) {
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbose = common::verbose::get(matches);
+        let maybe_block_id = common::block_identifier::get(matches);
+
+        let response =
+            casper_client::get_block_transfers(maybe_rpc_id, node_address, verbose, maybe_block_id)
+                .unwrap_or_else(|error| panic!("response error: {}", error));
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&response).expect("should encode to JSON")
+        );
+    }
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -14,7 +14,7 @@ use clap::{crate_description, crate_version, App};
 
 use casper_node::rpcs::{
     account::PutDeploy,
-    chain::{GetBlock, GetStateRootHash},
+    chain::{GetBlock, GetBlockTransfers, GetStateRootHash},
     docs::ListRpcs,
     info::GetDeploy,
     state::{GetAuctionInfo, GetBalance, GetItem as QueryState},
@@ -38,6 +38,7 @@ enum DisplayOrder {
     Transfer,
     GetDeploy,
     GetBlock,
+    GetBlockTransfers,
     ListDeploys,
     GetStateRootHash,
     QueryState,
@@ -59,6 +60,9 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
         .subcommand(Transfer::build(DisplayOrder::Transfer as usize))
         .subcommand(GetDeploy::build(DisplayOrder::GetDeploy as usize))
         .subcommand(GetBlock::build(DisplayOrder::GetBlock as usize))
+        .subcommand(GetBlockTransfers::build(
+            DisplayOrder::GetBlockTransfers as usize,
+        ))
         .subcommand(ListDeploys::build(DisplayOrder::ListDeploys as usize))
         .subcommand(GetBalance::build(DisplayOrder::GetBalance as usize))
         .subcommand(GetStateRootHash::build(
@@ -84,6 +88,7 @@ async fn main() {
         (Transfer::NAME, Some(matches)) => Transfer::run(matches),
         (GetDeploy::NAME, Some(matches)) => GetDeploy::run(matches),
         (GetBlock::NAME, Some(matches)) => GetBlock::run(matches),
+        (GetBlockTransfers::NAME, Some(matches)) => GetBlockTransfers::run(matches),
         (ListDeploys::NAME, Some(matches)) => ListDeploys::run(matches),
         (GetBalance::NAME, Some(matches)) => GetBalance::run(matches),
         (GetStateRootHash::NAME, Some(matches)) => GetStateRootHash::run(matches),

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -234,6 +234,11 @@ impl BlockExecutor {
             state.finalized_block.proposer().into(),
         );
 
+        // TODO: this is currently working coincidentally because we are passing only one
+        // deploy_item per exec. The execution results coming back from the ee lacks the
+        // mapping between deploy_hash and execution result, and this outer logic is enriching it
+        // with the deploy hash. If we were passing multiple deploys per exec the relation between
+        // the deploy and the execution results would be lost.
         effect_builder
             .request_execute(execute_request)
             .event(move |result| Event::DeployExecutionResult {

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -211,6 +211,16 @@ where
                     result: Box::new(result),
                     main_responder: responder,
                 }),
+            Event::RpcRequest(RpcRequest::GetBlockTransfers {
+                block_hash,
+                responder,
+            }) => effect_builder
+                .get_block_transfers_from_storage(block_hash)
+                .event(move |result| Event::GetBlockTransfersResult {
+                    block_hash,
+                    result: Box::new(result),
+                    main_responder: responder,
+                }),
             Event::RpcRequest(RpcRequest::QueryProtocolData {
                 protocol_version,
                 responder,
@@ -269,6 +279,11 @@ where
                 maybe_id: _,
                 result,
                 main_responder,
+            } => main_responder.respond(*result).ignore(),
+            Event::GetBlockTransfersResult {
+                result,
+                main_responder,
+                ..
             } => main_responder.respond(*result).ignore(),
             Event::QueryProtocolDataResult {
                 result,

--- a/node/src/components/rpc_server/event.rs
+++ b/node/src/components/rpc_server/event.rs
@@ -10,12 +10,12 @@ use casper_execution_engine::{
     core::engine_state::{self, BalanceResult, GetEraValidatorsError, QueryResult},
     storage::protocol_data::ProtocolData,
 };
-use casper_types::auction::EraValidators;
+use casper_types::{auction::EraValidators, Transfer};
 
 use crate::{
     effect::{requests::RpcRequest, Responder},
     rpcs::chain::BlockIdentifier,
-    types::{Block, Deploy, DeployHash, DeployMetadata, NodeId},
+    types::{Block, BlockHash, Deploy, DeployHash, DeployMetadata, NodeId},
 };
 
 #[derive(Debug, From)]
@@ -26,6 +26,11 @@ pub enum Event {
         maybe_id: Option<BlockIdentifier>,
         result: Box<Option<Block>>,
         main_responder: Responder<Option<Block>>,
+    },
+    GetBlockTransfersResult {
+        block_hash: BlockHash,
+        result: Box<Option<Vec<Transfer>>>,
+        main_responder: Responder<Option<Vec<Transfer>>>,
     },
     QueryProtocolDataResult {
         result: Result<Option<Box<ProtocolData>>, engine_state::Error>,
@@ -77,6 +82,13 @@ impl Display for Event {
                 result,
                 ..
             } => write!(formatter, "get latest block result: {:?}", result),
+            Event::GetBlockTransfersResult {
+                block_hash, result, ..
+            } => write!(
+                formatter,
+                "get block transfers result for block_hash {}: {:?}",
+                block_hash, result
+            ),
             Event::QueryProtocolDataResult { result, .. } => {
                 write!(formatter, "query protocol data result: {:?}", result)
             }

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -17,6 +17,7 @@ pub(super) async fn run<REv: ReactorEventT>(config: Config, effect_builder: Effe
     // RPC filters.
     let rpc_put_deploy = rpcs::account::PutDeploy::create_filter(effect_builder);
     let rpc_get_block = rpcs::chain::GetBlock::create_filter(effect_builder);
+    let rpc_get_block_transfers = rpcs::chain::GetBlockTransfers::create_filter(effect_builder);
     let rpc_get_state_root_hash = rpcs::chain::GetStateRootHash::create_filter(effect_builder);
     let rpc_get_item = rpcs::state::GetItem::create_filter(effect_builder);
     let rpc_get_balance = rpcs::state::GetBalance::create_filter(effect_builder);
@@ -29,6 +30,7 @@ pub(super) async fn run<REv: ReactorEventT>(config: Config, effect_builder: Effe
     let service = warp_json_rpc::service(
         rpc_put_deploy
             .or(rpc_get_block)
+            .or(rpc_get_block_transfers)
             .or(rpc_get_state_root_hash)
             .or(rpc_get_item)
             .or(rpc_get_balance)

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -144,7 +144,7 @@ impl DocExample for GetBlockTransfersParams {
     }
 }
 
-/// Result for "chain_get_block" RPC response.
+/// Result for "chain_get_block_transfers" RPC response.
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct GetBlockTransfersResult {

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -26,6 +26,7 @@ use crate::{
     reactor::QueueKind,
     types::{Block, BlockHash, Item, JsonBlock},
 };
+use casper_types::Transfer;
 
 static GET_BLOCK_PARAMS: Lazy<GetBlockParams> = Lazy::new(|| GetBlockParams {
     block_identifier: BlockIdentifier::Hash(Block::doc_example().id()),
@@ -34,6 +35,16 @@ static GET_BLOCK_RESULT: Lazy<GetBlockResult> = Lazy::new(|| GetBlockResult {
     api_version: CLIENT_API_VERSION.clone(),
     block: Some(Block::doc_example().clone().into()),
 });
+static GET_BLOCK_TRANSFERS_PARAMS: Lazy<GetBlockTransfersParams> =
+    Lazy::new(|| GetBlockTransfersParams {
+        block_identifier: BlockIdentifier::Hash(Block::doc_example().id()),
+    });
+static GET_BLOCK_TRANSFERS_RESULT: Lazy<GetBlockTransfersResult> =
+    Lazy::new(|| GetBlockTransfersResult {
+        api_version: CLIENT_API_VERSION.clone(),
+        block_hash: Some(Block::doc_example().id()),
+        transfers: Some(vec![Transfer::default()]),
+    });
 static GET_STATE_ROOT_HASH_PARAMS: Lazy<GetStateRootHashParams> =
     Lazy::new(|| GetStateRootHashParams {
         block_identifier: BlockIdentifier::Height(Block::doc_example().header().height()),
@@ -113,6 +124,103 @@ impl RpcWithOptionalParamsExt for GetBlock {
                 api_version: CLIENT_API_VERSION.clone(),
                 block: maybe_block.map(Into::into),
             };
+            Ok(response_builder.success(result)?)
+        }
+        .boxed()
+    }
+}
+
+/// Params for "chain_get_block_transfers" RPC request.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GetBlockTransfersParams {
+    /// The block hash.
+    pub block_identifier: BlockIdentifier,
+}
+
+impl DocExample for GetBlockTransfersParams {
+    fn doc_example() -> &'static Self {
+        &*GET_BLOCK_TRANSFERS_PARAMS
+    }
+}
+
+/// Result for "chain_get_block" RPC response.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GetBlockTransfersResult {
+    /// The RPC API version.
+    #[schemars(with = "String")]
+    pub api_version: Version,
+    /// The block hash, if found.
+    pub block_hash: Option<BlockHash>,
+    /// The block's transfers, if found.
+    pub transfers: Option<Vec<Transfer>>,
+}
+
+impl GetBlockTransfersResult {
+    /// Create an instance of GetBlockTransfersResult.
+    pub fn new(
+        api_version: Version,
+        block_hash: Option<BlockHash>,
+        transfers: Option<Vec<Transfer>>,
+    ) -> Self {
+        GetBlockTransfersResult {
+            api_version,
+            block_hash,
+            transfers,
+        }
+    }
+}
+
+impl DocExample for GetBlockTransfersResult {
+    fn doc_example() -> &'static Self {
+        &*GET_BLOCK_TRANSFERS_RESULT
+    }
+}
+
+/// "chain_get_block_transfers" RPC.
+pub struct GetBlockTransfers {}
+
+impl RpcWithOptionalParams for GetBlockTransfers {
+    const METHOD: &'static str = "chain_get_block_transfers";
+    type OptionalRequestParams = GetBlockTransfersParams;
+    type ResponseResult = GetBlockTransfersResult;
+}
+
+impl RpcWithOptionalParamsExt for GetBlockTransfers {
+    fn handle_request<REv: ReactorEventT>(
+        effect_builder: EffectBuilder<REv>,
+        response_builder: Builder,
+        maybe_params: Option<Self::OptionalRequestParams>,
+    ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
+        async move {
+            // Get the block.
+            let maybe_block_id = maybe_params.map(|params| params.block_identifier);
+            let block_hash = match get_block(maybe_block_id, effect_builder).await {
+                Ok(Some(block)) => *block.hash(),
+                Ok(None) => {
+                    return Ok(response_builder.success(Self::ResponseResult::new(
+                        CLIENT_API_VERSION.clone(),
+                        None,
+                        None,
+                    ))?)
+                }
+                Err(error) => return Ok(response_builder.error(error)?),
+            };
+
+            let transfers = effect_builder
+                .make_request(
+                    |responder| RpcRequest::GetBlockTransfers {
+                        block_hash,
+                        responder,
+                    },
+                    QueueKind::Api,
+                )
+                .await;
+
+            // Return the result.
+            let result =
+                Self::ResponseResult::new(CLIENT_API_VERSION.clone(), Some(block_hash), transfers);
             Ok(response_builder.success(result)?)
         }
         .boxed()

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -19,7 +19,7 @@ use warp_json_rpc::Builder;
 
 use super::{
     account::PutDeploy,
-    chain::{GetBlock, GetStateRootHash},
+    chain::{GetBlock, GetBlockTransfers, GetStateRootHash},
     info::{GetDeploy, GetPeers, GetStatus},
     state::{GetAuctionInfo, GetBalance, GetItem},
     Error, ReactorEventT, RpcWithOptionalParams, RpcWithParams, RpcWithoutParams,
@@ -68,6 +68,9 @@ static OPEN_RPC_SCHEMA: Lazy<OpenRpcSchema> = Lazy::new(|| {
     schema.push_without_params::<GetPeers>("returns a list of peers connected to the node");
     schema.push_without_params::<GetStatus>("returns the current status of the node");
     schema.push_with_optional_params::<GetBlock>("returns a Block from the network");
+    schema.push_with_optional_params::<GetBlockTransfers>(
+        "returns all transfers for a Block from the network",
+    );
     schema.push_with_optional_params::<GetStateRootHash>(
         "returns a state root hash at a given Block",
     );

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -95,7 +95,7 @@ use casper_execution_engine::{
 };
 use casper_types::{
     auction::{EraValidators, ValidatorWeights},
-    ExecutionResult, Key, ProtocolVersion,
+    ExecutionResult, Key, ProtocolVersion, Transfer,
 };
 
 use crate::{
@@ -648,6 +648,24 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(
             |responder| StorageRequest::GetBlock {
+                block_hash,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Gets the requested block's transfers from storage.
+    pub(crate) async fn get_block_transfers_from_storage(
+        self,
+        block_hash: BlockHash,
+    ) -> Option<Vec<Transfer>>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetBlockTransfers {
                 block_hash,
                 responder,
             },

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -32,7 +32,7 @@ use casper_execution_engine::{
 };
 use casper_types::{
     auction::{EraValidators, ValidatorWeights},
-    ExecutionResult, Key, ProtocolVersion, URef,
+    ExecutionResult, Key, ProtocolVersion, Transfer, URef,
 };
 use hex_fmt::HexFmt;
 
@@ -224,6 +224,14 @@ pub enum StorageRequest {
         /// local storage.
         responder: Responder<Option<BlockHeader>>,
     },
+    /// Retrieve all transfers in a block with given hash.
+    GetBlockTransfers {
+        /// Hash of block to get transfers of.
+        block_hash: BlockHash,
+        /// Responder to call with the result.  Returns `None` is the transfers do not exist in
+        /// local storage under the block_hash provided.
+        responder: Responder<Option<Vec<Transfer>>>,
+    },
     /// Store given deploy.
     PutDeploy {
         /// Deploy to store.
@@ -295,6 +303,9 @@ impl Display for StorageRequest {
             StorageRequest::GetHighestBlock { .. } => write!(formatter, "get highest block"),
             StorageRequest::GetBlockHeader { block_hash, .. } => {
                 write!(formatter, "get {}", block_hash)
+            }
+            StorageRequest::GetBlockTransfers { block_hash, .. } => {
+                write!(formatter, "get transfers for {}", block_hash)
             }
             StorageRequest::PutDeploy { deploy, .. } => write!(formatter, "put {}", deploy),
             StorageRequest::GetDeploys { deploy_hashes, .. } => {
@@ -423,6 +434,13 @@ pub enum RpcRequest<I> {
         /// Responder to call with the result.
         responder: Responder<Option<LinearBlock>>,
     },
+    /// Return transfers for block by hash (if any).
+    GetBlockTransfers {
+        /// The hash of the block to retrieve transfers for.
+        block_hash: BlockHash,
+        /// Responder to call with the result.
+        responder: Responder<Option<Vec<Transfer>>>,
+    },
     /// Query the global state at the given root hash.
     QueryGlobalState {
         /// The state root hash.
@@ -496,6 +514,9 @@ impl<I> Display for RpcRequest<I> {
                 ..
             } => write!(formatter, "get {}", height),
             RpcRequest::GetBlock { maybe_id: None, .. } => write!(formatter, "get latest block"),
+            RpcRequest::GetBlockTransfers { block_hash, .. } => {
+                write!(formatter, "get transfers {}", block_hash)
+            }
             RpcRequest::QueryProtocolData {
                 protocol_version, ..
             } => write!(formatter, "protocol_version {}", protocol_version),

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -200,7 +200,7 @@ pub type AccountHashBytes = [u8; ACCOUNT_HASH_LENGTH];
 
 /// A newtype wrapping a [`AccountHashBytes`] which is the raw bytes of
 /// the AccountHash, a hash of Public Key and Algorithm
-#[derive(DataSize, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(DataSize, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct AccountHash(AccountHashBytes);
 
 impl AccountHash {

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -101,7 +101,7 @@ impl<'de> Deserialize<'de> for DeployHash {
 }
 
 /// Represents a transfer from one purse to another
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "std", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Transfer {


### PR DESCRIPTION
This PR adds the get-block-transfers rpc endpoint and client subcommand, allowing external consumers to easily get all transfers for a given block (if any).

https://casperlabs.atlassian.net/browse/NDRS-625

```
{
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.0.0",
    "block_hash": "d577f98843c2b94b5e7e241aa8005b3ea86188211d10f702db684998143e4f70",
    "transfers": [
      {
        "amount": "100000000",
        "deploy_hash": "ab87c5f2c0f6f331bf488703676fb0c68f897282dfbb8e085752f220a3dfc25e",
        "from": "account-hash-1ace33e66142d5a0679ba5507ef75b9c09888d1567e86100d1db535fa819a962",
        "gas": "0",
        "id": null,
        "source": "uref-21f7316e72d1baa7b706a9083077d643665ad3a56673c594db9762ceac4f3788-007",
        "target": "uref-c5eb9788156b53c9a599dfb5e591c6399580b491c72086a6bc028dd18fdfcb2d-004"
      }
    ]
  },
  "id": 7229488934468542904
}
```