### PR TITLE
OP-1650 Enabling cargo publish to crates.io in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -357,7 +357,7 @@ steps:
 - name: publish-crate
   image: casperlabs/node-build-u1804
   commands:
-    - "./ci/publish.sh"
+    - "./ci/publish_to_crates_io.sh"
   environment:
     CARGO_TOKEN:
       from_secret: crates_io_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -42,6 +42,9 @@ trigger:
     - trying
     - staging
     - "release-*"
+  event:
+    exclude:
+      - tag
 
 ---
 # Failure state from pre-checks pipeline
@@ -72,6 +75,9 @@ trigger:
     - trying
     - staging
     - "release-*"
+  event:
+    exclude:
+      - tag
 
 depends_on:
   - pre-checks
@@ -114,6 +120,9 @@ trigger:
     - trying
     - staging
     - "release-*"
+  event:
+    exclude:
+      - tag
 
 ---
 # Packaging pipeline, runs in parallel with cargo-test pipeline
@@ -181,6 +190,9 @@ trigger:
     - trying
     - staging
     - "release-*"
+  event:
+    exclude:
+      - tag
 
 ---
 # Run on success of cargo-test and package pipelines.
@@ -236,7 +248,9 @@ trigger:
     - trying
     - staging
     - "release-*"
-
+  event:
+    exclude:
+      - tag
 
 ---
 # Runs on failure of cargo-test or package pipelines.
@@ -284,6 +298,9 @@ trigger:
     - trying
     - staging
     - "release-*"
+  event:
+    exclude:
+      - tag
 
 depends_on:
   - cargo-test
@@ -309,11 +326,6 @@ steps:
   image: casperlabs/node-build-u1804
   commands:
     - "make deb"
-
-- name: publish-crate-tag-TODO
-  image: casperlabs/node-build-u1804
-  commands:
-  - "echo TODO"
 
 - name: publish-prod-bintray
   image: casperlabs/node-build-u1804
@@ -342,7 +354,14 @@ steps:
     ref:
     - refs/tags/v*
 
-# push to test repo every time we are going to merge to master (via staging), trying or pushing to release (hot fix)
+- name: publish-crate
+  image: casperlabs/node-build-u1804
+  commands:
+    - "./ci/publish.sh"
+  environment:
+    CARGO_TOKEN:
+      from_secret: crates_io_token
+
 trigger:
   ref:
   - refs/tags/v*

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -62,7 +62,7 @@ publish() {
         printf "Publishing...\n"
         pushd $ROOT_DIR/$CRATE_DIR >/dev/null
         set +u
-        cargo publish ${@:2}
+        cargo publish ${@:2} --token ${CARGO_TOKEN}
         set -u
         popd >/dev/null
         printf "Published version %s\n" $LOCAL_VERSION
@@ -81,7 +81,7 @@ publish execution_engine
 publish node_macros
 publish node
 publish grpc/server
-publish client
+publish client  --no-verify
 publish smart_contracts/contract --features=std
 publish grpc/test_support
 publish grpc/cargo_casper --allow-dirty

--- a/ci/publish_to_crates_io.sh
+++ b/ci/publish_to_crates_io.sh
@@ -81,7 +81,7 @@ publish execution_engine
 publish node_macros
 publish node
 publish grpc/server
-publish client  --no-verify
+publish client
 publish smart_contracts/contract --features=std
 publish grpc/test_support
 publish grpc/cargo_casper --allow-dirty

--- a/grpc/server/Cargo.toml
+++ b/grpc/server/Cargo.toml
@@ -13,9 +13,9 @@ license-file = "../../LICENSE"
 include = [
     "**/*.rs",
     "Cargo.toml",
-    "protobuf/io/casperlabs/casper/consensus/state.proto",
-    "protobuf/io/casperlabs/ipc/ipc.proto",
-    "protobuf/io/casperlabs/ipc/transforms.proto",
+    "protobuf/casper/state.proto",
+    "protobuf/casper/ipc.proto",
+    "protobuf/casper/transforms.proto",
 ]
 
 [dependencies]


### PR DESCRIPTION
Adding cargo publish to .drone.yml and disabling non-tag workflows on tag.
Correcting grpc/server Cargo.toml to allow correct cargo publish
Adding explicit --token to publish.sh as it didn't honor cargo login in CI.

@Fraser999 Needed to use `--no-verify` with client publish.  Is this an issue?

Tested these changes in release-0.6.3 tagging and reworked until successful.

https://casperlabs.atlassian.net/browse/OP-1650