### PR TITLE
NO-TICKET: avoid injecting unique ID into each fresh round of address gossiping

### DIFF
--- a/node/src/components/gossiper/config.rs
+++ b/node/src/components/gossiper/config.rs
@@ -11,9 +11,15 @@ use super::Error;
 const DEFAULT_INFECTION_TARGET: u8 = 3;
 const DEFAULT_SATURATION_LIMIT_PERCENT: u8 = 80;
 pub(super) const MAX_SATURATION_LIMIT_PERCENT: u8 = 99;
-pub(super) const DEFAULT_FINISHED_ENTRY_DURATION_SECS: u64 = 3_600;
+pub(super) const DEFAULT_FINISHED_ENTRY_DURATION_SECS: u64 = 60;
 const DEFAULT_GOSSIP_REQUEST_TIMEOUT_SECS: u64 = 10;
 const DEFAULT_GET_REMAINDER_TIMEOUT_SECS: u64 = 60;
+#[cfg(test)]
+const SMALL_TIMEOUTS_FINISHED_ENTRY_DURATION_SECS: u64 = 2;
+#[cfg(test)]
+const SMALL_TIMEOUTS_GOSSIP_REQUEST_TIMEOUT_SECS: u64 = 1;
+#[cfg(test)]
+const SMALL_TIMEOUTS_GET_REMAINDER_TIMEOUT_SECS: u64 = 1;
 
 /// Configuration options for gossiping.
 #[derive(Copy, Clone, DataSize, Debug, Deserialize, Serialize)]
@@ -61,6 +67,16 @@ impl Config {
             gossip_request_timeout_secs,
             get_remainder_timeout_secs,
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_small_timeouts() -> Self {
+        Config {
+            finished_entry_duration_secs: SMALL_TIMEOUTS_FINISHED_ENTRY_DURATION_SECS,
+            gossip_request_timeout_secs: SMALL_TIMEOUTS_GOSSIP_REQUEST_TIMEOUT_SECS,
+            get_remainder_timeout_secs: SMALL_TIMEOUTS_GET_REMAINDER_TIMEOUT_SECS,
+            ..Default::default()
+        }
     }
 
     pub(crate) fn infection_target(&self) -> u8 {

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -149,9 +149,6 @@ where
     pending: HashSet<SocketAddr>,
     /// The interval between each fresh round of gossiping the node's public listening address.
     gossip_interval: Duration,
-    /// An index for an iteration of gossiping our own public listening address.  This is
-    /// incremented by 1 on each iteration, and wraps on overflow.
-    next_gossip_address_index: u32,
     /// The hash of the chainspec.  We only remain connected to peers with the same
     /// `genesis_config_hash` as us.
     genesis_config_hash: Digest,
@@ -214,7 +211,6 @@ where
                 pending: HashSet::new(),
                 blocklist: HashSet::new(),
                 gossip_interval: cfg.gossip_interval,
-                next_gossip_address_index: 0,
                 genesis_config_hash,
                 shutdown_sender: None,
                 shutdown_receiver: watch::channel(()).1,
@@ -276,7 +272,6 @@ where
             pending: HashSet::new(),
             blocklist: HashSet::new(),
             gossip_interval: cfg.gossip_interval,
-            next_gossip_address_index: 0,
             genesis_config_hash,
             shutdown_sender: Some(server_shutdown_sender),
             shutdown_receiver,
@@ -592,8 +587,7 @@ where
 
     /// Gossips our public listening address, and schedules the next such gossip round.
     fn gossip_our_address(&mut self, effect_builder: EffectBuilder<REv>) -> Effects<Event<P>> {
-        self.next_gossip_address_index = self.next_gossip_address_index.wrapping_add(1);
-        let our_address = GossipedAddress::new(self.public_address, self.next_gossip_address_index);
+        let our_address = GossipedAddress::new(self.public_address);
         let mut effects = effect_builder
             .announce_gossip_our_address(our_address)
             .ignore();

--- a/node/src/components/small_network/gossiped_address.rs
+++ b/node/src/components/small_network/gossiped_address.rs
@@ -12,28 +12,17 @@ use crate::types::{Item, Tag};
 #[derive(
     Copy, Clone, DataSize, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug,
 )]
-pub struct GossipedAddress {
-    /// Our public listening address.
-    address: SocketAddr,
-    /// The index of the gossip iteration.  This is used to avoid the gossip table from filtering
-    /// out the message - i.e. to make each fresh gossip iteration have a unique identifier for the
-    /// gossiped item.
-    index: u32,
-}
+pub struct GossipedAddress(SocketAddr);
 
 impl GossipedAddress {
-    pub(super) fn new(address: SocketAddr, index: u32) -> Self {
-        GossipedAddress { address, index }
+    pub(super) fn new(address: SocketAddr) -> Self {
+        GossipedAddress(address)
     }
 }
 
 impl Display for GossipedAddress {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "gossiped-address {} iter {}",
-            self.address, self.index
-        )
+        write!(formatter, "gossiped-address {}", self.0)
     }
 }
 
@@ -49,6 +38,6 @@ impl Item for GossipedAddress {
 
 impl From<GossipedAddress> for SocketAddr {
     fn from(gossiped_address: GossipedAddress) -> Self {
-        gossiped_address.address
+        gossiped_address.0
     }
 }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -111,7 +111,7 @@ impl Reactor for TestReactor {
         _rng: &mut NodeRng,
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
         let (net, effects) = SmallNetwork::new(event_queue, cfg, Digest::default(), false)?;
-        let gossiper_config = gossiper::Config::default();
+        let gossiper_config = gossiper::Config::new_with_small_timeouts();
         let address_gossiper =
             Gossiper::new_for_complete_items("address_gossiper", gossiper_config, registry)?;
 

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -13,7 +13,7 @@ use log::info;
 use num_rational::Ratio;
 
 use crate::{
-    components::{consensus::EraId, small_network, storage},
+    components::{consensus::EraId, gossiper, small_network, storage},
     crypto::asymmetric_key::{PublicKey, SecretKey},
     reactor::{initializer, joiner, validator, Runner},
     testing::{self, network::Network, ConditionCheckReactor, TestRng},
@@ -91,6 +91,7 @@ impl TestChain {
             } else {
                 small_network::Config::default_local_net(first_node_port)
             },
+            gossip: gossiper::Config::new_with_small_timeouts(),
             ..Default::default()
         };
 

--- a/node/src/testing/network.rs
+++ b/node/src/testing/network.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use fake_instant::FakeClock as Instant;
 use futures::future::{BoxFuture, FutureExt};
 use serde::Serialize;
 use tokio::time;
@@ -164,6 +165,7 @@ where
     async fn crank_and_check_indefinitely(&mut self, node_id: &R::NodeId, rng: &mut TestRng) {
         loop {
             if self.crank(node_id, rng).await == 0 {
+                Instant::advance_time(POLL_INTERVAL.as_millis() as u64);
                 time::delay_for(POLL_INTERVAL).await;
                 continue;
             }
@@ -223,6 +225,7 @@ where
                     break;
                 } else {
                     no_events = true;
+                    Instant::advance_time(quiet_for.as_millis() as u64);
                     time::delay_for(quiet_for).await;
                 }
             } else {
@@ -262,6 +265,7 @@ where
 
             if self.crank_all(rng).await == 0 {
                 // No events processed, wait for a bit to avoid 100% cpu usage.
+                Instant::advance_time(POLL_INTERVAL.as_millis() as u64);
                 time::delay_for(POLL_INTERVAL).await;
             }
         }


### PR DESCRIPTION
It appears from examining debug log files that expired addresses are continually circulated around the remaining peers.  This has an avalanche effect in terms of network traffic, latency and the size of nodes' event queues.

The change in this PR should help avoid old gossiped addresses cycling around the network continually, but relies on keeping the config value `gossip.finished_entry_duration_secs` a reasonably low value (we're using 60 seconds as of now), and certainly it must be a significantly lower value than `gossip.gossip_interval` (we'll be using 5 mins as of now).  If not, then nodes will likely be unable to fully connect, as their attempts to gossip their address will be thwarted by peers' filters timing out at varying moments and partially or totally stalling the progress of the gossip message across the network.

This change is anticipated to fix #691 and to fix #692 both which appear to be related to the node becoming overwhelmed with address gossiped messages.  It's unclear to me if it's also related to #693.