### PR TITLE
Remove the RUST_LOG env from serviced file, relying on default behavior.

### DIFF
--- a/resources/maintainer_scripts/casper_node/casper-node.service
+++ b/resources/maintainer_scripts/casper_node/casper-node.service
@@ -10,7 +10,6 @@ After=network-online.target
 Type=simple
 ExecStartPre=/etc/casper/systemd_pre_start.sh
 ExecStart=/usr/bin/casper-node validator /etc/casper/config.toml
-Environment=RUST_LOG=info
 Restart=no
 User=casper
 Group=casper


### PR DESCRIPTION
Now that RUST_LOG defaults to info, we are removing this explicit set in serviced unit.