### PR TITLE
NDRS-761: Parameterize `FetchResult` with peer type.

### DIFF
--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -147,7 +147,7 @@ where
                                 // ...then request it.
                                 let deploy_hash = *deploy_hash;
                                 let validate_deploy =
-                                    move |result: FetchResult<Deploy>| match result {
+                                    move |result: FetchResult<Deploy, I>| match result {
                                         FetchResult::FromStorage(deploy)
                                         | FetchResult::FromPeer(deploy, _) => {
                                             if deploy.header().is_valid(

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -128,7 +128,7 @@ pub trait ItemFetcher<T: Item + 'static> {
     fn signal(
         &mut self,
         id: T::Id,
-        result: Option<FetchResult<T>>,
+        result: Option<FetchResult<T, NodeId>>,
         peer: NodeId,
     ) -> Effects<Event<T>> {
         let mut effects = Effects::new();

--- a/node/src/components/fetcher/event.rs
+++ b/node/src/components/fetcher/event.rs
@@ -11,12 +11,12 @@ use crate::{
 };
 
 #[derive(Clone, DataSize, Debug, PartialEq)]
-pub enum FetchResult<T> {
+pub enum FetchResult<T, I> {
     FromStorage(Box<T>),
-    FromPeer(Box<T>, NodeId),
+    FromPeer(Box<T>, I),
 }
 
-pub(crate) type FetchResponder<T> = Responder<Option<FetchResult<T>>>;
+pub(crate) type FetchResponder<T> = Responder<Option<FetchResult<T, NodeId>>>;
 
 /// `Fetcher` events.
 #[derive(Debug, Serialize)]

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -191,10 +191,12 @@ fn announce_deploy_received(
     }
 }
 
+type FetchedDeployResult = Arc<Mutex<(bool, Option<FetchResult<Deploy, NodeId>>)>>;
+
 fn fetch_deploy(
     deploy_hash: DeployHash,
     node_id: NodeId,
-    fetched: Arc<Mutex<(bool, Option<FetchResult<Deploy>>)>>,
+    fetched: FetchedDeployResult,
 ) -> impl FnOnce(EffectBuilder<ReactorEvent>) -> Effects<ReactorEvent> {
     move |effect_builder: EffectBuilder<ReactorEvent>| {
         effect_builder
@@ -241,8 +243,8 @@ async fn store_deploy(
 async fn assert_settled(
     node_id: &NodeId,
     deploy_hash: DeployHash,
-    expected_result: Option<FetchResult<Deploy>>,
-    fetched: Arc<Mutex<(bool, Option<FetchResult<Deploy>>)>>,
+    expected_result: Option<FetchResult<Deploy, NodeId>>,
+    fetched: FetchedDeployResult,
     network: &mut Network<Reactor>,
     rng: &mut TestRng,
     timeout: Duration,

--- a/node/src/components/linear_chain_sync/event.rs
+++ b/node/src/components/linear_chain_sync/event.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Display};
 #[derive(Debug)]
 pub enum Event<I> {
     Start(I),
-    GetBlockHashResult(BlockHash, Option<FetchResult<Block>>),
+    GetBlockHashResult(BlockHash, Option<FetchResult<Block, I>>),
     GetBlockHeightResult(u64, BlockByHeightResult<I>),
     /// Deploys from the block have been found.
     DeploysFound(Box<BlockHeader>),

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -798,7 +798,7 @@ impl<REv> EffectBuilder<REv> {
         self,
         deploy_hash: DeployHash,
         peer: I,
-    ) -> Option<FetchResult<Deploy>>
+    ) -> Option<FetchResult<Deploy, I>>
     where
         REv: From<FetcherRequest<I, Deploy>>,
         I: Send + 'static,
@@ -819,7 +819,7 @@ impl<REv> EffectBuilder<REv> {
         self,
         block_hash: BlockHash,
         peer: I,
-    ) -> Option<FetchResult<Block>>
+    ) -> Option<FetchResult<Block, I>>
     where
         REv: From<FetcherRequest<I, Block>>,
         I: Send + 'static,
@@ -840,7 +840,7 @@ impl<REv> EffectBuilder<REv> {
         self,
         block_height: u64,
         peer: I,
-    ) -> Option<FetchResult<BlockByHeight>>
+    ) -> Option<FetchResult<BlockByHeight, I>>
     where
         REv: From<FetcherRequest<I, BlockByHeight>>,
         I: Send + 'static,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -798,7 +798,7 @@ pub enum FetcherRequest<I, T: Item> {
         /// The peer id of the peer to be asked if the item is not held locally
         peer: I,
         /// Responder to call with the result.
-        responder: Responder<Option<FetchResult<T>>>,
+        responder: Responder<Option<FetchResult<T, I>>>,
     },
 }
 


### PR DESCRIPTION
`LinearChainSync` component uses `FetchResult`'s `peer` but it was hardcoded to `NodeId` while the whole component operates with abstract type `I`. This is a vestigial element – everywhere else peer type is parameterized. 