### PR TITLE
HWY-195: Create and send a valid wire unit in tests

### DIFF
--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -42,6 +42,6 @@ impl From<CandidateBlock> for ProtoBlock {
 
 impl ConsensusValueT for CandidateBlock {
     fn needs_validation(&self) -> bool {
-        self.proto_block.wasm_deploys().is_empty() && self.proto_block.transfers().is_empty()
+        !self.proto_block.wasm_deploys().is_empty() || !self.proto_block.transfers().is_empty()
     }
 }

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -43,7 +43,7 @@ type ConsensusValue = Vec<u32>;
 
 impl ConsensusValueT for ConsensusValue {
     fn needs_validation(&self) -> bool {
-        self.is_empty()
+        !self.is_empty()
     }
 }
 

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -189,23 +189,10 @@ fn send_a_valid_wire_unit() {
     let mut highway_protocol = new_test_highway_protocol(validators, vec![]);
     let sender = NodeId(123);
     let msg = bincode::serialize(&highway_message).unwrap();
-    let mut outcomes = highway_protocol.handle_message(sender, msg, false, &mut rng);
 
-    assert_eq!(outcomes.len(), 1, "Unexpected outcomes: {:?}", outcomes);
+    let outcomes = highway_protocol.handle_message(sender, msg, false, &mut rng);
 
-    let opt_protocol_outcome = outcomes.pop();
-
-    let new_outcomes = match &opt_protocol_outcome {
-        None => unreachable!("We just checked that effects has length 1!"),
-        Some(ProtocolOutcome::ValidateConsensusValue(node_id, candidate_block, timestamp)) => {
-            assert_eq!(*node_id, NodeId(123));
-            assert_eq!(*timestamp, Timestamp::from(0));
-            highway_protocol.resolve_validity(candidate_block, true, &mut rng)
-        }
-        Some(protocol_outcome) => panic!("Unexpected protocol outcome {:?}", protocol_outcome),
-    };
-
-    match &new_outcomes[..] {
+    match &outcomes[..] {
         &[ProtocolOutcome::CreatedGossipMessage(_), ProtocolOutcome::FinalizedBlock(_)] => (),
         outcomes => panic!("Unexpected outcomes: {:?}", outcomes),
     }

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -178,8 +178,7 @@ fn send_a_valid_wire_unit() {
     let mut highway_protocol = new_test_highway_protocol(vec![]);
     let sender = NodeId(123);
     let msg = bincode::serialize(&highway_message).unwrap();
-    let mut effects =
-        highway_protocol.handle_message(sender.to_owned(), msg.to_owned(), false, &mut rng);
+    let mut effects = highway_protocol.handle_message(sender, msg, false, &mut rng);
     assert_eq!(effects.len(), 1);
 
     let opt_protocol_outcome = effects.pop();


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/HWY-195

This adds a test to `protocols::highway::tests` that creates and sends a valid unit. It's the first step to create a test of the fork spam defence mechanism (we discussed this with @xcthulhu and decided to first create such a simple test, and focus on testing the defence against fork spam only after this works).