### PR TITLE
HWY-212: Limit the number of units in endorsement evidence

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -88,7 +88,7 @@ impl<C: Context> ActiveValidator<C> {
             vidx,
             secret,
             next_round_exp: state.params().init_round_exp(),
-            next_timer: Timestamp::zero(),
+            next_timer: state.params().start_timestamp(),
             next_proposal: None,
         };
         let effects = av.schedule_timer(start_time, state);
@@ -384,7 +384,7 @@ impl<C: Context> ActiveValidator<C> {
     /// our previous unit, and it can't be the third unit in a single round.
     fn earliest_unit_time(&self, state: &State<C>) -> Timestamp {
         self.latest_unit(state)
-            .map_or_else(Timestamp::zero, |unit| {
+            .map_or(state.params().start_timestamp(), |unit| {
                 unit.previous().map_or(unit.timestamp, |vh2| {
                     let unit2 = state.unit(vh2);
                     unit.timestamp.max(unit2.round_id() + unit2.round_len())

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -138,7 +138,7 @@ fn round_participation<'a, C: Context>(
 mod tests {
     use super::*;
     use crate::components::consensus::highway_core::{
-        highway_testing::TEST_BLOCK_REWARD,
+        highway_testing::{TEST_BLOCK_REWARD, TEST_ENDORSEMENT_EVIDENCE_LIMIT},
         state::{tests::*, Params},
         validators::ValidatorMap,
     };
@@ -195,6 +195,7 @@ mod tests {
             u64::MAX,
             Timestamp::zero(),
             Timestamp::from(u64::MAX),
+            TEST_ENDORSEMENT_EVIDENCE_LIMIT,
         );
         let weights = &[Weight(ALICE_W), Weight(BOB_W), Weight(CAROL_W)];
         let mut state = State::new(weights, params, vec![]);

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -193,7 +193,7 @@ mod tests {
             19,
             3,
             u64::MAX,
-            Timestamp::from(u64::MAX),
+            Timestamp::zero(),
             Timestamp::from(u64::MAX),
         );
         let weights = &[Weight(ALICE_W), Weight(BOB_W), Weight(CAROL_W)];

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -494,7 +494,7 @@ impl<C: Context> Highway<C> {
                 Ok(self.state.pre_validate_unit(unit)?)
             }
             Vertex::Evidence(evidence) => {
-                Ok(evidence.validate(&self.validators, &self.instance_id)?)
+                Ok(evidence.validate(&self.validators, &self.instance_id, &self.state)?)
             }
             Vertex::Endorsements(endorsements) => {
                 let unit = *endorsements.unit();

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -47,6 +47,7 @@ const TEST_END_HEIGHT: u64 = 100000;
 pub(crate) const TEST_BLOCK_REWARD: u64 = 1_000_000_000_000;
 pub(crate) const TEST_REDUCED_BLOCK_REWARD: u64 = 200_000_000_000;
 pub(crate) const TEST_INSTANCE_ID: u64 = 42;
+pub(crate) const TEST_ENDORSEMENT_EVIDENCE_LIMIT: u64 = 1500;
 
 #[derive(Clone, Eq, PartialEq, Hash)]
 enum HighwayMessage {
@@ -858,6 +859,7 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
                     TEST_END_HEIGHT,
                     Timestamp::now(),
                     Timestamp::zero(), // Length depends only on block number.
+                    TEST_ENDORSEMENT_EVIDENCE_LIMIT,
                 );
                 let mut highway = Highway::new(instance_id, validators.clone(), params);
                 let effects = highway.activate_validator(vid, v_sec, start_time);

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -47,7 +47,7 @@ const TEST_END_HEIGHT: u64 = 100000;
 pub(crate) const TEST_BLOCK_REWARD: u64 = 1_000_000_000_000;
 pub(crate) const TEST_REDUCED_BLOCK_REWARD: u64 = 200_000_000_000;
 pub(crate) const TEST_INSTANCE_ID: u64 = 42;
-pub(crate) const TEST_ENDORSEMENT_EVIDENCE_LIMIT: u64 = 1500;
+pub(crate) const TEST_ENDORSEMENT_EVIDENCE_LIMIT: u64 = 20;
 
 #[derive(Clone, Eq, PartialEq, Hash)]
 enum HighwayMessage {

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -517,21 +517,26 @@ impl<C: Context> State<C> {
 
         // Create an Evidence instance for each conflict we found.
         conflicting_endorsements
-            .map(|(vidx, uhash1, sig1, uhash2, sig2)| {
+            .filter_map(|(vidx, uhash1, sig1, uhash2, sig2)| {
                 let unit1 = self.unit(uhash1);
+                let unit2 = self.unit(uhash2);
+                let ee_limit = self.params().endorsement_evidence_limit();
+                if unit1.seq_number.saturating_add(ee_limit) < unit2.seq_number {
+                    return None;
+                }
                 let swimlane2 = self
                     .swimlane(uhash2)
                     .skip(1)
                     .take_while(|(_, pred2)| pred2.seq_number >= unit1.seq_number)
                     .map(|(pred2_hash, _)| self.wire_unit(pred2_hash, *instance_id).unwrap())
                     .collect();
-                Evidence::Endorsements {
+                Some(Evidence::Endorsements {
                     endorsement1: SignedEndorsement::new(Endorsement::new(*uhash1, vidx), *sig1),
                     unit1: self.wire_unit(uhash1, *instance_id).unwrap(),
                     endorsement2: SignedEndorsement::new(Endorsement::new(*uhash2, vidx), *sig2),
                     unit2: self.wire_unit(uhash2, *instance_id).unwrap(),
                     swimlane2,
-                }
+                })
             })
             .collect()
     }

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -650,7 +650,9 @@ impl<C: Context> State<C> {
         let panorama = &wunit.panorama;
         let timestamp = wunit.timestamp;
         panorama.validate(self)?;
-        if panorama.iter_correct(self).any(|v| v.timestamp > timestamp) {
+        if panorama.iter_correct(self).any(|v| v.timestamp > timestamp)
+            || wunit.timestamp < self.params.start_timestamp()
+        {
             return Err(UnitError::Timestamps);
         }
         if wunit.seq_number != panorama.next_seq_num(self, creator) {

--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -12,6 +12,7 @@ pub(crate) struct Params {
     end_height: u64,
     start_timestamp: Timestamp,
     end_timestamp: Timestamp,
+    endorsement_evidence_limit: u64,
 }
 
 impl Params {
@@ -44,6 +45,7 @@ impl Params {
         end_height: u64,
         start_timestamp: Timestamp,
         end_timestamp: Timestamp,
+        endorsement_evidence_limit: u64,
     ) -> Params {
         assert!(
             reduced_block_reward <= block_reward,
@@ -59,6 +61,7 @@ impl Params {
             end_height,
             start_timestamp,
             end_timestamp,
+            endorsement_evidence_limit,
         }
     }
 
@@ -108,5 +111,12 @@ impl Params {
     /// Returns the minimum timestamp of the last block.
     pub(crate) fn end_timestamp(&self) -> Timestamp {
         self.end_timestamp
+    }
+
+    /// Returns the maximum number of additional units included in evidence for conflicting
+    /// endorsements. If you endorse two conflicting forks at sequence numbers that differ by more
+    /// than this, you get away with it and are not marked faulty.
+    pub(crate) fn endorsement_evidence_limit(&self) -> u64 {
+        self.endorsement_evidence_limit
     }
 }

--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -119,4 +119,11 @@ impl Params {
     pub(crate) fn endorsement_evidence_limit(&self) -> u64 {
         self.endorsement_evidence_limit
     }
+
+    /// Returns new `Params` with the update endorsement evidence limit.
+    #[cfg(test)]
+    pub(crate) fn with_endorsement_evidence_limit(mut self, new_limit: u64) -> Params {
+        self.endorsement_evidence_limit = new_limit;
+        self
+    }
 }

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -13,7 +13,9 @@ use crate::{
         highway_core::{
             endorsement::{Endorsement, SignedEndorsement},
             highway::{Dependency, Endorsements},
-            highway_testing::{TEST_BLOCK_REWARD, TEST_INSTANCE_ID},
+            highway_testing::{
+                TEST_BLOCK_REWARD, TEST_ENDORSEMENT_EVIDENCE_LIMIT, TEST_INSTANCE_ID,
+            },
         },
         traits::ValidatorSecret,
     },
@@ -126,6 +128,7 @@ impl State<TestContext> {
             TEST_ERA_HEIGHT,
             Timestamp::from(0),
             Timestamp::from(0),
+            TEST_ENDORSEMENT_EVIDENCE_LIMIT,
         );
         State::new(weights, params, vec![])
     }
@@ -242,6 +245,7 @@ fn ban_and_mark_faulty() -> Result<(), AddUnitError<TestContext>> {
         u64::MAX,
         Timestamp::zero(),
         Timestamp::from(u64::MAX),
+        TEST_ENDORSEMENT_EVIDENCE_LIMIT,
     );
     // Everyone already knows Alice is faulty, so she is banned.
     let mut state = State::new(WEIGHTS, params, vec![ALICE]);
@@ -776,7 +780,10 @@ fn conflicting_endorsements() -> Result<(), AddUnitError<TestContext>> {
         .opt_evidence(BOB)
         .expect("Bob should be considered faulty")
         .clone();
-    assert_eq!(Ok(()), evidence.validate(&validators, &TEST_INSTANCE_ID));
+    assert_eq!(
+        Ok(()),
+        evidence.validate(&validators, &TEST_INSTANCE_ID, &state)
+    );
 
     Ok(())
 }

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -240,7 +240,7 @@ fn ban_and_mark_faulty() -> Result<(), AddUnitError<TestContext>> {
         19,
         4,
         u64::MAX,
-        Timestamp::from(u64::MAX),
+        Timestamp::zero(),
         Timestamp::from(u64::MAX),
     );
     // Everyone already knows Alice is faulty, so she is banned.

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -12,6 +12,7 @@ use crate::{
     components::consensus::{
         highway_core::{
             endorsement::{Endorsement, SignedEndorsement},
+            evidence::EvidenceError,
             highway::{Dependency, Endorsements},
             highway_testing::{
                 TEST_BLOCK_REWARD, TEST_ENDORSEMENT_EVIDENCE_LIMIT, TEST_INSTANCE_ID,
@@ -115,22 +116,25 @@ impl<C: Context> SignedWireUnit<C> {
     }
 }
 
+fn test_params(seed: u64) -> Params {
+    Params::new(
+        seed,
+        TEST_BLOCK_REWARD,
+        TEST_BLOCK_REWARD / 5,
+        TEST_MIN_ROUND_EXP,
+        TEST_MAX_ROUND_EXP,
+        TEST_INIT_ROUND_EXP,
+        TEST_ERA_HEIGHT,
+        Timestamp::from(0),
+        Timestamp::from(0),
+        TEST_ENDORSEMENT_EVIDENCE_LIMIT,
+    )
+}
+
 impl State<TestContext> {
     /// Returns a new `State` with `TestContext` parameters suitable for tests.
     pub(crate) fn new_test(weights: &[Weight], seed: u64) -> Self {
-        let params = Params::new(
-            seed,
-            TEST_BLOCK_REWARD,
-            TEST_BLOCK_REWARD / 5,
-            TEST_MIN_ROUND_EXP,
-            TEST_MAX_ROUND_EXP,
-            TEST_INIT_ROUND_EXP,
-            TEST_ERA_HEIGHT,
-            Timestamp::from(0),
-            Timestamp::from(0),
-            TEST_ENDORSEMENT_EVIDENCE_LIMIT,
-        );
-        State::new(weights, params, vec![])
+        State::new(weights, test_params(seed), vec![])
     }
 
     /// Adds the unit to the protocol state, or returns an error if it is invalid.
@@ -783,6 +787,39 @@ fn conflicting_endorsements() -> Result<(), AddUnitError<TestContext>> {
     assert_eq!(
         Ok(()),
         evidence.validate(&validators, &TEST_INSTANCE_ID, &state)
+    );
+
+    let limit = TEST_ENDORSEMENT_EVIDENCE_LIMIT as usize;
+
+    let mut a = vec![a0, a1, a2];
+    while a.len() <= limit + 1 {
+        let prev_a = *a.last().unwrap();
+        a.push(add_unit!(state, rng, ALICE, None; prev_a, N, N)?);
+    }
+
+    // Carol endorses a0_prime.
+    endorse!(state, rng, CAROL, a0_prime);
+
+    // She also endorses a[limit + 1], and gets away with it because the evidence would be too big.
+    endorse!(state, rng, CAROL, a[limit + 1]);
+    assert!(!state.is_faulty(CAROL));
+
+    // But if she endorses a[limit], the units fit into an evidence vertex.
+    endorse!(state, rng, CAROL, a[limit]);
+    assert!(state.is_faulty(CAROL));
+
+    let evidence = state.opt_evidence(CAROL).expect("Carol is faulty").clone();
+    assert_eq!(
+        Ok(()),
+        evidence.validate(&validators, &TEST_INSTANCE_ID, &state)
+    );
+
+    // If the limit were less, that evidence would be considered invalid.
+    let params2 = test_params(0).with_endorsement_evidence_limit(limit as u64 - 1);
+    let state2 = State::new(WEIGHTS, params2, vec![]);
+    assert_eq!(
+        Err(EvidenceError::EndorsementTooManyUnits),
+        evidence.validate(&validators, &TEST_INSTANCE_ID, &state2)
     );
 
     Ok(())

--- a/node/src/components/consensus/highway_core/test_macros.rs
+++ b/node/src/components/consensus/highway_core/test_macros.rs
@@ -51,7 +51,7 @@ macro_rules! add_unit {
             .map(|unit| unit.timestamp + TimeDiff::from(1))
             .chain(two_units_limit)
             .max()
-            .unwrap_or_else(Timestamp::zero);
+            .unwrap_or($state.params().start_timestamp());
         // If this is a block: Find the next time we're a leader.
         if value.is_some() {
             let r_len = TimeDiff::from(1 << round_exp);

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -37,6 +37,7 @@ pub(crate) fn new_test_state(weights: &[state::Weight], seed: u64) -> State<ClCo
         u64::MAX,
         0.into(),
         Timestamp::from(u64::MAX),
+        highway_testing::TEST_ENDORSEMENT_EVIDENCE_LIMIT,
     );
     state::State::new(weights, params, vec![])
 }


### PR DESCRIPTION
We will need an upper limit for the size of our messages, and evidence of someone endorsing two conflicting forks includes a list of units. Limiting the number of entries in that list lets you get away with endorsing two conflicting forks at sequence numbers that differ by more than this. It still prevents the _exponential_ number of forks in the "fork bomb" scenario, though.

This PR also makes units invalid whose timestamp is before the beginning of the era. Together with the limit of two units per round, and the minimum round length, this effectively limits the sequence numbers. Thus even the linear increase in the number of conflicting forks that could be endorsed only becomes relevant after sufficiently many rounds have passed.

In `HighwayProtocol` we set the limit to roughly the expected number of units per validator per era.

https://casperlabs.atlassian.net/browse/HWY-212