### PR TITLE
NO-TICKET: Memory usage of `BlockValidator`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
     commands:
       - cargo install cargo-audit
       - cargo generate-lockfile
-      - cargo audit
+      - cargo audit --ignore RUSTSEC-2021-0013
 
 trigger:
   branch:

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -68,9 +68,10 @@ pub(crate) struct BlockValidationState<T> {
     responders: SmallVec<[Responder<(bool, T)>; 2]>,
 }
 
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub(crate) struct BlockValidatorReady<T, I> {
     /// Chainspec loaded for deploy validation.
+    #[data_size(skip)]
     chainspec: Arc<Chainspec>,
     /// State of validation of a specific block.
     validation_states: HashMap<T, BlockValidationState<T>>,
@@ -226,8 +227,9 @@ where
 }
 
 /// Block validator states.
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub(crate) enum BlockValidatorState<T, I> {
+    #[data_size(skip)]
     Loading(Vec<Event<T, I>>),
     Ready(BlockValidatorReady<T, I>),
 }
@@ -235,7 +237,6 @@ pub(crate) enum BlockValidatorState<T, I> {
 /// Block validator.
 #[derive(DataSize, Debug)]
 pub(crate) struct BlockValidator<T, I> {
-    #[data_size(skip)]
     state: BlockValidatorState<T, I>,
 }
 


### PR DESCRIPTION
I've added `data_size(skip)` annotation on `Loading` variant of the enum, mostly because we shouldn't be in the `Loading` state for long enough for this metric to be necessary but also because it is a pain to write an implementation of `DataSize`  for the `Event` enum.