### PR TITLE
NO-TICKET: Fix raw gas/motes conversions.

### DIFF
--- a/execution_engine/src/core/engine_state/execution_result.rs
+++ b/execution_engine/src/core/engine_state/execution_result.rs
@@ -254,7 +254,7 @@ impl ExecutionResult {
         error: error::Error,
         max_payment_cost: Motes,
         account_main_purse_balance: Motes,
-        gas_price: u64,
+        gas_cost: Gas,
         account_main_purse_balance_key: Key,
         proposer_main_purse_balance_key: Key,
     ) -> Result<ExecutionResult, CLValueError> {
@@ -264,13 +264,12 @@ impl ExecutionResult {
             account_main_purse_balance_key,
             proposer_main_purse_balance_key,
         )?;
-        let cost = Gas::from_motes(max_payment_cost, gas_price).expect("gas overflow");
         let transfers = Vec::default();
         Ok(ExecutionResult::Failure {
             error,
             effect,
             transfers,
-            cost,
+            cost: gas_cost,
         })
     }
 

--- a/execution_engine/src/core/engine_state/execution_result.rs
+++ b/execution_engine/src/core/engine_state/execution_result.rs
@@ -228,6 +228,7 @@ impl ExecutionResult {
         let payment_result_cost = match Motes::from_gas(self.cost(), gas_price) {
             Some(cost) => cost,
             // Multiplying cost by gas_price overflowed the U512 range
+            // TODO: Add a specific error variant to represent gas to motes conversion overflow.
             None => return Some(ForcedTransferResult::InsufficientPayment),
         };
         // payment_code_spec_3_b_ii: if (balance of PoS pay purse) < (gas spent during

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -716,9 +716,11 @@ where
                 match Motes::from_gas(wasmless_transfer_gas_cost, deploy_item.gas_price) {
                     Some(motes) => motes,
                     None => {
+                        // TODO: Add a specific error variant to represent gas to motes conversion
+                        // overflow.
                         return Ok(ExecutionResult::precondition_failure(
                             Error::InsufficientPayment,
-                        ))
+                        ));
                     }
                 };
 
@@ -884,9 +886,11 @@ where
             let payment_gas = match Gas::from_motes(payment_purse_balance, deploy_item.gas_price) {
                 Some(gas) => gas,
                 None => {
+                    // TODO: Add a specific error variant to represent motes to gas conversion
+                    // underflow.
                     return Ok(ExecutionResult::precondition_failure(
                         Error::InsufficientPayment,
-                    ))
+                    ));
                 }
             };
 
@@ -967,9 +971,11 @@ where
                     match Motes::from_gas(payment_result.cost(), deploy_item.gas_price) {
                         Some(motes) => motes,
                         None => {
+                            // TODO: Add a specific error variant to represent gas to motes
+                            // conversion overflow.
                             return Ok(ExecutionResult::precondition_failure(
                                 Error::InsufficientPayment,
-                            ))
+                            ));
                         }
                     };
 
@@ -1217,9 +1223,11 @@ where
             let payment_gas_limit = match Gas::from_motes(max_payment_cost, deploy_item.gas_price) {
                 Some(gas) => gas,
                 None => {
+                    // TODO: Add a specific error variant to represent motes to gas conversion
+                    // underflow
                     return Ok(ExecutionResult::precondition_failure(
                         Error::InsufficientPayment,
-                    ))
+                    ));
                 }
             };
 
@@ -1424,9 +1432,11 @@ where
             let gas_cost = match Gas::from_motes(max_payment_cost, deploy_item.gas_price) {
                 Some(gas) => gas,
                 None => {
+                    // TODO: Add a specific error variant to represent motes to gas conversion
+                    // underflow
                     return Ok(ExecutionResult::precondition_failure(
                         Error::InsufficientPayment,
-                    ))
+                    ));
                 }
             };
 
@@ -1513,9 +1523,11 @@ where
                 {
                     Some(gas) => gas,
                     None => {
+                        // TODO: Add a specific error variant to represent motes to gas conversion
+                        // underflow
                         return Ok(ExecutionResult::precondition_failure(
                             Error::InsufficientPayment,
-                        ))
+                        ));
                     }
                 };
             let system_contract_cache = SystemContractCache::clone(&self.system_contract_cache);
@@ -1581,7 +1593,10 @@ where
                 //((gas spent during payment code execution) + (gas spent during session code execution)) * gas_price
                 let finalize_cost_motes = match Motes::from_gas(execution_result_builder.total_cost(), deploy_item.gas_price) {
                         Some(motes) => motes,
-                        None => return Ok(ExecutionResult::precondition_failure(Error::InsufficientPayment))
+                        None => {
+                            // TODO: Add a specific error variant to represent gas to motes conversion overflow.
+                            return Ok(ExecutionResult::precondition_failure(Error::InsufficientPayment))
+                        }
                     };
 
                 let maybe_runtime_args = RuntimeArgs::try_new(|args| {

--- a/execution_engine/src/shared/gas.rs
+++ b/execution_engine/src/shared/gas.rs
@@ -28,6 +28,10 @@ impl Gas {
     pub fn checked_add(&self, rhs: Self) -> Option<Self> {
         self.0.checked_add(rhs.value()).map(Self::new)
     }
+
+    pub fn checked_sub(&self, rhs: Self) -> Option<Self> {
+        self.0.checked_sub(rhs.value()).map(Self::new)
+    }
 }
 
 impl fmt::Display for Gas {


### PR DESCRIPTION
There are some checks in the node (i.e. https://github.com/CasperLabs/casperlabs-node/blob/b992ae0f72fa7a5c72c101dca03e0271a5736481/node/src/components/block_proposer.rs#L454-L463) to avoid overflows so chances are bogus deploys with `gas_price == u64::max_value()` or similar won't reach EE but after merging #766 those are better to be matched rather than unwrap/expected.