### PR TITLE
NDRS-748: add System variant to {PublicKey,SecretKey,Signature}

### DIFF
--- a/node/src/crypto/asymmetric_key.rs
+++ b/node/src/crypto/asymmetric_key.rs
@@ -28,6 +28,9 @@ pub fn sign<T: AsRef<[u8]>>(
     rng: &mut NodeRng,
 ) -> Signature {
     match (secret_key, public_key) {
+        (SecretKey::System, PublicKey::System) => {
+            panic!("cannot create signature with system keys",)
+        }
         (SecretKey::Ed25519(secret_key), PublicKey::Ed25519(public_key)) => {
             let expanded_secret_key = ExpandedSecretKey::from(secret_key);
             let signature = expanded_secret_key.sign(message.as_ref(), public_key);
@@ -48,6 +51,9 @@ pub fn verify<T: AsRef<[u8]>>(
     public_key: &PublicKey,
 ) -> Result<()> {
     match (signature, public_key) {
+        (Signature::System, _) => Err(Error::AsymmetricKey(String::from(
+            "signatures based on the system key cannot be verified",
+        ))),
         (Signature::Ed25519(signature), PublicKey::Ed25519(public_key)) => public_key
             .verify_strict(
                 message.as_ref(),

--- a/node/src/crypto/asymmetric_key_ext.rs
+++ b/node/src/crypto/asymmetric_key_ext.rs
@@ -9,7 +9,7 @@ use pem::Pem;
 use rand::{Rng, RngCore};
 use untrusted::Input;
 
-use casper_types::{AsymmetricType, PublicKey, SecretKey, ED25519_TAG, SECP256K1_TAG};
+use casper_types::{AsymmetricType, PublicKey, SecretKey, ED25519_TAG, SECP256K1_TAG, SYSTEM_TAG};
 
 #[cfg(test)]
 use crate::testing::TestRng;
@@ -113,6 +113,7 @@ impl AsymmetricKeyExt for SecretKey {
 
     fn to_der(&self) -> Result<Vec<u8>, Error> {
         match self {
+            SecretKey::System => Err(Error::System(String::from("to_der"))),
             SecretKey::Ed25519(secret_key) => {
                 // See https://tools.ietf.org/html/rfc8410#section-10.3
                 let mut key_bytes = vec![];
@@ -215,6 +216,7 @@ impl AsymmetricKeyExt for SecretKey {
         })?;
 
         match key_type_tag {
+            SYSTEM_TAG => Err(Error::AsymmetricKey("cannot construct variant".to_string())),
             ED25519_TAG => SecretKey::ed25519_from_bytes(raw_bytes).map_err(Into::into),
             SECP256K1_TAG => SecretKey::secp256k1_from_bytes(raw_bytes).map_err(Into::into),
             _ => Err(Error::AsymmetricKey("unknown type tag".to_string())),
@@ -223,6 +225,7 @@ impl AsymmetricKeyExt for SecretKey {
 
     fn to_pem(&self) -> Result<String, Error> {
         let tag = match self {
+            SecretKey::System => return Err(Error::System(String::from("to_pem"))),
             SecretKey::Ed25519(_) => ED25519_PEM_SECRET_KEY_TAG.to_string(),
             SecretKey::Secp256k1(_) => SECP256K1_PEM_SECRET_KEY_TAG.to_string(),
         };
@@ -244,6 +247,7 @@ impl AsymmetricKeyExt for SecretKey {
         };
 
         match secret_key {
+            SecretKey::System => return Err(Error::System(String::from("from_pem"))),
             SecretKey::Ed25519(_) => {
                 if pem.tag != ED25519_PEM_SECRET_KEY_TAG {
                     return Err(bad_tag(ED25519_PEM_SECRET_KEY_TAG));
@@ -262,6 +266,7 @@ impl AsymmetricKeyExt for SecretKey {
     #[cfg(test)]
     fn duplicate(&self) -> Self {
         match self {
+            SecretKey::System => SecretKey::System,
             SecretKey::Ed25519(secret_key) => {
                 Self::ed25519_from_bytes(secret_key.as_ref()).expect("could not copy secret key")
             }
@@ -324,6 +329,7 @@ impl AsymmetricKeyExt for PublicKey {
 
     fn to_der(&self) -> Result<Vec<u8>, Error> {
         match self {
+            PublicKey::System => Err(Error::System(String::from("to_der"))),
             PublicKey::Ed25519(public_key) => {
                 // See https://tools.ietf.org/html/rfc8410#section-10.1
                 let mut encoded = vec![];
@@ -390,6 +396,7 @@ impl AsymmetricKeyExt for PublicKey {
 
     fn to_pem(&self) -> Result<String, Error> {
         let tag = match self {
+            PublicKey::System => return Err(Error::System(String::from("to_pem"))),
             PublicKey::Ed25519(_) => ED25519_PEM_PUBLIC_KEY_TAG.to_string(),
             PublicKey::Secp256k1(_) => SECP256K1_PEM_PUBLIC_KEY_TAG.to_string(),
         };
@@ -408,6 +415,7 @@ impl AsymmetricKeyExt for PublicKey {
             ))
         };
         match public_key {
+            PublicKey::System => return Err(Error::System(String::from("from_pem"))),
             PublicKey::Ed25519(_) => {
                 if pem.tag != ED25519_PEM_PUBLIC_KEY_TAG {
                     return Err(bad_tag(ED25519_PEM_PUBLIC_KEY_TAG));
@@ -425,6 +433,7 @@ impl AsymmetricKeyExt for PublicKey {
     #[cfg(test)]
     fn duplicate(&self) -> Self {
         match self {
+            PublicKey::System => PublicKey::System,
             PublicKey::Ed25519(public_key) => {
                 Self::ed25519_from_bytes(public_key.as_ref()).expect("could not copy public key")
             }

--- a/node/src/crypto/error.rs
+++ b/node/src/crypto/error.rs
@@ -49,6 +49,10 @@ pub enum Error {
     /// Error trying to write a public key.
     #[error("public key save failed: {0}")]
     PublicKeySave(WriteFileError),
+
+    /// Error trying to manipulate the system key.
+    #[error("invalid operation on system key: {0}")]
+    System(String),
 }
 
 impl From<PemError> for Error {

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -242,10 +242,12 @@ impl AccountHash {
         public_key: &PublicKey,
         blake2b_hash_fn: impl Fn(Vec<u8>) -> [u8; BLAKE2B_DIGEST_LENGTH],
     ) -> Self {
+        const SYSTEM_LOWERCASE: &str = "system";
         const ED25519_LOWERCASE: &str = "ed25519";
         const SECP256K1_LOWERCASE: &str = "secp256k1";
 
         let algorithm_name = match public_key {
+            PublicKey::System => SYSTEM_LOWERCASE,
             PublicKey::Ed25519(_) => ED25519_LOWERCASE,
             PublicKey::Secp256k1(_) => SECP256K1_LOWERCASE,
         };

--- a/types/src/crypto.rs
+++ b/types/src/crypto.rs
@@ -6,6 +6,7 @@ mod error;
 #[cfg(any(feature = "gens", test))]
 pub use asymmetric_key::gens;
 pub use asymmetric_key::{
-    AsymmetricType, PublicKey, SecretKey, Signature, ED25519_TAG, SECP256K1_TAG,
+    AsymmetricType, PublicKey, SecretKey, Signature, ED25519_TAG, SECP256K1_TAG, SYSTEM_ACCOUNT,
+    SYSTEM_TAG,
 };
 pub use error::Error;


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-748

Now that we are trafficking in well-formed public keys, we no longer can use the "zero key" for the system account as we did in the olden days.  This PR introduces a `System` variant to the types in the `asymmetric_key` module to allow us to retain a proper identity for the system account which is unrelated to the key types for users.  The most important property of this variant is that it cannot be used to create signatures nor can signatures using this variant be verified.

This work paves the way for the upcoming removal of `AccountHash`.