### PR TITLE
NDRS-801: Verify that the execution matches expected during sync.

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -143,7 +143,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
     {
         let height = block_header.height();
         let hash = block_header.hash();
-        trace!(%hash, %height, "Downloaded linear chain block.");
+        trace!(%hash, %height, "downloaded linear chain block.");
         // Reset peers before creating new requests.
         self.peers.reset(rng);
         let block_height = block_header.height();
@@ -502,8 +502,9 @@ where
             Event::BlockHandled(header) => {
                 let block_height = header.height();
                 let block_hash = header.hash();
+                let effects = self.block_handled(rng, effect_builder, *header);
                 trace!(%block_height, %block_hash, "block handled.");
-                self.block_handled(rng, effect_builder, *header)
+                effects
             }
         }
     }

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -153,9 +153,17 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             // Keep syncing from genesis if we haven't reached the trusted block hash
             State::SyncingTrustedHash {
                 highest_block_seen,
+                ref latest_block,
                 ref mut validator_weights,
                 ..
             } if highest_block_seen != block_height => {
+                match latest_block.as_ref() {
+                    Some(expected) => assert_eq!(
+                        expected, &block_header,
+                        "Block execution result doesn't match received block."
+                    ),
+                    None => panic!("Unexpected block execution results."),
+                }
                 if let Some(validator_weights_for_new_era) =
                     block_header.next_era_validator_weights()
                 {

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -437,8 +437,11 @@ impl DocExample for FinalizedBlock {
 
 impl From<BlockHeader> for FinalizedBlock {
     fn from(header: BlockHeader) -> Self {
-        let proto_block =
-            ProtoBlock::new(header.deploy_hashes().clone(), vec![], header.random_bit);
+        let proto_block = ProtoBlock::new(
+            header.deploy_hashes().clone(),
+            header.transfer_hashes().clone(),
+            header.random_bit,
+        );
 
         FinalizedBlock {
             proto_block,
@@ -1024,7 +1027,10 @@ impl BlockLike for Block {
 
 impl BlockLike for BlockHeader {
     fn deploys(&self) -> Vec<&DeployHash> {
-        self.deploy_hashes().iter().collect()
+        self.deploy_hashes()
+            .iter()
+            .chain(self.transfer_hashes().iter())
+            .collect()
     }
 }
 


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-801

The bug was introduced in #760 , where wasmless transfers got separated from the deploys but this change was not propagated when constructing a `ProtoBlock`. Which lead to a consensus not requesting wasmless transfers when fetching dependencies and, in a result, executing an incomplete block (hence different post-state hash).