### PR TITLE
NO-TICKET: remove unreachable calls from gossiper

### DIFF
--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -16,7 +16,7 @@ use std::{
     fmt::{self, Debug, Formatter},
     time::Duration,
 };
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::{
     components::Component,
@@ -266,7 +266,11 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
             ),
             GossipAction::Noop => Effects::new(),
             GossipAction::GetRemainder { .. } | GossipAction::AwaitingRemainder => {
-                unreachable!("can't have gossiped if we don't hold the complete data")
+                warn!(
+                    "can't have gossiped if we don't hold the complete data - likely the timeout \
+                    check was very delayed due to busy reactor"
+                );
+                Effects::new()
             }
         }
     }
@@ -422,7 +426,7 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
             )),
             GossipAction::Noop => (),
             GossipAction::GetRemainder { .. } | GossipAction::AwaitingRemainder => {
-                unreachable!("can't have gossiped if we don't hold the complete item")
+                error!("can't have gossiped if we don't hold the complete item");
             }
         }
 


### PR DESCRIPTION
This PR should fix #700 although it only addresses the symptom reported there rather than the underlying cause.

By running a 20 node network via nctl and sending a large number of deploys, I was able to see memory usage on a small number of the nodes peak at over 3.3 GiB, with the network killed as a node exceeded 7 GiB.

Investigation of the logs from that node shows that the reactor of that node is choked with consensus and fetcher events in its queue allowing the following flow to occur:
1. a deploy was received and stored locally via gossip
2. the deploy was gossiped to 3 peers, causing the entry in the gossip table to be flagged as finished and adding 3 timeouts of 10 seconds to check that each peer had responded in a timely manner
3. the entry was purged from the gossip table ~60 seconds later
4. a different peer gossiped the same deploy to us, causing a new entry to be made, but crucially this entry at this stage doesn't have us as a holder of the deploy
5. the first of the 3 timeouts from step 2 actually gets handled, a couple of minutes late.  Handling the timeout causes the panic as the gossiper was written with the expectation that a 10 second timeout would be handled after roughly 10 seconds, not a few minutes.

Replacing the `unreachable!` with a `warn!` log message will stop the node from panicking, but it does mean that the entry for the second iteration of the data gets polluted with state from the first.  I believe this is acceptable for now since it should only happen fairly infrequently, and it should ideally not happen at all if we resolve the issue whereby the reactor's event queue gets so choked that it is unable to process timeouts in a timely manner.

The second replacement of `unreachable!` I don't think can be hit without a peer sending a malicious message, but best to remove that point of attack now I think.

If the gossiper component is to stay long term, we should look to address another issue which can be seen at step 4 above: if we receive a gossip message for a deploy ID which we've already purged from the gossip table, we'll respond to the peer that we don't know that deploy, causing the peer to send the full deploy to us, even though we already have it stored locally.  This was meant to not be an issue outside of malicious actors (which would bear the burden of sending us the data, and hence wasn't deemed a likely point of attack), since the original concept was that finished entries would be retained for comfortably long enough to avoid the same data being gossiped to us multiple times.

The original timeout of an hour for finished data was reduced to a minute to reduce the memory usage of the address gossiper, but this has likely had the effect of causing slow nodes already under pressure due to backlogged event queues to receive the same deploy multiple times, putting them under even further pressure.

Some possible approaches to address this would be to check for the deploy in storage _before_ responding to a gossip message containing an apparently new deploy ID (that would add a couple more events per incoming gossip message though), or to increase the finished entry timeout, perhaps just for deploys.

