### PR TITLE
NDRS-680: Make SSE server channel buffer size configurable.

### DIFF
--- a/node/src/components/event_stream_server/config.rs
+++ b/node/src/components/event_stream_server/config.rs
@@ -9,6 +9,9 @@ const DEFAULT_ADDRESS: &str = "0.0.0.0:9999";
 /// Default number of SSEs to buffer.
 const DEFAULT_EVENT_STREAM_BUFFER_LENGTH: u32 = 100;
 
+/// Default broadcast channel size.
+const DEFAULT_BROADCAST_CHANNEL_SIZE: usize = 100;
+
 /// SSE HTTP server configuration.
 #[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
@@ -19,6 +22,11 @@ pub struct Config {
 
     /// Number of SSEs to buffer.
     pub event_stream_buffer_length: u32,
+
+    /// The number of events to buffer in the tokio broadcast channel to help slower clients to try
+    /// to avoid missing events.  See <https://docs.rs/tokio/0.2.22/tokio/sync/broadcast/index.html#lagging>
+    /// for further details.
+    pub broadcast_channel_size: usize,
 }
 
 impl Config {
@@ -27,6 +35,7 @@ impl Config {
         Config {
             address: DEFAULT_ADDRESS.to_string(),
             event_stream_buffer_length: DEFAULT_EVENT_STREAM_BUFFER_LENGTH,
+            broadcast_channel_size: DEFAULT_BROADCAST_CHANNEL_SIZE,
         }
     }
 }

--- a/node/src/components/event_stream_server/http_server.rs
+++ b/node/src/components/event_stream_server/http_server.rs
@@ -25,7 +25,7 @@ use crate::utils;
 pub(super) async fn run(config: Config, mut data_receiver: mpsc::UnboundedReceiver<SseData>) {
     // Event stream channels and filter.
     let (broadcaster, mut new_subscriber_info_receiver, sse_filter) =
-        sse_server::create_channels_and_filter();
+        sse_server::create_channels_and_filter(config.broadcast_channel_size);
 
     let service = warp_json_rpc::service(sse_filter);
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -113,6 +113,8 @@ address = '0.0.0.0:9999'
 # The number of event stream events to buffer.
 event_stream_buffer_length = 100
 
+# The capacity of the broadcast channel size.
+broadcast_channel_size = 100
 
 # ===============================================
 # Configuration options for the storage component

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -112,6 +112,8 @@ address = '0.0.0.0:9999'
 # The number of event stream events to buffer.
 event_stream_buffer_length = 100
 
+# The capacity of the broadcast channel size.
+broadcast_channel_size = 100
 
 # ===============================================
 # Configuration options for the storage component


### PR DESCRIPTION
The SSE server now has an configurable parameter that determines the channel broadcast buffer size within the server itself. The default value is set to 100 and is present within both `config.toml` and `config-example.toml`