### PR TITLE
NDRS-622: add address-gossiper to libp2p network component

### DIFF
--- a/node/src/components/network/behavior.rs
+++ b/node/src/components/network/behavior.rs
@@ -1,11 +1,12 @@
 use derive_more::From;
 use libp2p::{
     ping::{Ping, PingConfig, PingEvent},
-    NetworkBehaviour,
+    Multiaddr, NetworkBehaviour,
 };
 
 use super::{
-    Config, OneWayIncomingMessage, OneWayMessageBehavior, OneWayOutgoingMessage, PayloadT,
+    Config, GossipBehavior, ListeningAddresses, OneWayIncomingMessage, OneWayMessageBehavior,
+    OneWayOutgoingMessage, PayloadT,
 };
 use crate::{components::chainspec_loader::Chainspec, types::NodeId};
 
@@ -16,6 +17,8 @@ pub(super) enum SwarmBehaviorEvent<P: PayloadT> {
     #[from]
     OneWayMessage(OneWayIncomingMessage<P>),
     #[from]
+    AddressesGossiper(ListeningAddresses),
+    #[from]
     Ping(PingEvent),
 }
 
@@ -25,20 +28,29 @@ pub(super) enum SwarmBehaviorEvent<P: PayloadT> {
 #[behaviour(out_event = "SwarmBehaviorEvent<P>", event_process = false)]
 pub(super) struct Behavior<P: PayloadT> {
     one_way_message_behavior: OneWayMessageBehavior<P>,
+    addresses_gossiper: GossipBehavior,
     ping: Ping,
 }
 
 impl<P: PayloadT> Behavior<P> {
     pub(super) fn new(config: &Config, chainspec: &Chainspec, our_id: NodeId) -> Self {
-        let one_way_message_behavior = OneWayMessageBehavior::new(&config, chainspec, our_id);
+        let one_way_message_behavior =
+            OneWayMessageBehavior::new(config, chainspec, our_id.clone());
+        let addresses_gossiper = GossipBehavior::new(config, our_id);
         let ping = Ping::new(PingConfig::new().with_keep_alive(true));
         Behavior {
             one_way_message_behavior,
+            addresses_gossiper,
             ping,
         }
     }
 
     pub(super) fn send_one_way_message(&mut self, outgoing_message: OneWayOutgoingMessage<P>) {
         self.one_way_message_behavior.send_message(outgoing_message);
+    }
+
+    pub(super) fn gossip_our_listening_addresses(&mut self, listening_addresses: Vec<Multiaddr>) {
+        self.addresses_gossiper
+            .publish_our_addresses(listening_addresses);
     }
 }

--- a/node/src/components/network/error.rs
+++ b/node/src/components/network/error.rs
@@ -8,7 +8,15 @@ use thiserror::Error;
 pub enum Error {
     /// Invalid configuration: must have at least one known address.
     #[error("config must have at least one known address")]
-    InvalidConfig,
+    NoKnownAddress,
+
+    /// Invalid configuration: gossip_address_interval must not be less than
+    /// gossip_duplicate_cache_timeout.
+    #[error(
+        "gossip_address_interval must not be less than gossip_duplicate_cache_timeout so that \
+        gossiped addresses are not blocked as duplicates"
+    )]
+    InvalidAddressGossipConfig,
 
     /// Signing libp2p-noise static ID keypair failed.
     #[error("signing libp2p-noise static ID keypair failed: {0}")]

--- a/node/src/components/network/gossip.rs
+++ b/node/src/components/network/gossip.rs
@@ -1,0 +1,272 @@
+//! This module is home to the libp2p `GossipSub` behavior, used for gossiping this node's listening
+//! addresses in order to allow peers to discover and connect to it.
+
+use std::{
+    error::Error as StdError,
+    io,
+    task::{Context, Poll},
+};
+
+use libp2p::{
+    core::{
+        connection::{ConnectionId, ListenerId},
+        ConnectedPoint,
+    },
+    gossipsub::{
+        Gossipsub, GossipsubConfigBuilder, GossipsubEvent, MessageAuthenticity, Topic,
+        ValidationMode,
+    },
+    swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters, ProtocolsHandler},
+    Multiaddr, PeerId,
+};
+use once_cell::sync::Lazy;
+use tracing::{trace, warn};
+
+use crate::{components::network::Config, types::NodeId};
+
+static LISTENING_ADDRESSES_TOPIC: Lazy<Topic> =
+    Lazy::new(|| Topic::new("listening-addresses".into()));
+
+#[derive(Debug)]
+pub(in crate::components::network) struct ListeningAddresses {
+    pub source: PeerId,
+    pub addresses: Vec<Multiaddr>,
+}
+
+/// Implementor of the libp2p `NetworkBehaviour` for gossiping addresses.
+pub(in crate::components::network) struct Behavior {
+    gossipsub: Gossipsub,
+    our_id: NodeId,
+}
+
+impl Behavior {
+    pub(in crate::components::network) fn new(config: &Config, our_id: NodeId) -> Self {
+        let gossipsub_config = GossipsubConfigBuilder::new()
+            .heartbeat_interval(config.gossip_heartbeat_interval.into())
+            .max_transmit_size(config.gossip_max_message_size as usize)
+            .duplicate_cache_time(config.gossip_duplicate_cache_timeout.into())
+            .validation_mode(ValidationMode::Permissive)
+            .build();
+        let our_peer_id = match &our_id {
+            NodeId::P2p(peer_id) => peer_id.clone(),
+            _ => unreachable!(),
+        };
+        let mut gossipsub =
+            Gossipsub::new(MessageAuthenticity::Author(our_peer_id), gossipsub_config);
+        gossipsub.subscribe(LISTENING_ADDRESSES_TOPIC.clone());
+        Behavior { gossipsub, our_id }
+    }
+
+    /// Gossips our listening addresses.
+    pub(in crate::components::network) fn publish_our_addresses(
+        &mut self,
+        listening_addresses: Vec<Multiaddr>,
+    ) {
+        let serialized_message = bincode::serialize(&listening_addresses).unwrap_or_else(|error| {
+            warn!(
+                %error,
+                message = ?listening_addresses,
+                "{}: failed to serialize",
+                self.our_id
+            );
+            vec![]
+        });
+
+        if let Err(error) = self
+            .gossipsub
+            .publish(&*LISTENING_ADDRESSES_TOPIC, serialized_message)
+        {
+            warn!(?error, "{}: failed to gossip our addresses", self.our_id);
+        } else {
+            trace!("{}: gossiped our addresses", self.our_id);
+        }
+    }
+
+    /// Called when `self.gossipsub` generates an event.
+    ///
+    /// Returns a peer's listening addresses if the event provided any.
+    fn handle_generated_event(&mut self, event: GossipsubEvent) -> Option<ListeningAddresses> {
+        match event {
+            GossipsubEvent::Message(received_from, _, message) => {
+                trace!(?message, "{}: received addresses via gossip", self.our_id);
+
+                let source = match &message.source {
+                    Some(peer_id) => peer_id.clone(),
+                    None => {
+                        warn!(
+                            ?message,
+                            "{}: received gossiped listening addresses with no source ID",
+                            self.our_id
+                        );
+                        return None;
+                    }
+                };
+
+                match bincode::deserialize::<Vec<Multiaddr>>(&message.data) {
+                    Ok(addresses) => {
+                        let listening_addresses = ListeningAddresses { source, addresses };
+                        return Some(listening_addresses);
+                    }
+                    Err(error) => warn!(
+                        %received_from,
+                        ?message,
+                        ?error,
+                        "{}: failed to deserialize gossiped message",
+                        self.our_id
+                    ),
+                }
+            }
+            GossipsubEvent::Subscribed { peer_id, topic } => {
+                trace!(%peer_id, %topic, "{}: peer subscribed to gossip topic", self.our_id)
+            }
+            GossipsubEvent::Unsubscribed { peer_id, topic } => {
+                trace!(%peer_id, %topic, "{}: peer unsubscribed from gossip topic", self.our_id)
+            }
+        }
+        None
+    }
+}
+
+impl NetworkBehaviour for Behavior {
+    type ProtocolsHandler = <Gossipsub as NetworkBehaviour>::ProtocolsHandler;
+    type OutEvent = ListeningAddresses;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        self.gossipsub.new_handler()
+    }
+
+    fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        self.gossipsub.addresses_of_peer(peer_id)
+    }
+
+    fn inject_connected(&mut self, peer_id: &PeerId) {
+        self.gossipsub.inject_connected(peer_id);
+    }
+
+    fn inject_disconnected(&mut self, peer_id: &PeerId) {
+        self.gossipsub.inject_disconnected(peer_id);
+    }
+
+    fn inject_connection_established(
+        &mut self,
+        peer_id: &PeerId,
+        connection_id: &ConnectionId,
+        endpoint: &ConnectedPoint,
+    ) {
+        self.gossipsub
+            .inject_connection_established(peer_id, connection_id, endpoint);
+    }
+
+    fn inject_address_change(
+        &mut self,
+        peer_id: &PeerId,
+        connection_id: &ConnectionId,
+        old: &ConnectedPoint,
+        new: &ConnectedPoint,
+    ) {
+        self.gossipsub
+            .inject_address_change(peer_id, connection_id, old, new);
+    }
+
+    fn inject_connection_closed(
+        &mut self,
+        peer_id: &PeerId,
+        connection_id: &ConnectionId,
+        endpoint: &ConnectedPoint,
+    ) {
+        self.gossipsub
+            .inject_connection_closed(peer_id, connection_id, endpoint);
+    }
+
+    fn inject_addr_reach_failure(
+        &mut self,
+        peer_id: Option<&PeerId>,
+        addr: &Multiaddr,
+        error: &dyn StdError,
+    ) {
+        self.gossipsub
+            .inject_addr_reach_failure(peer_id, addr, error);
+    }
+
+    fn inject_dial_failure(&mut self, peer_id: &PeerId) {
+        self.gossipsub.inject_dial_failure(peer_id);
+    }
+
+    fn inject_new_listen_addr(&mut self, addr: &Multiaddr) {
+        self.gossipsub.inject_new_listen_addr(addr);
+    }
+
+    fn inject_expired_listen_addr(&mut self, addr: &Multiaddr) {
+        self.gossipsub.inject_expired_listen_addr(addr);
+    }
+
+    fn inject_new_external_addr(&mut self, addr: &Multiaddr) {
+        self.gossipsub.inject_new_external_addr(addr);
+    }
+
+    fn inject_listener_error(&mut self, id: ListenerId, err: &(dyn StdError + 'static)) {
+        self.gossipsub.inject_listener_error(id, err);
+    }
+
+    fn inject_listener_closed(&mut self, id: ListenerId, reason: Result<(), &io::Error>) {
+        self.gossipsub.inject_listener_closed(id, reason);
+    }
+
+    fn inject_event(
+        &mut self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        event: <Self::ProtocolsHandler as ProtocolsHandler>::OutEvent,
+    ) {
+        self.gossipsub.inject_event(peer_id, connection_id, event);
+    }
+
+    fn poll(
+        &mut self,
+        context: &mut Context,
+        poll_params: &mut impl PollParameters,
+    ) -> Poll<
+        NetworkBehaviourAction<
+            <Self::ProtocolsHandler as ProtocolsHandler>::InEvent,
+            Self::OutEvent,
+        >,
+    > {
+        // Simply pass most action variants though.  We're only interested in the `GeneratedEvent`
+        // variant.  These can be all be handled without needing to return `Poll::Ready` until we
+        // get an incoming message event.
+        loop {
+            match self.gossipsub.poll(context, poll_params) {
+                Poll::Ready(NetworkBehaviourAction::GenerateEvent(event)) => {
+                    if let Some(listening_addresses) = self.handle_generated_event(event) {
+                        return Poll::Ready(NetworkBehaviourAction::GenerateEvent(
+                            listening_addresses,
+                        ));
+                    }
+                }
+                Poll::Ready(NetworkBehaviourAction::DialAddress { address }) => {
+                    warn!(%address, "should not dial address via addresses-gossiper behavior");
+                    return Poll::Ready(NetworkBehaviourAction::DialAddress { address });
+                }
+                Poll::Ready(NetworkBehaviourAction::DialPeer { peer_id, condition }) => {
+                    warn!(%peer_id, "should not dial peer via addresses-gossiper behavior");
+                    return Poll::Ready(NetworkBehaviourAction::DialPeer { peer_id, condition });
+                }
+                Poll::Ready(NetworkBehaviourAction::NotifyHandler {
+                    peer_id,
+                    handler,
+                    event,
+                }) => {
+                    return Poll::Ready(NetworkBehaviourAction::NotifyHandler {
+                        peer_id,
+                        handler,
+                        event,
+                    });
+                }
+                Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address }) => {
+                    return Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address });
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}

--- a/node/src/components/network/one_way_message/message.rs
+++ b/node/src/components/network/one_way_message/message.rs
@@ -54,7 +54,7 @@ pub struct Codec {
 impl From<&Config> for Codec {
     fn from(config: &Config) -> Self {
         Codec {
-            max_message_size: config.max_message_size,
+            max_message_size: config.max_one_way_message_size,
         }
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -418,7 +418,7 @@ impl<REv> EffectBuilder<REv> {
     /// Usually causes the node to cease operations quickly and exit/crash.
     //
     // Note: This function is implemented manually without `async` sugar because the `Send`
-    // inferrence seems to not work in all cases otherwise.
+    // inference seems to not work in all cases otherwise.
     pub fn fatal(self, file: &str, line: u32, msg: String) -> impl Future<Output = ()> + Send {
         panic!("fatal error [{}:{}]: {}", file, line, msg);
         #[allow(unreachable_code)]


### PR DESCRIPTION
This change means the `network` component now matches the `small_network` in terms of behaviour.  