### PR TITLE
NDRS-698: if any HTTP server fails to start, causes the node to stop

### DIFF
--- a/node/src/components/event_stream_server/config.rs
+++ b/node/src/components/event_stream_server/config.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// Default binding address for the SSE HTTP server.
 ///
 /// Uses a fixed port per node, but binds on any interface.
-const DEFAULT_ADDRESS: &str = "0.0.0.0:9999";
+const DEFAULT_ADDRESS: &str = "0.0.0.0:0";
 
 /// Default number of SSEs to buffer.
 const DEFAULT_EVENT_STREAM_BUFFER_LENGTH: u32 = 100;

--- a/node/src/components/event_stream_server/http_server.rs
+++ b/node/src/components/event_stream_server/http_server.rs
@@ -4,57 +4,33 @@ use futures::{
     future::{self, select},
     FutureExt,
 };
-use hyper::Server;
+use hyper::server::{conn::AddrIncoming, Builder};
 use tokio::{
     select,
     sync::{mpsc, oneshot},
 };
-use tracing::{debug, info, trace, warn};
+use tracing::{info, trace};
 use wheelbuf::WheelBuf;
 
 use super::{
     sse_server::{self, BroadcastChannelMessage, ServerSentEvent, SSE_INITIAL_EVENT},
     Config, SseData,
 };
-use crate::utils;
 
 /// Run the HTTP server.
 ///
 /// `data_receiver` will provide the server with local events which should then be sent to all
 /// subscribed clients.
-pub(super) async fn run(config: Config, mut data_receiver: mpsc::UnboundedReceiver<SseData>) {
+pub(super) async fn run(
+    config: Config,
+    builder: Builder<AddrIncoming>,
+    mut data_receiver: mpsc::UnboundedReceiver<SseData>,
+) {
     // Event stream channels and filter.
     let (broadcaster, mut new_subscriber_info_receiver, sse_filter) =
         sse_server::create_channels_and_filter(config.broadcast_channel_size);
 
     let service = warp_json_rpc::service(sse_filter);
-
-    let mut server_address = match utils::resolve_address(&config.address) {
-        Ok(address) => address,
-        Err(error) => {
-            warn!(%error, "failed to start HTTP server, cannot parse address");
-            return;
-        }
-    };
-
-    // Try to bind to the user's chosen port, or if that fails, try once to bind to any port then
-    // error out if that fails too.
-    let builder = loop {
-        match Server::try_bind(&server_address) {
-            Ok(builder) => {
-                break builder;
-            }
-            Err(error) => {
-                if server_address.port() == 0 {
-                    warn!(%error, "failed to start HTTP server");
-                    return;
-                } else {
-                    server_address.set_port(0);
-                    debug!(%error, "failed to start HTTP server. retrying on random port");
-                }
-            }
-        }
-    };
 
     // Start the server, passing a oneshot receiver to allow the server to be shut down gracefully.
     let make_svc =

--- a/node/src/components/rest_server/config.rs
+++ b/node/src/components/rest_server/config.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// Default binding address for the REST HTTP server.
 ///
 /// Uses a fixed port per node, but binds on any interface.
-const DEFAULT_ADDRESS: &str = "0.0.0.0:8888";
+const DEFAULT_ADDRESS: &str = "0.0.0.0:0";
 
 /// REST HTTP server configuration.
 #[derive(Clone, DataSize, Debug, Deserialize, Serialize)]

--- a/node/src/components/rest_server/http_server.rs
+++ b/node/src/components/rest_server/http_server.rs
@@ -1,19 +1,19 @@
 use std::convert::Infallible;
 
 use futures::{future, TryFutureExt};
-use hyper::Server;
+use hyper::server::{conn::AddrIncoming, Builder};
 use tokio::sync::oneshot;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 use warp::Filter;
 
-use super::{filters, Config, ReactorEventT};
-use crate::{effect::EffectBuilder, utils};
+use super::{filters, ReactorEventT};
+use crate::effect::EffectBuilder;
 
 /// Run the REST HTTP server.
 ///
 /// A message received on `shutdown_receiver` will cause the server to exit cleanly.
 pub(super) async fn run<REv: ReactorEventT>(
-    config: Config,
+    builder: Builder<AddrIncoming>,
     effect_builder: EffectBuilder<REv>,
     shutdown_receiver: oneshot::Receiver<()>,
 ) {
@@ -22,33 +22,6 @@ pub(super) async fn run<REv: ReactorEventT>(
     let rest_metrics = filters::create_metrics_filter(effect_builder);
 
     let service = warp_json_rpc::service(rest_status.or(rest_metrics));
-
-    let mut server_address = match utils::resolve_address(&config.address) {
-        Ok(address) => address,
-        Err(error) => {
-            warn!(%error, "failed to start REST server, cannot parse address");
-            return;
-        }
-    };
-
-    // Try to bind to the user's chosen port, or if that fails, try once to bind to any port then
-    // error out if that fails too.
-    let builder = loop {
-        match Server::try_bind(&server_address) {
-            Ok(builder) => {
-                break builder;
-            }
-            Err(error) => {
-                if server_address.port() == 0 {
-                    warn!(%error, "failed to start REST server");
-                    return;
-                } else {
-                    server_address.set_port(0);
-                    debug!(%error, "failed to start REST server. retrying on random port");
-                }
-            }
-        }
-    };
 
     // Start the server, passing a oneshot receiver to allow the server to be shut down gracefully.
     let make_svc =

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -47,6 +47,7 @@ use crate::{
         EffectBuilder, EffectExt, Effects, Responder,
     },
     types::{NodeId, StatusFeed},
+    utils::{self, ListeningError},
     NodeRng,
 };
 
@@ -87,13 +88,17 @@ impl<REv> ReactorEventT for REv where
 pub(crate) struct RpcServer {}
 
 impl RpcServer {
-    pub(crate) fn new<REv>(config: Config, effect_builder: EffectBuilder<REv>) -> Self
+    pub(crate) fn new<REv>(
+        config: Config,
+        effect_builder: EffectBuilder<REv>,
+    ) -> Result<Self, ListeningError>
     where
         REv: ReactorEventT,
     {
-        tokio::spawn(http_server::run(config, effect_builder));
+        let builder = utils::start_listening(&config.address)?;
+        tokio::spawn(http_server::run(builder, effect_builder));
 
-        RpcServer {}
+        Ok(RpcServer {})
     }
 }
 

--- a/node/src/components/rpc_server/config.rs
+++ b/node/src/components/rpc_server/config.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// Default binding address for the JSON-RPC HTTP server.
 ///
 /// Uses a fixed port per node, but binds on any interface.
-const DEFAULT_ADDRESS: &str = "0.0.0.0:7777";
+const DEFAULT_ADDRESS: &str = "0.0.0.0:0";
 
 /// JSON-RPC HTTP server configuration.
 #[derive(Clone, DataSize, Debug, Deserialize, Serialize)]

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -413,10 +413,10 @@ impl reactor::Reactor for Reactor {
 
         let linear_chain_sync = LinearChainSync::new(init_hash);
 
-        let rest_server = RestServer::new(config.rest_server.clone(), effect_builder);
+        let rest_server = RestServer::new(config.rest_server.clone(), effect_builder)?;
 
         let event_stream_server =
-            EventStreamServer::new(config.event_stream_server.clone(), effect_builder);
+            EventStreamServer::new(config.event_stream_server.clone(), effect_builder)?;
 
         let (block_validator, block_validator_effects) = BlockValidator::new(effect_builder);
         effects.extend(reactor::wrap_effects(

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -382,8 +382,8 @@ impl reactor::Reactor for Reactor {
         let address_gossiper =
             Gossiper::new_for_complete_items("address_gossiper", config.gossip, registry)?;
 
-        let rpc_server = RpcServer::new(config.rpc_server.clone(), effect_builder);
-        let rest_server = RestServer::new(config.rest_server.clone(), effect_builder);
+        let rpc_server = RpcServer::new(config.rpc_server.clone(), effect_builder)?;
+        let rest_server = RestServer::new(config.rest_server.clone(), effect_builder)?;
 
         let deploy_acceptor = DeployAcceptor::new(config.deploy_acceptor);
         let deploy_fetcher = Fetcher::new(config.fetcher);

--- a/node/src/reactor/validator/error.rs
+++ b/node/src/reactor/validator/error.rs
@@ -1,6 +1,9 @@
 use thiserror::Error;
 
-use crate::components::{contract_runtime, network, small_network, storage};
+use crate::{
+    components::{contract_runtime, network, small_network, storage},
+    utils::ListeningError,
+};
 
 /// Error type returned by the validator reactor.
 #[derive(Debug, Error)]
@@ -16,6 +19,10 @@ pub enum Error {
     /// `SmallNetwork` component error.
     #[error("small network error: {0}")]
     SmallNetwork(#[from] small_network::Error),
+
+    /// An error starting one of the HTTP servers.
+    #[error("http server listening error: {0}")]
+    ListeningError(#[from] ListeningError),
 
     /// `Storage` component error.
     #[error("storage error: {0}")]

--- a/run-dev-tmux.sh
+++ b/run-dev-tmux.sh
@@ -82,6 +82,9 @@ run_node() {
 
     if [[ ${ID} != 1 ]]; then
         CMD+=("-C network.bind_address='0.0.0.0:0'")
+        CMD+=("-C rpc_server.address='0.0.0.0:0'")
+        CMD+=("-C rest_server.address='0.0.0.0:0'")
+        CMD+=("-C event_stream_server.address='0.0.0.0:0'")
     fi
 
     CMD+=("1> >(tee ${DATA_DIR}/node-${ID}.log) 2> >(tee ${DATA_DIR}/node-${ID}.log.stderr)")

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -41,9 +41,15 @@ run_node() {
     if [ $1 -ne 1 ]
     then
         BIND_ADDRESS_ARG=--config-ext=network.bind_address='0.0.0.0:0'
+        RPC_SERVER_ADDRESS_ARG=--config-ext=rpc_server.address='0.0.0.0:0'
+        REST_SERVER_ADDRESS_ARG=--config-ext=rest_server.address='0.0.0.0:0'
+        EVENT_STREAM_SERVER_ADDRESS_ARG=--config-ext=event_stream_server.address='0.0.0.0:0'
         DEPS="--property=After=node-1.service --property=Requires=node-1.service"
     else
         BIND_ADDRESS_ARG=
+        RPC_SERVER_ADDRESS_ARG=
+        REST_SERVER_ADDRESS_ARG=
+        EVENT_STREAM_SERVER_ADDRESS_ARG=
         DEPS=
     fi
 
@@ -80,6 +86,9 @@ run_node() {
         --config-ext=network.gossip_interval=1000 \
         --config-ext=node.chainspec_config_path=${CHAINSPEC} \
         ${BIND_ADDRESS_ARG} \
+        ${RPC_SERVER_ADDRESS_ARG} \
+        ${REST_SERVER_ADDRESS_ARG} \
+        ${EVENT_STREAM_SERVER_ADDRESS_ARG} \
         ${TRUSTED_HASH_ARG}
 
     echo "Started node $ID, logfile: ${LOGFILE}"


### PR DESCRIPTION
Completes [NDRS-698](https://casperlabs.atlassian.net/browse/NDRS-698).

Tagging @momipsl since this will be a new reason for nodes to fail to start in nctl: they need to be able to bind to not just the specified address for the small_network, but also the three addresses for the three HTTP servers.