### PR TITLE
Op 1750 casper-node redirect stderr into casper-node.stderr.log

### DIFF
--- a/resources/maintainer_scripts/casper_node/casper-node.service
+++ b/resources/maintainer_scripts/casper_node/casper-node.service
@@ -11,7 +11,7 @@ Type=simple
 ExecStartPre=/etc/casper/systemd_pre_start.sh
 #StandardOutput can only append log files from systemd version 240 + (Ubuntu 20.04). Use ExecStart with redirection as workaround.
 #seperate stderr logging as it outputs non-JSON stack traces
-ExecStart=/bin/sh -c 'exec /usr/bin/casper-node validator /etc/casper/config.toml >> /var/log/casper/casper-node.log 2> /var/log/casper/casper-node.stderr.log'
+ExecStart=/bin/sh -c 'exec /usr/bin/casper-node validator /etc/casper/config.toml 1>> /var/log/casper/casper-node.log 2>> /var/log/casper/casper-node.stderr.log'
 Restart=no
 User=casper
 Group=casper

--- a/resources/maintainer_scripts/casper_node/casper-node.service
+++ b/resources/maintainer_scripts/casper_node/casper-node.service
@@ -10,7 +10,8 @@ After=network-online.target
 Type=simple
 ExecStartPre=/etc/casper/systemd_pre_start.sh
 #StandardOutput can only append log files from systemd version 240 + (Ubuntu 20.04). Use ExecStart with redirection as workaround.
-ExecStart=/bin/sh -c 'exec /usr/bin/casper-node validator /etc/casper/config.toml >> /var/log/casper/casper-node.log' 
+#seperate stderr logging as it outputs non-JSON stack traces
+ExecStart=/bin/sh -c 'exec /usr/bin/casper-node validator /etc/casper/config.toml >> /var/log/casper/casper-node.log 2> /var/log/casper/casper-node.stderr.log'
 Restart=no
 User=casper
 Group=casper

--- a/resources/maintainer_scripts/logrotate.d/casper-node
+++ b/resources/maintainer_scripts/logrotate.d/casper-node
@@ -1,4 +1,4 @@
-/var/log/casper/casper-node.log {
+/var/log/casper/casper-node* {
   dateext
   dateformat .%Y-%m-%d-%s
   compress


### PR DESCRIPTION
- seperate stderr logging as it outputs non-JSON stack traces (without redirection ends up in journald)
- logrotate applied to /var/log/casper/casper-node* (glob)