### PR TITLE
NO-TICKET: Better reporting of DNS failures

### DIFF
--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use tokio::net::TcpStream;
 use tokio_openssl::HandshakeError;
 
-use crate::tls::ValidationError;
+use crate::{tls::ValidationError, utils::ResolveAddressError};
 
 pub(super) type Result<T> = result::Result<T, Error>;
 
@@ -58,7 +58,7 @@ pub enum Error {
     ResolveAddr(
         #[serde(skip_serializing)]
         #[source]
-        io::Error,
+        ResolveAddressError,
     ),
     /// Failed to send message.
     #[error("failed to send message")]

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -42,14 +42,51 @@ pub static OS_PAGE_SIZE: Lazy<usize> = Lazy::new(|| {
     }
 });
 
+/// DNS resolution error.
+#[derive(Debug, Error)]
+#[error("could not resolve `{address}`: {kind}")]
+pub struct ResolveAddressError {
+    /// Address that failed to resolve.
+    address: String,
+    /// Reason for resolution failure.
+    kind: ResolveAddressErrorKind,
+}
+
+/// DNS resolution error kind.
+#[derive(Debug)]
+enum ResolveAddressErrorKind {
+    /// Resolve returned an error.
+    ErrorResolving(io::Error),
+    /// Resolution did not yield any address.
+    NoAddressFound,
+}
+
+impl Display for ResolveAddressErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ResolveAddressErrorKind::ErrorResolving(err) => {
+                write!(f, "could not run dns resolution: {}", err)
+            }
+            ResolveAddressErrorKind::NoAddressFound => {
+                write!(f, "no addresses found")
+            }
+        }
+    }
+}
+
 /// Parses a network address from a string, with DNS resolution.
-pub(crate) fn resolve_address(address: &str) -> io::Result<SocketAddr> {
-    address.to_socket_addrs()?.next().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::Other,
-            format!("could not resolve `{}`", address),
-        )
-    })
+pub(crate) fn resolve_address(address: &str) -> Result<SocketAddr, ResolveAddressError> {
+    address
+        .to_socket_addrs()
+        .map_err(|err| ResolveAddressError {
+            address: address.to_string(),
+            kind: ResolveAddressErrorKind::ErrorResolving(err),
+        })?
+        .next()
+        .ok_or_else(|| ResolveAddressError {
+            address: address.to_string(),
+            kind: ResolveAddressErrorKind::NoAddressFound,
+        })
 }
 
 /// An error starting one of the HTTP servers.
@@ -57,7 +94,7 @@ pub(crate) fn resolve_address(address: &str) -> io::Result<SocketAddr> {
 pub enum ListeningError {
     /// Failed to resolve address.
     #[error("failed to resolve network address: {0}")]
-    ResolveAddress(io::Error),
+    ResolveAddress(ResolveAddressError),
 
     /// Failed to listen.
     #[error("failed to listen on {address}: {error}")]


### PR DESCRIPTION
Improves the error reporting in case of DNS failures by ensuring that the failed lookup error includes the address in question.