### PR TITLE
NO-TICKET: Small fixes

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -826,7 +826,7 @@ where
             .era_supervisor
             .active_eras
             .get(&self.era_supervisor.current_era)
-            .map(|era| era.consensus.has_received_messages())
+            .map(|era| !era.consensus.has_received_messages())
             .unwrap_or(true);
         if should_emit_error {
             fatal!(

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -687,7 +687,7 @@ where
     }
 
     fn has_received_messages(&self) -> bool {
-        self.highway.state().is_empty()
+        !self.highway.state().is_empty()
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/utils/nctl/sh/assets/setup_node.sh
+++ b/utils/nctl/sh/assets/setup_node.sh
@@ -70,6 +70,7 @@ function setup_node_config()
         "cfg['network']['known_addresses']=[$(get_network_known_addresses "$NODE_ID")];"
         "cfg['node']['chainspec_config_path']='../../../chainspec/chainspec.toml';"
         "cfg['storage']['path']='../storage';"
+        "cfg['consensus']['unit_hashes_folder']='../storage';"
         "cfg['rest_server']['address']='0.0.0.0:$(get_node_port_rest "$NODE_ID")';"
         "cfg['rpc_server']['address']='0.0.0.0:$(get_node_port_rpc "$NODE_ID")';"
         "cfg['event_stream_server']['address']='0.0.0.0:$(get_node_port_sse "$NODE_ID")';"


### PR DESCRIPTION
This fixes two things:

- `has_received_messages` was implemented in an inverted way: it returned true if _no_ messages have been received. An alternative fix would be to change the name of the method, but since it is a trait method, it makes sense to keep it this way.
- PR #705 introduced a new config value which should be treated by `nctl` the same way the storage path is. A relevant line to the asset setup script is added.