### PR TITLE
NO-TICKET Restoring default make execution.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,16 +66,16 @@ CRATES_WITH_DOCS_RS_MANIFEST_TABLE = \
 
 CRATES_WITH_DOCS_RS_MANIFEST_TABLE := $(patsubst %, doc-stable/%, $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE))
 
-.PHONY: list
-list:
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
-
 .PHONY: all
 all: build build-contracts
 
 .PHONY: build
 build:
 	$(CARGO) build $(CARGO_FLAGS)
+
+.PHONY: list
+list:
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
 
 build-contract-rs/%:
 	$(CARGO) build \

--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,6 @@ all: build build-contracts
 build:
 	$(CARGO) build $(CARGO_FLAGS)
 
-.PHONY: list
-list:
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
-
 build-contract-rs/%:
 	$(CARGO) build \
 	        --release $(filter-out --release, $(CARGO_FLAGS)) \

--- a/docker_make.sh
+++ b/docker_make.sh
@@ -49,8 +49,9 @@ done
 
 if [ -z "$1" ]; then
   echo "make command not given."
-  echo "Using 'list' to show targets."
-  make_command="list"
+#  echo "Using 'list' to show targets."
+#  make_command="list"
+  exit 1
 else
   make_command="$1"
 fi


### PR DESCRIPTION
Moving the `list` to after `all` to restore original non-argument `make` invocation.