### PR TITLE
NDRS-619: Remove FinalizedBlock Event from event stream

### DIFF
--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -91,15 +91,12 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {
-            Event::BlockFinalized(finalized_block) => {
-                self.broadcast(SseData::BlockFinalized(*finalized_block))
-            }
             Event::BlockAdded {
                 block_hash,
                 block_header,
             } => self.broadcast(SseData::BlockAdded {
                 block_hash,
-                block_header: *block_header,
+                block_header: Box::new(*block_header),
             }),
             Event::DeployProcessed {
                 deploy_hash,
@@ -107,12 +104,12 @@ where
                 block_hash,
                 execution_result,
             } => self.broadcast(SseData::DeployProcessed {
-                deploy_hash,
+                deploy_hash: Box::new(deploy_hash),
                 account: *deploy_header.account(),
                 timestamp: deploy_header.timestamp(),
                 ttl: deploy_header.ttl(),
                 dependencies: deploy_header.dependencies().clone(),
-                block_hash,
+                block_hash: Box::new(block_hash),
                 execution_result,
             }),
             Event::Fault {

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -4,15 +4,11 @@ use casper_types::{ExecutionResult, PublicKey};
 
 use crate::{
     components::consensus::EraId,
-    types::{
-        BlockHash, BlockHeader, DeployHash, DeployHeader, FinalitySignature, FinalizedBlock,
-        Timestamp,
-    },
+    types::{BlockHash, BlockHeader, DeployHash, DeployHeader, FinalitySignature, Timestamp},
 };
 
 #[derive(Debug)]
 pub enum Event {
-    BlockFinalized(Box<FinalizedBlock>),
     BlockAdded {
         block_hash: BlockHash,
         block_header: Box<BlockHeader>,
@@ -34,11 +30,6 @@ pub enum Event {
 impl Display for Event {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
-            Event::BlockFinalized(finalized_block) => write!(
-                formatter,
-                "block finalized {}",
-                finalized_block.proto_block().hash()
-            ),
             Event::BlockAdded { block_hash, .. } => write!(formatter, "block added {}", block_hash),
             Event::DeployProcessed { deploy_hash, .. } => {
                 write!(formatter, "deploy processed {}", deploy_hash)

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -727,7 +727,7 @@ impl reactor::Reactor for Reactor {
                     ),
                 ),
                 ConsensusAnnouncement::Finalized(_) => {
-                    info!("A block was finalized");
+                    // A block was finalized.
                     Effects::new()
                 }
                 ConsensusAnnouncement::Fault {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -726,14 +726,10 @@ impl reactor::Reactor for Reactor {
                         linear_chain_sync::Event::BlockHandled(block_header),
                     ),
                 ),
-                ConsensusAnnouncement::Finalized(block) => reactor::wrap_effects(
-                    Event::EventStreamServer,
-                    self.event_stream_server.handle_event(
-                        effect_builder,
-                        rng,
-                        event_stream_server::Event::BlockFinalized(block),
-                    ),
-                ),
+                ConsensusAnnouncement::Finalized(_) => {
+                    info!("A block was finalized");
+                    Effects::new()
+                }
                 ConsensusAnnouncement::Fault {
                     era_id,
                     public_key,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -787,15 +787,11 @@ impl reactor::Reactor for Reactor {
 
                 match consensus_announcement {
                     ConsensusAnnouncement::Finalized(block) => {
-                        let mut effects =
+                        let effects =
                             reactor_event_dispatch(block_proposer::Event::FinalizedProtoBlock {
                                 block: block.proto_block().clone(),
                                 height: block.height(),
                             });
-                        let reactor_event = Event::EventStreamServer(
-                            event_stream_server::Event::BlockFinalized(block),
-                        );
-                        effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                         effects
                     }
                     ConsensusAnnouncement::Handled(_) => {


### PR DESCRIPTION
REF: https://casperlabs.atlassian.net/browse/NDRS-619

Removed the `FinalizedBlock` event from the event stream, "actual block" as mentioned in the description is already part of the event stream as the `BlockHeader`