### PR TITLE
Don't slow down with fewer than 50% failed rounds.

### DIFF
--- a/node/src/components/consensus/protocols/highway/round_success_meter.rs
+++ b/node/src/components/consensus/protocols/highway/round_success_meter.rs
@@ -15,7 +15,7 @@ use crate::{
 const NUM_ROUNDS_TO_CONSIDER: usize = 40;
 // The maximum number of failures allowed among NUM_ROUNDS_TO_CONSIDER latest rounds, with which we
 // won't increase our round length. Exceeding this threshold will mean that we should slow down.
-const MAX_FAILED_ROUNDS: usize = 10;
+const MAX_FAILED_ROUNDS: usize = 20;
 // We will try to accelerate (decrease our round exponent) every `ACCELERATION_PARAMETER` rounds if
 // we have few enough failures.
 const ACCELERATION_PARAMETER: u64 = 40;


### PR DESCRIPTION
Since this is hard-coded and it's reasonable to set any fault tolerance threshold up to 50%, let's make sure that fewer than 50% of the validators cannot force the others to increase their round length.