### PR TITLE
NDRS-809: Add "insufficient balance" variant

### DIFF
--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -39,7 +39,7 @@ pub enum Event {
         deploy: Box<Deploy>,
         source: Source<NodeId>,
         account_key: Key,
-        verified: bool,
+        verified: Option<bool>,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     },
 }
@@ -90,7 +90,7 @@ impl Display for Event {
                 verified,
                 ..
             } => {
-                let prefix = if *verified { "" } else { "in" };
+                let prefix = if verified.unwrap_or(false) { "" } else { "in" };
                 write!(
                     formatter,
                     "{}valid deploy {} from account {}",

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1202,7 +1202,7 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    pub(crate) async fn is_verified_account(self, account_key: Key) -> bool
+    pub(crate) async fn is_verified_account(self, account_key: Key) -> Option<bool>
     where
         REv: From<ContractRuntimeRequest>,
         REv: From<StorageRequest>,
@@ -1218,13 +1218,13 @@ impl<REv> EffectBuilder<REv> {
                     let balance_request = BalanceRequest::new(state_hash, purse_uref);
                     if let Ok(balance_result) = self.get_balance(balance_request).await {
                         if let Some(motes) = balance_result.motes() {
-                            return motes >= &*MAX_PAYMENT;
+                            return Some(motes >= &*MAX_PAYMENT);
                         }
                     }
                 }
             }
         }
-        false
+        None
     }
 
     /// Requests a query be executed on the Contract Runtime component.


### PR DESCRIPTION
This commit improves UX so sending deploys from invalid account reports
different error than sending account that does not have minimum balance
required.

Testing done:

```
cargo run --bin casper-client -- transfer --node-address http://localhost:50101 --target-account 01cddd9ecbea7b8e2cec8ad2041bd2a8edb554fe737bb6053ab67eb04f40851911 --amount 1 --chain-name casper-example --secret-key ./resources/local/secret_keys/node-1.pem --payment-amount 1
# Wait for transfer to go through
cargo run --bin casper-client -- put-deploy --chain-name casper-example --node-address http://localhost:50101 --secret-key Foo_secret_key.pem --session-path ./target/wasm32-unknown-unknown/release/do_nothing.wasm  --payment-amount 5000000000
```

Result:

```
thread 'main' panicked at 'unable to put deploy ResponseIsError(Error { code: 32008, message: "insufficient balance", data: None })', client/src/deploy/put.rs:56:31
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```