### PR TITLE
NDRS-667: Keep finality signatures in memory if we don't have their block yet.

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -63,7 +63,7 @@ pub enum Event<I> {
         /// The deploys' execution results.
         execution_results: HashMap<DeployHash, ExecutionResult>,
     },
-    /// The result of requresting a block from storage to add a finality signature to it.
+    /// The result of requesting a block from storage to add a finality signature to it.
     GetBlockForFinalitySignaturesResult(BlockHash, Option<Box<Block>>),
 }
 

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -141,7 +141,7 @@ impl<I> LinearChain<I> {
         &mut self,
         mut block: Block,
         effect_builder: EffectBuilder<REv>,
-    ) -> (Box<Block>, Effects<Event<I>>)
+    ) -> (Block, Effects<Event<I>>)
     where
         REv: From<StorageRequest>
             + From<ConsensusRequest>
@@ -168,7 +168,7 @@ impl<I> LinearChain<I> {
             effects.extend(effect_builder.broadcast_message(message).ignore());
             effects.extend(effect_builder.announce_finality_signature(fs).ignore());
         }
-        (Box::new(block), effects)
+        (block, effects)
     }
 }
 
@@ -246,6 +246,7 @@ where
             } => {
                 let (block, mut effects) =
                     self.add_pending_finality_signatures(*block, effect_builder);
+                let block = Box::new(block);
                 effects.extend(effect_builder.put_block_to_storage(block.clone()).event(
                     move |_| Event::PutBlockResult {
                         block,
@@ -336,6 +337,7 @@ where
                 let (block, mut effects) =
                     self.add_pending_finality_signatures(*block, effect_builder);
                 if block.proofs().len() > old_count {
+                    let block = Box::new(block);
                     effects.extend(effect_builder.put_block_to_storage(block).ignore());
                 }
                 effects

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -240,21 +240,16 @@ where
                 }
                 debug!(%block_hash, %public_key, "received new finality signature");
                 async move {
-                    let maybe_block = effect_builder
-                        .get_block_from_storage(block_hash)
-                        .await;
+                    let maybe_block = effect_builder.get_block_from_storage(block_hash).await;
                     match maybe_block {
-                        None => {
-                            let block_hash = fs.block_hash;
-                            let public_key = fs.public_key;
-                            warn!(%block_hash, %public_key, "received a signature for a block that was not found in storage");
-                        }
+                        None => warn!(
+                            %block_hash, %public_key,
+                            "received a signature for a block that was not found in storage"
+                        ),
                         Some(mut block) => {
                             if !block.proofs().iter().any(|proof| proof == &fs.signature) {
                                 block.append_proof(fs.signature);
-                                let _ = effect_builder
-                                    .put_block_to_storage(Box::new(block))
-                                    .await;
+                                let _ = effect_builder.put_block_to_storage(Box::new(block)).await;
                                 let _ = effect_builder
                                     .broadcast_message(Message::FinalitySignature(fs.clone()))
                                     .await;
@@ -263,7 +258,8 @@ where
                         }
                     }
                 }
-            }.ignore()
+            }
+            .ignore(),
         }
     }
 }

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -115,7 +115,6 @@ impl<I: Display> Display for Event<I> {
 #[derive(DataSize, Debug)]
 pub(crate) struct LinearChain<I> {
     /// The most recently added block.
-    // TODO: Refactor to proper LRU cache. Or read from storage?
     latest_block: Option<Block>,
     /// Finality signatures to be inserted in a block once it is available.
     pending_finality_signatures: HashMap<PublicKey, HashMap<BlockHash, FinalitySignature>>,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -849,7 +849,7 @@ impl Reactor {
                 storage: self.storage,
                 consensus: self.consensus,
                 init_consensus_effects: self.init_consensus_effects,
-                linear_chain: self.linear_chain.linear_chain().clone(),
+                latest_block: self.linear_chain.latest_block().clone(),
                 event_stream_server: self.event_stream_server,
             },
         );

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -291,7 +291,7 @@ pub struct ValidatorInitConfig {
     pub(super) contract_runtime: ContractRuntime,
     pub(super) consensus: EraSupervisor<NodeId>,
     pub(super) init_consensus_effects: Effects<consensus::Event<NodeId>>,
-    pub(super) linear_chain: Vec<Block>,
+    pub(super) latest_block: Option<Block>,
     pub(super) event_stream_server: EventStreamServer,
 }
 
@@ -357,7 +357,7 @@ impl reactor::Reactor for Reactor {
             contract_runtime,
             consensus,
             init_consensus_effects,
-            linear_chain,
+            latest_block,
             event_stream_server,
         } = config;
 
@@ -401,7 +401,7 @@ impl reactor::Reactor for Reactor {
             .genesis_state_root_hash()
             .expect("should have state root hash");
         let block_executor = BlockExecutor::new(genesis_state_root_hash, registry.clone())
-            .with_parent_map(linear_chain.last().cloned());
+            .with_parent_map(latest_block);
         let proto_block_validator = BlockValidator::new();
         let linear_chain = LinearChain::new();
 


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-667