### PR TITLE
EE-1122: Wasmless transfer gas cost

### DIFF
--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -9,7 +9,7 @@ use crate::{
     storage,
 };
 
-#[derive(Error, Debug)]
+#[derive(Clone, Error, Debug)]
 pub enum Error {
     #[error("Invalid hash length: expected {expected}, actual {actual}")]
     InvalidHashLength { expected: usize, actual: usize },
@@ -39,10 +39,6 @@ pub enum Error {
     MissingSystemContract(String),
     #[error("Bytesrepr error: {0}")]
     Bytesrepr(String),
-    #[error("bincode serialization: {0}")]
-    BincodeSerialization(#[source] bincode::ErrorKind),
-    #[error("bincode deserialization: {0}")]
-    BincodeDeserialization(#[source] bincode::ErrorKind),
     #[error("Mint error: {0}")]
     Mint(String),
     #[error("Unsupported key type: {0}")]
@@ -51,12 +47,6 @@ pub enum Error {
     InvalidUpgradeResult,
     #[error("Unsupported deploy item variant: {0}")]
     InvalidDeployItemVariant(String),
-}
-
-impl Error {
-    pub fn from_serialization(error: bincode::ErrorKind) -> Self {
-        Error::BincodeSerialization(error)
-    }
 }
 
 impl From<execution::Error> for Error {

--- a/execution_engine/src/core/engine_state/execution_result.rs
+++ b/execution_engine/src/core/engine_state/execution_result.rs
@@ -43,7 +43,7 @@ fn make_payment_error_effects(
     ExecutionEffect::new(ops, transforms)
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ExecutionResult {
     /// An error condition that happened during execution
     Failure {

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -268,6 +268,7 @@ pub struct ExecConfig {
     locked_funds_period: EraId,
     round_seigniorage_rate: Ratio<u64>,
     unbonding_delay: EraId,
+    wasmless_transfer_cost: u64,
 }
 
 impl ExecConfig {
@@ -284,6 +285,7 @@ impl ExecConfig {
         locked_funds_period: EraId,
         round_seigniorage_rate: Ratio<u64>,
         unbonding_delay: EraId,
+        wasmless_transfer_cost: u64,
     ) -> ExecConfig {
         ExecConfig {
             mint_installer_bytes,
@@ -297,6 +299,7 @@ impl ExecConfig {
             locked_funds_period,
             round_seigniorage_rate,
             unbonding_delay,
+            wasmless_transfer_cost,
         }
     }
 
@@ -353,6 +356,10 @@ impl ExecConfig {
     pub fn unbonding_delay(&self) -> EraId {
         self.unbonding_delay
     }
+
+    pub fn wasmless_transfer_cost(&self) -> u64 {
+        self.wasmless_transfer_cost
+    }
 }
 
 impl Distribution<ExecConfig> for Standard {
@@ -387,6 +394,7 @@ impl Distribution<ExecConfig> for Standard {
             rng.gen_range(1, 1_000_000_000),
             rng.gen_range(1, 1_000_000_000),
         );
+        let wasmless_transfer_cost = rng.gen();
 
         ExecConfig {
             mint_installer_bytes,
@@ -400,6 +408,7 @@ impl Distribution<ExecConfig> for Standard {
             locked_funds_period,
             round_seigniorage_rate,
             unbonding_delay,
+            wasmless_transfer_cost,
         }
     }
 }

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -19,6 +19,7 @@ pub mod upgrade;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet},
+    convert::TryFrom,
     iter::FromIterator,
     rc::Rc,
 };
@@ -41,10 +42,10 @@ use casper_types::{
     contracts::{NamedKeys, ENTRY_POINT_NAME_INSTALL, UPGRADE_ENTRY_POINT_NAME},
     mint::{self, ARG_ROUND_SEIGNIORAGE_RATE, ROUND_SEIGNIORAGE_RATE_KEY},
     proof_of_stake, runtime_args,
-    system_contract_errors::mint::Error as MintError,
-    AccessRights, BlockTime, CLValue, Contract, ContractHash, ContractPackage, ContractPackageHash,
-    ContractVersionKey, DeployHash, DeployInfo, EntryPoint, EntryPointType, Key, Phase,
-    ProtocolVersion, RuntimeArgs, URef, U512,
+    system_contract_errors::{self, mint::Error as MintError},
+    AccessRights, ApiError, BlockTime, CLValue, Contract, ContractHash, ContractPackage,
+    ContractPackageHash, ContractVersionKey, DeployHash, DeployInfo, EntryPoint, EntryPointType,
+    Key, Phase, ProtocolVersion, RuntimeArgs, URef, U512,
 };
 
 pub use self::{
@@ -55,11 +56,12 @@ pub use self::{
     error::{Error, RootNotFound},
     executable_deploy_item::ExecutableDeployItem,
     execute_request::ExecuteRequest,
+    execution::Error as ExecError,
     execution_result::{ExecutionResult, ExecutionResults, ForcedTransferResult},
     genesis::{ExecConfig, GenesisAccount, GenesisResult, POS_PAYMENT_PURSE},
     query::{QueryRequest, QueryResult},
     system_contract_cache::SystemContractCache,
-    transfer::{TransferRuntimeArgsBuilder, TransferTargetMode},
+    transfer::{TransferArgs, TransferRuntimeArgsBuilder, TransferTargetMode},
     upgrade::{UpgradeConfig, UpgradeResult},
 };
 use crate::{
@@ -97,6 +99,10 @@ use crate::{
 pub const CONV_RATE: u64 = 1;
 
 pub static MAX_PAYMENT: Lazy<U512> = Lazy::new(|| U512::from(2_500_000_000 * CONV_RATE));
+
+/// Default cost for wasmless transfer.
+pub static DEFAULT_WASMLESS_TRANSFER_COST: Lazy<Motes> =
+    Lazy::new(|| Motes::new(U512::from(10_000)));
 
 pub const SYSTEM_ACCOUNT_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 
@@ -917,6 +923,7 @@ where
                         exec_request.parent_state_hash,
                         BlockTime::new(exec_request.block_time),
                         deploy_item,
+                        exec_request.proposer,
                     ),
                     _ => self.deploy(
                         correlation_id,
@@ -1149,6 +1156,7 @@ where
         prestate_hash: Blake2bHash,
         blocktime: BlockTime,
         deploy_item: DeployItem,
+        proposer: casper_types::PublicKey,
     ) -> Result<ExecutionResult, RootNotFound> {
         let protocol_data = match self.state.get_protocol_data(protocol_version) {
             Ok(Some(protocol_data)) => protocol_data,
@@ -1218,9 +1226,40 @@ where
             }
         };
 
-        let mut named_keys = mint_contract.named_keys().to_owned();
-        let mut extra_keys: Vec<Key> = vec![];
-        let base_key = Key::from(protocol_data.mint());
+        let mut mint_named_keys = mint_contract.named_keys().to_owned();
+        let mut mint_extra_keys: Vec<Key> = vec![];
+        let mint_base_key = Key::from(protocol_data.mint());
+
+        let pos_contract = match tracking_copy
+            .borrow_mut()
+            .get_contract(correlation_id, protocol_data.proof_of_stake())
+        {
+            Ok(contract) => contract,
+            Err(error) => {
+                return Ok(ExecutionResult::precondition_failure(error.into()));
+            }
+        };
+
+        let pos_module = {
+            let contract_wasm_hash = pos_contract.contract_wasm_hash();
+            let use_system_contracts = self.config.use_system_contracts();
+            match tracking_copy.borrow_mut().get_system_module(
+                correlation_id,
+                contract_wasm_hash,
+                use_system_contracts,
+                preprocessor,
+            ) {
+                Ok(module) => module,
+                Err(error) => {
+                    return Ok(ExecutionResult::precondition_failure(error.into()));
+                }
+            }
+        };
+
+        let mut pos_named_keys = pos_contract.named_keys().to_owned();
+        let pos_extra_keys: Vec<Key> = vec![];
+        let pos_base_key = Key::from(protocol_data.proof_of_stake());
+
         let gas_limit = Gas::new(U512::from(std::u64::MAX));
 
         let input_runtime_args = match deploy_item.session.into_runtime_args() {
@@ -1238,9 +1277,9 @@ where
                             DirectSystemContractCall::CreatePurse,
                             mint_module.clone(),
                             runtime_args! {}, // mint create takes no arguments
-                            &mut named_keys,
+                            &mut mint_named_keys,
                             Default::default(),
-                            base_key,
+                            mint_base_key,
                             &account,
                             authorization_keys.clone(),
                             blocktime,
@@ -1257,7 +1296,7 @@ where
                         Some(main_purse) => {
                             let new_account =
                                 Account::create(public_key, Default::default(), main_purse);
-                            extra_keys.push(Key::from(main_purse));
+                            mint_extra_keys.push(Key::from(main_purse));
                             // write new account
                             tracking_copy
                                 .borrow_mut()
@@ -1279,7 +1318,171 @@ where
             }
         }
 
-        let runtime_args =
+        // Construct a payment code that will put cost of wasmless payment into payment purse
+        let payment_result = {
+            let transfer_args = match runtime_args_builder.clone().build(
+                &account,
+                correlation_id,
+                Rc::clone(&tracking_copy),
+            ) {
+                Ok(transfer_args) => transfer_args,
+                Err(error) => {
+                    return Ok(ExecutionResult::Failure {
+                        error,
+                        effect: Default::default(),
+                        transfers: Vec::default(),
+                        cost: Gas::default(),
+                    });
+                }
+            };
+
+            let (payment_uref, get_payment_purse_result): (Option<URef>, ExecutionResult) =
+                executor.exec_system_contract(
+                    DirectSystemContractCall::GetPaymentPurse,
+                    pos_module.clone(),
+                    RuntimeArgs::default(),
+                    &mut pos_named_keys,
+                    pos_extra_keys.as_slice(),
+                    pos_base_key,
+                    &account,
+                    authorization_keys.clone(),
+                    blocktime,
+                    deploy_item.deploy_hash,
+                    gas_limit,
+                    protocol_version,
+                    correlation_id,
+                    Rc::clone(&tracking_copy),
+                    Phase::Payment,
+                    protocol_data,
+                    SystemContractCache::clone(&self.system_contract_cache),
+                );
+
+            let payment_uref = match payment_uref {
+                Some(payment_uref) => payment_uref,
+                None => {
+                    return Ok(ExecutionResult::Failure {
+                        error: Error::InsufficientPayment,
+                        effect: Default::default(),
+                        transfers: Vec::default(),
+                        cost: Gas::default(),
+                    })
+                }
+            };
+
+            if let Some(error) = get_payment_purse_result.take_error() {
+                return Ok(ExecutionResult::Failure {
+                    error,
+                    effect: Default::default(),
+                    transfers: Vec::default(),
+                    cost: Gas::default(),
+                });
+            }
+
+            let wasmless_transfer_gas_cost =
+                Gas::from_motes(*DEFAULT_WASMLESS_TRANSFER_COST, CONV_RATE)
+                    .expect("gas overflow")
+                    .value();
+
+            // Create a new transfer arguments that will transfer wasmless transfer cost into the
+            // payment purse.
+            let new_transfer_args = TransferArgs::new(
+                transfer_args.to(),
+                transfer_args.source(),
+                payment_uref,
+                wasmless_transfer_gas_cost,
+                transfer_args.arg_id(),
+            );
+
+            let (actual_result, payment_result): (Option<Result<(), u8>>, ExecutionResult) =
+                executor.exec_system_contract(
+                    DirectSystemContractCall::Transfer,
+                    mint_module.clone(),
+                    RuntimeArgs::from(new_transfer_args),
+                    &mut mint_named_keys,
+                    mint_extra_keys.as_slice(),
+                    mint_base_key,
+                    &account,
+                    authorization_keys.clone(),
+                    blocktime,
+                    deploy_item.deploy_hash,
+                    gas_limit,
+                    protocol_version,
+                    correlation_id,
+                    Rc::clone(&tracking_copy),
+                    Phase::Payment,
+                    protocol_data,
+                    SystemContractCache::clone(&self.system_contract_cache),
+                );
+
+            if let Some(error) = payment_result.as_error().cloned() {
+                return Ok(ExecutionResult::Failure {
+                    error,
+                    effect: Default::default(),
+                    transfers: Vec::default(),
+                    cost: Gas::default(),
+                });
+            }
+
+            let transfer_result = match actual_result {
+                Some(Ok(())) => Ok(()),
+                Some(Err(mint_error)) => {
+                    match system_contract_errors::mint::Error::try_from(mint_error) {
+                        Ok(mint_error) => Err(ApiError::from(mint_error)),
+                        Err(_) => Err(ApiError::Transfer),
+                    }
+                }
+                None => Err(ApiError::Transfer),
+            };
+
+            if let Err(transfer_result) = transfer_result {
+                return Ok(ExecutionResult::Failure {
+                    error: Error::Exec(ExecError::Revert(transfer_result)),
+                    effect: Default::default(),
+                    transfers: Vec::default(),
+                    cost: Gas::default(),
+                });
+            }
+
+            let payment_purse_balance_key = match tracking_copy
+                .borrow_mut()
+                .get_purse_balance_key(correlation_id, Key::URef(payment_uref))
+            {
+                Ok(payment_purse_balance_key) => payment_purse_balance_key,
+                Err(error) => {
+                    return Ok(ExecutionResult::Failure {
+                        error: Error::Exec(error),
+                        effect: Default::default(),
+                        transfers: Vec::default(),
+                        cost: Gas::default(),
+                    })
+                }
+            };
+
+            let payment_purse_balance = match tracking_copy
+                .borrow_mut()
+                .get_purse_balance(correlation_id, payment_purse_balance_key)
+            {
+                Ok(payment_purse_balance) => payment_purse_balance,
+                Err(error) => {
+                    return Ok(ExecutionResult::Failure {
+                        error: Error::Exec(error),
+                        effect: Default::default(),
+                        transfers: Vec::default(),
+                        cost: Gas::default(),
+                    })
+                }
+            };
+
+            // Wasmless transfer payment code pre & post conditions:
+            // (a) payment purse should be empty before the payment operation
+            // (b) after executing payment code it's balance has to be equal to the wasmless gas
+            // cost price
+            debug_assert_eq!(payment_purse_balance.value(), wasmless_transfer_gas_cost);
+            // This assumes the cost incurred is already denominated in gas
+            payment_result.with_cost(Gas::new(payment_purse_balance.value()))
+        };
+
+        let transfer_args =
             match runtime_args_builder.build(&account, correlation_id, Rc::clone(&tracking_copy)) {
                 Ok(runtime_args) => runtime_args,
                 Err(error) => {
@@ -1296,12 +1499,12 @@ where
             .exec_system_contract(
                 DirectSystemContractCall::Transfer,
                 mint_module,
-                runtime_args,
-                &mut named_keys,
-                extra_keys.as_slice(),
-                base_key,
+                RuntimeArgs::from(transfer_args),
+                &mut mint_named_keys,
+                mint_extra_keys.as_slice(),
+                mint_base_key,
                 &account,
-                authorization_keys,
+                authorization_keys.clone(),
                 blocktime,
                 deploy_item.deploy_hash,
                 gas_limit,
@@ -1313,13 +1516,72 @@ where
                 SystemContractCache::clone(&self.system_contract_cache),
             );
 
-        let payment_result = ExecutionResult::default();
-        let payment_result_cost = payment_result.cost();
+        let finalize_result = {
+            let proposer_purse = {
+                let proposer_account: Account = match tracking_copy
+                    .borrow_mut()
+                    .get_account(correlation_id, proposer.into())
+                {
+                    Ok(account) => account,
+                    Err(error) => {
+                        return Ok(ExecutionResult::precondition_failure(error.into()));
+                    }
+                };
+                proposer_account.main_purse()
+            };
+
+            let proof_of_stake_args = {
+                //((gas spent during payment code execution) + (gas spent during session code execution)) * conv_rate
+                let finalize_cost_motes: Motes =
+                    Motes::from_gas(payment_result.cost(), CONV_RATE)
+                        .expect("motes overflow");
+                runtime_args! {
+                    proof_of_stake::ARG_AMOUNT => finalize_cost_motes.value(),
+                    proof_of_stake::ARG_ACCOUNT => deploy_item.address,
+                    proof_of_stake::ARG_TARGET => proposer_purse,
+                }
+            };
+
+            // let system_account = AccountHash::new([0; 32]);
+            let system_account = Account::new(
+                SYSTEM_ACCOUNT_ADDR,
+                Default::default(),
+                URef::new(Default::default(), AccessRights::READ_ADD_WRITE),
+                Default::default(),
+                Default::default(),
+            );
+
+            let tc = tracking_copy.borrow();
+            let finalization_tc = Rc::new(RefCell::new(tc.fork()));
+
+            let (_ret, finalize_result): (Option<()>, ExecutionResult) = executor
+                .exec_system_contract(
+                    DirectSystemContractCall::FinalizePayment,
+                    pos_module,
+                    proof_of_stake_args,
+                    &mut pos_named_keys,
+                    Default::default(),
+                    Key::from(protocol_data.proof_of_stake()),
+                    &system_account,
+                    authorization_keys,
+                    blocktime,
+                    deploy_item.deploy_hash,
+                    gas_limit,
+                    protocol_version,
+                    correlation_id,
+                    finalization_tc,
+                    Phase::FinalizePayment,
+                    protocol_data,
+                    SystemContractCache::clone(&self.system_contract_cache),
+                );
+
+            finalize_result
+        };
 
         // Create + persist deploy info.
         {
             let transfers = session_result.transfers();
-            let cost = payment_result_cost.value() + session_result.cost().value();
+            let cost = payment_result.cost().value() + session_result.cost().value();
             let deploy_info = DeployInfo::new(
                 deploy_item.deploy_hash,
                 &transfers,
@@ -1340,7 +1602,7 @@ where
         let mut execution_result_builder = ExecutionResultBuilder::new();
         execution_result_builder.set_payment_execution_result(payment_result);
         execution_result_builder.set_session_execution_result(session_result);
-        execution_result_builder.set_finalize_execution_result(ExecutionResult::default());
+        execution_result_builder.set_finalize_execution_result(finalize_result);
 
         let execution_result = execution_result_builder
             .build(tracking_copy.borrow().reader(), correlation_id)

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1588,8 +1588,7 @@ where
             let proof_of_stake_args = {
                 // Gas spent during payment code execution
                 let finalize_cost_motes: Motes =
-                    Motes::from_gas(payment_result.cost(), CONV_RATE)
-                        .expect("motes overflow");
+                    Motes::from_gas(payment_result.cost(), CONV_RATE).expect("motes overflow");
                 runtime_args! {
                     proof_of_stake::ARG_AMOUNT => finalize_cost_motes.value(),
                     proof_of_stake::ARG_ACCOUNT => deploy_item.address,

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1586,7 +1586,7 @@ where
             };
 
             let proof_of_stake_args = {
-                //((gas spent during payment code execution) + (gas spent during session code execution)) * conv_rate
+                // Gas spent during payment code execution
                 let finalize_cost_motes: Motes =
                     Motes::from_gas(payment_result.cost(), CONV_RATE)
                         .expect("motes overflow");
@@ -1597,7 +1597,6 @@ where
                 }
             };
 
-            // let system_account = AccountHash::new([0; 32]);
             let system_account = Account::new(
                 SYSTEM_ACCOUNT_ADDR,
                 Default::default(),

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1532,7 +1532,7 @@ where
                 Gas::from_motes(payment_purse_balance, CONV_RATE).expect("gas overflow");
 
             debug_assert_eq!(payment_gas, wasmless_transfer_gas_cost);
-            
+
             // This assumes the cost incurred is already denominated in gas
 
             payment_result.with_cost(payment_gas)

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1532,6 +1532,7 @@ where
                 Gas::from_motes(payment_purse_balance, CONV_RATE).expect("gas overflow");
 
             debug_assert_eq!(payment_gas, wasmless_transfer_gas_cost);
+            
             // This assumes the cost incurred is already denominated in gas
 
             payment_result.with_cost(payment_gas)

--- a/execution_engine/src/core/engine_state/transfer.rs
+++ b/execution_engine/src/core/engine_state/transfer.rs
@@ -14,8 +14,6 @@ use crate::{
     storage::global_state::StateReader,
 };
 
-use super::DEFAULT_WASMLESS_TRANSFER_COST;
-
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum TransferTargetMode {
     Unknown,
@@ -324,20 +322,6 @@ impl TransferRuntimeArgsBuilder {
 
         if source_uref.addr() == target_uref.addr() {
             return Err(ExecError::Revert(ApiError::InvalidPurse).into());
-        }
-
-        let source_purse_balance_key = tracking_copy
-            .borrow_mut()
-            .get_purse_balance_key(correlation_id, Key::URef(source_uref))?;
-
-        let purse_balance = tracking_copy
-            .borrow_mut()
-            .get_purse_balance(correlation_id, source_purse_balance_key)?;
-
-        if purse_balance < *DEFAULT_WASMLESS_TRANSFER_COST {
-            // We can't continue if the minimum funds in source purse are lower than
-            // `DEFAULT_WASMLESS_TRANSFER_COST`.
-            return Err(Error::InsufficientPayment);
         }
 
         let amount = self.resolve_amount()?;

--- a/execution_engine/src/core/engine_state/upgrade.rs
+++ b/execution_engine/src/core/engine_state/upgrade.rs
@@ -70,6 +70,7 @@ pub struct UpgradeConfig {
     new_locked_funds_period: Option<EraId>,
     new_round_seigniorage_rate: Option<Ratio<u64>>,
     new_unbonding_delay: Option<EraId>,
+    new_wasmless_transfer_cost: Option<u64>,
 }
 
 impl UpgradeConfig {
@@ -87,6 +88,7 @@ impl UpgradeConfig {
         new_locked_funds_period: Option<EraId>,
         new_round_seigniorage_rate: Option<Ratio<u64>>,
         new_unbonding_delay: Option<EraId>,
+        new_wasmless_transfer_cost: Option<u64>,
     ) -> Self {
         UpgradeConfig {
             pre_state_hash,
@@ -101,6 +103,7 @@ impl UpgradeConfig {
             new_locked_funds_period,
             new_round_seigniorage_rate,
             new_unbonding_delay,
+            new_wasmless_transfer_cost,
         }
     }
 
@@ -152,5 +155,9 @@ impl UpgradeConfig {
 
     pub fn new_unbonding_delay(&self) -> Option<EraId> {
         self.new_unbonding_delay
+    }
+
+    pub fn new_wasmless_transfer_cost(&self) -> Option<u64> {
+        self.new_wasmless_transfer_cost
     }
 }

--- a/grpc/server/protobuf/casper/ipc.proto
+++ b/grpc/server/protobuf/casper/ipc.proto
@@ -467,6 +467,8 @@ message ChainSpec {
         Ratio new_round_seigniorage_rate = 10;
         // Change the unbonding delay (optional)
         NewUnbondingDelay new_unbonding_delay = 11;
+        // Change the wasmless transfer cost (optional)
+        NewWasmlessTransferCost new_wasmless_transfer_cost = 12;
     }
 
     message NewValidatorSlots {
@@ -488,6 +490,10 @@ message ChainSpec {
 
     message NewUnbondingDelay {
         uint64 new_unbonding_delay = 1;
+    }
+
+    message NewWasmlessTransferCost {
+        uint64 new_wasmless_transfer_cost = 1;
     }
 }
 

--- a/grpc/server/protobuf/casper/ipc.proto
+++ b/grpc/server/protobuf/casper/ipc.proto
@@ -299,6 +299,8 @@ message ChainSpec {
             Ratio round_seigniorage_rate = 11;
             // Unbonding delay expressed in eras.
             uint64 unbonding_delay = 12;
+            // Wasmless transfer cost expressed in gas.
+            uint64 wasmless_transfer_cost = 13;
 
             message GenesisAccount {
                 bytes public_key_bytes = 1;

--- a/grpc/server/src/engine_server/mappings/ipc/deploy_result.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/deploy_result.rs
@@ -57,8 +57,6 @@ impl From<(EngineStateError, ExecutionEffect, Gas)> for DeployResult {
             | error @ EngineStateError::Deploy
             | error @ EngineStateError::Finalization
             | error @ EngineStateError::Bytesrepr(_)
-            | error @ EngineStateError::BincodeSerialization(_)
-            | error @ EngineStateError::BincodeDeserialization(_)
             | error @ EngineStateError::Mint(_) => detail::execution_error(error, effect, cost),
             EngineStateError::Exec(exec_error) => (exec_error, effect, cost).into(),
         }

--- a/grpc/server/src/engine_server/mappings/ipc/exec_config.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/exec_config.rs
@@ -25,6 +25,7 @@ impl TryFrom<ipc::ChainSpec_GenesisConfig_ExecConfig> for ExecConfig {
         let locked_funds_period = pb_exec_config.get_locked_funds_period();
         let round_seigniorage_rate = pb_exec_config.take_round_seigniorage_rate().into();
         let unbonding_delay = pb_exec_config.get_unbonding_delay();
+        let wasmless_transfer_cost = pb_exec_config.get_wasmless_transfer_cost();
         Ok(ExecConfig::new(
             mint_initializer_bytes,
             proof_of_stake_initializer_bytes,
@@ -37,6 +38,7 @@ impl TryFrom<ipc::ChainSpec_GenesisConfig_ExecConfig> for ExecConfig {
             locked_funds_period,
             round_seigniorage_rate,
             unbonding_delay,
+            wasmless_transfer_cost,
         ))
     }
 }
@@ -65,6 +67,7 @@ impl From<ExecConfig> for ipc::ChainSpec_GenesisConfig_ExecConfig {
         pb_exec_config.set_locked_funds_period(exec_config.locked_funds_period());
         pb_exec_config.set_round_seigniorage_rate(exec_config.round_seigniorage_rate().into());
         pb_exec_config.set_unbonding_delay(exec_config.unbonding_delay());
+        pb_exec_config.set_wasmless_transfer_cost(exec_config.wasmless_transfer_cost());
         pb_exec_config
     }
 }

--- a/grpc/server/src/engine_server/mappings/ipc/upgrade_request.rs
+++ b/grpc/server/src/engine_server/mappings/ipc/upgrade_request.rs
@@ -90,6 +90,17 @@ impl TryFrom<UpgradeRequest> for UpgradeConfig {
             )
         };
 
+        let new_wasmless_transfer_cost: Option<u64> =
+            if !upgrade_point.has_new_wasmless_transfer_cost() {
+                None
+            } else {
+                Some(
+                    upgrade_point
+                        .take_new_wasmless_transfer_cost()
+                        .get_new_wasmless_transfer_cost(),
+                )
+            };
+
         Ok(UpgradeConfig::new(
             pre_state_hash,
             current_protocol_version,
@@ -103,6 +114,7 @@ impl TryFrom<UpgradeRequest> for UpgradeConfig {
             new_locked_funds_period,
             new_round_seigniorage_rate,
             new_unbonding_delay,
+            new_wasmless_transfer_cost,
         ))
     }
 }

--- a/grpc/test_support/src/internal/exec_with_return.rs
+++ b/grpc/test_support/src/internal/exec_with_return.rs
@@ -12,7 +12,10 @@ use casper_execution_engine::{
         runtime_context::RuntimeContext,
     },
     shared::{gas::Gas, newtypes::CorrelationId, wasm_prep::Preprocessor},
-    storage::{global_state::StateProvider, protocol_data::ProtocolData},
+    storage::{
+        global_state::StateProvider,
+        protocol_data::{ProtocolData, DEFAULT_WASMLESS_TRANSFER_COST},
+    },
 };
 use casper_types::{
     account::AccountHash,
@@ -93,7 +96,14 @@ where
         let pos = builder.get_mint_contract_hash();
         let standard_payment = builder.get_standard_payment_contract_hash();
         let auction = builder.get_auction_contract_hash();
-        ProtocolData::new(*DEFAULT_WASM_CONFIG, mint, pos, standard_payment, auction)
+        ProtocolData::new(
+            *DEFAULT_WASM_CONFIG,
+            mint,
+            pos,
+            standard_payment,
+            auction,
+            DEFAULT_WASMLESS_TRANSFER_COST,
+        )
     };
 
     let transfers = Vec::default();

--- a/grpc/test_support/src/internal/mod.rs
+++ b/grpc/test_support/src/internal/mod.rs
@@ -17,6 +17,7 @@ use casper_execution_engine::{
         run_genesis_request::RunGenesisRequest,
     },
     shared::{motes::Motes, newtypes::Blake2bHash, wasm_config::WasmConfig},
+    storage::protocol_data::DEFAULT_WASMLESS_TRANSFER_COST,
 };
 use casper_types::{account::AccountHash, auction::EraId, ProtocolVersion, PublicKey, U512};
 
@@ -114,6 +115,7 @@ pub static DEFAULT_EXEC_CONFIG: Lazy<ExecConfig> = Lazy::new(|| {
         DEFAULT_LOCKED_FUNDS_PERIOD,
         DEFAULT_ROUND_SEIGNIORAGE_RATE,
         DEFAULT_UNBONDING_DELAY,
+        DEFAULT_WASMLESS_TRANSFER_COST,
     )
 });
 pub static DEFAULT_GENESIS_CONFIG: Lazy<GenesisConfig> = Lazy::new(|| {

--- a/grpc/test_support/src/internal/utils.rs
+++ b/grpc/test_support/src/internal/utils.rs
@@ -17,6 +17,7 @@ use casper_execution_engine::{
         account::Account, additive_map::AdditiveMap, gas::Gas, stored_value::StoredValue,
         transform::Transform,
     },
+    storage::protocol_data::DEFAULT_WASMLESS_TRANSFER_COST,
 };
 use casper_types::Key;
 
@@ -144,6 +145,7 @@ pub fn create_exec_config(accounts: Vec<GenesisAccount>) -> ExecConfig {
     let locked_funds_period = DEFAULT_LOCKED_FUNDS_PERIOD;
     let round_seigniorage_rate = DEFAULT_ROUND_SEIGNIORAGE_RATE;
     let unbonding_delay = DEFAULT_UNBONDING_DELAY;
+    let wasmless_transfer_cost = DEFAULT_WASMLESS_TRANSFER_COST;
     ExecConfig::new(
         mint_installer_bytes,
         proof_of_stake_installer_bytes,
@@ -156,6 +158,7 @@ pub fn create_exec_config(accounts: Vec<GenesisAccount>) -> ExecConfig {
         locked_funds_period,
         round_seigniorage_rate,
         unbonding_delay,
+        wasmless_transfer_cost,
     )
 }
 

--- a/grpc/tests/src/profiling/state_initializer.rs
+++ b/grpc/tests/src/profiling/state_initializer.rs
@@ -14,13 +14,13 @@ use casper_engine_test_support::internal::{
     DEFAULT_VALIDATOR_SLOTS, DEFAULT_WASM_CONFIG, MINT_INSTALL_CONTRACT, POS_INSTALL_CONTRACT,
     STANDARD_PAYMENT_INSTALL_CONTRACT,
 };
+use casper_engine_tests::profiling;
 use casper_execution_engine::{
     core::engine_state::{
         engine_config::EngineConfig, genesis::ExecConfig, run_genesis_request::RunGenesisRequest,
     },
     storage::protocol_data::DEFAULT_WASMLESS_TRANSFER_COST,
 };
-use casper_engine_tests::profiling;
 use casper_types::{runtime_args, RuntimeArgs};
 
 const ABOUT: &str = "Initializes global state in preparation for profiling runs. Outputs the root \

--- a/grpc/tests/src/profiling/state_initializer.rs
+++ b/grpc/tests/src/profiling/state_initializer.rs
@@ -14,10 +14,12 @@ use casper_engine_test_support::internal::{
     DEFAULT_VALIDATOR_SLOTS, DEFAULT_WASM_CONFIG, MINT_INSTALL_CONTRACT, POS_INSTALL_CONTRACT,
     STANDARD_PAYMENT_INSTALL_CONTRACT,
 };
-use casper_execution_engine::core::engine_state::{
-    engine_config::EngineConfig, genesis::ExecConfig, run_genesis_request::RunGenesisRequest,
+use casper_execution_engine::{
+    core::engine_state::{
+        engine_config::EngineConfig, genesis::ExecConfig, run_genesis_request::RunGenesisRequest,
+    },
+    storage::protocol_data::DEFAULT_WASMLESS_TRANSFER_COST,
 };
-
 use casper_engine_tests::profiling;
 use casper_types::{runtime_args, RuntimeArgs};
 
@@ -86,6 +88,7 @@ fn main() {
         DEFAULT_LOCKED_FUNDS_PERIOD,
         DEFAULT_ROUND_SEIGNIORAGE_RATE,
         DEFAULT_UNBONDING_DELAY,
+        DEFAULT_WASMLESS_TRANSFER_COST,
     );
     let run_genesis_request = RunGenesisRequest::new(
         *DEFAULT_GENESIS_CONFIG_HASH,

--- a/grpc/tests/src/test/deploy/receipts.rs
+++ b/grpc/tests/src/test/deploy/receipts.rs
@@ -1,12 +1,12 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use casper_execution_engine::core::engine_state::DEFAULT_WASMLESS_TRANSFER_COST;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
     DEFAULT_ACCOUNT_ADDR,
 };
+use casper_execution_engine::storage::protocol_data::DEFAULT_WASMLESS_TRANSFER_COST;
 use casper_types::{
     account::AccountHash, runtime_args, AccessRights, DeployHash, PublicKey, RuntimeArgs, Transfer,
     TransferAddr, U512,
@@ -89,7 +89,7 @@ fn should_record_wasmless_transfer() {
 
     // TODO: this is borked
     if !cfg!(feature = "use-system-contracts") {
-        assert_eq!(deploy_info.gas, DEFAULT_WASMLESS_TRANSFER_COST.value());
+        assert_eq!(deploy_info.gas, U512::from(DEFAULT_WASMLESS_TRANSFER_COST));
     }
 
     let transfers = deploy_info.transfers;

--- a/grpc/tests/src/test/deploy/receipts.rs
+++ b/grpc/tests/src/test/deploy/receipts.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use casper_execution_engine::core::engine_state::DEFAULT_WASMLESS_TRANSFER_COST;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -88,7 +89,7 @@ fn should_record_wasmless_transfer() {
 
     // TODO: this is borked
     if !cfg!(feature = "use-system-contracts") {
-        assert_eq!(deploy_info.gas, U512::zero());
+        assert_eq!(deploy_info.gas, DEFAULT_WASMLESS_TRANSFER_COST.value());
     }
 
     let transfers = deploy_info.transfers;

--- a/grpc/tests/src/test/system_contracts/genesis.rs
+++ b/grpc/tests/src/test/system_contracts/genesis.rs
@@ -16,6 +16,7 @@ use casper_execution_engine::{
         SYSTEM_ACCOUNT_ADDR,
     },
     shared::{motes::Motes, stored_value::StoredValue},
+    storage::protocol_data::DEFAULT_WASMLESS_TRANSFER_COST,
 };
 use casper_types::{mint::TOTAL_SUPPLY_KEY, ProtocolVersion, PublicKey, U512};
 
@@ -71,6 +72,7 @@ fn should_run_genesis() {
     let locked_funds_period = DEFAULT_LOCKED_FUNDS_PERIOD;
     let round_seigniorage_rate = DEFAULT_ROUND_SEIGNIORAGE_RATE;
     let unbonding_delay = DEFAULT_UNBONDING_DELAY;
+    let wasmless_transfer_cost = DEFAULT_WASMLESS_TRANSFER_COST;
 
     let exec_config = ExecConfig::new(
         mint_installer_bytes,
@@ -84,6 +86,7 @@ fn should_run_genesis() {
         locked_funds_period,
         round_seigniorage_rate,
         unbonding_delay,
+        wasmless_transfer_cost,
     );
     let run_genesis_request =
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, exec_config);
@@ -145,6 +148,7 @@ fn should_track_total_token_supply_in_mint() {
     let locked_funds_period = DEFAULT_LOCKED_FUNDS_PERIOD;
     let round_seigniorage_rate = DEFAULT_ROUND_SEIGNIORAGE_RATE;
     let unbonding_delay = DEFAULT_UNBONDING_DELAY;
+    let wasmless_transfer_cost = DEFAULT_WASMLESS_TRANSFER_COST;
     let ee_config = ExecConfig::new(
         mint_installer_bytes,
         proof_of_stake_installer_bytes,
@@ -157,6 +161,7 @@ fn should_track_total_token_supply_in_mint() {
         locked_funds_period,
         round_seigniorage_rate,
         unbonding_delay,
+        wasmless_transfer_cost,
     );
     let run_genesis_request =
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, ee_config);
@@ -206,6 +211,7 @@ fn should_fail_if_bad_mint_install_contract_is_provided() {
         let locked_funds_period = DEFAULT_LOCKED_FUNDS_PERIOD;
         let round_seigniorage_rate = DEFAULT_ROUND_SEIGNIORAGE_RATE;
         let unbonding_delay = DEFAULT_UNBONDING_DELAY;
+        let wasmless_transfer_cost = DEFAULT_WASMLESS_TRANSFER_COST;
 
         let exec_config = ExecConfig::new(
             mint_installer_bytes,
@@ -219,6 +225,7 @@ fn should_fail_if_bad_mint_install_contract_is_provided() {
             locked_funds_period,
             round_seigniorage_rate,
             unbonding_delay,
+            wasmless_transfer_cost,
         );
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, exec_config)
     };
@@ -246,6 +253,7 @@ fn should_fail_if_bad_pos_install_contract_is_provided() {
         let locked_funds_period = DEFAULT_LOCKED_FUNDS_PERIOD;
         let round_seigniorage_rate = DEFAULT_ROUND_SEIGNIORAGE_RATE;
         let unbonding_delay = DEFAULT_UNBONDING_DELAY;
+        let wasmless_transfer_cost = DEFAULT_WASMLESS_TRANSFER_COST;
 
         let exec_config = ExecConfig::new(
             mint_installer_bytes,
@@ -259,6 +267,7 @@ fn should_fail_if_bad_pos_install_contract_is_provided() {
             locked_funds_period,
             round_seigniorage_rate,
             unbonding_delay,
+            wasmless_transfer_cost,
         );
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, exec_config)
     };

--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -362,6 +362,7 @@ pub(crate) struct UpgradePoint {
     pub(crate) new_wasm_config: Option<WasmConfig>,
     pub(crate) new_deploy_config: Option<DeployConfig>,
     pub(crate) new_validator_slots: Option<u32>,
+    pub(crate) new_wasmless_transfer_cost: Option<u64>,
 }
 
 #[cfg(test)]
@@ -393,6 +394,7 @@ impl UpgradePoint {
             None
         };
         let new_validator_slots = rng.gen::<Option<u32>>();
+        let new_wasmless_transfer_cost = rng.gen();
 
         UpgradePoint {
             activation_point,
@@ -402,6 +404,7 @@ impl UpgradePoint {
             new_wasm_config: new_costs,
             new_deploy_config,
             new_validator_slots,
+            new_wasmless_transfer_cost,
         }
     }
 }

--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -222,6 +222,8 @@ pub struct GenesisConfig {
     pub(crate) round_seigniorage_rate: Ratio<u64>,
     /// The delay for paying out the the unbonding amount.
     pub(crate) unbonding_delay: EraId,
+    /// Wasmless transfer cost expressed in gas.
+    pub(crate) wasmless_transfer_cost: u64,
     // We don't have an implementation for the semver version type, we skip it for now
     #[data_size(skip)]
     pub(crate) protocol_version: Version,
@@ -321,6 +323,7 @@ impl GenesisConfig {
         let deploy_config = DeployConfig::random(rng);
         let highway_config = HighwayConfig::random(rng);
         let unbonding_delay = rng.gen();
+        let wasmless_transfer_cost = rng.gen();
 
         GenesisConfig {
             name,
@@ -329,6 +332,8 @@ impl GenesisConfig {
             auction_delay,
             locked_funds_period,
             round_seigniorage_rate,
+            unbonding_delay,
+            wasmless_transfer_cost,
             protocol_version,
             mint_installer_bytes,
             pos_installer_bytes,
@@ -338,7 +343,6 @@ impl GenesisConfig {
             wasm_config: costs,
             deploy_config,
             highway_config,
-            unbonding_delay,
         }
     }
 }
@@ -458,6 +462,7 @@ impl Into<ExecConfig> for Chainspec {
             self.genesis.locked_funds_period,
             self.genesis.round_seigniorage_rate,
             self.genesis.unbonding_delay,
+            self.genesis.wasmless_transfer_cost,
         )
     }
 }

--- a/node/src/components/chainspec_loader/config.rs
+++ b/node/src/components/chainspec_loader/config.rs
@@ -88,6 +88,7 @@ struct UpgradePoint {
     new_wasm_config: Option<WasmConfig>,
     new_deploy_config: Option<DeployConfig>,
     new_validator_slots: Option<u32>,
+    new_wasmless_transfer_cost: Option<u64>,
 }
 
 impl From<&chainspec::UpgradePoint> for UpgradePoint {
@@ -99,6 +100,7 @@ impl From<&chainspec::UpgradePoint> for UpgradePoint {
             new_wasm_config: upgrade_point.new_wasm_config,
             new_deploy_config: upgrade_point.new_deploy_config,
             new_validator_slots: upgrade_point.new_validator_slots,
+            new_wasmless_transfer_cost: upgrade_point.new_wasmless_transfer_cost,
         }
     }
 }
@@ -124,6 +126,7 @@ impl UpgradePoint {
             new_wasm_config: self.new_wasm_config,
             new_deploy_config: self.new_deploy_config,
             new_validator_slots: self.new_validator_slots,
+            new_wasmless_transfer_cost: self.new_wasmless_transfer_cost,
         })
     }
 }

--- a/node/src/components/chainspec_loader/config.rs
+++ b/node/src/components/chainspec_loader/config.rs
@@ -36,6 +36,7 @@ const DEFAULT_LOCKED_FUNDS_PERIOD: EraId = 15;
 /// (1+0.02)^((2^14)/31536000000)-1 is expressed as a fraction below.
 const DEFAULT_ROUND_SEIGNIORAGE_RATE: Ratio<u64> = Ratio::new_raw(6414, 623437335209);
 const DEFAULT_UNBONDING_DELAY: EraId = 14;
+const DEFAULT_WASMLESS_TRANSFER_COST: u64 = 10_000;
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
 struct Genesis {
@@ -47,6 +48,7 @@ struct Genesis {
     protocol_version: Version,
     round_seigniorage_rate: Ratio<u64>,
     unbonding_delay: EraId,
+    wasmless_transfer_cost: u64,
     mint_installer_path: External<Vec<u8>>,
     pos_installer_path: External<Vec<u8>>,
     standard_payment_installer_path: External<Vec<u8>>,
@@ -65,6 +67,7 @@ impl Default for Genesis {
             protocol_version: Version::from((1, 0, 0)),
             round_seigniorage_rate: DEFAULT_ROUND_SEIGNIORAGE_RATE,
             unbonding_delay: DEFAULT_UNBONDING_DELAY,
+            wasmless_transfer_cost: DEFAULT_WASMLESS_TRANSFER_COST,
             mint_installer_path: External::path(DEFAULT_MINT_INSTALLER_PATH),
             pos_installer_path: External::path(DEFAULT_POS_INSTALLER_PATH),
             standard_payment_installer_path: External::path(
@@ -147,6 +150,7 @@ impl From<&chainspec::Chainspec> for ChainspecConfig {
             protocol_version: chainspec.genesis.protocol_version.clone(),
             round_seigniorage_rate: chainspec.genesis.round_seigniorage_rate,
             unbonding_delay: chainspec.genesis.unbonding_delay,
+            wasmless_transfer_cost: chainspec.genesis.wasmless_transfer_cost,
             mint_installer_path: External::path(DEFAULT_MINT_INSTALLER_PATH),
             pos_installer_path: External::path(DEFAULT_POS_INSTALLER_PATH),
             standard_payment_installer_path: External::path(
@@ -228,6 +232,7 @@ pub(super) fn parse_toml<P: AsRef<Path>>(chainspec_path: P) -> Result<chainspec:
         locked_funds_period: chainspec.genesis.locked_funds_period,
         round_seigniorage_rate: chainspec.genesis.round_seigniorage_rate,
         unbonding_delay: chainspec.genesis.unbonding_delay,
+        wasmless_transfer_cost: chainspec.genesis.wasmless_transfer_cost,
         protocol_version: chainspec.genesis.protocol_version,
         mint_installer_bytes,
         pos_installer_bytes,

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -41,6 +41,8 @@ unbonding_delay = 14
 #
 # (1+0.02)^((2^12)/31536000000)-1 is expressed as a fractional number below.
 round_seigniorage_rate = [15_959, 6_204_824_582_392]
+# Wasmless transfer cost expressed in gas.
+wasmless_transfer_cost = 10_000
 
 [highway]
 # Era duration.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -41,6 +41,8 @@ unbonding_delay = 14
 #
 # (1+0.02)^((2^17)/31536000000)-1 is expressed as a fractional number below.
 round_seigniorage_rate = [16_837, 204_568_405_924]
+# Wasmless transfer cost expressed in gas.
+wasmless_transfer_cost = 10_000
 
 [highway]
 # Era duration.

--- a/resources/production/validation.md5
+++ b/resources/production/validation.md5
@@ -1,2 +1,2 @@
 7562c32ae6c92f1d1e4f12409ee1bc8d  accounts.csv
-b75f7297873143eb679926a7f5c4ce2d  chainspec.toml
+9cdd96934ac96c9c69a5ad0677d5414a  chainspec.toml

--- a/resources/test/valid/chainspec.toml
+++ b/resources/test/valid/chainspec.toml
@@ -13,6 +13,8 @@ locked_funds_period = 0
 # (1+0.02)^((2^14)/31536000000)-1 is expressed as a fractional number below.
 round_seigniorage_rate = [6_414, 623_437_335_209]
 unbonding_delay = 14
+# Wasmless transfer cost expressed in gas.
+wasmless_transfer_cost = 10_000
 
 [highway]
 era_duration = '3minutes'

--- a/types/src/proof_of_stake.rs
+++ b/types/src/proof_of_stake.rs
@@ -53,15 +53,10 @@ mod internal {
         Key, Phase, URef, U512,
     };
 
+    use super::{PAYMENT_PURSE_KEY, REFUND_PURSE_KEY};
+
     /// Account used to run system functions (in particular `finalize_payment`).
     const SYSTEM_ACCOUNT: AccountHash = AccountHash::new([0u8; 32]);
-
-    /// The uref name where the PoS accepts payment for computation on behalf of validators.
-    const PAYMENT_PURSE_KEY: &str = "pos_payment_purse";
-
-    /// The uref name where the PoS will refund unused payment back to the user. The uref this name
-    /// corresponds to is set by the user.
-    const REFUND_PURSE_KEY: &str = "pos_refund_purse";
 
     /// Attempts to look up a purse from the named_keys
     fn get_purse<R: RuntimeProvider>(

--- a/types/src/proof_of_stake/constants.rs
+++ b/types/src/proof_of_stake/constants.rs
@@ -22,3 +22,10 @@ pub const POS_PAYMENT_PURSE: &str = "pos_payment_purse";
 pub const HASH_KEY: &str = "pos_hash";
 /// Storage for proof of stake access key.
 pub const ACCESS_KEY: &str = "pos_access";
+
+/// The uref name where the PoS accepts payment for computation on behalf of validators.
+pub const PAYMENT_PURSE_KEY: &str = "pos_payment_purse";
+
+/// The uref name where the PoS will refund unused payment back to the user. The uref this name
+/// corresponds to is set by the user.
+pub const REFUND_PURSE_KEY: &str = "pos_refund_purse";


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1122

- Wasmless transfer now has fixed price which pays to the proposer of the block i.e. payment and finialization code is simulated similar to normal deploys
- Added this cost to chainspec and internally this cost is part of the ProtocolData
- Upgrade support 