### PR TITLE
NDRS-708: Cache finality signatures.

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -353,11 +353,6 @@ where
             }
             Event::GetBlockForFinalitySignaturesResult(fs, maybe_block) => {
                 if let Some(block) = &maybe_block {
-                    assert_eq!(
-                        block.hash(),
-                        &fs.block_hash,
-                        "block loaded from storage should have a matching block hash."
-                    );
                     if block.header().era_id() != fs.era_id {
                         warn!(public_key=%fs.public_key, "Finality signature with invalid era id.");
                         // TODO: Disconnect from the sender.

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -368,7 +368,7 @@ where
                 let block_hash = block_header.hash();
                 let era_id = block_header.era_id();
                 let height = block_header.height();
-                info!(?block_hash, ?era_id, ?height, "Linear chain block stored.");
+                info!(%block_hash, %era_id, %height, "linear chain block stored");
                 let mut effects = effect_builder
                     .put_execution_results_to_storage(block_hash, execution_results)
                     .ignore();

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -154,18 +154,14 @@ impl BlockCache {
     }
 
     fn get(&self, hash: &BlockHash) -> Option<Block> {
-        match self.blocks.get(hash) {
-            None => None,
-            Some(block_header) => {
-                let mut block = Block::from_header(block_header.clone());
-                if let Some(proofs) = self.proofs.get(hash) {
-                    for (pub_key, sig) in proofs {
-                        block.append_proof(*pub_key, *sig);
-                    }
-                }
-                Some(block)
+        let block_header = self.blocks.get(hash)?;
+        let mut block = Block::from_header(block_header.clone());
+        if let Some(proofs) = self.proofs.get(hash) {
+            for (pub_key, sig) in proofs {
+                block.append_proof(*pub_key, *sig);
             }
         }
+        Some(block)
     }
 
     /// Inserts new block to the cache.

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -191,6 +191,10 @@ impl<I> LinearChain<I> {
                 // TODO: disconnect from the sender.
                 break;
             }
+            if block.proofs().contains_key(&fs.public_key) {
+                // Don't send finality signatures we already know of.
+                continue;
+            }
             block.append_proof(fs.public_key, fs.signature);
             let message = Message::FinalitySignature(fs.clone());
             effects.extend(effect_builder.broadcast_message(message).ignore());

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -306,6 +306,7 @@ impl<I> LinearChain<I> {
         if let Some(validator_sigs) = self.pending_finality_signatures.get_mut(public_key) {
             validator_sigs.remove(&block_hash);
         }
+        self.remove_empty_entries();
     }
 }
 

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -199,7 +199,7 @@ impl<I> LinearChain<I> {
             if fs.era_id != block_era {
                 // finality signature was created with era id that doesn't match block's era.
                 // TODO: disconnect from the sender.
-                break;
+                continue;
             }
             if block.proofs().contains_key(&fs.public_key) {
                 // Don't send finality signatures we already know of.

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -397,6 +397,8 @@ where
                             .map(|res| {
                                 match res {
                                     // Promote this error to a non-error case.
+                                    // It's not an error that we can't find the era that this
+                                    // FinalitySignature is for.
                                     Err(error) if error.is_era_validators_missing() => Ok(false),
                                     _ => res,
                                 }

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -834,6 +834,18 @@ impl Block {
         }
     }
 
+    /// Creates an instance of the block from the block header.
+    pub(crate) fn from_header(header: BlockHeader) -> Self {
+        let body = ();
+        let hash = header.hash();
+        Block {
+            hash,
+            header,
+            body,
+            proofs: BTreeMap::new(),
+        }
+    }
+
     pub(crate) fn header(&self) -> &BlockHeader {
         &self.header
     }

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1442,7 +1442,7 @@ mod tests {
             signature,
             public_key,
         };
-        // Test should fails b/c `signature` is over `era_id=1` and here we're using `era_id=2`.
+        // Test should fail b/c `signature` is over `era_id=1` and here we're using `era_id=2`.
         assert!(fs_manufactured.verify().is_err());
     }
 }


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-708

When running the network, we observed an unexpectedly high number of `FinalitySignature`s being gossiped. For a single `(block_hash, validator)` pair each peer was broadcasting hundreds of those messages (in a 5 node network). It turns out that the cause of this was the asynchronous nature of a `LinearChain` component communicating with itself. Between the time that a block was updated to include new proofs (finality signatures), another `FinalitySignature` message (for the same `(block_hash, validator)` pair) arrived and was recognized as new. It went through the same chain of `LinearChain::Event`s as the previous one: stored and gossiped eventually. The solution was to cache pending finality signatures (ones that are being validated and stored right now) and reject duplicates.

For the 5-node network, the final result is the decrease in the amount of `FinalitySignature` message being broadcasted from a couple of hundreds (for each `(block_hash, validator)`) down to single-digit (mostly 5, which is the number of nodes in the network). This PR also adds a cache for blocks themselves, so that we don't query the block store for the same block hash multiple times in a row (sometimes even with a millisecond difference).