### PR TITLE
HWY-229: Use the same numbers for adaptive round length as in the paper.

### DIFF
--- a/node/src/components/consensus/protocols/highway/round_success_meter.rs
+++ b/node/src/components/consensus/protocols/highway/round_success_meter.rs
@@ -11,22 +11,29 @@ use crate::{
     types::Timestamp,
 };
 
-// The number of most recent rounds we will be keeping track of.
+/// The number of most recent rounds we will be keeping track of.
 const NUM_ROUNDS_TO_CONSIDER: usize = 40;
-// The maximum number of failures allowed among NUM_ROUNDS_TO_CONSIDER latest rounds, with which we
-// won't increase our round length. Exceeding this threshold will mean that we should slow down.
-const MAX_FAILED_ROUNDS: usize = 20;
-// We will try to accelerate (decrease our round exponent) every `ACCELERATION_PARAMETER` rounds if
-// we have few enough failures.
+/// The number of successful rounds that triggers us to slow down: With this many or fewer
+/// successes per `NUM_ROUNDS_TO_CONSIDER`, we increase our round exponent.
+const NUM_ROUNDS_SLOWDOWN: usize = 10;
+/// The number of successful rounds that triggers us to speed up: With this many or more successes
+/// per `NUM_ROUNDS_TO_CONSIDER`, we decrease our round exponent.
+const NUM_ROUNDS_SPEEDUP: usize = 32;
+/// We will try to accelerate (decrease our round exponent) every `ACCELERATION_PARAMETER` rounds if
+/// we have few enough failures.
 const ACCELERATION_PARAMETER: u64 = 40;
-// The maximum number of failures with which we will attempt to accelerate (decrease the round
-// exponent).
-const MAX_FAILURES_FOR_ACCELERATION: usize = 3;
-// The FTT, as a percentage (i.e. `THRESHOLD = 1` means 1% of the validators' total weight), which
-// we will use for looking for a summit in order to determine a proposal's finality.
-// The required quorum in a summit we will look for to check if a round was successful is
-// determined by this FTT.
+/// The FTT, as a percentage (i.e. `THRESHOLD = 1` means 1% of the validators' total weight), which
+/// we will use for looking for a summit in order to determine a proposal's finality.
+/// The required quorum in a summit we will look for to check if a round was successful is
+/// determined by this FTT.
 const THRESHOLD: u64 = 1;
+
+/// The maximum number of failures allowed among NUM_ROUNDS_TO_CONSIDER latest rounds, with which we
+/// won't increase our round length. Exceeding this threshold will mean that we should slow down.
+const MAX_FAILED_ROUNDS: usize = NUM_ROUNDS_TO_CONSIDER - NUM_ROUNDS_SLOWDOWN - 1;
+/// The maximum number of failures with which we will attempt to accelerate (decrease the round
+/// exponent).
+const MAX_FAILURES_FOR_ACCELERATION: usize = NUM_ROUNDS_TO_CONSIDER - NUM_ROUNDS_SPEEDUP;
 
 #[derive(DataSize, Debug)]
 pub(crate) struct RoundSuccessMeter<C>


### PR DESCRIPTION
This makes us a bit less eager to slow down, and a bit more eager to speed up, which is appropriate if we set the minimum round length to a reasonable value anyway.

https://casperlabs.atlassian.net/browse/HWY-229