### PR TITLE
HWY-217: Add `needs_validation` method to `ConsensusValueT`.

### DIFF
--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -1,7 +1,10 @@
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
-use crate::{crypto::asymmetric_key::PublicKey, types::ProtoBlock};
+use crate::{
+    components::consensus::traits::ConsensusValueT, crypto::asymmetric_key::PublicKey,
+    types::ProtoBlock,
+};
 
 /// A proposed block. Once the consensus protocol reaches agreement on it, it will be converted to
 /// a `FinalizedBlock`.
@@ -34,5 +37,11 @@ impl CandidateBlock {
 impl From<CandidateBlock> for ProtoBlock {
     fn from(cb: CandidateBlock) -> ProtoBlock {
         cb.proto_block
+    }
+}
+
+impl ConsensusValueT for CandidateBlock {
+    fn is_empty(&self) -> bool {
+        self.proto_block.wasm_deploys().is_empty() && self.proto_block.transfers().is_empty()
     }
 }

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -41,7 +41,7 @@ impl From<CandidateBlock> for ProtoBlock {
 }
 
 impl ConsensusValueT for CandidateBlock {
-    fn is_empty(&self) -> bool {
+    fn needs_validation(&self) -> bool {
         self.proto_block.wasm_deploys().is_empty() && self.proto_block.transfers().is_empty()
     }
 }

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -42,7 +42,7 @@ use crate::{
 type ConsensusValue = Vec<u32>;
 
 impl ConsensusValueT for ConsensusValue {
-    fn is_empty(&self) -> bool {
+    fn needs_validation(&self) -> bool {
         self.is_empty()
     }
 }

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -32,7 +32,7 @@ use crate::{
             },
             queue::QueueEntry,
         },
-        traits::{Context, ValidatorSecret},
+        traits::{ConsensusValueT, Context, ValidatorSecret},
         BlockContext,
     },
     types::Timestamp,
@@ -40,6 +40,12 @@ use crate::{
 };
 
 type ConsensusValue = Vec<u32>;
+
+impl ConsensusValueT for ConsensusValue {
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+}
 
 const TEST_MIN_ROUND_EXP: u8 = 12;
 const TEST_MAX_ROUND_EXP: u8 = 19;

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -62,7 +62,7 @@ pub(crate) const BOB_SEC: TestSecret = TestSecret(1);
 pub(crate) const CAROL_SEC: TestSecret = TestSecret(2);
 
 impl ConsensusValueT for u32 {
-    fn is_empty(&self) -> bool {
+    fn needs_validation(&self) -> bool {
         false
     }
 }

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -18,7 +18,7 @@ use crate::{
                 TEST_BLOCK_REWARD, TEST_ENDORSEMENT_EVIDENCE_LIMIT, TEST_INSTANCE_ID,
             },
         },
-        traits::ValidatorSecret,
+        traits::{ConsensusValueT, ValidatorSecret},
     },
     NodeRng,
 };
@@ -60,6 +60,12 @@ impl ValidatorSecret for TestSecret {
 pub(crate) const ALICE_SEC: TestSecret = TestSecret(0);
 pub(crate) const BOB_SEC: TestSecret = TestSecret(1);
 pub(crate) const CAROL_SEC: TestSecret = TestSecret(2);
+
+impl ConsensusValueT for u32 {
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
 
 impl Context for TestContext {
     type ConsensusValue = u32;

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -300,7 +300,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                                 (vertex.value().cloned(), vertex.timestamp())
                             {
                                 // It's a block…
-                                if value.is_empty() {
+                                if value.needs_validation() {
                                     // Consensus value is empty. Nothing to validate.
                                     let now = Timestamp::now();
                                     results.extend(self.add_valid_vertex(vv, rng, now));

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -19,8 +19,8 @@ impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash {}
 pub(crate) trait ConsensusValueT:
     Eq + Clone + Debug + Hash + Serialize + DeserializeOwned
 {
-    /// Returns whether the consensus value is empty.
-    fn is_empty(&self) -> bool;
+    /// Returns whether the consensus value needs validation.
+    fn needs_validation(&self) -> bool;
 }
 
 /// A hash, as an identifier for a block or unit.

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -19,8 +19,9 @@ impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash {}
 pub(crate) trait ConsensusValueT:
     Eq + Clone + Debug + Hash + Serialize + DeserializeOwned
 {
+    /// Returns whether the consensus value is empty.
+    fn is_empty(&self) -> bool;
 }
-impl<T> ConsensusValueT for T where T: Eq + Clone + Debug + Hash + Serialize + DeserializeOwned {}
 
 /// A hash, as an identifier for a block or unit.
 pub(crate) trait HashT:


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/HWY-217

If consensus value is empty then consensus doesn't have to ask for its validation and add the vertex to the state immediately, saving some reactor events and processing.

It also simplifies tests since we can propose empty vectors without having to handle `ResolveValidity` requests.