### PR TITLE
NDRS-725: Support an optional state root hash in genesis

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -311,6 +311,7 @@ pub struct ExecConfig {
     locked_funds_period: EraId,
     round_seigniorage_rate: Ratio<u64>,
     unbonding_delay: EraId,
+    state_root_hash: Option<Blake2bHash>,
 }
 
 impl ExecConfig {
@@ -324,6 +325,7 @@ impl ExecConfig {
         locked_funds_period: EraId,
         round_seigniorage_rate: Ratio<u64>,
         unbonding_delay: EraId,
+        state_root_hash: Option<Blake2bHash>,
     ) -> ExecConfig {
         ExecConfig {
             accounts,
@@ -334,6 +336,7 @@ impl ExecConfig {
             locked_funds_period,
             round_seigniorage_rate,
             unbonding_delay,
+            state_root_hash,
         }
     }
 
@@ -378,6 +381,10 @@ impl ExecConfig {
     pub fn unbonding_delay(&self) -> EraId {
         self.unbonding_delay
     }
+
+    pub fn state_root_hash(&self) -> Option<Blake2bHash> {
+        self.state_root_hash
+    }
 }
 
 impl Distribution<ExecConfig> for Standard {
@@ -403,6 +410,12 @@ impl Distribution<ExecConfig> for Standard {
             rng.gen_range(1, 1_000_000_000),
         );
 
+        let state_root_hash = if rng.gen() {
+            Some(Blake2bHash::new(&rng.gen::<[u8; Blake2bHash::LENGTH]>()))
+        } else {
+            None
+        };
+
         ExecConfig {
             accounts,
             wasm_config,
@@ -412,6 +425,7 @@ impl Distribution<ExecConfig> for Standard {
             locked_funds_period,
             round_seigniorage_rate,
             unbonding_delay,
+            state_root_hash,
         }
     }
 }

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -437,6 +437,10 @@ pub enum GenesisError {
     MissingMintContract,
     UnexpectedStoredValue,
     MissingPublicKey,
+    MissingStateKeys {
+        state_root_hash: Blake2bHash,
+        missing_descendants: Vec<Blake2bHash>,
+    },
     ExecutionError(execution::Error),
     MintError(mint::Error),
     CLValue(String),

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -525,6 +525,11 @@ where
         }
     }
 
+    pub(crate) fn with_protocol_data(mut self, protocol_data: ProtocolData) -> Self {
+        self.protocol_data = protocol_data;
+        self
+    }
+
     pub(crate) fn finalize(self) -> ExecutionEffect {
         self.tracking_copy.borrow_mut().effect()
     }

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -130,7 +130,14 @@ where
         ee_config: &ExecConfig,
     ) -> Result<GenesisResult, Error> {
         // Preliminaries
-        let initial_root_hash = self.state.empty_root();
+        let initial_root_hash = if let Some(state_root_hash) = ee_config.state_root_hash() {
+            return Ok(GenesisResult::Success {
+                post_state_hash: state_root_hash,
+                effect: Default::default(),
+            });
+        } else {
+            self.state.empty_root()
+        };
         let system_config = ee_config.system_config();
 
         let tracking_copy = match self.tracking_copy(initial_root_hash) {

--- a/grpc/server/protobuf/casper/ipc.proto
+++ b/grpc/server/protobuf/casper/ipc.proto
@@ -298,6 +298,10 @@ message ChainSpec {
             uint64 unbonding_delay = 12;
             // costs associated with the system
             SystemConfig system_config = 13;
+            // initial state root hash
+            oneof optional_state_root_hash {
+                bytes state_root_hash_bytes = 15;
+            }
 
             message GenesisAccount {
                 bytes public_key_bytes = 1;

--- a/grpc/test_support/src/internal/mod.rs
+++ b/grpc/test_support/src/internal/mod.rs
@@ -104,6 +104,7 @@ pub static DEFAULT_EXEC_CONFIG: Lazy<ExecConfig> = Lazy::new(|| {
         DEFAULT_LOCKED_FUNDS_PERIOD,
         DEFAULT_ROUND_SEIGNIORAGE_RATE,
         DEFAULT_UNBONDING_DELAY,
+        None,
     )
 });
 pub static DEFAULT_GENESIS_CONFIG: Lazy<GenesisConfig> = Lazy::new(|| {

--- a/grpc/test_support/src/internal/utils.rs
+++ b/grpc/test_support/src/internal/utils.rs
@@ -149,6 +149,7 @@ pub fn create_exec_config(accounts: Vec<GenesisAccount>) -> ExecConfig {
         locked_funds_period,
         round_seigniorage_rate,
         unbonding_delay,
+        None,
     )
 }
 

--- a/grpc/tests/src/profiling/state_initializer.rs
+++ b/grpc/tests/src/profiling/state_initializer.rs
@@ -76,6 +76,7 @@ fn main() {
         DEFAULT_LOCKED_FUNDS_PERIOD,
         DEFAULT_ROUND_SEIGNIORAGE_RATE,
         DEFAULT_UNBONDING_DELAY,
+        None,
     );
     let run_genesis_request = RunGenesisRequest::new(
         *DEFAULT_GENESIS_CONFIG_HASH,

--- a/grpc/tests/src/test/system_contracts/genesis.rs
+++ b/grpc/tests/src/test/system_contracts/genesis.rs
@@ -76,6 +76,7 @@ fn should_run_genesis() {
         locked_funds_period,
         round_seigniorage_rate,
         unbonding_delay,
+        None,
     );
     let run_genesis_request =
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, exec_config);
@@ -142,6 +143,7 @@ fn should_track_total_token_supply_in_mint() {
         locked_funds_period,
         round_seigniorage_rate,
         unbonding_delay,
+        None,
     );
     let run_genesis_request =
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, ee_config);

--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -226,6 +226,7 @@ pub struct GenesisConfig {
     pub(crate) system_config: SystemConfig,
     pub(crate) deploy_config: DeployConfig,
     pub(crate) highway_config: HighwayConfig,
+    pub(crate) state_root_hash: Option<Digest>,
 }
 
 impl GenesisConfig {
@@ -267,6 +268,7 @@ impl Debug for GenesisConfig {
             .field("costs", &self.wasm_config)
             .field("deploy_config", &self.deploy_config)
             .field("highway_config", &self.highway_config)
+            .field("state_root_hash", &self.state_root_hash)
             .finish()
     }
 }
@@ -295,6 +297,7 @@ impl GenesisConfig {
         let highway_config = HighwayConfig::random(rng);
         let unbonding_delay = rng.gen();
         let system_config = rng.gen();
+        let state_root_hash = rng.gen();
 
         GenesisConfig {
             name,
@@ -310,6 +313,7 @@ impl GenesisConfig {
             system_config,
             deploy_config,
             highway_config,
+            state_root_hash,
         }
     }
 }

--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -419,6 +419,7 @@ impl Into<ExecConfig> for Chainspec {
             self.genesis.locked_funds_period,
             self.genesis.round_seigniorage_rate,
             self.genesis.unbonding_delay,
+            self.genesis.state_root_hash.map(|hash| hash.into()),
         )
     }
 }

--- a/node/src/components/chainspec_loader/config.rs
+++ b/node/src/components/chainspec_loader/config.rs
@@ -14,6 +14,7 @@ use casper_types::auction::EraId;
 
 use super::{chainspec, DeployConfig, Error, HighwayConfig};
 use crate::{
+    crypto::hash::Digest,
     types::Timestamp,
     utils::{read_file, External},
 };
@@ -44,6 +45,7 @@ struct Genesis {
     round_seigniorage_rate: Ratio<u64>,
     unbonding_delay: EraId,
     accounts_path: External<Vec<GenesisAccount>>,
+    state_root_hash: Option<Digest>,
 }
 
 impl Default for Genesis {
@@ -58,6 +60,7 @@ impl Default for Genesis {
             round_seigniorage_rate: DEFAULT_ROUND_SEIGNIORAGE_RATE,
             unbonding_delay: DEFAULT_UNBONDING_DELAY,
             accounts_path: External::path(DEFAULT_ACCOUNTS_CSV_PATH),
+            state_root_hash: None,
         }
     }
 }
@@ -123,6 +126,7 @@ impl From<&chainspec::Chainspec> for ChainspecConfig {
             round_seigniorage_rate: chainspec.genesis.round_seigniorage_rate,
             unbonding_delay: chainspec.genesis.unbonding_delay,
             accounts_path: External::path(DEFAULT_ACCOUNTS_CSV_PATH),
+            state_root_hash: chainspec.genesis.state_root_hash,
         };
 
         let highway = chainspec.genesis.highway_config.clone();
@@ -181,6 +185,7 @@ pub(super) fn parse_toml<P: AsRef<Path>>(chainspec_path: P) -> Result<chainspec:
         system_config: chainspec.system_config,
         deploy_config: chainspec.deploys,
         highway_config: chainspec.highway,
+        state_root_hash: chainspec.genesis.state_root_hash,
     };
 
     let chainspec_upgrades = chainspec.upgrade.unwrap_or_default();

--- a/node/src/components/gossiper/gossip_table.rs
+++ b/node/src/components/gossiper/gossip_table.rs
@@ -479,7 +479,7 @@ mod tests {
     use test::Bencher;
 
     use super::{super::config::DEFAULT_FINISHED_ENTRY_DURATION_SECS, *};
-    use crate::{crypto::hash::Digest, testing::TestRng, types::DeployHash, utils::DisplayIter};
+    use crate::{testing::TestRng, types::DeployHash, utils::DisplayIter};
 
     const EXPECTED_DEFAULT_INFECTION_TARGET: usize = 3;
     const EXPECTED_DEFAULT_HOLDERS_LIMIT: usize = 15;
@@ -948,7 +948,7 @@ mod tests {
         const ENTRY_COUNT: usize = 10_000;
         let mut rng = crate::new_rng();
         let node_ids = random_node_ids(&mut rng);
-        let deploy_ids = iter::repeat_with(|| DeployHash::new(Digest::random(&mut rng)))
+        let deploy_ids = iter::repeat_with(|| DeployHash::new(rng.gen()))
             .take(ENTRY_COUNT)
             .collect::<Vec<_>>();
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -388,7 +388,7 @@ impl FinalizedBlock {
     #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
         let deploy_count = rng.gen_range(0, 11);
-        let deploy_hashes = iter::repeat_with(|| DeployHash::new(Digest::random(rng)))
+        let deploy_hashes = iter::repeat_with(|| DeployHash::new(rng.gen()))
             .take(deploy_count)
             .collect();
         let random_bit = rng.gen();
@@ -503,8 +503,7 @@ impl BlockHash {
     /// Creates a random block hash.
     #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
-        let hash = Digest::random(rng);
-        BlockHash(hash)
+        BlockHash(rng.gen())
     }
 }
 
@@ -917,10 +916,10 @@ impl Block {
     /// Generates a random instance using a `TestRng`.
     #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
-        let parent_hash = BlockHash::new(Digest::random(rng));
-        let state_root_hash = Digest::random(rng);
+        let parent_hash = BlockHash::new(rng.gen());
+        let state_root_hash = rng.gen();
         let finalized_block = FinalizedBlock::random(rng);
-        let parent_seed = Digest::random(rng);
+        let parent_seed = rng.gen();
 
         let mut block = Block::new(
             parent_hash,

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -207,8 +207,7 @@ impl DeployHash {
     /// Creates a random deploy hash.
     #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
-        let hash = Digest::random(rng);
-        DeployHash(hash)
+        DeployHash(rng.gen())
     }
 }
 
@@ -845,7 +844,7 @@ mod tests {
     #[test]
     fn bytesrepr_roundtrip() {
         let mut rng = crate::new_rng();
-        let hash = DeployHash(Digest::random(&mut rng));
+        let hash = DeployHash(rng.gen());
         bytesrepr::test_serialization_roundtrip(&hash);
 
         let deploy = Deploy::random(&mut rng);


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-725

The idea is to be able to specify the genesis state root hash in the chainspec. It should be an optional value. If no hash is specified, we initialize genesis as usual. If one is specified, it is taken to be the post state hash of genesis.