### PR TITLE
NO-TICKET: Make Block::proofs a map, keyed by public key.

### DIFF
--- a/node/src/testing/test_rng.rs
+++ b/node/src/testing/test_rng.rs
@@ -121,6 +121,14 @@ impl Drop for TestRng {
     }
 }
 
+impl SeedableRng for TestRng {
+    type Seed = <Pcg64Mcg as SeedableRng>::Seed;
+
+    fn from_seed(seed: Self::Seed) -> Self {
+        Self::from_seed(seed)
+    }
+}
+
 impl RngCore for TestRng {
     fn next_u32(&mut self) -> u32 {
         self.rng.next_u32()

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1128,7 +1128,7 @@ pub(crate) mod json_compatibility {
         hash: BlockHash,
         header: JsonBlockHeader,
         body: (),
-        proofs: BTreeMap<PublicKey, Signature>,
+        proofs: Vec<JsonProof>,
     }
 
     impl JsonBlock {
@@ -1144,7 +1144,7 @@ pub(crate) mod json_compatibility {
                 hash: block.hash,
                 header: JsonBlockHeader::from(block.header),
                 body: block.body,
-                proofs: block.proofs,
+                proofs: block.proofs.into_iter().map(JsonProof::from).collect(),
             }
         }
     }
@@ -1155,8 +1155,31 @@ pub(crate) mod json_compatibility {
                 hash: block.hash,
                 header: BlockHeader::from(block.header),
                 body: block.body,
-                proofs: block.proofs,
+                proofs: block.proofs.into_iter().map(JsonProof::into).collect(),
             }
+        }
+    }
+
+    /// A JSON-friendly representation of a proof, i.e. a block's finality signature.
+    #[derive(Debug, Serialize, Deserialize, JsonSchema)]
+    #[serde(deny_unknown_fields)]
+    pub struct JsonProof {
+        public_key: PublicKey,
+        signature: Signature,
+    }
+
+    impl From<(PublicKey, Signature)> for JsonProof {
+        fn from((public_key, signature): (PublicKey, Signature)) -> JsonProof {
+            JsonProof {
+                public_key,
+                signature,
+            }
+        }
+    }
+
+    impl From<JsonProof> for (PublicKey, Signature) {
+        fn from(proof: JsonProof) -> (PublicKey, Signature) {
+            (proof.public_key, proof.signature)
         }
     }
 }


### PR DESCRIPTION
This is another preparation for [NDRS-527](https://casperlabs.atlassian.net/browse/NDRS-527), where we'll need to determine the total weight that signed a switch block.