### PR TITLE
HWY-207: Fix the code to get rid of warnings about too late timestamps.

### DIFF
--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -244,7 +244,10 @@ impl HighwayValidator {
                                 // TODO: Don't send both messages to every peer. Add different
                                 // strategies.
                                 let mut wunit = swunit.wire_unit.clone();
-                                wunit.timestamp += 1.into();
+                                match wunit.value.as_mut() {
+                                    None => wunit.timestamp += 1.into(),
+                                    Some(v) => v.push(0),
+                                }
                                 let secret = TestSecret(wunit.creator.0.into());
                                 let swunit2 = SignedWireUnit::new(wunit, &secret, rng);
                                 vec![

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -857,7 +857,7 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
                     TEST_MAX_ROUND_EXP,
                     TEST_MIN_ROUND_EXP,
                     TEST_END_HEIGHT,
-                    Timestamp::now(),
+                    Timestamp::zero(),
                     Timestamp::zero(), // Length depends only on block number.
                     TEST_ENDORSEMENT_EVIDENCE_LIMIT,
                 );

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -1138,7 +1138,6 @@ mod test_harness {
     }
 
     #[test]
-    #[ignore] // TODO(HWY-206)
     fn liveness_test_some_equivocate() {
         let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true, true));
 


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/HWY-207

The warnings were printed for cases that were already covered with different tests (like "is our own proposal?", "is the creator faulty?", etc.) but those checks were done later than the test for `earliest_unit_timestamp`. The solution was simply to rearrange the code so that the `earliest_unit_timestamp is greater than …` is logged only if that's the last error possible.

There was also another small issue in the DES tests setup where it used `Timestamp::now` which was different by a millisecond or two between validators.

I've also modified how equivocation creation is done in the tests to make it more successful to equivocate rather than create an invalid message.