### PR TITLE
NDRS-636 - handle untracked finalized deploys

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -188,7 +188,9 @@ where
 struct BlockProposerReady {
     /// Set of deploys currently stored in the block proposer.
     sets: BlockProposerDeploySets,
-    /// "Unhandled" deploys are deploys that the BlockProposer have not yet been seen.
+    /// `unhandled_finalized` is a set of hashes for deploys that the `BlockProposer` has not yet
+    /// seen but were reported as reported to `finalized_deploys()`. They are used to
+    /// filter deploys for proposal, similar to `self.sets.finalized_deploys`.
     unhandled_finalized: HashSet<DeployHash>,
     // We don't need the whole Chainspec here, just the deploy config.
     deploy_config: DeployConfig,

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -42,6 +42,14 @@ impl DeployType {
         }
     }
 
+    /// Extract into header and drop `DeployType`.
+    pub fn into_header(self) -> DeployHeader {
+        match self {
+            Self::Transfer { header, .. } => header,
+            Self::Other { header, .. } => header,
+        }
+    }
+
     /// Access payment_amount from all variants.
     pub fn payment_amount(&self) -> Motes {
         match self {

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -43,7 +43,7 @@ impl DeployType {
     }
 
     /// Extract into header and drop `DeployType`.
-    pub fn into_header(self) -> DeployHeader {
+    pub fn take_header(self) -> DeployHeader {
         match self {
             Self::Transfer { header, .. } => header,
             Self::Other { header, .. } => header,

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -288,7 +288,11 @@ fn should_keep_track_of_unhandled_deploys() {
     );
     assert!(
         proposer.contains_finalized(deploy2.id()),
-        "should contain deploy2"
+        "should deploy2's hash should be considered seen"
+    );
+    assert!(
+        !proposer.sets.finalized_deploys.contains_key(deploy2.id()),
+        "should not yet contain deploy2"
     );
 
     let past_deploys = HashSet::new();
@@ -300,6 +304,17 @@ fn should_keep_track_of_unhandled_deploys() {
             &past_deploys
         ),
         "deploy2 should -not- be valid"
+    );
+
+    // Now we add Deploy2
+    proposer.add_deploy_or_transfer(creation_time, *deploy2.id(), deploy2.deploy_type().unwrap());
+    assert!(
+        proposer.sets.finalized_deploys.contains_key(deploy2.id()),
+        "deploy2 should now be in finalized_deploys"
+    );
+    assert!(
+        !proposer.unhandled_finalized.contains(deploy2.id()),
+        "deploy2 should not be in unhandled_finalized"
     );
 }
 

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -288,7 +288,7 @@ fn should_keep_track_of_unhandled_deploys() {
     );
     assert!(
         proposer.contains_finalized(deploy2.id()),
-        "should deploy2's hash should be considered seen"
+        "deploy2's hash should be considered seen"
     );
     assert!(
         !proposer.sets.finalized_deploys.contains_key(deploy2.id()),


### PR DESCRIPTION
This PR is a bugfix for https://casperlabs.atlassian.net/browse/NDRS-636 - with this we are now keeping note of deploys that we have not yet tracked for proposal, and checking them when we propose new deploys for a block.