### PR TITLE
NDRS-668 - block validator - validate blocks similar to block_proposer

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -406,11 +406,7 @@ impl BlockProposerReady {
                 .iter()
                 .all(|dep| past_deploys.contains(dep) || self.contains_finalized(dep))
         };
-        let ttl_valid = header.ttl() <= deploy_config.max_ttl;
-        let timestamp_valid = header.timestamp() <= block_timestamp;
-        let deploy_valid = header.timestamp() + header.ttl() >= block_timestamp;
-        let num_deps_valid = header.dependencies().len() <= deploy_config.max_dependencies as usize;
-        ttl_valid && timestamp_valid && deploy_valid && num_deps_valid && all_deps_resolved()
+        header.is_valid(deploy_config, block_timestamp) && all_deps_resolved()
     }
 
     /// Returns a list of candidates for inclusion into a block.

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -26,11 +26,14 @@ use crate::{
         EffectBuilder, EffectExt, EffectOptionExt, Effects, Responder,
     },
     types::{BlockLike, Deploy, DeployHash},
-    NodeRng,
+    Chainspec, NodeRng,
 };
 use keyed_counter::KeyedCounter;
 
 use super::fetcher::FetchResult;
+use crate::effect::requests::StorageRequest;
+use semver::Version;
+use std::sync::Arc;
 
 /// Block validator component event.
 #[derive(Debug, From, Display)]
@@ -46,6 +49,9 @@ pub enum Event<T, I> {
     /// A request to find a specific deploy, potentially from a peer, failed.
     #[display(fmt = "deploy {} missing", _0)]
     DeployMissing(DeployHash),
+
+    #[display(fmt = "block validator loaded")]
+    Loaded { chainspec: Arc<Chainspec> },
 }
 
 /// State of the current process of block validation.
@@ -59,103 +65,108 @@ pub(crate) struct BlockValidationState<T> {
     responders: SmallVec<[Responder<(bool, T)>; 2]>,
 }
 
-/// Block validator.
-#[derive(DataSize, Debug, Default)]
-pub(crate) struct BlockValidator<T, I> {
+#[derive(Debug)]
+pub(crate) struct BlockValidatorReady<T, I> {
+    /// Chainspec loaded for deploy validation.
+    chainspec: Arc<Chainspec>,
     /// State of validation of a specific block.
     validation_states: HashMap<T, BlockValidationState<T>>,
-
     /// Number of requests for a specific deploy hash still in flight.
     in_flight: KeyedCounter<DeployHash>,
 
     _marker: std::marker::PhantomData<I>,
 }
 
-impl<T, I> BlockValidator<T, I> {
-    /// Creates a new block validator instance.
-    pub(crate) fn new() -> Self {
-        BlockValidator {
-            validation_states: Default::default(),
-            in_flight: Default::default(),
-            _marker: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<T, I, REv> Component<REv> for BlockValidator<T, I>
-where
-    T: BlockLike + Send + Clone + 'static,
-    I: Clone + Send + 'static,
-    REv: From<Event<T, I>>
-        + From<BlockValidationRequest<T, I>>
-        + From<FetcherRequest<I, Deploy>>
-        + Send,
+impl<T, I> BlockValidatorReady<T, I>
+    where
+        T: BlockLike + Send + Clone + 'static,
+        I: Clone + Send + 'static,
 {
-    type Event = Event<T, I>;
-    type ConstructionError = Infallible;
-
-    fn handle_event(
+    fn handle_event<REv>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
-        _rng: &mut NodeRng,
-        event: Self::Event,
-    ) -> Effects<Self::Event> {
+        event: Event<T, I>,
+    ) -> Effects<Event<T, I>>
+        where
+            REv: From<Event<T, I>>
+            + From<BlockValidationRequest<T, I>>
+            + From<StorageRequest>
+            + From<FetcherRequest<I, Deploy>>
+            + Send,
+    {
+        let mut effects = Effects::new();
         match event {
             Event::Request(BlockValidationRequest {
-                block,
-                sender,
-                responder,
-                block_timestamp,
-            }) => {
-                if block.deploys().is_empty() {
+                               block,
+                               sender,
+                               responder,
+                               block_timestamp,
+                           }) => {
+                let block_deploys = block
+                    .deploys()
+                    .iter()
+                    .map(|deploy_hash| **deploy_hash)
+                    .collect::<HashSet<_>>();
+                if block_deploys.is_empty() {
                     // If there are no deploys, return early.
                     let mut effects = Effects::new();
                     effects.extend(responder.respond((true, block)).ignore());
                     return effects;
                 }
-                // No matter the current state, we will request the deploys inside this protoblock
-                // for now. Duplicate requests must still be answered, but are
-                // de-duplicated by the fetcher.
-                let effects = block
-                    .deploys()
-                    .iter()
-                    .flat_map(|deploy_hash| {
-                        // For every request, increase the number of in-flight...
-                        self.in_flight.inc(*deploy_hash);
-
-                        // ...then request it.
-                        let dh_found = **deploy_hash;
-                        let dh_not_found = **deploy_hash;
-                        effect_builder
-                            .fetch_deploy(**deploy_hash, sender.clone())
-                            .map_or_else(
-                                move |result: FetchResult<Deploy>| match result {
-                                    FetchResult::FromStorage(deploy)
-                                    | FetchResult::FromPeer(deploy, _) => {
-                                        if deploy.header().timestamp() > block_timestamp {
-                                            Event::DeployMissing(dh_found)
-                                        } else {
-                                            Event::DeployFound(dh_found)
-                                        }
-                                    }
-                                },
-                                move || Event::DeployMissing(dh_not_found),
-                            )
-                    })
-                    .collect();
 
                 // TODO: Clean this up to use `or_insert_with_key` once
                 // https://github.com/rust-lang/rust/issues/71024 is stabilized.
                 match self.validation_states.entry(block) {
                     Entry::Occupied(mut entry) => {
-                        // The entry already exists. We register ourselves as someone interested in
-                        // the ultimate validation result.
-                        entry.get_mut().responders.push(responder);
+                        // The entry already exists.
+                        if entry.get().missing_deploys.is_empty() {
+                            // Block has already been validated successfully, early return to
+                            // caller.
+                            effects.extend(responder.respond((true, entry.key().clone())).ignore());
+                        } else {
+                            // We register ourselves as someone interested in the ultimate
+                            // validation result.
+                            entry.get_mut().responders.push(responder);
+                        }
                     }
                     Entry::Vacant(entry) => {
                         // Our entry is vacant - create an entry to track the state.
                         let missing_deploys: HashSet<DeployHash> =
                             entry.key().deploys().iter().map(|hash| **hash).collect();
+
+                        let in_flight = &mut self.in_flight;
+                        let chainspec = self.chainspec.clone();
+                        let fetch_effects: Effects<Event<T, I>> = block_deploys
+                            .iter()
+                            .flat_map(|deploy_hash| {
+                                let chainspec = chainspec.clone();
+                                // For every request, increase the number of in-flight...
+                                in_flight.inc(deploy_hash);
+
+                                // ...then request it.
+                                let dh_found = *deploy_hash;
+                                let dh_not_found = *deploy_hash;
+                                effect_builder
+                                    .fetch_deploy(*deploy_hash, sender.clone())
+                                    .map_or_else(
+                                        move |result: FetchResult<Deploy>| match result {
+                                            FetchResult::FromStorage(deploy)
+                                            | FetchResult::FromPeer(deploy, _) => {
+                                                if deploy
+                                                    .header()
+                                                    .is_valid(&chainspec.genesis.deploy_config, block_timestamp)
+                                                {
+                                                    Event::DeployMissing(dh_found)
+                                                } else {
+                                                    Event::DeployFound(dh_found)
+                                                }
+                                            }
+                                        },
+                                        move || Event::DeployMissing(dh_not_found),
+                                    )
+                            })
+                            .collect();
+                        effects.extend(fetch_effects);
 
                         entry.insert(BlockValidationState {
                             missing_deploys,
@@ -163,10 +174,7 @@ where
                         });
                     }
                 }
-
-                effects
             }
-
             Event::DeployFound(deploy_hash) => {
                 // We successfully found a hash. Decrease the number of outstanding requests.
                 self.in_flight.dec(&deploy_hash);
@@ -176,7 +184,6 @@ where
                     state.missing_deploys.remove(&deploy_hash);
                 }
 
-                let mut effects = Effects::new();
                 // Now we remove all states that have finished and notify the requestors.
                 self.validation_states.retain(|key, state| {
                     if state.missing_deploys.is_empty() {
@@ -189,10 +196,7 @@ where
                         true
                     }
                 });
-
-                effects
             }
-
             Event::DeployMissing(deploy_hash) => {
                 // A deploy failed to fetch. If there is still hope (i.e. other outstanding
                 // requests), we just ignore this little accident.
@@ -201,9 +205,6 @@ where
                 }
 
                 // Otherwise notify everyone still waiting on it that all is lost.
-
-                let mut effects = Effects::new();
-
                 self.validation_states.retain(|key, state| {
                     if state.missing_deploys.contains(&deploy_hash) {
                         // This validation state contains a failed deploy hash, it can never
@@ -216,9 +217,98 @@ where
                         true
                     }
                 });
-
-                effects
             }
+            Event::Loaded { .. } => {}
         }
+        effects
+    }
+}
+
+/// Block validator.
+#[derive(Debug)]
+pub(crate) enum BlockValidatorState<T, I> {
+    Loading(Vec<Event<T, I>>),
+    Ready(BlockValidatorReady<T, I>),
+}
+
+/// Block validator.
+#[derive(DataSize, Debug)]
+pub(crate) struct BlockValidator<T, I> {
+    #[data_size(skip)]
+    state: BlockValidatorState<T, I>,
+    _marker: std::marker::PhantomData<I>,
+}
+
+impl<T, I> BlockValidator<T, I>
+    where
+        T: BlockLike + Send + Clone + 'static,
+        I: Clone + Send + 'static + Send,
+{
+    /// Creates a new block validator instance.
+    pub(crate) fn new<REv>(effect_builder: EffectBuilder<REv>) -> (Self, Effects<Event<T, I>>)
+        where
+            REv: From<Event<T, I>> + From<StorageRequest> + Send + 'static,
+    {
+        let effects = async move {
+            effect_builder
+                .get_chainspec(Version::new(1, 0, 0))
+                .await
+                .expect("chainspec should be infallible")
+        }
+            .event(move |chainspec| Event::Loaded { chainspec });
+        (
+            BlockValidator {
+                state: BlockValidatorState::Loading(Vec::new()),
+                _marker: std::marker::PhantomData,
+            },
+            effects,
+        )
+    }
+}
+
+impl<T, I, REv> Component<REv> for BlockValidator<T, I>
+    where
+        T: BlockLike + Send + Clone + 'static,
+        I: Clone + Send + 'static,
+        REv: From<Event<T, I>>
+        + From<BlockValidationRequest<T, I>>
+        + From<FetcherRequest<I, Deploy>>
+        + From<StorageRequest>
+        + Send,
+{
+    type Event = Event<T, I>;
+    type ConstructionError = Infallible;
+
+    fn handle_event(
+        &mut self,
+        effect_builder: EffectBuilder<REv>,
+        _rng: &mut NodeRng,
+        event: Self::Event,
+    ) -> Effects<Self::Event> {
+        let mut effects = Effects::new();
+        match (&mut self.state, event) {
+            (BlockValidatorState::Loading(requests), Event::Loaded { chainspec }) => {
+                let mut new_ready_state = BlockValidatorReady {
+                    chainspec,
+                    validation_states: Default::default(),
+                    in_flight: Default::default(),
+                    _marker: std::marker::PhantomData,
+                };
+                let requests = requests;
+                // Replay postponed events onto new state.
+                for ev in requests.drain(..) {
+                    effects.extend(new_ready_state.handle_event(effect_builder, ev));
+                }
+                self.state = BlockValidatorState::Ready(new_ready_state);
+            }
+            (BlockValidatorState::Loading(requests), request @ Event::Request(_)) => {
+                requests.push(request);
+            }
+            (BlockValidatorState::Ready(ref mut ready_state), event) => {
+                effects.extend(ready_state.handle_event(effect_builder, event));
+            }
+            _ => {}
+        }
+        effects
     }
 }

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -78,17 +78,17 @@ pub(crate) struct BlockValidatorReady<T, I> {
 }
 
 impl<T, I> BlockValidatorReady<T, I>
-    where
-        T: BlockLike + Send + Clone + 'static,
-        I: Clone + Send + 'static,
+where
+    T: BlockLike + Send + Clone + 'static,
+    I: Clone + Send + 'static,
 {
     fn handle_event<REv>(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         event: Event<T, I>,
     ) -> Effects<Event<T, I>>
-        where
-            REv: From<Event<T, I>>
+    where
+        REv: From<Event<T, I>>
             + From<BlockValidationRequest<T, I>>
             + From<StorageRequest>
             + From<FetcherRequest<I, Deploy>>
@@ -97,11 +97,11 @@ impl<T, I> BlockValidatorReady<T, I>
         let mut effects = Effects::new();
         match event {
             Event::Request(BlockValidationRequest {
-                               block,
-                               sender,
-                               responder,
-                               block_timestamp,
-                           }) => {
+                block,
+                sender,
+                responder,
+                block_timestamp,
+            }) => {
                 let block_deploys = block
                     .deploys()
                     .iter()
@@ -152,10 +152,10 @@ impl<T, I> BlockValidatorReady<T, I>
                                         move |result: FetchResult<Deploy>| match result {
                                             FetchResult::FromStorage(deploy)
                                             | FetchResult::FromPeer(deploy, _) => {
-                                                if deploy
-                                                    .header()
-                                                    .is_valid(&chainspec.genesis.deploy_config, block_timestamp)
-                                                {
+                                                if deploy.header().is_valid(
+                                                    &chainspec.genesis.deploy_config,
+                                                    block_timestamp,
+                                                ) {
                                                     Event::DeployMissing(dh_found)
                                                 } else {
                                                     Event::DeployFound(dh_found)
@@ -240,14 +240,14 @@ pub(crate) struct BlockValidator<T, I> {
 }
 
 impl<T, I> BlockValidator<T, I>
-    where
-        T: BlockLike + Send + Clone + 'static,
-        I: Clone + Send + 'static + Send,
+where
+    T: BlockLike + Send + Clone + 'static,
+    I: Clone + Send + 'static + Send,
 {
     /// Creates a new block validator instance.
     pub(crate) fn new<REv>(effect_builder: EffectBuilder<REv>) -> (Self, Effects<Event<T, I>>)
-        where
-            REv: From<Event<T, I>> + From<StorageRequest> + Send + 'static,
+    where
+        REv: From<Event<T, I>> + From<StorageRequest> + Send + 'static,
     {
         let effects = async move {
             effect_builder
@@ -255,7 +255,7 @@ impl<T, I> BlockValidator<T, I>
                 .await
                 .expect("chainspec should be infallible")
         }
-            .event(move |chainspec| Event::Loaded { chainspec });
+        .event(move |chainspec| Event::Loaded { chainspec });
         (
             BlockValidator {
                 state: BlockValidatorState::Loading(Vec::new()),
@@ -267,10 +267,10 @@ impl<T, I> BlockValidator<T, I>
 }
 
 impl<T, I, REv> Component<REv> for BlockValidator<T, I>
-    where
-        T: BlockLike + Send + Clone + 'static,
-        I: Clone + Send + 'static,
-        REv: From<Event<T, I>>
+where
+    T: BlockLike + Send + Clone + 'static,
+    I: Clone + Send + 'static,
+    REv: From<Event<T, I>>
         + From<BlockValidationRequest<T, I>>
         + From<FetcherRequest<I, Deploy>>
         + From<StorageRequest>

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -156,9 +156,9 @@ where
                                                     &chainspec.genesis.deploy_config,
                                                     block_timestamp,
                                                 ) {
-                                                    Event::DeployMissing(dh_found)
-                                                } else {
                                                     Event::DeployFound(dh_found)
+                                                } else {
+                                                    Event::DeployMissing(dh_found)
                                                 }
                                             }
                                         },

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -406,6 +406,13 @@ where
                 .await
                 .expect("could not serialize snapshot");
 
+            let mut file =
+                File::create("queue_dump_debug.txt").expect("could not create dump file");
+            self.scheduler
+                .debug_dump(&mut file)
+                .await
+                .expect("unable to dump queues to file");
+
             // Indicate we are done with the dump.
             crate::QUEUE_DUMP_REQUESTED.store(false, Ordering::SeqCst);
         }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -418,7 +418,11 @@ impl reactor::Reactor for Reactor {
         let event_stream_server =
             EventStreamServer::new(config.event_stream_server.clone(), effect_builder);
 
-        let block_validator = BlockValidator::new();
+        let (block_validator, block_validator_effects) = BlockValidator::new(effect_builder);
+        effects.extend(reactor::wrap_effects(
+            Event::BlockValidator,
+            block_validator_effects,
+        ));
 
         let deploy_fetcher = Fetcher::new(config.fetcher);
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -408,9 +408,13 @@ impl reactor::Reactor for Reactor {
             .expect("should have state root hash");
         let block_executor = BlockExecutor::new(genesis_state_root_hash, registry.clone())
             .with_parent_map(latest_block);
-        let proto_block_validator = BlockValidator::new();
+        let (proto_block_validator, block_validator_effects) = BlockValidator::new(effect_builder);
         let linear_chain = LinearChain::new();
 
+        effects.extend(reactor::wrap_effects(
+            Event::ProtoBlockValidator,
+            block_validator_effects,
+        ));
         effects.extend(reactor::wrap_effects(Event::Network, network_effects));
         effects.extend(reactor::wrap_effects(
             Event::SmallNetwork,

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -34,7 +34,7 @@ use super::{BlockHash, Item, Tag, TimeDiff, Timestamp};
 #[cfg(test)]
 use crate::testing::TestRng;
 use crate::{
-    components::block_proposer::DeployType,
+    components::{block_proposer::DeployType, chainspec_loader::DeployConfig},
     crypto::{
         asymmetric_key::{self, PublicKey, SecretKey, Signature},
         hash::{self, Digest},
@@ -261,6 +261,15 @@ impl DeployHeader {
     /// Which chain the deploy is supposed to be run on.
     pub fn chain_name(&self) -> &str {
         &self.chain_name
+    }
+
+    /// Determine if this deploy header has valid values based on a `DeployConfig` and timestamp.
+    pub fn is_valid(&self, deploy_config: &DeployConfig, current_timestamp: Timestamp) -> bool {
+        let ttl_valid = self.ttl() <= deploy_config.max_ttl;
+        let timestamp_valid = self.timestamp() <= current_timestamp;
+        let not_expired = !self.expired(current_timestamp);
+        let num_deps_valid = self.dependencies().len() <= deploy_config.max_dependencies as usize;
+        ttl_valid && timestamp_valid && not_expired && num_deps_valid
     }
 }
 

--- a/node/src/utils/round_robin.rs
+++ b/node/src/utils/round_robin.rs
@@ -174,8 +174,7 @@ where
             }
             writer.write_all(b"]\n")?;
         }
-        writer.flush()?;
-        Ok(())
+        writer.flush()
     }
 }
 

--- a/node/src/utils/round_robin.rs
+++ b/node/src/utils/round_robin.rs
@@ -9,14 +9,13 @@ use std::{
     fmt::Debug,
     fs::File,
     hash::Hash,
-    io::{self, Write},
+    io::{self, BufWriter, Write},
     num::NonZeroUsize,
     sync::atomic::{AtomicUsize, Ordering},
 };
 
 use enum_iterator::IntoEnumIterator;
 use serde::{ser::SerializeMap, Serialize, Serializer};
-use std::io::BufWriter;
 use tokio::sync::{Mutex, Semaphore};
 
 /// Weighted round-robin scheduler.
@@ -175,6 +174,7 @@ where
             }
             writer.write_all(b"]\n")?;
         }
+        writer.flush()?;
         Ok(())
     }
 }


### PR DESCRIPTION
With this PR I started out trying to solve [NDRS-668](https://casperlabs.atlassian.net/browse/NDRS-668):

1. add a state machine to block_validator that loads the chainspec from storage (needed to validate deploys).
2. validate deploys against chainspec values

That _should_ have been it, but it turned out that `BlockValidator` was the source of many extra events on the queue:

The `BlockValidator` would always fetch all deploys when a `BlockValidationRequest` was received by it, regardless of if it has already validated it, or if there was a previous request in-flight for that block. This PR therefore also implements fetching the deploys for a block _if it has not been successfully validated in the past_. If it has been successfully validated, we can exit early, returning the validation to the caller.

I also add a `Debug` dump of the queue items to file (piggybacking on the already written json dump) where you can send a SIGUSR1 signal to get a dump in `queue_dump_debug.txt`, which can aid in debugging the queue. There are hashes present in this debug dump, making it possible to correlate requests/responses and other messages in general.
