### PR TITLE
EE-1126: rename AuctionInfo to EraInfo

### DIFF
--- a/execution_engine/src/core/resolvers/v1_function_index.rs
+++ b/execution_engine/src/core/resolvers/v1_function_index.rs
@@ -51,7 +51,7 @@ pub enum FunctionIndex {
     RemoveContractUserGroupURefsIndex,
     Blake2b,
     RecordTransfer,
-    RecordAuctionInfo,
+    RecordEraInfo,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution_engine/src/core/resolvers/v1_resolver.rs
+++ b/execution_engine/src/core/resolvers/v1_resolver.rs
@@ -212,9 +212,9 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 8][..], Some(ValueType::I32)),
                 FunctionIndex::RecordTransfer.into(),
             ),
-            "casper_record_auction_info" => FuncInstance::alloc_host(
+            "casper_record_era_info" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
-                FunctionIndex::RecordAuctionInfo.into(),
+                FunctionIndex::RecordEraInfo.into(),
             ),
             #[cfg(feature = "test-support")]
             "casper_print" => FuncInstance::alloc_host(

--- a/execution_engine/src/core/runtime/auction_internal.rs
+++ b/execution_engine/src/core/runtime/auction_internal.rs
@@ -1,9 +1,7 @@
 use casper_types::{
     account,
     account::AccountHash,
-    auction::{
-        Auction, AuctionInfo, MintProvider, RuntimeProvider, StorageProvider, SystemProvider,
-    },
+    auction::{Auction, EraInfo, MintProvider, RuntimeProvider, StorageProvider, SystemProvider},
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::auction::Error,
     ApiError, CLTyped, CLValue, Key, TransferredTo, URef, BLAKE2B_DIGEST_LENGTH, U512,
@@ -66,9 +64,8 @@ where
         }
     }
 
-    fn record_auction_info(&mut self, era_id: u64, auction_info: AuctionInfo) -> Result<(), Error> {
-        Runtime::record_auction_info(self, era_id, auction_info)
-            .map_err(|_| Error::RecordAuctionInfo)
+    fn record_era_info(&mut self, era_id: u64, era_info: EraInfo) -> Result<(), Error> {
+        Runtime::record_era_info(self, era_id, era_info).map_err(|_| Error::RecordEraInfo)
     }
 }
 

--- a/execution_engine/src/core/runtime/externals.rs
+++ b/execution_engine/src/core/runtime/externals.rs
@@ -6,7 +6,7 @@ use casper_types::{
     account,
     account::AccountHash,
     api_error,
-    auction::{AuctionInfo, EraId},
+    auction::{EraId, EraInfo},
     bytesrepr::{self, ToBytes},
     contracts::{EntryPoints, NamedKeys},
     ContractHash, ContractPackageHash, ContractVersion, Group, Key, URef, U512,
@@ -977,23 +977,17 @@ where
                 Ok(Some(RuntimeValue::I32(0)))
             }
 
-            FunctionIndex::RecordAuctionInfo => {
-                // RecordAuctionInfo is a special cased internal host function only callable by the
+            FunctionIndex::RecordEraInfo => {
+                // RecordEraInfo is a special cased internal host function only callable by the
                 // auction contract and for accounting purposes it isn't represented in protocol
                 // data.
-                let (era_id_ptr, era_id_size, auction_info_ptr, auction_info_size): (
-                    u32,
-                    u32,
-                    u32,
-                    u32,
-                ) = Args::parse(args)?;
+                let (era_id_ptr, era_id_size, era_info_ptr, era_info_size): (u32, u32, u32, u32) =
+                    Args::parse(args)?;
                 scoped_instrumenter.add_property("era_id_size", era_id_size.to_string());
-                scoped_instrumenter
-                    .add_property("auction_info_size", auction_info_size.to_string());
+                scoped_instrumenter.add_property("era_info_size", era_info_size.to_string());
                 let era_id: EraId = self.t_from_mem(era_id_ptr, era_id_size)?;
-                let auction_info: AuctionInfo =
-                    self.t_from_mem(auction_info_ptr, auction_info_size)?;
-                self.record_auction_info(era_id, auction_info)?;
+                let era_info: EraInfo = self.t_from_mem(era_info_ptr, era_info_size)?;
+                self.record_era_info(era_id, era_info)?;
                 Ok(Some(RuntimeValue::I32(0)))
             }
         }

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -19,7 +19,7 @@ use wasmi::{ImportsBuilder, MemoryRef, ModuleInstance, ModuleRef, Trap, TrapKind
 
 use casper_types::{
     account::{AccountHash, ActionType, Weight},
-    auction::{self, Auction, AuctionInfo, EraId},
+    auction::{self, Auction, EraId, EraInfo},
     bytesrepr::{self, FromBytes, ToBytes},
     contracts::{
         self, Contract, ContractPackage, ContractVersion, ContractVersions, DisabledVersions,
@@ -108,7 +108,7 @@ pub fn key_to_tuple(key: Key) -> Option<([u8; 32], AccessRights)> {
         Key::Hash(_) => None,
         Key::Transfer(_) => None,
         Key::DeployInfo(_) => None,
-        Key::AuctionInfo(_) => None,
+        Key::EraInfo(_) => None,
     }
 }
 
@@ -2455,11 +2455,7 @@ where
     }
 
     /// Records given auction info at a given era id
-    fn record_auction_info(
-        &mut self,
-        era_id: EraId,
-        auction_info: AuctionInfo,
-    ) -> Result<(), Error> {
+    fn record_era_info(&mut self, era_id: EraId, era_info: EraInfo) -> Result<(), Error> {
         if self.context.base_key() != Key::from(self.protocol_data().auction()) {
             return Err(Error::InvalidContext);
         }
@@ -2468,8 +2464,7 @@ where
             return Ok(());
         }
 
-        self.context
-            .write_auction_info(Key::AuctionInfo(era_id), auction_info);
+        self.context.write_era_info(Key::EraInfo(era_id), era_info);
 
         Ok(())
     }

--- a/execution_engine/src/core/runtime/scoped_instrumenter.rs
+++ b/execution_engine/src/core/runtime/scoped_instrumenter.rs
@@ -141,7 +141,7 @@ impl Drop for ScopedInstrumenter {
             }
             FunctionIndex::Blake2b => "host_blake2b",
             FunctionIndex::RecordTransfer => "host_record_transfer",
-            FunctionIndex::RecordAuctionInfo => "host_record_auction",
+            FunctionIndex::RecordEraInfo => "host_record_era_info",
         };
 
         let mut properties = mem::take(&mut self.properties);

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -16,7 +16,7 @@ use casper_types::{
         AccountHash, ActionType, AddKeyFailure, RemoveKeyFailure, SetThresholdFailure,
         UpdateKeyFailure, Weight,
     },
-    auction::AuctionInfo,
+    auction::EraInfo,
     bytesrepr,
     bytesrepr::ToBytes,
     contracts::NamedKeys,
@@ -247,10 +247,10 @@ where
                 // Users cannot remove deploy infos from global state
                 Ok(())
             }
-            auction_info_addr @ Key::AuctionInfo(_) => {
-                let _auction_info: AuctionInfo = self.read_gs_typed(&auction_info_addr)?;
+            era_info_addr @ Key::EraInfo(_) => {
+                let _era_info: EraInfo = self.read_gs_typed(&era_info_addr)?;
                 self.named_keys.remove(name);
-                // Users cannot remove auction infos from global state
+                // Users cannot remove era infos from global state
                 Ok(())
             }
         }
@@ -484,13 +484,13 @@ where
         }
     }
 
-    pub fn write_auction_info(&mut self, key: Key, value: AuctionInfo) {
-        if let Key::AuctionInfo(_) = key {
+    pub fn write_era_info(&mut self, key: Key, value: EraInfo) {
+        if let Key::EraInfo(_) = key {
             self.tracking_copy
                 .borrow_mut()
-                .write(key, StoredValue::AuctionInfo(value));
+                .write(key, StoredValue::EraInfo(value));
         } else {
-            panic!("Do not use this function for writing non-auction-info keys")
+            panic!("Do not use this function for writing non-era-info keys")
         }
     }
 
@@ -595,7 +595,7 @@ where
             StoredValue::ContractPackage(_) => Ok(()),
             StoredValue::Transfer(_) => Ok(()),
             StoredValue::DeployInfo(_) => Ok(()),
-            StoredValue::AuctionInfo(_) => Ok(()),
+            StoredValue::EraInfo(_) => Ok(()),
         }
     }
 
@@ -681,7 +681,7 @@ where
             Key::URef(uref) => uref.is_readable(),
             Key::Transfer(_) => true,
             Key::DeployInfo(_) => true,
-            Key::AuctionInfo(_) => true,
+            Key::EraInfo(_) => true,
         }
     }
 
@@ -692,7 +692,7 @@ where
             Key::URef(uref) => uref.is_addable(),
             Key::Transfer(_) => false,
             Key::DeployInfo(_) => false,
-            Key::AuctionInfo(_) => false,
+            Key::EraInfo(_) => false,
         }
     }
 
@@ -703,7 +703,7 @@ where
             Key::URef(uref) => uref.is_writeable(),
             Key::Transfer(_) => false,
             Key::DeployInfo(_) => false,
-            Key::AuctionInfo(_) => false,
+            Key::EraInfo(_) => false,
         }
     }
 

--- a/execution_engine/src/core/tracking_copy/byte_size.rs
+++ b/execution_engine/src/core/tracking_copy/byte_size.rs
@@ -42,7 +42,7 @@ impl ByteSize for StoredValue {
                 }
                 StoredValue::DeployInfo(deploy_info) => deploy_info.serialized_length(),
                 StoredValue::Transfer(transfer) => transfer.serialized_length(),
-                StoredValue::AuctionInfo(auction_info) => auction_info.serialized_length(),
+                StoredValue::EraInfo(era_info) => era_info.serialized_length(),
             }
     }
 }

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -424,8 +424,8 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
                 StoredValue::DeployInfo(_) => {
                     return Ok(query.into_not_found_result(&"DeployInfo value found."));
                 }
-                StoredValue::AuctionInfo(_) => {
-                    return Ok(query.into_not_found_result(&"AuctionInfo value found."));
+                StoredValue::EraInfo(_) => {
+                    return Ok(query.into_not_found_result(&"EraInfo value found."));
                 }
             }
         }

--- a/execution_engine/src/shared/stored_value.rs
+++ b/execution_engine/src/shared/stored_value.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use casper_types::{
-    auction::AuctionInfo,
+    auction::EraInfo,
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     contracts::ContractPackage,
     CLValue, Contract, ContractWasm, DeployInfo, Transfer,
@@ -18,7 +18,7 @@ enum Tag {
     ContractPackage = 4,
     Transfer = 5,
     DeployInfo = 6,
-    AuctionInfo = 7,
+    EraInfo = 7,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]
@@ -30,7 +30,7 @@ pub enum StoredValue {
     ContractPackage(ContractPackage),
     Transfer(Transfer),
     DeployInfo(DeployInfo),
-    AuctionInfo(AuctionInfo),
+    EraInfo(EraInfo),
 }
 
 impl StoredValue {
@@ -76,9 +76,9 @@ impl StoredValue {
         }
     }
 
-    pub fn as_auction_info(&self) -> Option<&AuctionInfo> {
+    pub fn as_era_info(&self) -> Option<&EraInfo> {
         match self {
-            StoredValue::AuctionInfo(auction_info) => Some(auction_info),
+            StoredValue::EraInfo(era_info) => Some(era_info),
             _ => None,
         }
     }
@@ -92,7 +92,7 @@ impl StoredValue {
             StoredValue::ContractPackage(_) => "ContractPackage".to_string(),
             StoredValue::Transfer(_) => "Transfer".to_string(),
             StoredValue::DeployInfo(_) => "DeployInfo".to_string(),
-            StoredValue::AuctionInfo(_) => "AuctionInfo".to_string(),
+            StoredValue::EraInfo(_) => "EraInfo".to_string(),
         }
     }
 }
@@ -218,16 +218,13 @@ impl TryFrom<StoredValue> for DeployInfo {
     }
 }
 
-impl TryFrom<StoredValue> for AuctionInfo {
+impl TryFrom<StoredValue> for EraInfo {
     type Error = TypeMismatch;
 
     fn try_from(value: StoredValue) -> Result<Self, Self::Error> {
         match value {
-            StoredValue::AuctionInfo(auction_info) => Ok(auction_info),
-            _ => Err(TypeMismatch::new(
-                "AuctionInfo".to_string(),
-                value.type_name(),
-            )),
+            StoredValue::EraInfo(era_info) => Ok(era_info),
+            _ => Err(TypeMismatch::new("EraInfo".to_string(), value.type_name())),
         }
     }
 }
@@ -247,7 +244,7 @@ impl ToBytes for StoredValue {
             }
             StoredValue::Transfer(transfer) => (Tag::Transfer, transfer.to_bytes()?),
             StoredValue::DeployInfo(deploy_info) => (Tag::DeployInfo, deploy_info.to_bytes()?),
-            StoredValue::AuctionInfo(auction_info) => (Tag::AuctionInfo, auction_info.to_bytes()?),
+            StoredValue::EraInfo(era_info) => (Tag::EraInfo, era_info.to_bytes()?),
         };
         result.push(tag as u8);
         result.append(&mut serialized_data);
@@ -266,7 +263,7 @@ impl ToBytes for StoredValue {
                 }
                 StoredValue::Transfer(transfer) => transfer.serialized_length(),
                 StoredValue::DeployInfo(deploy_info) => deploy_info.serialized_length(),
-                StoredValue::AuctionInfo(auction_info) => auction_info.serialized_length(),
+                StoredValue::EraInfo(era_info) => era_info.serialized_length(),
             }
     }
 }
@@ -295,8 +292,8 @@ impl FromBytes for StoredValue {
                 .map(|(transfer, remainder)| (StoredValue::Transfer(transfer), remainder)),
             tag if tag == Tag::DeployInfo as u8 => DeployInfo::from_bytes(remainder)
                 .map(|(deploy_info, remainder)| (StoredValue::DeployInfo(deploy_info), remainder)),
-            tag if tag == Tag::AuctionInfo as u8 => AuctionInfo::from_bytes(remainder)
-                .map(|(deploy_info, remainder)| (StoredValue::AuctionInfo(deploy_info), remainder)),
+            tag if tag == Tag::EraInfo as u8 => EraInfo::from_bytes(remainder)
+                .map(|(deploy_info, remainder)| (StoredValue::EraInfo(deploy_info), remainder)),
             _ => Err(bytesrepr::Error::Formatting),
         }
     }

--- a/execution_engine/src/shared/transform.rs
+++ b/execution_engine/src/shared/transform.rs
@@ -189,9 +189,9 @@ impl Transform {
                     let found = "DeployInfo".to_string();
                     Err(TypeMismatch::new(expected, found).into())
                 }
-                StoredValue::AuctionInfo(_) => {
+                StoredValue::EraInfo(_) => {
                     let expected = "Contract or Account".to_string();
-                    let found = "AuctionInfo".to_string();
+                    let found = "EraInfo".to_string();
                     Err(TypeMismatch::new(expected, found).into())
                 }
             },
@@ -326,8 +326,8 @@ impl From<&Transform> for casper_types::Transform {
             Transform::Write(StoredValue::DeployInfo(deploy_info)) => {
                 casper_types::Transform::WriteDeployInfo(deploy_info.clone())
             }
-            Transform::Write(StoredValue::AuctionInfo(auction_info)) => {
-                casper_types::Transform::WriteAuctionInfo(auction_info.clone())
+            Transform::Write(StoredValue::EraInfo(era_info)) => {
+                casper_types::Transform::WriteEraInfo(era_info.clone())
             }
             Transform::AddInt32(value) => casper_types::Transform::AddInt32(*value),
             Transform::AddUInt64(value) => casper_types::Transform::AddUInt64(*value),

--- a/grpc/server/protobuf/casper/state.proto
+++ b/grpc/server/protobuf/casper/state.proto
@@ -279,7 +279,7 @@ message SeigniorageAllocation {
     }
 }
 
-message AuctionInfo {
+message EraInfo {
     repeated SeigniorageAllocation seigniorage_allocations = 1;
 }
 
@@ -293,7 +293,7 @@ message StoredValue {
         ContractWasm contract_wasm = 5;
         Transfer transfer = 6;
         DeployInfo deploy_info = 7;
-        AuctionInfo auction_info = 8;
+        EraInfo era_info = 8;
     }
 }
 
@@ -332,7 +332,7 @@ message Key {
 		URef uref = 3;
 		TransferAddr transfer = 4;
 		DeployHash deploy_info = 5;
-		uint64 auction_info = 6;
+		uint64 era_info = 6;
 	}
 
 	message Address {

--- a/grpc/server/src/engine_server/mappings/state/auction_info.rs
+++ b/grpc/server/src/engine_server/mappings/state/auction_info.rs
@@ -5,7 +5,7 @@ use crate::engine_server::{
 };
 
 use casper_types::{
-    auction::{AuctionInfo, SeigniorageAllocation},
+    auction::{EraInfo, SeigniorageAllocation},
     bytesrepr::{self, ToBytes},
     U512,
 };
@@ -80,11 +80,11 @@ impl TryFrom<state::SeigniorageAllocation> for SeigniorageAllocation {
     }
 }
 
-impl From<AuctionInfo> for state::AuctionInfo {
-    fn from(auction_info: AuctionInfo) -> Self {
-        let mut ret = state::AuctionInfo::new();
+impl From<EraInfo> for state::EraInfo {
+    fn from(era_info: EraInfo) -> Self {
+        let mut ret = state::EraInfo::new();
         let mut pb_vec_seigniorage_allocations = Vec::new();
-        for allocation in auction_info.seigniorage_allocations().iter() {
+        for allocation in era_info.seigniorage_allocations().iter() {
             pb_vec_seigniorage_allocations.push(allocation.to_owned().into());
         }
         ret.set_seigniorage_allocations(pb_vec_seigniorage_allocations.into());
@@ -92,15 +92,15 @@ impl From<AuctionInfo> for state::AuctionInfo {
     }
 }
 
-impl TryFrom<state::AuctionInfo> for AuctionInfo {
+impl TryFrom<state::EraInfo> for EraInfo {
     type Error = ParsingError;
 
-    fn try_from(pb_auction_info: state::AuctionInfo) -> Result<Self, Self::Error> {
+    fn try_from(pb_era_info: state::EraInfo) -> Result<Self, Self::Error> {
         let mut seigniorage_allocations = Vec::new();
-        for pb_seigniorage_allocation in pb_auction_info.get_seigniorage_allocations().iter() {
+        for pb_seigniorage_allocation in pb_era_info.get_seigniorage_allocations().iter() {
             seigniorage_allocations.push(pb_seigniorage_allocation.to_owned().try_into()?);
         }
-        let mut ret = AuctionInfo::new();
+        let mut ret = EraInfo::new();
         *ret.seigniorage_allocations_mut() = seigniorage_allocations;
         Ok(ret)
     }

--- a/grpc/server/src/engine_server/mappings/state/key.rs
+++ b/grpc/server/src/engine_server/mappings/state/key.rs
@@ -34,7 +34,7 @@ impl From<Key> for state::Key {
                 pb_transfer_addr.set_transfer_addr(transfer_addr.value().to_vec());
                 pb_key.set_transfer(pb_transfer_addr)
             }
-            Key::AuctionInfo(era_id) => pb_key.set_auction_info(era_id),
+            Key::EraInfo(era_id) => pb_key.set_era_info(era_id),
         }
         pb_key
     }
@@ -75,7 +75,7 @@ impl TryFrom<state::Key> for Key {
                 )?);
                 Key::DeployInfo(deploy_hash)
             }
-            Key_oneof_value::auction_info(era_id) => Key::AuctionInfo(era_id),
+            Key_oneof_value::era_info(era_id) => Key::EraInfo(era_id),
         };
         Ok(key)
     }

--- a/grpc/server/src/engine_server/mappings/state/stored_value.rs
+++ b/grpc/server/src/engine_server/mappings/state/stored_value.rs
@@ -25,9 +25,7 @@ impl From<StoredValue> for state::StoredValue {
             }
             StoredValue::Transfer(transfer) => pb_value.set_transfer(transfer.into()),
             StoredValue::DeployInfo(deploy_info) => pb_value.set_deploy_info(deploy_info.into()),
-            StoredValue::AuctionInfo(auction_info) => {
-                pb_value.set_auction_info(auction_info.into())
-            }
+            StoredValue::EraInfo(era_info) => pb_value.set_era_info(era_info.into()),
         }
 
         pb_value
@@ -64,8 +62,8 @@ impl TryFrom<state::StoredValue> for StoredValue {
             StoredValue_oneof_variants::deploy_info(pb_deploy_info) => {
                 StoredValue::DeployInfo(pb_deploy_info.try_into()?)
             }
-            StoredValue_oneof_variants::auction_info(pb_auction_info) => {
-                StoredValue::AuctionInfo(pb_auction_info.try_into()?)
+            StoredValue_oneof_variants::era_info(pb_era_info) => {
+                StoredValue::EraInfo(pb_era_info.try_into()?)
             }
         };
 

--- a/grpc/tests/src/test/system_contracts/auction/distribute.rs
+++ b/grpc/tests/src/test/system_contracts/auction/distribute.rs
@@ -317,33 +317,33 @@ fn should_distribute_delegation_rate_zero() {
     );
     assert!(delegator_2_balance.is_zero());
 
-    let auction_info = {
+    let era_info = {
         let era = builder.get_era();
 
-        let auction_info_value = builder
-            .query(None, Key::AuctionInfo(era), &[])
+        let era_info_value = builder
+            .query(None, Key::EraInfo(era), &[])
             .expect("should have value");
 
-        auction_info_value
-            .as_auction_info()
+        era_info_value
+            .as_era_info()
             .cloned()
-            .expect("should be auction info")
+            .expect("should be era info")
     };
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_1).next(),
+        era_info.select(VALIDATOR_1).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_1).next(),
+        era_info.select(DELEGATOR_1).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_1 && *amount == expected_delegator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_2).next(),
+        era_info.select(DELEGATOR_2).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_2 && *amount == expected_delegator_1_balance
     ));
@@ -514,33 +514,33 @@ fn should_distribute_delegation_rate_half() {
     let total_payout = validator_1_balance + delegator_1_balance + delegator_2_balance;
     assert_eq!(total_payout, expected_total_reward_integer);
 
-    let auction_info = {
+    let era_info = {
         let era = builder.get_era();
 
-        let auction_info_value = builder
-            .query(None, Key::AuctionInfo(era), &[])
+        let era_info_value = builder
+            .query(None, Key::EraInfo(era), &[])
             .expect("should have value");
 
-        auction_info_value
-            .as_auction_info()
+        era_info_value
+            .as_era_info()
             .cloned()
-            .expect("should be auction info")
+            .expect("should be era info")
     };
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_1).next(),
+        era_info.select(VALIDATOR_1).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_1).next(),
+        era_info.select(DELEGATOR_1).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_1 && *amount == expected_delegator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_2).next(),
+        era_info.select(DELEGATOR_2).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_2 && *amount == expected_delegator_1_balance
     ));
@@ -702,33 +702,33 @@ fn should_distribute_delegation_rate_full() {
     let total_payout = validator_1_balance + delegator_1_balance + delegator_2_balance;
     assert_eq!(total_payout, expected_total_reward_integer);
 
-    let auction_info = {
+    let era_info = {
         let era = builder.get_era();
 
-        let auction_info_value = builder
-            .query(None, Key::AuctionInfo(era), &[])
+        let era_info_value = builder
+            .query(None, Key::EraInfo(era), &[])
             .expect("should have value");
 
-        auction_info_value
-            .as_auction_info()
+        era_info_value
+            .as_era_info()
             .cloned()
-            .expect("should be auction info")
+            .expect("should be era info")
     };
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_1).next(),
+        era_info.select(VALIDATOR_1).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_1).next(),
+        era_info.select(DELEGATOR_1).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_1 && *amount == expected_delegator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_2).next(),
+        era_info.select(DELEGATOR_2).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_2 && *amount == expected_delegator_1_balance
     ));
@@ -896,33 +896,33 @@ fn should_distribute_uneven_delegation_rate_zero() {
     let total_payout = validator_1_balance + delegator_1_balance + delegator_2_balance;
     assert_eq!(total_payout, expected_total_reward_integer);
 
-    let auction_info = {
+    let era_info = {
         let era = builder.get_era();
 
-        let auction_info_value = builder
-            .query(None, Key::AuctionInfo(era), &[])
+        let era_info_value = builder
+            .query(None, Key::EraInfo(era), &[])
             .expect("should have value");
 
-        auction_info_value
-            .as_auction_info()
+        era_info_value
+            .as_era_info()
             .cloned()
-            .expect("should be auction info")
+            .expect("should be era info")
     };
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_1).next(),
+        era_info.select(VALIDATOR_1).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_1).next(),
+        era_info.select(DELEGATOR_1).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_1 && *amount == expected_delegator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_2).next(),
+        era_info.select(DELEGATOR_2).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_2 && *amount == expected_delegator_2_balance
     ));
@@ -1087,33 +1087,33 @@ fn should_distribute_by_factor() {
     let rounded_amount = U512::from(2);
     assert_eq!(total_payout, expected_total_reward_integer - rounded_amount);
 
-    let auction_info = {
+    let era_info = {
         let era = builder.get_era();
 
-        let auction_info_value = builder
-            .query(None, Key::AuctionInfo(era), &[])
+        let era_info_value = builder
+            .query(None, Key::EraInfo(era), &[])
             .expect("should have value");
 
-        auction_info_value
-            .as_auction_info()
+        era_info_value
+            .as_era_info()
             .cloned()
-            .expect("should be auction info")
+            .expect("should be era info")
     };
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_1).next(),
+        era_info.select(VALIDATOR_1).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_2).next(),
+        era_info.select(VALIDATOR_2).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_2 && *amount == expected_validator_2_balance
     ));
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_3).next(),
+        era_info.select(VALIDATOR_3).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_3 && *amount == expected_validator_3_balance
     ));
@@ -1277,33 +1277,33 @@ fn should_distribute_by_factor_regardless_of_stake() {
     let rounded_amount = U512::from(2);
     assert_eq!(total_payout, expected_total_reward_integer - rounded_amount);
 
-    let auction_info = {
+    let era_info = {
         let era = builder.get_era();
 
-        let auction_info_value = builder
-            .query(None, Key::AuctionInfo(era), &[])
+        let era_info_value = builder
+            .query(None, Key::EraInfo(era), &[])
             .expect("should have value");
 
-        auction_info_value
-            .as_auction_info()
+        era_info_value
+            .as_era_info()
             .cloned()
-            .expect("should be auction info")
+            .expect("should be era info")
     };
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_1).next(),
+        era_info.select(VALIDATOR_1).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_2).next(),
+        era_info.select(VALIDATOR_2).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_2 && *amount == expected_validator_2_balance
     ));
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_3).next(),
+        era_info.select(VALIDATOR_3).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_3 && *amount == expected_validator_3_balance
     ));
@@ -1465,33 +1465,33 @@ fn should_distribute_by_factor_uneven() {
     let rounded_amount = U512::one();
     assert_eq!(total_payout, expected_total_reward_integer - rounded_amount);
 
-    let auction_info = {
+    let era_info = {
         let era = builder.get_era();
 
-        let auction_info_value = builder
-            .query(None, Key::AuctionInfo(era), &[])
+        let era_info_value = builder
+            .query(None, Key::EraInfo(era), &[])
             .expect("should have value");
 
-        auction_info_value
-            .as_auction_info()
+        era_info_value
+            .as_era_info()
             .cloned()
-            .expect("should be auction info")
+            .expect("should be era info")
     };
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_1).next(),
+        era_info.select(VALIDATOR_1).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_2).next(),
+        era_info.select(VALIDATOR_2).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_2 && *amount == expected_validator_2_balance
     ));
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_3).next(),
+        era_info.select(VALIDATOR_3).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_3 && *amount == expected_validator_3_balance
     ));
@@ -1754,51 +1754,51 @@ fn should_distribute_with_multiple_validators_and_delegators() {
 
     assert_eq!(total_payout, expected_total_reward_integer - remainder);
 
-    let auction_info = {
+    let era_info = {
         let era = builder.get_era();
 
-        let auction_info_value = builder
-            .query(None, Key::AuctionInfo(era), &[])
+        let era_info_value = builder
+            .query(None, Key::EraInfo(era), &[])
             .expect("should have value");
 
-        auction_info_value
-            .as_auction_info()
+        era_info_value
+            .as_era_info()
             .cloned()
-            .expect("should be auction info")
+            .expect("should be era info")
     };
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_1).next(),
+        era_info.select(VALIDATOR_1).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_1 && *amount == validator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_2).next(),
+        era_info.select(VALIDATOR_2).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_2 && *amount == validator_2_balance
     ));
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_3).next(),
+        era_info.select(VALIDATOR_3).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_3 && *amount == validator_3_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_1).next(),
+        era_info.select(DELEGATOR_1).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_1 && *amount == delegator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_2).next(),
+        era_info.select(DELEGATOR_2).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_2 && *amount == delegator_2_balance
     ));
 
     assert!(matches!(
-        auction_info.select(DELEGATOR_3).next(),
+        era_info.select(DELEGATOR_3).next(),
         Some(SeigniorageAllocation::Delegator { delegator_public_key, amount, .. })
         if *delegator_public_key == DELEGATOR_3 && *amount == delegator_3_balance
     ));
@@ -2089,39 +2089,39 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
 
     assert_eq!(total_payout, expected_total_reward_integer - remainder);
 
-    let auction_info = {
+    let era_info = {
         let era = builder.get_era();
 
-        let auction_info_value = builder
-            .query(None, Key::AuctionInfo(era), &[])
+        let era_info_value = builder
+            .query(None, Key::EraInfo(era), &[])
             .expect("should have value");
 
-        auction_info_value
-            .as_auction_info()
+        era_info_value
+            .as_era_info()
             .cloned()
-            .expect("should be auction info")
+            .expect("should be era info")
     };
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_1).next(),
+        era_info.select(VALIDATOR_1).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_1 && *amount == expected_validator_1_balance
     ));
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_2).next(),
+        era_info.select(VALIDATOR_2).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_2 && *amount == expected_validator_2_balance
     ));
 
     assert!(matches!(
-        auction_info.select(VALIDATOR_3).next(),
+        era_info.select(VALIDATOR_3).next(),
         Some(SeigniorageAllocation::Validator { validator_public_key, amount })
         if *validator_public_key == VALIDATOR_3 && *amount == expected_validator_3_balance
     ));
 
     let delegator_1_allocations: Vec<SeigniorageAllocation> =
-        auction_info.select(DELEGATOR_1).cloned().collect();
+        era_info.select(DELEGATOR_1).cloned().collect();
 
     assert_eq!(delegator_1_allocations.len(), 3);
 

--- a/node/src/types/json_compatibility/stored_value.rs
+++ b/node/src/types/json_compatibility/stored_value.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use casper_execution_engine::shared::stored_value::StoredValue as ExecutionEngineStoredValue;
 use casper_types::{
-    auction::AuctionInfo,
+    auction::EraInfo,
     bytesrepr::{self, ToBytes},
     CLValue, DeployInfo, Transfer,
 };
@@ -42,7 +42,7 @@ pub enum StoredValue {
     /// A record of a deploy
     DeployInfo(DeployInfo),
     /// Auction metadata
-    AuctionInfo(AuctionInfo),
+    EraInfo(EraInfo),
 }
 
 impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
@@ -65,9 +65,7 @@ impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
             ExecutionEngineStoredValue::DeployInfo(deploy_info) => {
                 StoredValue::DeployInfo(deploy_info.clone())
             }
-            ExecutionEngineStoredValue::AuctionInfo(auction_info) => {
-                StoredValue::AuctionInfo(auction_info.clone())
-            }
+            ExecutionEngineStoredValue::EraInfo(era_info) => StoredValue::EraInfo(era_info.clone()),
         };
 
         Ok(stored_value)

--- a/smart_contracts/contract/src/contract_api/system.rs
+++ b/smart_contracts/contract/src/contract_api/system.rs
@@ -6,7 +6,7 @@ use core::mem::MaybeUninit;
 use casper_types::{
     account::AccountHash,
     api_error,
-    auction::{AuctionInfo, EraId},
+    auction::{EraId, EraInfo},
     bytesrepr,
     system_contract_errors::auction,
     ApiError, ContractHash, SystemContractType, TransferResult, TransferredTo, URef, U512,
@@ -229,23 +229,18 @@ pub fn record_transfer(
     }
 }
 
-/// Records auction info.  Can only be called from within the auction contract.
+/// Records era info.  Can only be called from within the auction contract.
 /// Needed to support system contract-based execution.
 #[doc(hidden)]
-pub fn record_auction_info(era_id: EraId, auction_info: AuctionInfo) -> Result<(), ApiError> {
+pub fn record_era_info(era_id: EraId, era_info: EraInfo) -> Result<(), ApiError> {
     let (era_id_ptr, era_id_size, _bytes1) = contract_api::to_ptr(era_id);
-    let (auction_info_ptr, auction_info_size, _bytes2) = contract_api::to_ptr(auction_info);
+    let (era_info_ptr, era_info_size, _bytes2) = contract_api::to_ptr(era_info);
     let result = unsafe {
-        ext_ffi::casper_record_auction_info(
-            era_id_ptr,
-            era_id_size,
-            auction_info_ptr,
-            auction_info_size,
-        )
+        ext_ffi::casper_record_era_info(era_id_ptr, era_id_size, era_info_ptr, era_info_size)
     };
     if result == 0 {
         Ok(())
     } else {
-        Err(auction::Error::RecordAuctionInfo.into())
+        Err(auction::Error::RecordEraInfo.into())
     }
 }

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -421,20 +421,20 @@ extern "C" {
         id_ptr: *const u8,
         id_size: usize,
     ) -> i32;
-    /// Records auction info.  Can only be called from within the auction contract.
+    /// Records era info.  Can only be called from within the auction contract.
     /// Needed to support system contract-based execution.
     ///
     /// # Arguments
     ///
     /// * `era_id_ptr` - pointer in wasm memory to bytes representing the `EraId`
     /// * `era_id_size` - size of the `EraId` (in bytes)
-    /// * `auction_info_ptr` - pointer in wasm memory to bytes representing the `AuctionInfo`
-    /// * `auction_info_size` - size of the `AuctionInfo` (in bytes)
-    pub fn casper_record_auction_info(
+    /// * `era_info_ptr` - pointer in wasm memory to bytes representing the `EraInfo`
+    /// * `era_info_size` - size of the `EraInfo` (in bytes)
+    pub fn casper_record_era_info(
         era_id_ptr: *const u8,
         era_id_size: usize,
-        auction_info_ptr: *const u8,
-        auction_info_size: usize,
+        era_info_ptr: *const u8,
+        era_info_size: usize,
     ) -> i32;
     /// This function uses the mint contract's balance function to get the balance
     /// of the specified purse. It causes a `Trap` if the bytes in wasm memory

--- a/smart_contracts/contracts/system/auction/src/lib.rs
+++ b/smart_contracts/contracts/system/auction/src/lib.rs
@@ -13,7 +13,7 @@ use casper_contract::{
 use casper_types::{
     account::AccountHash,
     auction::{
-        Auction, AuctionInfo, DelegationRate, EraId, MintProvider, RuntimeProvider,
+        Auction, DelegationRate, EraId, EraInfo, MintProvider, RuntimeProvider,
         SeigniorageRecipients, StorageProvider, SystemProvider, ValidatorWeights, ARG_AMOUNT,
         ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_DELEGATOR_PUBLIC_KEY, ARG_PUBLIC_KEY,
         ARG_REWARD_FACTORS, ARG_SOURCE_PURSE, ARG_TARGET_PURSE, ARG_UNBOND_PURSE, ARG_VALIDATOR,
@@ -61,12 +61,8 @@ impl SystemProvider for AuctionContract {
         system::transfer_from_purse_to_purse(source, target, amount, None)
     }
 
-    fn record_auction_info(
-        &mut self,
-        era_id: EraId,
-        auction_info: AuctionInfo,
-    ) -> Result<(), Error> {
-        system::record_auction_info(era_id, auction_info).map_err(|_| Error::RecordAuctionInfo)
+    fn record_era_info(&mut self, era_id: EraId, era_info: EraInfo) -> Result<(), Error> {
+        system::record_era_info(era_id, era_info).map_err(|_| Error::RecordEraInfo)
     }
 }
 

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -1,9 +1,9 @@
 //! Contains implementation of a Auction contract functionality.
-mod auction_info;
 mod bid;
 mod constants;
 mod delegator;
 mod detail;
+mod era_info;
 mod providers;
 mod seigniorage_recipient;
 mod types;
@@ -19,10 +19,10 @@ use crate::{
     PublicKey, URef, U512,
 };
 
-pub use auction_info::*;
 pub use bid::Bid;
 pub use constants::*;
 pub use delegator::Delegator;
+pub use era_info::*;
 pub use providers::{MintProvider, RuntimeProvider, StorageProvider, SystemProvider};
 pub use seigniorage_recipient::SeigniorageRecipient;
 pub use types::*;
@@ -420,8 +420,8 @@ pub trait Auction:
             return Err(Error::MismatchedEraValidators);
         }
 
-        let mut auction_info = AuctionInfo::new();
-        let mut seigniorage_allocations = auction_info.seigniorage_allocations_mut();
+        let mut era_info = EraInfo::new();
+        let mut seigniorage_allocations = era_info.seigniorage_allocations_mut();
 
         for (public_key, reward_factor) in reward_factors {
             let recipient = seigniorage_recipients
@@ -510,7 +510,7 @@ pub trait Auction:
             .map_err(|_| Error::DelegatorRewardTransfer)?;
         }
 
-        self.record_auction_info(era_id, auction_info)?;
+        self.record_era_info(era_id, era_info)?;
 
         Ok(())
     }

--- a/types/src/auction/era_info.rs
+++ b/types/src/auction/era_info.rs
@@ -161,15 +161,15 @@ impl CLTyped for SeigniorageAllocation {
 #[derive(Debug, Default, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "std", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
-pub struct AuctionInfo {
+pub struct EraInfo {
     seigniorage_allocations: Vec<SeigniorageAllocation>,
 }
 
-impl AuctionInfo {
-    /// Constructs a [`AuctionInfo`].
+impl EraInfo {
+    /// Constructs a [`EraInfo`].
     pub fn new() -> Self {
         let seigniorage_allocations = Vec::new();
-        AuctionInfo {
+        EraInfo {
             seigniorage_allocations,
         }
     }
@@ -206,7 +206,7 @@ impl AuctionInfo {
     }
 }
 
-impl ToBytes for AuctionInfo {
+impl ToBytes for EraInfo {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         self.seigniorage_allocations.to_bytes()
     }
@@ -216,11 +216,11 @@ impl ToBytes for AuctionInfo {
     }
 }
 
-impl FromBytes for AuctionInfo {
+impl FromBytes for EraInfo {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (seigniorage_allocations, rem) = Vec::<SeigniorageAllocation>::from_bytes(bytes)?;
         Ok((
-            AuctionInfo {
+            EraInfo {
                 seigniorage_allocations,
             },
             rem,
@@ -228,7 +228,7 @@ impl FromBytes for AuctionInfo {
     }
 }
 
-impl CLTyped for AuctionInfo {
+impl CLTyped for EraInfo {
     fn cl_type() -> CLType {
         CLType::List(Box::new(SeigniorageAllocation::cl_type()))
     }
@@ -243,7 +243,7 @@ pub(crate) mod gens {
     };
 
     use crate::{
-        auction::{AuctionInfo, SeigniorageAllocation},
+        auction::{EraInfo, SeigniorageAllocation},
         gens::u512_arb,
         public_key::gens::public_key_arb,
     };
@@ -269,11 +269,11 @@ pub(crate) mod gens {
         ]
     }
 
-    pub fn auction_info_arb(size: impl Into<SizeRange>) -> impl Strategy<Value = AuctionInfo> {
+    pub fn era_info_arb(size: impl Into<SizeRange>) -> impl Strategy<Value = EraInfo> {
         collection::vec(seigniorage_allocation_arb(), size).prop_map(|allocations| {
-            let mut auction_info = AuctionInfo::new();
-            *auction_info.seigniorage_allocations_mut() = allocations;
-            auction_info
+            let mut era_info = EraInfo::new();
+            *era_info.seigniorage_allocations_mut() = allocations;
+            era_info
         })
     }
 }
@@ -288,8 +288,8 @@ mod tests {
 
     proptest! {
         #[test]
-        fn test_serialization_roundtrip(auction_info in gens::auction_info_arb(0..32)) {
-            bytesrepr::test_serialization_roundtrip(&auction_info)
+        fn test_serialization_roundtrip(era_info in gens::era_info_arb(0..32)) {
+            bytesrepr::test_serialization_roundtrip(&era_info)
         }
     }
 }

--- a/types/src/auction/providers.rs
+++ b/types/src/auction/providers.rs
@@ -1,6 +1,6 @@
 use crate::{
     account::AccountHash,
-    auction::{AuctionInfo, EraId},
+    auction::{EraId, EraInfo},
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::auction::Error,
     ApiError, CLTyped, Key, TransferResult, URef, BLAKE2B_DIGEST_LENGTH, U512,
@@ -46,12 +46,8 @@ pub trait SystemProvider {
         amount: U512,
     ) -> Result<(), ApiError>;
 
-    /// Records auction info at the given era id.
-    fn record_auction_info(
-        &mut self,
-        era_id: EraId,
-        auction_info: AuctionInfo,
-    ) -> Result<(), Error>;
+    /// Records era info at the given era id.
+    fn record_era_info(&mut self, era_id: EraId, era_info: EraInfo) -> Result<(), Error>;
 }
 
 /// Provides an access to mint.

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use crate::KEY_HASH_LENGTH;
 use crate::{
     account::AccountHash,
-    auction::AuctionInfo,
+    auction::EraInfo,
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     CLValue, DeployInfo, NamedKey, Transfer, TransferAddr, U128, U256, U512,
 };
@@ -53,7 +53,7 @@ const TRANSFORM_WRITE_CONTRACT_TAG: u8 = 4;
 const TRANSFORM_WRITE_CONTRACT_PACKAGE_TAG: u8 = 5;
 const TRANSFORM_WRITE_DEPLOY_INFO_TAG: u8 = 6;
 const TRANSFORM_WRITE_TRANSFER_TAG: u8 = 7;
-const TRANSFORM_WRITE_AUCTION_INFO_TAG: u8 = 8;
+const TRANSFORM_WRITE_ERA_INFO_TAG: u8 = 8;
 const TRANSFORM_ADD_INT32_TAG: u8 = 9;
 const TRANSFORM_ADD_UINT64_TAG: u8 = 10;
 const TRANSFORM_ADD_UINT128_TAG: u8 = 11;
@@ -444,8 +444,8 @@ pub enum Transform {
     WriteContractPackage,
     /// Writes the given DeployInfo to global state.
     WriteDeployInfo(DeployInfo),
-    /// Writes the given AuctionInfo to global state.
-    WriteAuctionInfo(AuctionInfo),
+    /// Writes the given EraInfo to global state.
+    WriteEraInfo(EraInfo),
     /// Writes the given Transfer to global state.
     WriteTransfer(Transfer),
     /// Adds the given `i32`.
@@ -486,9 +486,9 @@ impl ToBytes for Transform {
                 buffer.insert(0, TRANSFORM_WRITE_DEPLOY_INFO_TAG);
                 buffer.extend(deploy_info.to_bytes()?);
             }
-            Transform::WriteAuctionInfo(auction_info) => {
-                buffer.insert(0, TRANSFORM_WRITE_AUCTION_INFO_TAG);
-                buffer.extend(auction_info.to_bytes()?);
+            Transform::WriteEraInfo(era_info) => {
+                buffer.insert(0, TRANSFORM_WRITE_ERA_INFO_TAG);
+                buffer.extend(era_info.to_bytes()?);
             }
             Transform::WriteTransfer(transfer) => {
                 buffer.insert(0, TRANSFORM_WRITE_TRANSFER_TAG);
@@ -531,6 +531,7 @@ impl ToBytes for Transform {
             Transform::WriteCLValue(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
             Transform::WriteAccount(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
             Transform::WriteDeployInfo(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
+            Transform::WriteEraInfo(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
             Transform::WriteTransfer(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
             Transform::AddInt32(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
             Transform::AddUInt64(value) => value.serialized_length() + U8_SERIALIZED_LENGTH,
@@ -565,6 +566,10 @@ impl FromBytes for Transform {
             TRANSFORM_WRITE_DEPLOY_INFO_TAG => {
                 let (deploy_info, remainder) = DeployInfo::from_bytes(remainder)?;
                 Ok((Transform::WriteDeployInfo(deploy_info), remainder))
+            }
+            TRANSFORM_WRITE_ERA_INFO_TAG => {
+                let (era_info, remainder) = EraInfo::from_bytes(remainder)?;
+                Ok((Transform::WriteEraInfo(era_info), remainder))
             }
             TRANSFORM_WRITE_TRANSFER_TAG => {
                 let (transfer, remainder) = Transfer::from_bytes(remainder)?;

--- a/types/src/system_contract_errors/auction.rs
+++ b/types/src/system_contract_errors/auction.rs
@@ -119,9 +119,9 @@ pub enum Error {
     /// Failed to transfer desired amount into unbonding purse.
     #[fail(display = "Transfer to unbonding purse error")]
     TransferToUnbondingPurse = 32,
-    /// Failed to record auction info.
-    #[fail(display = "Record auction info error")]
-    RecordAuctionInfo = 33,
+    /// Failed to record era info.
+    #[fail(display = "Record era info error")]
+    RecordEraInfo = 33,
 
     #[cfg(test)]
     #[doc(hidden)]
@@ -186,7 +186,7 @@ impl TryFrom<u8> for Error {
             d if d == Error::WithdrawDelegatorReward as u8 => Ok(Error::WithdrawDelegatorReward),
             d if d == Error::WithdrawValidatorReward as u8 => Ok(Error::WithdrawValidatorReward),
             d if d == Error::TransferToUnbondingPurse as u8 => Ok(Error::TransferToUnbondingPurse),
-            d if d == Error::RecordAuctionInfo as u8 => Ok(Error::RecordAuctionInfo),
+            d if d == Error::RecordEraInfo as u8 => Ok(Error::RecordEraInfo),
             _ => Err(TryFromU8ForError(())),
         }
     }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1127

Doing this to avoid naming conflicts with the existing `GetAuctionInfo` RPC endpoint.