### PR TITLE
OP-1775 0.7.0 packaging updates.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ clean:
 	$(CARGO) clean
 
 .PHONY: build-for-packaging
-build-for-packaging:  build-client-contracts
+build-for-packaging: build-client-contracts
 	$(CARGO) build --release
 
 .PHONY: deb

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ clean:
 	$(CARGO) clean
 
 .PHONY: build-for-packaging
-build-for-packaging:
+build-for-packaging:  build-client-contracts
 	$(CARGO) build --release
 
 .PHONY: deb

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ clean:
 	$(CARGO) clean
 
 .PHONY: build-for-packaging
-build-for-packaging: build-client-contracts
+build-for-packaging:
 	$(CARGO) build --release
 
 .PHONY: deb

--- a/resources/maintainer_scripts/casper_node/casper-node.service
+++ b/resources/maintainer_scripts/casper_node/casper-node.service
@@ -8,6 +8,8 @@ After=network-online.target
 
 [Service]
 Type=simple
+# Enabling new network for testing, value is not important, just that env var exists
+Environment="CASPER_ENABLE_LIBP2P=TRUE"
 ExecStartPre=/etc/casper/systemd_pre_start.sh
 #StandardOutput can only append log files from systemd version 240 + (Ubuntu 20.04). Use ExecStart with redirection as workaround.
 #seperate stderr logging as it outputs non-JSON stack traces


### PR DESCRIPTION
Removed wasm build in Makefile.  Other changes were already done.
Added defaulting to new networking.