### PR TITLE
NO-TICKET: Take cached vertices into account

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -415,6 +415,7 @@ where
                 // If the era is already unbonded, only accept new evidence, because still-bonded
                 // eras could depend on that.
                 let evidence_only = !self.era_supervisor.is_bonded(era_id);
+                trace!(era = era_id.0, "received a consensus message");
                 self.delegate_to_era(era_id, move |consensus, rng| {
                     consensus.handle_message(sender, payload, evidence_only, rng)
                 })
@@ -831,7 +832,8 @@ where
         if should_emit_error {
             fatal!(
                 self.effect_builder,
-                "Consensus shutting down due to inability to participate in the network"
+                "Consensus shutting down due to inability to participate in the network; inactive era = {}",
+                self.era_supervisor.current_era
             )
         } else {
             Default::default()

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -687,7 +687,7 @@ where
     }
 
     fn has_received_messages(&self) -> bool {
-        !self.highway.state().is_empty()
+        !self.highway.state().is_empty() || !self.vertex_deps.is_empty()
     }
 
     fn as_any(&self) -> &dyn Any {


### PR DESCRIPTION
We panic if consensus doesn't receive any messages in 5 minutes. We currently judge this only by the Highway state - but we won't store anything in the state before we finish syncing the DAG, and this can take more than 5 minutes. Because of this, we should take vertices stored in the synchronizer cache into account as well (we received _them_, after all).