### PR TITLE
NO_TICKET - panic when block-proposer state is corrupted

### DIFF
--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1106,7 +1106,10 @@ impl<REv> EffectBuilder<REv> {
         .transpose()
         .unwrap_or_else(|err| {
             let type_name = type_name::<T>();
-            panic!("could not deserialize state from storage type name {:?} err {:?}", type_name, err);
+            panic!(
+                "could not deserialize state from storage type name {:?} err {:?}",
+                type_name, err
+            );
         })
     }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1106,8 +1106,7 @@ impl<REv> EffectBuilder<REv> {
         .transpose()
         .unwrap_or_else(|err| {
             let type_name = type_name::<T>();
-            warn!(%type_name, %err, "could not deserialize state from storage");
-            None
+            panic!("could not deserialize state from storage type name {:?} err {:?}", type_name, err);
         })
     }
 


### PR DESCRIPTION
This PR causes the node to panic if we load a corrupted state for the block-proposer. This is a short-term fix to prevent a node from starting in a bad state.