### PR TITLE
NDRS-763: Cleanup of `linear_chain_sync.rs` 

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -414,12 +414,7 @@ where
                             error!(%block_hash, "could not download deploys from linear chain block.");
                             panic!("Failed to download linear chain deploys.")
                         }
-                        Some(peer) => {
-                            let block_hash = (*block_header).hash();
-                            trace!(%block_hash, next_peer=%peer,
-                                "failed to download deploys from a peer. Trying next one");
-                            fetch_block_deploys(effect_builder, peer, *block_header)
-                        }
+                        Some(peer) => fetch_block_deploys(effect_builder, peer, *block_header),
                     }
                 }
             },

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -24,6 +24,7 @@
 //! we might miss more eras.
 
 mod event;
+mod traits;
 
 use std::{collections::BTreeMap, convert::Infallible, fmt::Display, mem};
 
@@ -37,35 +38,13 @@ use self::event::BlockByHashResult;
 
 use super::{fetcher::FetchResult, Component};
 use crate::{
-    effect::{
-        requests::{BlockExecutorRequest, BlockValidationRequest, FetcherRequest, StorageRequest},
-        EffectBuilder, EffectExt, EffectOptionExt, Effects,
-    },
-    types::{Block, BlockByHeight, BlockHash, BlockHeader, FinalizedBlock},
+    effect::{EffectBuilder, EffectExt, EffectOptionExt, Effects},
+    types::{BlockByHeight, BlockHash, BlockHeader, FinalizedBlock},
     NodeRng,
 };
 use event::BlockByHeightResult;
 pub use event::Event;
-
-pub trait ReactorEventT<I>:
-    From<StorageRequest>
-    + From<FetcherRequest<I, Block>>
-    + From<FetcherRequest<I, BlockByHeight>>
-    + From<BlockValidationRequest<BlockHeader, I>>
-    + From<BlockExecutorRequest>
-    + Send
-{
-}
-
-impl<I, REv> ReactorEventT<I> for REv where
-    REv: From<StorageRequest>
-        + From<FetcherRequest<I, Block>>
-        + From<FetcherRequest<I, BlockByHeight>>
-        + From<BlockValidationRequest<BlockHeader, I>>
-        + From<BlockExecutorRequest>
-        + Send
-{
-}
+pub use traits::ReactorEventT;
 
 #[derive(DataSize, Debug)]
 enum State {

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -410,7 +410,6 @@ where
                     trace!(%block_hash, %peer, "deploy for linear chain block not found. Trying next peer");
                     match self.peers.random_peer() {
                         None => {
-                            let block_hash = block_header.hash();
                             error!(%block_hash, "could not download deploys from linear chain block.");
                             panic!("Failed to download linear chain deploys.")
                         }

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -24,6 +24,7 @@
 //! we might miss more eras.
 
 mod event;
+mod state;
 mod traits;
 
 use std::{collections::BTreeMap, convert::Infallible, fmt::Display, mem};
@@ -44,107 +45,8 @@ use crate::{
 };
 use event::BlockByHeightResult;
 pub use event::Event;
+pub use state::State;
 pub use traits::ReactorEventT;
-
-#[derive(DataSize, Debug)]
-enum State {
-    /// No syncing of the linear chain configured.
-    None,
-    /// Synchronizing the linear chain up until trusted hash.
-    SyncingTrustedHash {
-        /// Linear chain block to start sync from.
-        trusted_hash: BlockHash,
-        /// During synchronization we might see new eras being created.
-        /// Track the highest height and wait until it's handled by consensus.
-        highest_block_seen: u64,
-        /// Chain of downloaded blocks from the linear chain.
-        /// We will `pop()` when executing blocks.
-        linear_chain: Vec<BlockHeader>,
-        /// The most recent block we started to execute. This is updated whenever we start
-        /// downloading deploys for the next block to be executed.
-        latest_block: Box<Option<BlockHeader>>,
-        /// The weights of the validators for latest block being added.
-        validator_weights: BTreeMap<PublicKey, U512>,
-    },
-    /// Synchronizing the descendants of the trusted hash.
-    SyncingDescendants {
-        trusted_hash: BlockHash,
-        /// The most recent block we started to execute. This is updated whenever we start
-        /// downloading deploys for the next block to be executed.
-        latest_block: Box<BlockHeader>,
-        /// During synchronization we might see new eras being created.
-        /// Track the highest height and wait until it's handled by consensus.
-        highest_block_seen: u64,
-        /// The validator set for the most recent block being synchronized.
-        validators_for_latest_block: BTreeMap<PublicKey, U512>,
-    },
-    /// Synchronizing done.
-    Done,
-}
-
-impl Display for State {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            State::None => write!(f, "None"),
-            State::SyncingTrustedHash { trusted_hash, .. } => {
-                write!(f, "SyncingTrustedHash(trusted_hash: {:?})", trusted_hash)
-            }
-            State::SyncingDescendants {
-                highest_block_seen, ..
-            } => write!(
-                f,
-                "SyncingDescendants(highest_block_seen: {})",
-                highest_block_seen
-            ),
-            State::Done => write!(f, "Done"),
-        }
-    }
-}
-
-impl State {
-    fn sync_trusted_hash(
-        trusted_hash: BlockHash,
-        validator_weights: BTreeMap<PublicKey, U512>,
-    ) -> Self {
-        State::SyncingTrustedHash {
-            trusted_hash,
-            highest_block_seen: 0,
-            linear_chain: Vec::new(),
-            latest_block: Box::new(None),
-            validator_weights,
-        }
-    }
-
-    fn sync_descendants(
-        trusted_hash: BlockHash,
-        latest_block: BlockHeader,
-        validators_for_latest_block: BTreeMap<PublicKey, U512>,
-    ) -> Self {
-        State::SyncingDescendants {
-            trusted_hash,
-            latest_block: Box::new(latest_block),
-            highest_block_seen: 0,
-            validators_for_latest_block,
-        }
-    }
-
-    fn block_downloaded(&mut self, block: &BlockHeader) {
-        match self {
-            State::None | State::Done => {}
-            State::SyncingTrustedHash {
-                highest_block_seen, ..
-            }
-            | State::SyncingDescendants {
-                highest_block_seen, ..
-            } => {
-                let curr_height = block.height();
-                if curr_height > *highest_block_seen {
-                    *highest_block_seen = curr_height;
-                }
-            }
-        };
-    }
-}
 
 #[derive(DataSize, Debug)]
 pub(crate) struct LinearChainSync<I> {

--- a/node/src/components/linear_chain_sync/event.rs
+++ b/node/src/components/linear_chain_sync/event.rs
@@ -9,7 +9,7 @@ pub enum Event<I> {
     /// Deploys from the block have been found.
     DeploysFound(Box<BlockHeader>),
     /// Deploys from the block have not been found.
-    DeploysNotFound(Box<BlockHeader>),
+    DeploysNotFound(Box<BlockHeader>, I),
     StartDownloadingDeploys,
     NewPeerConnected(I),
     BlockHandled(Box<BlockHeader>),
@@ -40,8 +40,8 @@ where
                 write!(f, "Get block result for {}: {:?}", block_hash, r)
             }
             Event::DeploysFound(block) => write!(f, "Deploys for block found: {}", block.hash()),
-            Event::DeploysNotFound(block_hash) => {
-                write!(f, "Deploy for block found: {}", block_hash.hash())
+            Event::DeploysNotFound(block_hash, _) => {
+                write!(f, "Deploy for block not found: {}", block_hash.hash())
             }
             Event::StartDownloadingDeploys => write!(f, "Start downloading deploys event."),
             Event::NewPeerConnected(peer_id) => write!(f, "A new peer connected: {}", peer_id),

--- a/node/src/components/linear_chain_sync/event.rs
+++ b/node/src/components/linear_chain_sync/event.rs
@@ -6,13 +6,16 @@ pub enum Event<I> {
     Start(I),
     GetBlockHashResult(BlockHash, BlockByHashResult<I>),
     GetBlockHeightResult(u64, BlockByHeightResult<I>),
-    /// Deploys from the block have been found.
-    DeploysFound(Box<BlockHeader>),
-    /// Deploys from the block have not been found.
-    DeploysNotFound(Box<BlockHeader>, I),
+    GetDeploysResult(DeploysResult<I>),
     StartDownloadingDeploys,
     NewPeerConnected(I),
     BlockHandled(Box<BlockHeader>),
+}
+
+#[derive(Debug)]
+pub enum DeploysResult<I> {
+    Found(Box<BlockHeader>),
+    NotFound(Box<BlockHeader>, I),
 }
 
 #[derive(Debug)]
@@ -39,9 +42,8 @@ where
             Event::GetBlockHashResult(block_hash, r) => {
                 write!(f, "Get block result for {}: {:?}", block_hash, r)
             }
-            Event::DeploysFound(block) => write!(f, "Deploys for block found: {}", block.hash()),
-            Event::DeploysNotFound(block_hash, _) => {
-                write!(f, "Deploy for block not found: {}", block_hash.hash())
+            Event::GetDeploysResult(result) => {
+                write!(f, "Get deploys for block result {:?}", result)
             }
             Event::StartDownloadingDeploys => write!(f, "Start downloading deploys event."),
             Event::NewPeerConnected(peer_id) => write!(f, "A new peer connected: {}", peer_id),

--- a/node/src/components/linear_chain_sync/peers.rs
+++ b/node/src/components/linear_chain_sync/peers.rs
@@ -3,10 +3,10 @@ use rand::{seq::SliceRandom, Rng};
 
 #[derive(DataSize, Debug)]
 pub struct PeersState<I> {
-    // Set of peers that we can requests block from.
+    // Set of peers that we can request blocks from.
     peers: Vec<I>,
     // Peers we have not yet requested current block from.
-    // NOTE: Maybe use a bitmask to decide which peers were tried?.
+    // NOTE: Maybe use a bitmask to decide which peers were tried?
     peers_to_try: Vec<I>,
 }
 
@@ -19,25 +19,25 @@ impl<I: Clone + PartialEq + 'static> PeersState<I> {
     }
 
     /// Resets `peers_to_try` back to all `peers` we know of.
-    pub(crate) fn reset_peers<R: Rng + ?Sized>(&mut self, rng: &mut R) {
+    pub(crate) fn reset<R: Rng + ?Sized>(&mut self, rng: &mut R) {
         self.peers_to_try = self.peers.clone();
         self.peers_to_try.as_mut_slice().shuffle(rng);
     }
 
     /// Returns a random peer.
-    pub(crate) fn random_peer(&mut self) -> Option<I> {
+    pub(crate) fn random(&mut self) -> Option<I> {
         self.peers_to_try.pop()
     }
 
     /// Unsafe version of `random_peer`.
     /// Panics if no peer is available for querying.
-    pub(crate) fn random_peer_unsafe(&mut self) -> I {
-        self.random_peer().expect("At least one peer available.")
+    pub(crate) fn random_unsafe(&mut self) -> I {
+        self.random().expect("At least one peer available.")
     }
 
     /// Peer misbehaved (returned us invalid data).
     /// Removes it from the set of nodes we request data from.
-    pub(crate) fn ban_peer(&mut self, peer: I) {
+    pub(crate) fn ban(&mut self, peer: I) {
         let index = self.peers.iter().position(|p| *p == peer);
         index.map(|idx| self.peers.remove(idx));
     }

--- a/node/src/components/linear_chain_sync/peers.rs
+++ b/node/src/components/linear_chain_sync/peers.rs
@@ -1,0 +1,54 @@
+use datasize::DataSize;
+use rand::{seq::SliceRandom, Rng};
+
+#[derive(DataSize, Debug)]
+pub struct PeersState<I> {
+    // Set of peers that we can requests block from.
+    peers: Vec<I>,
+    // Peers we have not yet requested current block from.
+    // NOTE: Maybe use a bitmask to decide which peers were tried?.
+    peers_to_try: Vec<I>,
+}
+
+impl<I: Clone + PartialEq + 'static> PeersState<I> {
+    pub fn new() -> Self {
+        PeersState {
+            peers: Default::default(),
+            peers_to_try: Default::default(),
+        }
+    }
+
+    /// Resets `peers_to_try` back to all `peers` we know of.
+    pub(crate) fn reset_peers<R: Rng + ?Sized>(&mut self, rng: &mut R) {
+        self.peers_to_try = self.peers.clone();
+        self.peers_to_try.as_mut_slice().shuffle(rng);
+    }
+
+    /// Returns a random peer.
+    pub(crate) fn random_peer(&mut self) -> Option<I> {
+        self.peers_to_try.pop()
+    }
+
+    /// Unsafe version of `random_peer`.
+    /// Panics if no peer is available for querying.
+    pub(crate) fn random_peer_unsafe(&mut self) -> I {
+        self.random_peer().expect("At least one peer available.")
+    }
+
+    /// Peer misbehaved (returned us invalid data).
+    /// Removes it from the set of nodes we request data from.
+    pub(crate) fn ban_peer(&mut self, peer: I) {
+        let index = self.peers.iter().position(|p| *p == peer);
+        index.map(|idx| self.peers.remove(idx));
+    }
+
+    /// Returns whether known peer set is empty.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
+
+    /// Adds a new peer.
+    pub(crate) fn push(&mut self, peer: I) {
+        self.peers.push(peer)
+    }
+}

--- a/node/src/components/linear_chain_sync/state.rs
+++ b/node/src/components/linear_chain_sync/state.rs
@@ -1,0 +1,106 @@
+use std::{collections::BTreeMap, fmt::Display};
+
+use datasize::DataSize;
+
+use crate::types::{BlockHash, BlockHeader};
+use casper_types::{PublicKey, U512};
+
+#[derive(DataSize, Debug)]
+pub enum State {
+    /// No syncing of the linear chain configured.
+    None,
+    /// Synchronizing the linear chain up until trusted hash.
+    SyncingTrustedHash {
+        /// Linear chain block to start sync from.
+        trusted_hash: BlockHash,
+        /// During synchronization we might see new eras being created.
+        /// Track the highest height and wait until it's handled by consensus.
+        highest_block_seen: u64,
+        /// Chain of downloaded blocks from the linear chain.
+        /// We will `pop()` when executing blocks.
+        linear_chain: Vec<BlockHeader>,
+        /// The most recent block we started to execute. This is updated whenever we start
+        /// downloading deploys for the next block to be executed.
+        latest_block: Box<Option<BlockHeader>>,
+        /// The weights of the validators for latest block being added.
+        validator_weights: BTreeMap<PublicKey, U512>,
+    },
+    /// Synchronizing the descendants of the trusted hash.
+    SyncingDescendants {
+        trusted_hash: BlockHash,
+        /// The most recent block we started to execute. This is updated whenever we start
+        /// downloading deploys for the next block to be executed.
+        latest_block: Box<BlockHeader>,
+        /// During synchronization we might see new eras being created.
+        /// Track the highest height and wait until it's handled by consensus.
+        highest_block_seen: u64,
+        /// The validator set for the most recent block being synchronized.
+        validators_for_latest_block: BTreeMap<PublicKey, U512>,
+    },
+    /// Synchronizing done.
+    Done,
+}
+
+impl Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            State::None => write!(f, "None"),
+            State::SyncingTrustedHash { trusted_hash, .. } => {
+                write!(f, "SyncingTrustedHash(trusted_hash: {:?})", trusted_hash)
+            }
+            State::SyncingDescendants {
+                highest_block_seen, ..
+            } => write!(
+                f,
+                "SyncingDescendants(highest_block_seen: {})",
+                highest_block_seen
+            ),
+            State::Done => write!(f, "Done"),
+        }
+    }
+}
+
+impl State {
+    pub fn sync_trusted_hash(
+        trusted_hash: BlockHash,
+        validator_weights: BTreeMap<PublicKey, U512>,
+    ) -> Self {
+        State::SyncingTrustedHash {
+            trusted_hash,
+            highest_block_seen: 0,
+            linear_chain: Vec::new(),
+            latest_block: Box::new(None),
+            validator_weights,
+        }
+    }
+
+    pub fn sync_descendants(
+        trusted_hash: BlockHash,
+        latest_block: BlockHeader,
+        validators_for_latest_block: BTreeMap<PublicKey, U512>,
+    ) -> Self {
+        State::SyncingDescendants {
+            trusted_hash,
+            latest_block: Box::new(latest_block),
+            highest_block_seen: 0,
+            validators_for_latest_block,
+        }
+    }
+
+    pub fn block_downloaded(&mut self, block: &BlockHeader) {
+        match self {
+            State::None | State::Done => {}
+            State::SyncingTrustedHash {
+                highest_block_seen, ..
+            }
+            | State::SyncingDescendants {
+                highest_block_seen, ..
+            } => {
+                let curr_height = block.height();
+                if curr_height > *highest_block_seen {
+                    *highest_block_seen = curr_height;
+                }
+            }
+        };
+    }
+}

--- a/node/src/components/linear_chain_sync/traits.rs
+++ b/node/src/components/linear_chain_sync/traits.rs
@@ -1,0 +1,25 @@
+use crate::{
+    effect::requests::{
+        BlockExecutorRequest, BlockValidationRequest, FetcherRequest, StorageRequest,
+    },
+    types::{Block, BlockByHeight, BlockHeader},
+};
+pub trait ReactorEventT<I>:
+    From<StorageRequest>
+    + From<FetcherRequest<I, Block>>
+    + From<FetcherRequest<I, BlockByHeight>>
+    + From<BlockValidationRequest<BlockHeader, I>>
+    + From<BlockExecutorRequest>
+    + Send
+{
+}
+
+impl<I, REv> ReactorEventT<I> for REv where
+    REv: From<StorageRequest>
+        + From<FetcherRequest<I, Block>>
+        + From<FetcherRequest<I, BlockByHeight>>
+        + From<BlockValidationRequest<BlockHeader, I>>
+        + From<BlockExecutorRequest>
+        + Send
+{
+}


### PR DESCRIPTION
Small clean-up of `lienar_chain_sync.rs` file:
* Extracts `ReactorEventT` trait to a file,
* Extracts `State` struct to a file.
* Wraps peer-related information with a `PeersState` struct and extracts it to a file.
* Adds `peer` to a `DeploysNotFound` result (follows the pattern of other results in the component).
* Adds `GetDeploysResult` enum variant to follow the pattern used when downloading blocks.

### Recommend reviewing commit-by-commit.