### PR TITLE
NO-TICKET: update get-era-info endpoint

### DIFF
--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -567,9 +567,9 @@ pub extern "C" fn casper_get_balance(
 
 /// Retrieves era information from the network.
 ///
-/// See [super::get_era_info](super::get_era_info) for more details.
+/// See [super::get_era_info_by_switch_block](super::get_era_info_by_switch_block) for more details.
 #[no_mangle]
-pub extern "C" fn casper_get_era_info(
+pub extern "C" fn casper_get_era_info_by_switch_block(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
     verbose: bool,
@@ -583,7 +583,12 @@ pub extern "C" fn casper_get_era_info(
     let node_address = try_unsafe_arg!(node_address);
     let maybe_block_id = try_unsafe_arg!(maybe_block_id);
     runtime.block_on(async move {
-        let result = super::get_era_info(maybe_rpc_id, node_address, verbose, maybe_block_id);
+        let result = super::get_era_info_by_switch_block(
+            maybe_rpc_id,
+            node_address,
+            verbose,
+            maybe_block_id,
+        );
         let response = try_unwrap_rpc!(result);
         copy_str_to_buf(&response, response_buf, response_buf_len);
         casper_error_t::CASPER_SUCCESS

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -352,13 +352,13 @@ pub fn get_balance(
 /// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the
 ///   `Block` height or empty. If empty, era information from the latest block will be returned if
 ///   available.
-pub fn get_era_info(
+pub fn get_era_info_by_switch_block(
     maybe_rpc_id: &str,
     node_address: &str,
     verbose: bool,
     maybe_block_id: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_era_info(maybe_block_id)
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_era_info_by_switch_block(maybe_block_id)
 }
 
 /// Retrieves the bids and validators as of the most recently added `Block`.

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -14,7 +14,7 @@ use casper_node::{
         account::{PutDeploy, PutDeployParams},
         chain::{
             BlockIdentifier, GetBlock, GetBlockParams, GetBlockTransfers, GetBlockTransfersParams,
-            GetEraInfo, GetEraInfoParams, GetStateRootHash, GetStateRootHashParams,
+            GetEraInfoBySwitchBlock, GetEraInfoParams, GetStateRootHash, GetStateRootHashParams,
         },
         docs::ListRpcs,
         info::{GetDeploy, GetDeployParams},
@@ -147,12 +147,15 @@ impl RpcCall {
         Ok(response)
     }
 
-    pub(crate) fn get_era_info(self, maybe_block_identifier: &str) -> Result<JsonRpc> {
+    pub(crate) fn get_era_info_by_switch_block(
+        self,
+        maybe_block_identifier: &str,
+    ) -> Result<JsonRpc> {
         let response = match Self::block_identifier(maybe_block_identifier)? {
-            None => GetEraInfo::request(self),
+            None => GetEraInfoBySwitchBlock::request(self),
             Some(block_identifier) => {
                 let params = GetEraInfoParams { block_identifier };
-                GetEraInfo::request_with_map_params(self, params)
+                GetEraInfoBySwitchBlock::request_with_map_params(self, params)
             }
         }?;
         validation::validate_get_era_info_response(&response)?;
@@ -361,7 +364,7 @@ impl RpcClient for GetItem {
     const RPC_METHOD: &'static str = <Self as RpcWithParams>::METHOD;
 }
 
-impl RpcClient for GetEraInfo {
+impl RpcClient for GetEraInfoBySwitchBlock {
     const RPC_METHOD: &'static str = Self::METHOD;
 }
 

--- a/client/src/get_era_info_by_switch_block.rs
+++ b/client/src/get_era_info_by_switch_block.rs
@@ -2,7 +2,7 @@ use std::str;
 
 use clap::{App, ArgMatches, SubCommand};
 
-use casper_node::rpcs::chain::GetEraInfo;
+use casper_node::rpcs::chain::GetEraInfoBySwitchBlock;
 
 use crate::{command::ClientCommand, common};
 
@@ -14,8 +14,8 @@ enum DisplayOrder {
     BlockIdentifier,
 }
 
-impl<'a, 'b> ClientCommand<'a, 'b> for GetEraInfo {
-    const NAME: &'static str = "get-era-info";
+impl<'a, 'b> ClientCommand<'a, 'b> for GetEraInfoBySwitchBlock {
+    const NAME: &'static str = "get-era-info-by-switch-block";
     const ABOUT: &'static str = "Retrieves era information from the network";
 
     fn build(display_order: usize) -> App<'a, 'b> {
@@ -38,9 +38,13 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetEraInfo {
         let verbose = common::verbose::get(matches);
         let maybe_block_id = common::block_identifier::get(&matches);
 
-        let response =
-            casper_client::get_era_info(maybe_rpc_id, node_address, verbose, maybe_block_id)
-                .unwrap_or_else(|error| panic!("response error: {}", error));
+        let response = casper_client::get_era_info_by_switch_block(
+            maybe_rpc_id,
+            node_address,
+            verbose,
+            maybe_block_id,
+        )
+        .unwrap_or_else(|error| panic!("response error: {}", error));
         println!(
             "{}",
             serde_json::to_string_pretty(&response).expect("should encode to JSON")

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -6,7 +6,7 @@ mod docs;
 mod generate_completion;
 mod get_auction_info;
 mod get_balance;
-mod get_era_info;
+mod get_era_info_by_switch_block;
 mod get_state_hash;
 mod keygen;
 mod query_state;
@@ -15,7 +15,7 @@ use clap::{crate_description, crate_version, App};
 
 use casper_node::rpcs::{
     account::PutDeploy,
-    chain::{GetBlock, GetBlockTransfers, GetEraInfo, GetStateRootHash},
+    chain::{GetBlock, GetBlockTransfers, GetEraInfoBySwitchBlock, GetStateRootHash},
     docs::ListRpcs,
     info::GetDeploy,
     state::{GetAuctionInfo, GetBalance, GetItem as QueryState},
@@ -71,7 +71,9 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
             DisplayOrder::GetStateRootHash as usize,
         ))
         .subcommand(QueryState::build(DisplayOrder::QueryState as usize))
-        .subcommand(GetEraInfo::build(DisplayOrder::GetEraInfo as usize))
+        .subcommand(GetEraInfoBySwitchBlock::build(
+            DisplayOrder::GetEraInfo as usize,
+        ))
         .subcommand(GetAuctionInfo::build(DisplayOrder::GetAuctionInfo as usize))
         .subcommand(Keygen::build(DisplayOrder::Keygen as usize))
         .subcommand(GenerateCompletion::build(
@@ -96,7 +98,7 @@ async fn main() {
         (GetBalance::NAME, Some(matches)) => GetBalance::run(matches),
         (GetStateRootHash::NAME, Some(matches)) => GetStateRootHash::run(matches),
         (QueryState::NAME, Some(matches)) => QueryState::run(matches),
-        (GetEraInfo::NAME, Some(matches)) => GetEraInfo::run(matches),
+        (GetEraInfoBySwitchBlock::NAME, Some(matches)) => GetEraInfoBySwitchBlock::run(matches),
         (GetAuctionInfo::NAME, Some(matches)) => GetAuctionInfo::run(matches),
         (Keygen::NAME, Some(matches)) => Keygen::run(matches),
         (GenerateCompletion::NAME, Some(matches)) => GenerateCompletion::run(matches),

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -24,7 +24,7 @@ pub(super) async fn run<REv: ReactorEventT>(config: Config, effect_builder: Effe
     let rpc_get_deploy = rpcs::info::GetDeploy::create_filter(effect_builder);
     let rpc_get_peers = rpcs::info::GetPeers::create_filter(effect_builder);
     let rpc_get_status = rpcs::info::GetStatus::create_filter(effect_builder);
-    let rpc_get_era_info = rpcs::chain::GetEraInfo::create_filter(effect_builder);
+    let rpc_get_era_info = rpcs::chain::GetEraInfoBySwitchBlock::create_filter(effect_builder);
     let rpc_get_auction_info = rpcs::state::GetAuctionInfo::create_filter(effect_builder);
     let rpc_get_rpcs = rpcs::docs::ListRpcs::create_filter(effect_builder);
 

--- a/node/src/components/rpc_server/rpcs/chain/era_summary.rs
+++ b/node/src/components/rpc_server/rpcs/chain/era_summary.rs
@@ -1,0 +1,35 @@
+use once_cell::sync::Lazy;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use casper_types::auction::EraInfo;
+
+use crate::{
+    crypto::hash::Digest,
+    rpcs::{common::MERKLE_PROOF, docs::DocExample},
+    types::{json_compatibility::StoredValue, Block, BlockHash, Item},
+};
+
+pub(super) static ERA_SUMMARY: Lazy<EraSummary> = Lazy::new(|| EraSummary {
+    block_hash: Block::doc_example().id(),
+    era_id: 42,
+    stored_value: StoredValue::EraInfo(EraInfo::new()),
+    state_root_hash: *Block::doc_example().header().state_root_hash(),
+    merkle_proof: MERKLE_PROOF.clone(),
+});
+
+/// The summary of an era
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EraSummary {
+    /// The block hash
+    pub block_hash: BlockHash,
+    /// The era id
+    pub era_id: u64,
+    /// The StoredValue containing era information
+    pub stored_value: StoredValue,
+    /// Hex-encoded hash of the state root
+    pub state_root_hash: Digest,
+    /// The merkle proof
+    pub merkle_proof: String,
+}

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -25,7 +25,9 @@ use super::{
     Error, ReactorEventT, RpcWithOptionalParams, RpcWithParams, RpcWithoutParams,
     RpcWithoutParamsExt,
 };
-use crate::{components::CLIENT_API_VERSION, effect::EffectBuilder, rpcs::chain::GetEraInfo};
+use crate::{
+    components::CLIENT_API_VERSION, effect::EffectBuilder, rpcs::chain::GetEraInfoBySwitchBlock,
+};
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 
@@ -76,7 +78,9 @@ static OPEN_RPC_SCHEMA: Lazy<OpenRpcSchema> = Lazy::new(|| {
     );
     schema.push_with_params::<GetItem>("returns a stored value from the network");
     schema.push_with_params::<GetBalance>("returns a purse's balance from the network");
-    schema.push_with_optional_params::<GetEraInfo>("returns an EraInfo from the network");
+    schema.push_with_optional_params::<GetEraInfoBySwitchBlock>(
+        "returns an EraInfo from the network",
+    );
     schema.push_without_params::<GetAuctionInfo>(
         "returns the bids and validators as of the most recently added Block",
     );


### PR DESCRIPTION
Based on comments from @Fraser999 and discussion with @momipsl, this PR:
- updates the name of the rpc method to `chain_get_era_info_by_switch_block`, the library functions to `get_era_info_by_switch_block`, and the CLI command to `get-era-info-by-switch-block`
- updates the response struct to contain an optional struct rather than having it contain several optional fields.