### PR TITLE
NDRS-785: abbreviate large string JSON fields

### DIFF
--- a/client/examples/ffi/src/get_auction_info.c
+++ b/client/examples/ffi/src/get_auction_info.c
@@ -6,7 +6,7 @@
 #define ERROR_LEN 255
 #define NODE_ADDRESS "http://localhost:50101"
 #define RPC_ID "1"
-#define VERBOSE false
+#define VERBOSE 0
 
 int main(int argc, char **argv) {
     casper_setup_client();

--- a/client/examples/ffi/src/put_deploy.c
+++ b/client/examples/ffi/src/put_deploy.c
@@ -6,7 +6,7 @@
 #define ERROR_LEN 255
 #define NODE_ADDRESS "http://localhost:50101"
 #define RPC_ID "1"
-#define VERBOSE false
+#define VERBOSE 0
 
 int main(int argc, char **argv) {
     casper_setup_client();

--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -255,7 +255,7 @@ pub extern "C" fn casper_get_last_error(buf: *mut c_uchar, len: usize) -> usize 
 pub extern "C" fn casper_put_deploy(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     deploy_params: *const casper_deploy_params_t,
     session_params: *const casper_session_params_t,
     payment_params: *const casper_payment_params_t,
@@ -273,7 +273,7 @@ pub extern "C" fn casper_put_deploy(
         let result = super::put_deploy(
             maybe_rpc_id,
             node_address,
-            verbose,
+            verbosity_level,
             deploy_params,
             session_params,
             payment_params,
@@ -333,7 +333,7 @@ pub extern "C" fn casper_sign_deploy_file(
 pub extern "C" fn casper_send_deploy_file(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     input_path: *const c_char,
     response_buf: *mut c_uchar,
     response_buf_len: usize,
@@ -344,7 +344,8 @@ pub extern "C" fn casper_send_deploy_file(
     let node_address = try_unsafe_arg!(node_address);
     let input_path = try_unsafe_arg!(input_path);
     runtime.block_on(async move {
-        let result = super::send_deploy_file(maybe_rpc_id, node_address, verbose, input_path);
+        let result =
+            super::send_deploy_file(maybe_rpc_id, node_address, verbosity_level, input_path);
         let response = try_unwrap_rpc!(result);
         copy_str_to_buf(&response, response_buf, response_buf_len);
         casper_error_t::CASPER_SUCCESS
@@ -358,7 +359,7 @@ pub extern "C" fn casper_send_deploy_file(
 pub extern "C" fn casper_transfer(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     amount: *const c_char,
     maybe_target_account: *const c_char,
     maybe_id: *const c_char,
@@ -380,7 +381,7 @@ pub extern "C" fn casper_transfer(
         let result = super::transfer(
             maybe_rpc_id,
             node_address,
-            verbose,
+            verbosity_level,
             amount,
             maybe_target_account,
             maybe_id,
@@ -400,7 +401,7 @@ pub extern "C" fn casper_transfer(
 pub extern "C" fn casper_get_deploy(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     deploy_hash: *const c_char,
     response_buf: *mut c_uchar,
     response_buf_len: usize,
@@ -411,7 +412,7 @@ pub extern "C" fn casper_get_deploy(
     let node_address = try_unsafe_arg!(node_address);
     let deploy_hash = try_unsafe_arg!(deploy_hash);
     runtime.block_on(async move {
-        let result = super::get_deploy(maybe_rpc_id, node_address, verbose, deploy_hash);
+        let result = super::get_deploy(maybe_rpc_id, node_address, verbosity_level, deploy_hash);
         let response = try_unwrap_rpc!(result);
         copy_str_to_buf(&response, response_buf, response_buf_len);
         casper_error_t::CASPER_SUCCESS
@@ -425,7 +426,7 @@ pub extern "C" fn casper_get_deploy(
 pub extern "C" fn casper_get_block(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     maybe_block_id: *const c_char,
     response_buf: *mut c_uchar,
     response_buf_len: usize,
@@ -436,7 +437,7 @@ pub extern "C" fn casper_get_block(
     let node_address = try_unsafe_arg!(node_address);
     let maybe_block_id = try_unsafe_arg!(maybe_block_id);
     runtime.block_on(async move {
-        let result = super::get_block(maybe_rpc_id, node_address, verbose, maybe_block_id);
+        let result = super::get_block(maybe_rpc_id, node_address, verbosity_level, maybe_block_id);
         let response = try_unwrap_rpc!(result);
         copy_str_to_buf(&response, response_buf, response_buf_len);
         casper_error_t::CASPER_SUCCESS
@@ -450,7 +451,7 @@ pub extern "C" fn casper_get_block(
 pub extern "C" fn casper_get_block_transfers(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     maybe_block_id: *const c_char,
     response_buf: *mut c_uchar,
     response_buf_len: usize,
@@ -462,7 +463,7 @@ pub extern "C" fn casper_get_block_transfers(
     let maybe_block_id = try_unsafe_arg!(maybe_block_id);
     runtime.block_on(async move {
         let result =
-            super::get_block_transfers(maybe_rpc_id, node_address, verbose, maybe_block_id);
+            super::get_block_transfers(maybe_rpc_id, node_address, verbosity_level, maybe_block_id);
         let response = try_unwrap_rpc!(result);
         copy_str_to_buf(&response, response_buf, response_buf_len);
         casper_error_t::CASPER_SUCCESS
@@ -476,7 +477,7 @@ pub extern "C" fn casper_get_block_transfers(
 pub extern "C" fn casper_get_state_root_hash(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     maybe_block_id: *const c_char,
     response_buf: *mut c_uchar,
     response_buf_len: usize,
@@ -488,7 +489,7 @@ pub extern "C" fn casper_get_state_root_hash(
     let maybe_block_id = try_unsafe_arg!(maybe_block_id);
     runtime.block_on(async move {
         let result =
-            super::get_state_root_hash(maybe_rpc_id, node_address, verbose, maybe_block_id);
+            super::get_state_root_hash(maybe_rpc_id, node_address, verbosity_level, maybe_block_id);
         let response = try_unwrap_rpc!(result);
         copy_str_to_buf(&response, response_buf, response_buf_len);
         casper_error_t::CASPER_SUCCESS
@@ -502,7 +503,7 @@ pub extern "C" fn casper_get_state_root_hash(
 pub extern "C" fn casper_get_item(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     state_root_hash: *const c_char,
     key: *const c_char,
     path: *const c_char,
@@ -520,7 +521,7 @@ pub extern "C" fn casper_get_item(
         let result = super::get_item(
             maybe_rpc_id,
             node_address,
-            verbose,
+            verbosity_level,
             state_root_hash,
             key,
             path,
@@ -538,7 +539,7 @@ pub extern "C" fn casper_get_item(
 pub extern "C" fn casper_get_balance(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     state_root_hash: *const c_char,
     purse: *const c_char,
     response_buf: *mut c_uchar,
@@ -551,8 +552,13 @@ pub extern "C" fn casper_get_balance(
     let state_root_hash = try_unsafe_arg!(state_root_hash);
     let purse = try_unsafe_arg!(purse);
     runtime.block_on(async move {
-        let result =
-            super::get_balance(maybe_rpc_id, node_address, verbose, state_root_hash, purse);
+        let result = super::get_balance(
+            maybe_rpc_id,
+            node_address,
+            verbosity_level,
+            state_root_hash,
+            purse,
+        );
         let response = try_unwrap_rpc!(result);
         copy_str_to_buf(&response, response_buf, response_buf_len);
         casper_error_t::CASPER_SUCCESS
@@ -566,7 +572,7 @@ pub extern "C" fn casper_get_balance(
 pub extern "C" fn casper_get_era_info_by_switch_block(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     maybe_block_id: *const c_char,
     response_buf: *mut c_uchar,
     response_buf_len: usize,
@@ -580,7 +586,7 @@ pub extern "C" fn casper_get_era_info_by_switch_block(
         let result = super::get_era_info_by_switch_block(
             maybe_rpc_id,
             node_address,
-            verbose,
+            verbosity_level,
             maybe_block_id,
         );
         let response = try_unwrap_rpc!(result);
@@ -596,7 +602,7 @@ pub extern "C" fn casper_get_era_info_by_switch_block(
 pub extern "C" fn casper_get_auction_info(
     maybe_rpc_id: *const c_char,
     node_address: *const c_char,
-    verbose: bool,
+    verbosity_level: u64,
     response_buf: *mut c_uchar,
     response_buf_len: usize,
 ) -> casper_error_t {
@@ -605,7 +611,7 @@ pub extern "C" fn casper_get_auction_info(
     let maybe_rpc_id = try_unsafe_arg!(maybe_rpc_id);
     let node_address = try_unsafe_arg!(node_address);
     runtime.block_on(async move {
-        let result = super::get_auction_info(maybe_rpc_id, node_address, verbose);
+        let result = super::get_auction_info(maybe_rpc_id, node_address, verbosity_level);
         let response = try_unwrap_rpc!(result);
         copy_str_to_buf(&response, response_buf, response_buf_len);
         casper_error_t::CASPER_SUCCESS

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -25,6 +25,7 @@ mod validation;
 use std::{convert::TryInto, fs::File};
 
 use jsonrpc_lite::JsonRpc;
+use serde::Serialize;
 
 use casper_execution_engine::core::engine_state::ExecutableDeployItem;
 use casper_node::types::Deploy;
@@ -46,7 +47,11 @@ pub use validation::ValidateResponseError;
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
 /// * `deploy` contains deploy-related options for this `Deploy`. See
 ///   [`DeployStrParams`](struct.DeployStrParams.html) for more details.
 /// * `session` contains session-related options for this `Deploy`. See
@@ -56,7 +61,7 @@ pub use validation::ValidateResponseError;
 pub fn put_deploy(
     maybe_rpc_id: &str,
     node_address: &str,
-    verbose: bool,
+    verbosity_level: u64,
     deploy: DeployStrParams<'_>,
     session: SessionStrParams<'_>,
     payment: PaymentStrParams<'_>,
@@ -66,7 +71,7 @@ pub fn put_deploy(
         payment.try_into()?,
         session.try_into()?,
     );
-    RpcCall::new(maybe_rpc_id, node_address, verbose).put_deploy(deploy)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).put_deploy(deploy)
 }
 
 /// Creates a `Deploy` and outputs it to a file or stdout.
@@ -142,15 +147,19 @@ pub fn sign_deploy_file(input_path: &str, secret_key: &str, maybe_output_path: &
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
 /// * `input_path` specifies the path to the previously-saved `Deploy` file.
 pub fn send_deploy_file(
     maybe_rpc_id: &str,
     node_address: &str,
-    verbose: bool,
+    verbosity_level: u64,
     input_path: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose).send_deploy_file(input_path)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).send_deploy_file(input_path)
 }
 
 /// Transfers funds between purses.
@@ -160,7 +169,11 @@ pub fn send_deploy_file(
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
 /// * `amount` specifies the amount to be transferred.
 /// * `maybe_source_purse` is the purse `URef` from which the funds will be transferred, formatted
 ///   as e.g. `uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007`. If it is
@@ -181,7 +194,7 @@ pub fn send_deploy_file(
 pub fn transfer(
     maybe_rpc_id: &str,
     node_address: &str,
-    verbose: bool,
+    verbosity_level: u64,
     amount: &str,
     maybe_target_account: &str,
     maybe_id: &str,
@@ -197,7 +210,7 @@ pub fn transfer(
 
     let maybe_id = parsing::transfer_id(maybe_id)?;
 
-    RpcCall::new(maybe_rpc_id, node_address, verbose).transfer(
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).transfer(
         amount,
         source_purse,
         target,
@@ -214,15 +227,19 @@ pub fn transfer(
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
 /// * `deploy_hash` must be a hex-encoded, 32-byte hash digest.
 pub fn get_deploy(
     maybe_rpc_id: &str,
     node_address: &str,
-    verbose: bool,
+    verbosity_level: u64,
     deploy_hash: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose).get_deploy(deploy_hash)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_deploy(deploy_hash)
 }
 
 /// Retrieves a `Block` from the network.
@@ -232,16 +249,20 @@ pub fn get_deploy(
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
 /// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the
 ///   `Block` height or empty. If empty, the latest `Block` will be retrieved.
 pub fn get_block(
     maybe_rpc_id: &str,
     node_address: &str,
-    verbose: bool,
+    verbosity_level: u64,
     maybe_block_id: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose).get_block(maybe_block_id)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_block(maybe_block_id)
 }
 
 /// Retrieves all `Transfer` items for a `Block` from the network.
@@ -251,16 +272,20 @@ pub fn get_block(
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
 /// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the
 ///   `Block` height or empty. If empty, the latest `Block` transfers will be retrieved.
 pub fn get_block_transfers(
     maybe_rpc_id: &str,
     node_address: &str,
-    verbose: bool,
+    verbosity_level: u64,
     maybe_block_id: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose).get_block_transfers(maybe_block_id)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_block_transfers(maybe_block_id)
 }
 
 /// Retrieves a state root hash at a given `Block`.
@@ -270,16 +295,20 @@ pub fn get_block_transfers(
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
 /// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the
 ///   `Block` height or empty. If empty, the latest `Block` will be used.
 pub fn get_state_root_hash(
     maybe_rpc_id: &str,
     node_address: &str,
-    verbose: bool,
+    verbosity_level: u64,
     maybe_block_id: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose).get_state_root_hash(maybe_block_id)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_state_root_hash(maybe_block_id)
 }
 
 /// Retrieves a stored value from the network.
@@ -289,7 +318,11 @@ pub fn get_state_root_hash(
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
 /// * `state_root_hash` must be a hex-encoded, 32-byte hash digest.
 /// * `key` must be a formatted [`PublicKey`](https://docs.rs/casper-node/latest/casper-node/crypto/asymmetric_key/enum.PublicKey.html)
 ///   or [`Key`](https://docs.rs/casper-types/latest/casper-types/enum.PublicKey.html). This will
@@ -306,12 +339,12 @@ pub fn get_state_root_hash(
 pub fn get_item(
     maybe_rpc_id: &str,
     node_address: &str,
-    verbose: bool,
+    verbosity_level: u64,
     state_root_hash: &str,
     key: &str,
     path: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose).get_item(state_root_hash, key, path)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_item(state_root_hash, key, path)
 }
 
 /// Retrieves a purse's balance from the network.
@@ -321,7 +354,11 @@ pub fn get_item(
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
 /// * `state_root_hash` must be a hex-encoded, 32-byte hash digest.
 /// * `purse` is a URef, formatted as e.g.
 /// ```text
@@ -330,11 +367,11 @@ pub fn get_item(
 pub fn get_balance(
     maybe_rpc_id: &str,
     node_address: &str,
-    verbose: bool,
+    verbosity_level: u64,
     state_root_hash: &str,
     purse: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose).get_balance(state_root_hash, purse)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_balance(state_root_hash, purse)
 }
 
 /// Retrieves era information from the network.
@@ -344,17 +381,22 @@ pub fn get_balance(
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
 /// * `maybe_block_id` must be a hex-encoded, 32-byte hash digest or a `u64` representing the
 ///   `Block` height or empty. If empty, era information from the latest block will be returned if
 ///   available.
 pub fn get_era_info_by_switch_block(
     maybe_rpc_id: &str,
     node_address: &str,
-    verbose: bool,
+    verbosity_level: u64,
     maybe_block_id: &str,
 ) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose).get_era_info_by_switch_block(maybe_block_id)
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level)
+        .get_era_info_by_switch_block(maybe_block_id)
 }
 
 /// Retrieves the bids and validators as of the most recently added `Block`.
@@ -364,9 +406,17 @@ pub fn get_era_info_by_switch_block(
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
-pub fn get_auction_info(maybe_rpc_id: &str, node_address: &str, verbose: bool) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose).get_auction_info()
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
+pub fn get_auction_info(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbosity_level: u64,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).get_auction_info()
 }
 
 /// Retrieves information and examples for all currently supported RPCs.
@@ -376,9 +426,13 @@ pub fn get_auction_info(maybe_rpc_id: &str, node_address: &str, verbose: bool) -
 ///   random `i64` will be assigned. Otherwise the provided string will be used verbatim.
 /// * `node_address` is the hostname or IP and port of the node on which the HTTP service is
 ///   running, e.g. `"http://127.0.0.1:7777"`.
-/// * When `verbose` is `true`, the JSON-RPC request will be printed to `stdout`.
-pub fn list_rpcs(maybe_rpc_id: &str, node_address: &str, verbose: bool) -> Result<JsonRpc> {
-    RpcCall::new(maybe_rpc_id, node_address, verbose).list_rpcs()
+/// * When `verbosity_level` is `1`, the JSON-RPC request will be printed to `stdout` with long
+///   string fields (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char
+///   count of the field.  When `verbosity_level` is greater than `1`, the request will be printed
+///   to `stdout` with no abbreviation of long fields.  When `verbosity_level` is `0`, the request
+///   will not be printed to `stdout`.
+pub fn list_rpcs(maybe_rpc_id: &str, node_address: &str, verbosity_level: u64) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbosity_level).list_rpcs()
 }
 
 /// Container for `Deploy` construction options.
@@ -850,6 +904,29 @@ impl<'a> SessionStrParams<'a> {
             session_args_simple,
             session_args_complex,
             ..Default::default()
+        }
+    }
+}
+
+/// When `verbosity_level` is `1`, the value will be printed to `stdout` with long string fields
+/// (e.g. hex-formatted raw Wasm bytes) shortened to a string indicating the char count of the
+/// field.  When `verbosity_level` is greater than `1`, the value will be printed to `stdout` with
+/// no abbreviation of long fields.  When `verbosity_level` is `0`, the value will not be printed to
+/// `stdout`.
+pub fn pretty_print_at_level<T: ?Sized + Serialize>(value: &T, verbosity_level: u64) {
+    match verbosity_level {
+        0 => (),
+        1 => {
+            println!(
+                "{}",
+                casper_types::json_pretty_print(value).expect("should encode to JSON")
+            );
+        }
+        _ => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(value).expect("should encode to JSON")
+            );
         }
     }
 }

--- a/client/src/block/get.rs
+++ b/client/src/block/get.rs
@@ -35,15 +35,16 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
     fn run(matches: &ArgMatches<'_>) {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
         let maybe_block_id = common::block_identifier::get(matches);
 
         let response =
-            casper_client::get_block(maybe_rpc_id, node_address, verbose, maybe_block_id)
+            casper_client::get_block(maybe_rpc_id, node_address, verbosity_level, maybe_block_id)
                 .unwrap_or_else(|error| panic!("response error: {}", error));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/src/block/transfers.rs
+++ b/client/src/block/transfers.rs
@@ -35,15 +35,20 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlockTransfers {
     fn run(matches: &ArgMatches<'_>) {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
         let maybe_block_id = common::block_identifier::get(matches);
 
-        let response =
-            casper_client::get_block_transfers(maybe_rpc_id, node_address, verbose, maybe_block_id)
-                .unwrap_or_else(|error| panic!("response error: {}", error));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+        let response = casper_client::get_block_transfers(
+            maybe_rpc_id,
+            node_address,
+            verbosity_level,
+            maybe_block_id,
+        )
+        .unwrap_or_else(|error| panic!("response error: {}", error));
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -11,18 +11,21 @@ pub mod verbose {
 
     pub const ARG_NAME: &str = "verbose";
     const ARG_NAME_SHORT: &str = "v";
-    const ARG_HELP: &str = "Generates verbose output, e.g. prints the RPC request";
+    const ARG_HELP: &str =
+        "Generates verbose output, e.g. prints the RPC request.  If repeated by using '-vv' then \
+        all output will be extra verbose, meaning that large JSON strings will be shown in full";
 
     pub fn arg(order: usize) -> Arg<'static, 'static> {
         Arg::with_name(ARG_NAME)
             .short(ARG_NAME_SHORT)
             .required(false)
+            .multiple(true)
             .help(ARG_HELP)
             .display_order(order)
     }
 
-    pub fn get(matches: &ArgMatches) -> bool {
-        matches.is_present(ARG_NAME)
+    pub fn get(matches: &ArgMatches) -> u64 {
+        matches.occurrences_of(ARG_NAME)
     }
 }
 

--- a/client/src/deploy/get.rs
+++ b/client/src/deploy/get.rs
@@ -56,14 +56,16 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetDeploy {
     fn run(matches: &ArgMatches<'_>) {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
         let deploy_hash = deploy_hash::get(matches);
 
-        let response = casper_client::get_deploy(maybe_rpc_id, node_address, verbose, deploy_hash)
-            .unwrap_or_else(|error| panic!("response error: {}", error));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+        let response =
+            casper_client::get_deploy(maybe_rpc_id, node_address, verbosity_level, deploy_hash)
+                .unwrap_or_else(|error| panic!("response error: {}", error));
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/src/deploy/put.rs
+++ b/client/src/deploy/put.rs
@@ -26,7 +26,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for PutDeploy {
 
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
 
         let secret_key = common::secret_key::get(matches);
         let timestamp = creation_common::timestamp::get(matches);
@@ -41,7 +41,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for PutDeploy {
         let response = casper_client::put_deploy(
             maybe_rpc_id,
             node_address,
-            verbose,
+            verbosity_level,
             DeployStrParams {
                 secret_key,
                 timestamp,
@@ -54,9 +54,10 @@ impl<'a, 'b> ClientCommand<'a, 'b> for PutDeploy {
             payment_str_params,
         )
         .unwrap_or_else(|err| panic!("unable to put deploy {:?}", err));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/src/deploy/send.rs
+++ b/client/src/deploy/send.rs
@@ -25,15 +25,20 @@ impl<'a, 'b> ClientCommand<'a, 'b> for SendDeploy {
     fn run(matches: &ArgMatches<'_>) {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
         let input_path = creation_common::input::get(matches);
 
-        let response =
-            casper_client::send_deploy_file(maybe_rpc_id, node_address, verbose, &input_path)
-                .unwrap_or_else(|error| panic!("response error: {}", error));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+        let response = casper_client::send_deploy_file(
+            maybe_rpc_id,
+            node_address,
+            verbosity_level,
+            &input_path,
+        )
+        .unwrap_or_else(|error| panic!("response error: {}", error));
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/src/deploy/transfer.rs
+++ b/client/src/deploy/transfer.rs
@@ -116,7 +116,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for Transfer {
 
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
 
         let secret_key = common::secret_key::get(matches);
         let timestamp = creation_common::timestamp::get(matches);
@@ -130,7 +130,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for Transfer {
         let response = casper_client::transfer(
             maybe_rpc_id,
             node_address,
-            verbose,
+            verbosity_level,
             amount,
             target_account,
             transfer_id,
@@ -145,9 +145,10 @@ impl<'a, 'b> ClientCommand<'a, 'b> for Transfer {
             payment_str_params,
         )
         .unwrap_or_else(|err| panic!("unable to put deploy {:?}", err));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/src/docs.rs
+++ b/client/src/docs.rs
@@ -30,9 +30,9 @@ impl<'a, 'b> ClientCommand<'a, 'b> for ListRpcs {
     fn run(matches: &ArgMatches<'_>) {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let verbosity_level = common::verbose::get(matches);
 
-        let response = casper_client::list_rpcs(maybe_rpc_id, node_address, verbose)
+        let response = casper_client::list_rpcs(maybe_rpc_id, node_address, verbosity_level)
             .unwrap_or_else(|error| panic!("response error: {}", error));
         println!(
             "{}",

--- a/client/src/get_auction_info.rs
+++ b/client/src/get_auction_info.rs
@@ -32,13 +32,14 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetAuctionInfo {
     fn run(matches: &ArgMatches<'_>) {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
 
-        let response = casper_client::get_auction_info(maybe_rpc_id, node_address, verbose)
+        let response = casper_client::get_auction_info(maybe_rpc_id, node_address, verbosity_level)
             .unwrap_or_else(|error| panic!("response error: {}", error));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/src/get_balance.rs
+++ b/client/src/get_balance.rs
@@ -65,21 +65,22 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBalance {
     fn run(matches: &ArgMatches<'_>) {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
         let state_root_hash = common::state_root_hash::get(&matches);
         let purse_uref = purse_uref::get(&matches);
 
         let response = casper_client::get_balance(
             maybe_rpc_id,
             node_address,
-            verbose,
+            verbosity_level,
             state_root_hash,
             purse_uref,
         )
         .unwrap_or_else(|error| panic!("response error: {}", error));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/src/get_era_info_by_switch_block.rs
+++ b/client/src/get_era_info_by_switch_block.rs
@@ -35,19 +35,20 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetEraInfoBySwitchBlock {
     fn run(matches: &ArgMatches<'_>) {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
         let maybe_block_id = common::block_identifier::get(&matches);
 
         let response = casper_client::get_era_info_by_switch_block(
             maybe_rpc_id,
             node_address,
-            verbose,
+            verbosity_level,
             maybe_block_id,
         )
         .unwrap_or_else(|error| panic!("response error: {}", error));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/src/get_state_hash.rs
+++ b/client/src/get_state_hash.rs
@@ -35,15 +35,20 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetStateRootHash {
     fn run(matches: &ArgMatches<'_>) {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
         let maybe_block_id = common::block_identifier::get(matches);
 
-        let response =
-            casper_client::get_state_root_hash(maybe_rpc_id, node_address, verbose, maybe_block_id)
-                .unwrap_or_else(|error| panic!("response error: {}", error));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+        let response = casper_client::get_state_root_hash(
+            maybe_rpc_id,
+            node_address,
+            verbosity_level,
+            maybe_block_id,
+        )
+        .unwrap_or_else(|error| panic!("response error: {}", error));
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/src/query_state.rs
+++ b/client/src/query_state.rs
@@ -121,7 +121,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
     fn run(matches: &ArgMatches<'_>) {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
-        let verbose = common::verbose::get(matches);
+        let mut verbosity_level = common::verbose::get(matches);
         let state_root_hash = common::state_root_hash::get(matches);
         let key = key::get(matches);
         let path = path::get(matches);
@@ -129,15 +129,16 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
         let response = casper_client::get_item(
             maybe_rpc_id,
             node_address,
-            verbose,
+            verbosity_level,
             state_root_hash,
             &key,
             path,
         )
         .unwrap_or_else(|error| panic!("response error: {}", error));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+        casper_client::pretty_print_at_level(&response, verbosity_level);
     }
 }

--- a/client/tests/integration_test.rs
+++ b/client/tests/integration_test.rs
@@ -93,31 +93,31 @@ impl MockServerHandle {
     }
 
     fn get_balance(&self, state_root_hash: &str, purse_uref: &str) -> Result<(), ErrWrapper> {
-        casper_client::get_balance("1", &self.url(), false, state_root_hash, purse_uref)
+        casper_client::get_balance("1", &self.url(), 0, state_root_hash, purse_uref)
             .map(|_| ())
             .map_err(ErrWrapper)
     }
 
     fn get_deploy(&self, deploy_hash: &str) -> Result<(), ErrWrapper> {
-        casper_client::get_deploy("1", &self.url(), false, deploy_hash)
+        casper_client::get_deploy("1", &self.url(), 0, deploy_hash)
             .map(|_| ())
             .map_err(ErrWrapper)
     }
 
     fn get_state_root_hash(&self, maybe_block_id: &str) -> Result<(), ErrWrapper> {
-        casper_client::get_state_root_hash("1", &self.url(), false, maybe_block_id)
+        casper_client::get_state_root_hash("1", &self.url(), 0, maybe_block_id)
             .map(|_| ())
             .map_err(ErrWrapper)
     }
 
     fn get_block(&self, maybe_block_id: &str) -> Result<(), ErrWrapper> {
-        casper_client::get_block("1", &self.url(), false, maybe_block_id)
+        casper_client::get_block("1", &self.url(), 0, maybe_block_id)
             .map(|_| ())
             .map_err(ErrWrapper)
     }
 
     fn get_item(&self, state_root_hash: &str, key: &str, path: &str) -> Result<(), ErrWrapper> {
-        casper_client::get_item("1", &self.url(), false, state_root_hash, key, path)
+        casper_client::get_item("1", &self.url(), 0, state_root_hash, key, path)
             .map(|_| ())
             .map_err(ErrWrapper)
     }
@@ -132,7 +132,7 @@ impl MockServerHandle {
         casper_client::transfer(
             "1",
             &self.url(),
-            false,
+            0,
             amount,
             maybe_target_account,
             "",
@@ -152,7 +152,7 @@ impl MockServerHandle {
         casper_client::put_deploy(
             "1",
             &self.url(),
-            false,
+            0,
             deploy_params,
             session_params,
             payment_params,
@@ -162,13 +162,13 @@ impl MockServerHandle {
     }
 
     fn send_deploy_file(&self, input_path: &str) -> Result<(), ErrWrapper> {
-        casper_client::send_deploy_file("1", &self.url(), false, input_path)
+        casper_client::send_deploy_file("1", &self.url(), 0, input_path)
             .map(|_| ())
             .map_err(ErrWrapper)
     }
 
     fn get_auction_info(&self) -> Result<(), ErrWrapper> {
-        casper_client::get_auction_info("1", &self.url(), false)
+        casper_client::get_auction_info("1", &self.url(), 0)
             .map(|_| ())
             .map_err(ErrWrapper)
     }

--- a/types/src/json_pretty_printer.rs
+++ b/types/src/json_pretty_printer.rs
@@ -1,0 +1,141 @@
+extern crate alloc;
+
+use alloc::{format, string::String};
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+const MAX_STRING_LEN: usize = 100;
+
+/// Serialize the given data structure as a pretty-printed String of JSON using
+/// `serde_json::to_string_pretty()`, but after first reducing any string values over
+/// `MAX_STRING_LEN` to display the field's number of chars instead of the actual value.
+pub fn json_pretty_print<T>(value: &T) -> serde_json::Result<String>
+where
+    T: ?Sized + Serialize,
+{
+    let mut json_value = json!(value);
+    shorten_string_field(&mut json_value);
+
+    serde_json::to_string_pretty(&json_value)
+}
+
+fn shorten_string_field(value: &mut Value) {
+    match value {
+        Value::String(string) => {
+            if string.len() > MAX_STRING_LEN {
+                *string = format!("{} chars", string.len());
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                shorten_string_field(value);
+            }
+        }
+        Value::Object(map) => {
+            for map_value in map.values_mut() {
+                shorten_string_field(map_value);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::iter::{self, FromIterator};
+
+    use super::*;
+
+    #[test]
+    fn should_shorten_long_strings() {
+        let mut long_strings = vec![];
+        for i in 1..=5 {
+            long_strings.push(String::from_iter(
+                iter::repeat('a').take(MAX_STRING_LEN + i),
+            ));
+        }
+        let value = json!({
+            "field_1": Option::<usize>::None,
+            "field_2": true,
+            "field_3": 123,
+            "field_4": long_strings[0],
+            "field_5": [
+                "short string value",
+                long_strings[1]
+            ],
+            "field_6": {
+                "f1": Option::<usize>::None,
+                "f2": false,
+                "f3": -123,
+                "f4": long_strings[2],
+                "f5": [
+                    "short string value",
+                    long_strings[3]
+                ],
+                "f6": {
+                    "final long string": long_strings[4]
+                }
+            }
+        });
+
+        let expected = r#"{
+  "field_1": null,
+  "field_2": true,
+  "field_3": 123,
+  "field_4": "101 chars",
+  "field_5": [
+    "short string value",
+    "102 chars"
+  ],
+  "field_6": {
+    "f1": null,
+    "f2": false,
+    "f3": -123,
+    "f4": "103 chars",
+    "f5": [
+      "short string value",
+      "104 chars"
+    ],
+    "f6": {
+      "final long string": "105 chars"
+    }
+  }
+}"#;
+
+        let output = json_pretty_print(&value).unwrap();
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn should_not_modify_short_strings() {
+        let max_string = String::from_iter(iter::repeat('a').take(MAX_STRING_LEN));
+        let value = json!({
+            "field_1": Option::<usize>::None,
+            "field_2": true,
+            "field_3": 123,
+            "field_4": max_string,
+            "field_5": [
+                "short string value",
+                "another short string"
+            ],
+            "field_6": {
+                "f1": Option::<usize>::None,
+                "f2": false,
+                "f3": -123,
+                "f4": "short",
+                "f5": [
+                    "short string value",
+                    "another short string"
+                ],
+                "f6": {
+                    "final string": "the last short string"
+                }
+            }
+        });
+
+        let expected = serde_json::to_string_pretty(&value).unwrap();
+        let output = json_pretty_print(&value).unwrap();
+        assert_eq!(output, expected);
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -38,6 +38,7 @@ mod deploy_info;
 mod execution_result;
 #[cfg(any(feature = "gens", test))]
 pub mod gens;
+mod json_pretty_printer;
 mod key;
 pub mod mint;
 mod named_key;
@@ -72,6 +73,7 @@ pub use deploy_info::DeployInfo;
 pub use execution_result::{
     ExecutionEffect, ExecutionResult, OpKind, Operation, Transform, TransformEntry,
 };
+pub use json_pretty_printer::json_pretty_print;
 #[doc(inline)]
 pub use key::{HashAddr, Key, BLAKE2B_DIGEST_LENGTH, KEY_HASH_LENGTH};
 pub use named_key::NamedKey;


### PR DESCRIPTION
This provides a `json_pretty_print()` function in casper-types which replaces large (over 100 char) strings with `x chars` where `x` is the number of chars in the field.

The client has been updated to use this function by default.  However, if the user specifies extra verbosity by passing the `-v` arg twice (i.e. `-vv` or `-v -v`) then the full hex-encoded bytes of all values will be shown, as they are currently.

Example output of a `put-deploy` request using `-v`:

```json
{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "account_put_deploy",
  "params": {
    "deploy": {
      "approvals": [
        {
          "signature": "130 chars",
          "signer": "01f60bce2bb1059c41910eac1e7ee6c3ef4c8fcc63a901eb9603c1524cadfb0c18"
        }
      ],
      "hash": "5c61b4096243a8bfe89f9337c60c8276a598dfdad94ccbb0eb9497bd614a0e14",
      "header": {
        "account": "01f60bce2bb1059c41910eac1e7ee6c3ef4c8fcc63a901eb9603c1524cadfb0c18",
        "body_hash": "89f13f2b89fc304b849ed047e3d5c6c1fc2e7ad81619e02bd9558028451eae3a",
        "chain_name": "net",
        "dependencies": [],
        "gas_price": 1,
        "timestamp": "2021-01-24T15:35:26.295Z",
        "ttl": "1h"
      },
      "payment": {
        "ModuleBytes": {
          "args": [],
          "module_bytes": "1308110 chars"
        }
      },
      "session": {
        "ModuleBytes": {
          "args": [],
          "module_bytes": "176328 chars"
        }
      }
    }
  }
}
```