### PR TITLE
NDRS-750: remove Key::into_seed

### DIFF
--- a/execution_engine/src/core/execution/executor.rs
+++ b/execution_engine/src/core/execution/executor.rs
@@ -303,7 +303,7 @@ impl Executor {
             DirectSystemContractCall::Slash
             | DirectSystemContractCall::RunAuction
             | DirectSystemContractCall::DistributeRewards => {
-                if protocol_data.auction() != base_key.into_seed() {
+                if Some(protocol_data.auction()) != base_key.into_hash() {
                     panic!(
                         "{} should only be called with the auction contract",
                         direct_system_contract_call.entry_point_name()
@@ -312,7 +312,7 @@ impl Executor {
             }
             DirectSystemContractCall::FinalizePayment
             | DirectSystemContractCall::GetPaymentPurse => {
-                if protocol_data.proof_of_stake() != base_key.into_seed() {
+                if Some(protocol_data.proof_of_stake()) != base_key.into_hash() {
                     panic!(
                         "{} should only be called with the proof of stake contract",
                         direct_system_contract_call.entry_point_name()
@@ -320,7 +320,7 @@ impl Executor {
                 }
             }
             DirectSystemContractCall::CreatePurse | DirectSystemContractCall::Transfer => {
-                if protocol_data.mint() != base_key.into_seed() {
+                if Some(protocol_data.mint()) != base_key.into_hash() {
                     panic!(
                         "{} should only be called with the mint contract",
                         direct_system_contract_call.entry_point_name()
@@ -328,7 +328,7 @@ impl Executor {
                 }
             }
             DirectSystemContractCall::GetEraValidators => {
-                if protocol_data.auction() != base_key.into_seed() {
+                if Some(protocol_data.auction()) != base_key.into_hash() {
                     panic!(
                         "{} should only be called with the auction contract",
                         direct_system_contract_call.entry_point_name()

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -1228,15 +1228,15 @@ where
     }
 
     pub fn is_mint(&self, key: Key) -> bool {
-        key.into_seed() == self.protocol_data().mint()
+        key.into_hash() == Some(self.protocol_data().mint())
     }
 
     pub fn is_proof_of_stake(&self, key: Key) -> bool {
-        key.into_seed() == self.protocol_data().proof_of_stake()
+        key.into_hash() == Some(self.protocol_data().proof_of_stake())
     }
 
     pub fn is_auction(&self, key: Key) -> bool {
-        key.into_seed() == self.protocol_data().auction()
+        key.into_hash() == Some(self.protocol_data().auction())
     }
 
     fn get_named_argument<T: FromBytes + CLTyped>(
@@ -1928,7 +1928,9 @@ where
         };
 
         let module = {
-            let maybe_module = self.system_contract_cache.get(key.into_seed());
+            let maybe_module = key
+                .into_hash()
+                .and_then(|hash_addr| self.system_contract_cache.get(hash_addr));
             let wasm_key = contract.contract_wasm_key();
 
             let contract_wasm: ContractWasm = match self.context.read_gs(&wasm_key)? {

--- a/smart_contracts/contracts/test/groups/src/main.rs
+++ b/smart_contracts/contracts/test/groups/src/main.rs
@@ -40,8 +40,9 @@ pub extern "C" fn restricted_contract() {}
 pub extern "C" fn restricted_session_caller() {
     let package_hash: Key = runtime::get_named_arg(ARG_PACKAGE_HASH);
     let contract_version = Some(CONTRACT_INITIAL_VERSION);
+    let contract_package_hash = package_hash.into_hash().unwrap_or_revert();
     runtime::call_versioned_contract(
-        package_hash.into_seed(),
+        contract_package_hash,
         contract_version,
         RESTRICTED_SESSION,
         runtime_args! {},
@@ -50,8 +51,8 @@ pub extern "C" fn restricted_session_caller() {
 
 fn contract_caller() {
     let package_hash: Key = runtime::get_named_arg(ARG_PACKAGE_HASH);
-    let contract_package_hash = package_hash.into_seed();
     let contract_version = Some(CONTRACT_INITIAL_VERSION);
+    let contract_package_hash = package_hash.into_hash().unwrap_or_revert();
     let runtime_args = runtime_args! {};
     runtime::call_versioned_contract(
         contract_package_hash,

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -242,27 +242,6 @@ impl Key {
         }
     }
 
-    // TODO: remove this nightmare
-    /// Creates the seed of a local key for a context with the given base key.
-    pub fn into_seed(self) -> [u8; BLAKE2B_DIGEST_LENGTH] {
-        match self {
-            Key::Account(account_hash) => account_hash.value(),
-            Key::Hash(bytes) => bytes,
-            Key::URef(uref) => uref.addr(),
-            Key::Transfer(transfer_addr) => transfer_addr.value(),
-            Key::DeployInfo(addr) => addr.value(),
-            Key::EraInfo(era_id) => {
-                // stop-gap measure until this method is removed
-                let mut ret = [0u8; BLAKE2B_DIGEST_LENGTH];
-                let era_id_bytes = era_id.to_le_bytes();
-                let era_id_bytes_len = era_id_bytes.len();
-                assert!(era_id_bytes_len < BLAKE2B_DIGEST_LENGTH);
-                ret[..era_id_bytes_len].clone_from_slice(&era_id_bytes);
-                ret
-            }
-        }
-    }
-
     /// Casts a [`Key::URef`] to a [`Key::Hash`]
     pub fn uref_to_hash(&self) -> Option<Key> {
         let uref = self.as_uref()?;


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-750

`Key::into_seed` is a vestige of our old "local state" implementation, now removed.  It is currently used in several places where `Key::into_hash` would suffice.  Recent additions to `Key` have rendered it ever more dubious, so this PR does the proverbial deed, liberating it from a confused existence.

(This also paves the way for removal of `AccountHash`)

