### PR TITLE
NDRS-760: Track which peers had the data and prioritize them.

### DIFF
--- a/node/src/components/linear_chain_sync/peers.rs
+++ b/node/src/components/linear_chain_sync/peers.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use datasize::DataSize;
 use rand::{seq::SliceRandom, Rng};
 
@@ -8,6 +10,11 @@ pub struct PeersState<I> {
     // Peers we have not yet requested current block from.
     // NOTE: Maybe use a bitmask to decide which peers were tried?
     peers_to_try: Vec<I>,
+    // Peers we successfuly downloaded data from previously.
+    // Have higher chance of having the next data.
+    succ_peers: VecDeque<I>,
+    succ_attempts: u8,
+    succ_attempts_max: u8,
 }
 
 impl<I: Clone + PartialEq + 'static> PeersState<I> {
@@ -15,6 +22,9 @@ impl<I: Clone + PartialEq + 'static> PeersState<I> {
         PeersState {
             peers: Default::default(),
             peers_to_try: Default::default(),
+            succ_peers: Default::default(),
+            succ_attempts: 0,
+            succ_attempts_max: 5,
         }
     }
 
@@ -26,7 +36,12 @@ impl<I: Clone + PartialEq + 'static> PeersState<I> {
 
     /// Returns a random peer.
     pub(crate) fn random(&mut self) -> Option<I> {
-        self.peers_to_try.pop()
+        if self.succ_attempts < self.succ_attempts_max {
+            self.next_succ().or_else(|| self.peers_to_try.pop())
+        } else {
+            self.succ_attempts = 0;
+            self.peers_to_try.pop()
+        }
     }
 
     /// Unsafe version of `random_peer`.
@@ -36,10 +51,10 @@ impl<I: Clone + PartialEq + 'static> PeersState<I> {
     }
 
     /// Peer misbehaved (returned us invalid data).
-    /// Removes it from the set of nodes we request data from.
-    pub(crate) fn ban(&mut self, peer: I) {
-        let index = self.peers.iter().position(|p| *p == peer);
-        index.map(|idx| self.peers.remove(idx));
+    /// Remove it from the set of nodes we request data from.
+    pub(crate) fn ban(&mut self, peer: &I) {
+        self.peers.retain(|p| p != peer);
+        self.succ_peers.retain(|p| p != peer);
     }
 
     /// Returns whether known peer set is empty.
@@ -50,5 +65,24 @@ impl<I: Clone + PartialEq + 'static> PeersState<I> {
     /// Adds a new peer.
     pub(crate) fn push(&mut self, peer: I) {
         self.peers.push(peer)
+    }
+
+    /// Returns the next peer, if any, that we downloaded data the previous time.
+    /// Keeps the peer in the set of `succ_peers`.
+    fn next_succ(&mut self) -> Option<I> {
+        let peer = self.succ_peers.pop_front()?;
+        self.succ_peers.push_back(peer.clone());
+        Some(peer)
+    }
+
+    /// Peer didn't respond or didn't have the data we asked for.
+    pub(crate) fn failure(&mut self, peer: &I) {
+        self.succ_peers.retain(|id| id != peer);
+    }
+
+    /// Peer had the data we asked for.
+    pub(crate) fn success(&mut self, peer: I) {
+        self.succ_attempts += 1;
+        self.succ_peers.push_back(peer);
     }
 }

--- a/node/src/components/linear_chain_sync/peers.rs
+++ b/node/src/components/linear_chain_sync/peers.rs
@@ -40,7 +40,7 @@ impl<I: Clone + PartialEq + 'static> PeersState<I> {
             self.next_succ().or_else(|| self.peers_to_try.pop())
         } else {
             self.succ_attempts = 0;
-            self.peers_to_try.pop()
+            self.peers_to_try.pop().or_else(|| self.next_succ())
         }
     }
 


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-760

Track which peers we successfully have downloaded data from and prioritize them when we request the next piece of data.

Every 5 successful attempts we will try 1 new peer (which is not in the set of the successful peer). If it has the data, it will be added to the set.