### PR TITLE
OP-1705 remove maxsize directive from logrotate config

### DIFF
--- a/resources/maintainer_scripts/logrotate.d/casper-node
+++ b/resources/maintainer_scripts/logrotate.d/casper-node
@@ -7,5 +7,4 @@
   missingok
   notifempty
   copytruncate
-  maxsize 50M
 }


### PR DESCRIPTION
**maxsize** would only been considered if the system logrotate execution interval was lowered (default daily via /etc/cron.daily) to be less than the casper-node logrotate interval. 


```
maxsize size
    Log files are rotated when they grow bigger than size bytes even before the additionally specified time interval ( daily, weekly, monthly, or yearly).
```

remove to avoid confusion. discussed in https://casperlabs.atlassian.net/browse/OP-1705