### PR TITLE
Update libp2p to 0.34.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
  "fastrand",
  "futures-lite",
  "libc",
- "log 0.4.13",
+ "log 0.4.14",
  "nb-connect",
  "once_cell",
  "parking",
@@ -288,7 +288,7 @@ dependencies = [
  "futures-lite",
  "gloo-timers",
  "kv-log-macro",
- "log 0.4.13",
+ "log 0.4.14",
  "memchr",
  "num_cpus",
  "once_cell",
@@ -313,6 +313,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -562,12 +575,6 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
-
-[[package]]
-name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
@@ -703,7 +710,7 @@ dependencies = [
  "dirs",
  "grpc",
  "lmdb",
- "log 0.4.13",
+ "log 0.4.14",
  "num",
  "num-rational 0.3.2",
  "parity-wasm 0.42.1",
@@ -723,7 +730,7 @@ dependencies = [
  "casper-types",
  "grpc",
  "lmdb",
- "log 0.4.13",
+ "log 0.4.14",
  "num-rational 0.3.2",
  "num-traits",
  "once_cell",
@@ -748,7 +755,7 @@ dependencies = [
  "crossbeam-channel 0.5.0",
  "env_logger",
  "grpc",
- "log 0.4.13",
+ "log 0.4.14",
  "num-rational 0.3.2",
  "num-traits",
  "once_cell",
@@ -780,7 +787,7 @@ dependencies = [
  "libc",
  "linked-hash-map",
  "lmdb",
- "log 0.4.13",
+ "log 0.4.14",
  "num",
  "num-derive",
  "num-rational 0.3.2",
@@ -797,7 +804,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
- "uint",
+ "uint 0.8.5",
  "uuid",
  "wasmi",
 ]
@@ -845,8 +852,8 @@ dependencies = [
  "libp2p",
  "linked-hash-map",
  "lmdb",
- "log 0.4.13",
- "multihash",
+ "log 0.4.14",
+ "multihash 0.11.4",
  "num",
  "num-derive",
  "num-rational 0.3.2",
@@ -890,7 +897,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
- "uint",
+ "uint 0.8.5",
  "untrusted",
  "uuid",
  "vergen",
@@ -939,7 +946,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
- "uint",
+ "uint 0.8.5",
  "version-sync",
 ]
 
@@ -971,7 +978,7 @@ dependencies = [
  "clap",
  "heck",
  "indexmap",
- "log 0.4.13",
+ "log 0.4.14",
  "proc-macro2",
  "quote",
  "serde",
@@ -1366,7 +1373,7 @@ dependencies = [
  "crossterm_winapi",
  "lazy_static",
  "libc",
- "mio",
+ "mio 0.6.23",
  "parking_lot 0.10.2",
  "signal-hook",
  "winapi 0.3.9",
@@ -1925,7 +1932,7 @@ checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.13",
+ "log 0.4.14",
  "regex",
  "termcolor",
 ]
@@ -2223,18 +2230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures_codec"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
-dependencies = [
- "bytes 0.5.6",
- "futures 0.3.12",
- "memchr",
- "pin-project 0.4.27",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,7 +2372,7 @@ dependencies = [
  "futures 0.1.30",
  "futures-cpupool",
  "httpbis",
- "log 0.4.13",
+ "log 0.4.14",
  "protobuf",
  "tls-api",
  "tls-api-stub",
@@ -2584,7 +2579,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
  "futures-cpupool",
- "log 0.4.13",
+ "log 0.4.14",
  "net2",
  "tls-api",
  "tls-api-stub",
@@ -2679,6 +2674,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-watch"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b8538953a3f0d0d3868f0a706eb4273535e10d72acb5c82c1c23ae48835c85"
+dependencies = [
+ "async-io",
+ "futures 0.3.12",
+ "futures-lite",
+ "if-addrs",
+ "ipnet",
+ "libc",
+ "log 0.4.14",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,15 +2740,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c3eaab3ac0ede60ffa41add21970a7df7d91772c03383aac6c2c3d53cc716b"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -2858,7 +2860,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -2881,12 +2883,12 @@ checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libp2p"
-version = "0.29.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021f703bfef6e3da78ef9828c8a244d639b8d57eedf58360922aca5ff69dfdcd"
+checksum = "d5133112ce42be9482f6a87be92a605dd6bbc9e93c297aee77d172ff06908f3a"
 dependencies = [
  "atomic",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures 0.3.12",
  "lazy_static",
  "libp2p-core",
@@ -2906,7 +2908,6 @@ dependencies = [
  "libp2p-tcp",
  "libp2p-uds",
  "libp2p-yamux",
- "multihash",
  "parity-multiaddr",
  "parking_lot 0.11.1",
  "pin-project 1.0.4",
@@ -2916,12 +2917,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.23.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3960524389409633550567e8a9e0684d25a33f4f8408887ff897dd9fdfbdb771"
+checksum = "dad04d3cef6c1df366a6ab58c9cf8b06497699e335d83ac2174783946ff847d6"
 dependencies = [
  "asn1_der",
- "bs58 0.3.1",
+ "bs58",
  "ed25519-dalek",
  "either",
  "fnv",
@@ -2929,8 +2930,8 @@ dependencies = [
  "futures-timer",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.13",
- "multihash",
+ "log 0.4.14",
+ "multihash 0.13.2",
  "multistream-select",
  "parity-multiaddr",
  "parking_lot 0.11.1",
@@ -2943,16 +2944,16 @@ dependencies = [
  "sha2 0.9.2",
  "smallvec 1.6.1",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "void",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
+checksum = "f4bc40943156e42138d22ed3c57ff0e1a147237742715937622a99b10fbe0156"
 dependencies = [
  "quote",
  "syn",
@@ -2960,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.23.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567962c5c5f8a1282979441300e1739ba939024010757c3dbfab4d462189df77"
+checksum = "6d42eed63305f0420736fa487f9acef720c4528bd7852a6a760f5ccde4813345"
 dependencies = [
  "flate2",
  "futures 0.3.12",
@@ -2971,27 +2972,27 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436280f5fe21a58fcaff82c2606945579241f32bc0eaf2d39321aa4624a66e7f"
+checksum = "5153b6db68fd4baa3b304e377db744dd8fea8ff4e4504509ee636abcde88d3e3"
 dependencies = [
  "futures 0.3.12",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc175613c5915332fd6458895407ec242ea055ae3b107a586626d5e3349350a"
+checksum = "b3c63dfa06581b24b1d12bf9815b43689a784424be217d6545c800c7c75a207f"
 dependencies = [
  "cuckoofilter",
  "fnv",
  "futures 0.3.12",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3000,40 +3001,40 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d500ad89ba14de4d18bebdff61a0ce3e769f1c5c5a95026c5da90187e5fff5c9"
+checksum = "12451ba9493e87c91baf2a6dffce9ddf1fbc807a0861532d7cf477954f8ebbee"
 dependencies = [
+ "asynchronous-codec",
  "base64 0.13.0",
  "byteorder",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "fnv",
  "futures 0.3.12",
- "futures_codec",
  "hex_fmt",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
- "lru_time_cache",
+ "log 0.4.14",
  "prost",
  "prost-build",
  "rand 0.7.3",
+ "regex",
  "sha2 0.9.2",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b90b350e37f398b73d778bd94422f4e6a3afa2c1582742ce2446b8a0dba787"
+checksum = "b40fb36a059b7a8cce1514bd8b546fa612e006c9937caa7f5950cb20021fe91e"
 dependencies = [
  "futures 0.3.12",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "prost",
  "prost-build",
  "smallvec 1.6.1",
@@ -3042,83 +3043,81 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.24.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb78341f114bf686d5fe50b33ff1a804d88fb326c0d39ee1c22db4346b21fc27"
+checksum = "456f5de8e283d7800ca848b9b9a4e2a578b790bd8ae582b885e831353cf0e5df"
 dependencies = [
  "arrayvec",
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "either",
  "fnv",
  "futures 0.3.12",
- "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
- "multihash",
+ "log 0.4.14",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "sha2 0.9.2",
  "smallvec 1.6.1",
- "uint",
- "unsigned-varint",
+ "uint 0.9.0",
+ "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.23.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b575514fce0a3ccbd065d6aa377bd4d5102001b05c1a22a5eee49c450254ef0f"
+checksum = "b974db63233fc0e199f4ede7794294aae285c96f4b6010f853eac4099ef08590"
 dependencies = [
+ "async-io",
  "data-encoding",
  "dns-parser",
- "either",
  "futures 0.3.12",
+ "if-watch",
  "lazy_static",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
- "net2",
+ "log 0.4.14",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "tokio 0.2.24",
+ "socket2",
  "void",
- "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.23.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92b538238c80067c6417a58a07e41002b69d129355b60ec147d6337fdff0eb0"
+checksum = "2705dc94b01ab9e3779b42a09bbf3712e637ed213e875c30face247291a85af0"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "futures 0.3.12",
- "futures_codec",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
  "nohash-hasher",
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c77142e3e5b18fefa7d267305c777c9cbe9b2232ec489979390100bebcc1e6"
+checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "curve25519-dalek",
  "futures 0.3.12",
  "lazy_static",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3131,14 +3130,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7257135609e8877f4d286935cbe1e572b2018946881c3e7f63054577074a7ee7"
+checksum = "6f3813276d0708c8db0f500d8beda1bda9ad955723b9cb272c41f4727256f73c"
 dependencies = [
  "futures 0.3.12",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "rand 0.7.3",
  "void",
  "wasm-timer",
@@ -3146,34 +3145,34 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.4.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ba1aa5727ccc118c09ba5111480873f2fe5608cb304e258fd12c173ecf27c9"
+checksum = "d37637a4b33b5390322ccc068a33897d0aa541daf4fec99f6a7efbf37295346e"
 dependencies = [
  "async-trait",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures 0.3.12",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "lru",
  "minicbor",
  "rand 0.7.3",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.23.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6fa33b16956b8a58afbfebe1406866011a1ab8960765bd36868952d7be6a1"
+checksum = "d4f89ebb4d8953bda12623e9871959fe728dea3bf6eae0421dc9c42dc821e488"
 dependencies = [
  "either",
  "futures 0.3.12",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
  "rand 0.7.3",
  "smallvec 1.6.1",
  "void",
@@ -3182,37 +3181,40 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0b6f4ef48d9493607fae069deecce0579320a1f3de6cb056770b151018a9a5"
+checksum = "3dbd3d7076a478ac5a6aca55e74bdc250ac539b95de09b9d09915e0b8d01a6b2"
 dependencies = [
+ "async-io",
  "futures 0.3.12",
  "futures-timer",
  "if-addrs",
+ "if-watch",
  "ipnet",
+ "libc",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
  "socket2",
- "tokio 0.2.24",
+ "tokio 1.1.0",
 ]
 
 [[package]]
 name = "libp2p-uds"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945bed3c989a1b290b5a0d4e8fa6e44e01840efb9a5ab3f0d3d174f0e451ac0e"
+checksum = "80ac51ce419f60be966e02103c17f67ff5dc4422ba83ba54d251d6c62a4ed487"
 dependencies = [
  "async-std",
  "futures 0.3.12",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c0c9b6ef7a168c2ae854170b0b6b77550599afe06cc3ac390eb45c5d9c7110"
+checksum = "490b8b27fc40fe35212df1b6a3d14bffaa4117cbff956fdc2892168a371102ad"
 dependencies = [
  "futures 0.3.12",
  "libp2p-core",
@@ -3297,17 +3299,18 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
+ "value-bag",
 ]
 
 [[package]]
@@ -3318,12 +3321,6 @@ checksum = "3aae342b73d57ad0b8b364bd12584819f2c1fe9114285dfcf8b0722607671635"
 dependencies = [
  "hashbrown",
 ]
-
-[[package]]
-name = "lru_time_cache"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f957950068c53af3b32a1b3a6e69f6dd3c19fa6f0dcc1168b846662d5e10b1"
 
 [[package]]
 name = "mach"
@@ -3439,18 +3436,18 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2ef6aa869726518c5d8206fa5d1337bda8a0442807611be617891c018fa781"
+checksum = "3265a9f5210bb726f81ef9c456ae0aff5321cd95748c0e71889b0e19d8f0332b"
 dependencies = [
  "minicbor-derive",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3569c0dbfff1b8d5f1434c642b67f5bf81c0f354a3f5f8f180b549dba3c07c"
+checksum = "130b9455e28a3f308f6579671816a6f2621e2e0cbf55dc2f886345bef699481e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3487,11 +3484,24 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.13",
- "miow",
+ "log 0.4.14",
+ "miow 0.2.2",
  "net2",
  "slab 0.4.2",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+dependencies = [
+ "libc",
+ "log 0.4.14",
+ "miow 0.3.6",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3502,7 +3512,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.23",
 ]
 
 [[package]]
@@ -3518,6 +3528,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "multihash"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,7 +3549,34 @@ dependencies = [
  "sha-1 0.9.2",
  "sha2 0.9.2",
  "sha3",
- "unsigned-varint",
+ "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "multihash"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "multihash-derive",
+ "sha2 0.9.2",
+ "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ee3c48cb9d9b275ad967a0e96715badc13c6029adb92f34fa17b9ff28fd81f"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -3546,7 +3593,7 @@ checksum = "d050aeedc89243f5347c3e237e3e13dc76fbe4ae3742a57b94dc14f69acf76d4"
 dependencies = [
  "buf_redux",
  "httparse",
- "log 0.4.13",
+ "log 0.4.14",
  "mime",
  "mime_guess",
  "quick-error",
@@ -3558,16 +3605,16 @@ dependencies = [
 
 [[package]]
 name = "multistream-select"
-version = "0.8.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
+checksum = "10ddc0eb0117736f19d556355464fc87efc8ad98b29e3fd84f02531eb6e90840"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures 0.3.12",
- "log 0.4.13",
+ "log 0.4.14",
  "pin-project 1.0.4",
  "smallvec 1.6.1",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
@@ -3594,7 +3641,7 @@ checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.13",
+ "log 0.4.14",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -3642,6 +3689,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "num"
@@ -3846,19 +3902,19 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.7"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbecae7b7cfaafea47ceb5253ecdd14155ca8410e3487ed86031a6c2d5c15873"
+checksum = "8bfda2e46fc5e14122649e2645645a81ee5844e0fb2e727ef560cc71a8b2d801"
 dependencies = [
  "arrayref",
- "bs58 0.4.0",
+ "bs58",
  "byteorder",
  "data-encoding",
- "multihash",
+ "multihash 0.13.2",
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.6.0",
  "url",
 ]
 
@@ -4198,7 +4254,7 @@ checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "log 0.4.13",
+ "log 0.4.14",
  "wepoll-sys",
  "winapi 0.3.9",
 ]
@@ -4278,6 +4334,15 @@ checksum = "aee95d988ee893cb35c06b148c80ed2cd52c8eea927f50ba7a0be1a786aeab73"
 dependencies = [
  "predicates-core",
  "treeline",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
 ]
 
 [[package]]
@@ -4362,24 +4427,24 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "heck",
- "itertools 0.8.2",
- "log 0.4.13",
+ "itertools 0.9.0",
+ "log 0.4.14",
  "multimap",
  "petgraph",
  "prost",
@@ -4390,12 +4455,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4403,11 +4468,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "prost",
 ]
 
@@ -4435,7 +4500,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d9500ea1488a61aa96da139039b78a92eef64a0f3c82d38173729f0ad73cf8"
 dependencies = [
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -4505,7 +4570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
 dependencies = [
  "byteorder",
- "log 0.4.13",
+ "log 0.4.14",
  "parity-wasm 0.41.0",
 ]
 
@@ -4516,7 +4581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c8ac87af529432d3a4f0e2b3bbf08af49f28f09cc73ed7e551161bdaef5f78d"
 dependencies = [
  "byteorder",
- "log 0.4.13",
+ "log 0.4.14",
  "parity-wasm 0.41.0",
 ]
 
@@ -4810,7 +4875,7 @@ dependencies = [
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.13",
+ "log 0.4.14",
  "mime",
  "mime_guess",
  "native-tls",
@@ -5270,7 +5335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.6.23",
  "signal-hook-registry",
 ]
 
@@ -5660,7 +5725,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049c03787a0595182357fbd487577947f4351b78ce20c3668f6d49f17feb13d1"
 dependencies = [
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -5681,7 +5746,7 @@ checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "tokio-codec",
  "tokio-current-thread",
@@ -5709,11 +5774,23 @@ dependencies = [
  "iovec",
  "lazy_static",
  "memchr",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "pin-project-lite 0.1.11",
  "slab 0.4.2",
  "tokio-macros",
+]
+
+[[package]]
+name = "tokio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8efab2086f17abcddb8f756117665c958feee6b2e39974c2f1600592ab3a4195"
+dependencies = [
+ "autocfg",
+ "libc",
+ "mio 0.7.7",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -5736,8 +5813,8 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
  "iovec",
- "log 0.4.13",
- "mio",
+ "log 0.4.14",
+ "mio 0.6.23",
  "scoped-tls 0.1.2",
  "tokio 0.1.22",
  "tokio-executor",
@@ -5785,7 +5862,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -5818,8 +5895,8 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.30",
  "lazy_static",
- "log 0.4.13",
- "mio",
+ "log 0.4.14",
+ "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
  "slab 0.4.2",
@@ -5861,7 +5938,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
  "iovec",
- "mio",
+ "mio 0.6.23",
  "tokio-io",
  "tokio-reactor",
 ]
@@ -5877,7 +5954,7 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.30",
  "lazy_static",
- "log 0.4.13",
+ "log 0.4.14",
  "num_cpus",
  "slab 0.4.2",
  "tokio-executor",
@@ -5933,7 +6010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
 dependencies = [
  "futures-util",
- "log 0.4.13",
+ "log 0.4.14",
  "pin-project 0.4.27",
  "tokio 0.2.24",
  "tungstenite",
@@ -5947,8 +6024,8 @@ checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
- "log 0.4.13",
- "mio",
+ "log 0.4.14",
+ "mio 0.6.23",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
@@ -5965,7 +6042,7 @@ dependencies = [
  "iovec",
  "libc",
  "log 0.3.9",
- "mio",
+ "mio 0.6.23",
  "mio-uds",
  "tokio-core",
  "tokio-io",
@@ -5981,8 +6058,8 @@ dependencies = [
  "futures 0.1.30",
  "iovec",
  "libc",
- "log 0.4.13",
- "mio",
+ "log 0.4.14",
+ "mio 0.6.23",
  "mio-uds",
  "tokio-codec",
  "tokio-io",
@@ -5998,7 +6075,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log 0.4.13",
+ "log 0.4.14",
  "pin-project-lite 0.1.11",
  "tokio 0.2.24",
 ]
@@ -6025,7 +6102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.13",
+ "log 0.4.14",
  "pin-project-lite 0.2.4",
  "tracing-attributes",
  "tracing-core",
@@ -6068,7 +6145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 dependencies = [
  "lazy_static",
- "log 0.4.13",
+ "log 0.4.14",
  "tracing-core",
 ]
 
@@ -6252,7 +6329,7 @@ dependencies = [
  "http",
  "httparse",
  "input_buffer",
- "log 0.4.13",
+ "log 0.4.14",
  "rand 0.7.3",
  "sha-1 0.9.2",
  "url",
@@ -6289,6 +6366,18 @@ dependencies = [
  "byteorder",
  "crunchy",
  "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
  "static_assertions",
 ]
 
@@ -6376,11 +6465,17 @@ name = "unsigned-varint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "futures-io",
  "futures-util",
- "futures_codec",
 ]
 
 [[package]]
@@ -6421,6 +6516,15 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.2",
  "serde",
+]
+
+[[package]]
+name = "value-bag"
+version = "1.0.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
+dependencies = [
+ "ctor",
 ]
 
 [[package]]
@@ -6510,7 +6614,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.13",
+ "log 0.4.14",
  "try-lock",
 ]
 
@@ -6525,7 +6629,7 @@ dependencies = [
  "headers",
  "http",
  "hyper",
- "log 0.4.13",
+ "log 0.4.14",
  "mime",
  "mime_guess",
  "multipart",
@@ -6554,7 +6658,7 @@ dependencies = [
  "http",
  "hyper",
  "lazycell",
- "log 0.4.13",
+ "log 0.4.14",
  "serde",
  "serde_json",
  "warp",
@@ -6592,7 +6696,7 @@ checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.13",
+ "log 0.4.14",
  "proc-macro2",
  "quote",
  "syn",
@@ -6717,11 +6821,12 @@ checksum = "62945bc99a6a121cb2759c7bfa7b779ddf0e69b68bb35a9b23ab72276cfdcd3c"
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
 dependencies = [
  "libc",
+ "thiserror",
 ]
 
 [[package]]
@@ -6828,7 +6933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
 dependencies = [
  "futures 0.3.12",
- "log 0.4.13",
+ "log 0.4.14",
  "nohash-hasher",
  "parking_lot 0.11.1",
  "rand 0.7.3",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -46,7 +46,7 @@ jemallocator = "0.3.2"
 jemalloc-ctl = "0.3.3"
 k256 = { version = "0.4.2", features = ["ecdsa", "zeroize"] }
 libc = "0.2.66"
-libp2p = { version = "0.29.1", default-features = false, features = ["deflate", "dns", "floodsub", "gossipsub", "identify", "kad", "mdns-tokio", "mplex", "noise", "ping", "request-response", "tcp-tokio", "uds", "yamux"] }
+libp2p = { version = "0.34.0", default-features = false, features = ["deflate", "dns", "floodsub", "gossipsub", "identify", "kad", "mdns", "mplex", "noise", "ping", "request-response", "tcp-tokio", "uds", "yamux"] }
 linked-hash-map = "0.5.3"
 lmdb = "0.8.0"
 log = { version = "0.4.8", features = ["std", "serde", "kv_unstable"] }

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -33,7 +33,7 @@ use libp2p::{
     request_response::{RequestResponseEvent, RequestResponseMessage},
     swarm::{SwarmBuilder, SwarmEvent},
     tcp::TokioTcpConfig,
-    yamux::Config as YamuxConfig,
+    yamux::YamuxConfig,
     Multiaddr, PeerId, Swarm, Transport,
 };
 use rand::seq::IteratorRandom;
@@ -145,7 +145,7 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
         // Create a new Ed25519 keypair for this session.
         let our_id_keys = Keypair::generate_ed25519();
         let our_peer_id = PeerId::from(our_id_keys.public());
-        let our_id = NodeId::from(our_peer_id.clone());
+        let our_id = NodeId::from(our_peer_id);
 
         // Convert the known addresses to multiaddr format and prepare the shutdown signal.
         let known_addresses = config
@@ -206,7 +206,8 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
             .boxed();
 
         // Create a Swarm to manage peers and events.
-        let behavior = Behavior::new(&config, chainspec, our_id_keys.public());
+        let behavior = Behavior::new(&config, chainspec, our_id_keys.public())?;
+
         let mut swarm = SwarmBuilder::new(transport, behavior, our_peer_id)
             .executor(Box::new(|future| {
                 tokio::spawn(future);
@@ -393,7 +394,7 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
 }
 
 fn our_id(swarm: &Swarm<Behavior>) -> NodeId {
-    NodeId::P2p(Swarm::local_peer_id(swarm).clone())
+    NodeId::P2p(*Swarm::local_peer_id(swarm))
 }
 
 async fn server_task<REv: ReactorEventT<P>, P: PayloadT>(
@@ -614,6 +615,7 @@ async fn handle_one_way_messaging_event<REv: ReactorEventT<P>, P: PayloadT>(
                 our_id(swarm)
             )
         }
+        RequestResponseEvent::ResponseSent { .. } => {}
     }
 }
 
@@ -623,13 +625,17 @@ async fn handle_gossip_event<REv: ReactorEventT<P>, P: PayloadT>(
     event: GossipsubEvent,
 ) {
     match event {
-        GossipsubEvent::Message(_sender, _message_id, message) => {
+        GossipsubEvent::Message {
+            propagation_source: sender,
+            message,
+            ..
+        } => {
             // We've received a gossiped message: announce it via the reactor on the
             // `NetworkIncoming` queue.
             let sender = match message.source {
                 Some(source) => NodeId::from(source),
                 None => {
-                    warn!(%_sender, ?message, "{}: libp2p gossiped message without source", our_id(swarm));
+                    warn!(%sender, ?message, "{}: libp2p gossiped message without source", our_id(swarm));
                     return;
                 }
             };

--- a/node/src/components/network/error.rs
+++ b/node/src/components/network/error.rs
@@ -1,6 +1,9 @@
 use std::io;
 
-use libp2p::{core::connection::ConnectionLimit, noise::NoiseError, Multiaddr, TransportError};
+use libp2p::{
+    core::connection::ConnectionLimit, gossipsub::error::SubscriptionError, noise::NoiseError,
+    Multiaddr, TransportError,
+};
 use thiserror::Error;
 
 /// Error type returned by the `Network` component.
@@ -39,4 +42,18 @@ pub enum Error {
     /// Message too large.
     #[error("message of {actual_size} bytes exceeds limit of {max_size} bytes")]
     MessageTooLarge { max_size: u32, actual_size: u64 },
+
+    /// Behavior error.
+    #[error("unable to create new behavior {0}")]
+    Behavior(String),
+
+    /// Subscription error.
+    #[error("subscription error")]
+    Subscription,
+}
+
+impl From<SubscriptionError> for Error {
+    fn from(_error: SubscriptionError) -> Self {
+        Error::Subscription
+    }
 }

--- a/node/src/components/network/gossip.rs
+++ b/node/src/components/network/gossip.rs
@@ -2,20 +2,21 @@
 //! gossiping data to subscribed peers.
 
 use libp2p::{
-    core::{ProtocolName, PublicKey},
-    gossipsub::{Gossipsub, GossipsubConfigBuilder, MessageAuthenticity, Topic, ValidationMode},
+    core::PublicKey,
+    gossipsub::{
+        Gossipsub, GossipsubConfigBuilder, IdentTopic, MessageAuthenticity, ValidationMode,
+    },
     PeerId,
 };
 use once_cell::sync::Lazy;
 
-use super::{Config, Error, PayloadT, ProtocolId};
-use crate::components::chainspec_loader::Chainspec;
+use super::{Config, Error, PayloadT};
 
 /// The inner portion of the `ProtocolId` for the gossip behavior.  A standard prefix and suffix
 /// will be applied to create the full protocol name.
 const PROTOCOL_NAME_INNER: &str = "validator/gossip";
 
-pub(super) static TOPIC: Lazy<Topic> = Lazy::new(|| Topic::new("all".into()));
+pub(super) static TOPIC: Lazy<IdentTopic> = Lazy::new(|| IdentTopic::new("all"));
 
 pub(super) struct GossipMessage(pub Vec<u8>);
 
@@ -42,21 +43,18 @@ impl From<GossipMessage> for Vec<u8> {
 }
 
 /// Constructs a new libp2p behavior suitable for gossiping.
-pub(super) fn new_behavior(
-    config: &Config,
-    chainspec: &Chainspec,
-    our_public_key: PublicKey,
-) -> Gossipsub {
-    let protocol_id = ProtocolId::new(chainspec, PROTOCOL_NAME_INNER);
-    let gossipsub_config = GossipsubConfigBuilder::new()
-        .protocol_id(protocol_id.protocol_name().to_vec())
+pub(super) fn new_behavior(config: &Config, our_public_key: PublicKey) -> Result<Gossipsub, Error> {
+    let gossipsub_config = GossipsubConfigBuilder::default()
+        .protocol_id_prefix(PROTOCOL_NAME_INNER)
         .heartbeat_interval(config.gossip_heartbeat_interval.into())
         .max_transmit_size(config.max_gossip_message_size as usize)
         .duplicate_cache_time(config.gossip_duplicate_cache_timeout.into())
         .validation_mode(ValidationMode::Permissive)
-        .build();
+        .build()
+        .map_err(|error| Error::Behavior(error.to_owned()))?;
     let our_peer_id = PeerId::from(our_public_key);
-    let mut gossipsub = Gossipsub::new(MessageAuthenticity::Author(our_peer_id), gossipsub_config);
-    gossipsub.subscribe(TOPIC.clone());
-    gossipsub
+    let mut gossipsub = Gossipsub::new(MessageAuthenticity::Author(our_peer_id), gossipsub_config)
+        .map_err(|error| Error::Behavior(error.to_owned()))?;
+    gossipsub.subscribe(&TOPIC.clone())?;
+    Ok(gossipsub)
 }

--- a/node/src/components/network/one_way_messaging.rs
+++ b/node/src/components/network/one_way_messaging.rs
@@ -56,9 +56,9 @@ impl Outgoing {
             });
         }
 
-        match &destination {
+        match destination {
             NodeId::P2p(destination) => Ok(Outgoing {
-                destination: destination.clone(),
+                destination,
                 message: serialized_message,
             }),
             destination => {

--- a/node/src/components/network/peer_discovery.rs
+++ b/node/src/components/network/peer_discovery.rs
@@ -32,7 +32,7 @@ pub(super) fn new_behaviors(
         max_value_bytes: 0,
         ..Default::default()
     };
-    let memory_store = MemoryStore::with_config(our_peer_id.clone(), memory_store_config);
+    let memory_store = MemoryStore::with_config(our_peer_id, memory_store_config);
 
     let protocol_id = ProtocolId::new(chainspec, KADEMLIA_PROTOCOL_NAME_INNER);
     let mut kademlia_config = KademliaConfig::default();

--- a/node/src/types/node_id.rs
+++ b/node/src/types/node_id.rs
@@ -5,10 +5,13 @@ use std::{
 
 use datasize::DataSize;
 use hex_fmt::HexFmt;
+#[cfg(test)]
+use libp2p::multihash::Multihash;
 use libp2p::PeerId;
 use once_cell::sync::Lazy;
 #[cfg(test)]
 use rand::{Rng, RngCore};
+
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(test)]
@@ -45,7 +48,8 @@ impl NodeId {
     pub(crate) fn random_p2p(rng: &mut TestRng) -> Self {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes[..]);
-        let multihash = multihash::wrap(multihash::Code::Identity, &bytes);
+        let multihash =
+            Multihash::wrap(multihash::Code::Identity as u64, &bytes).expect("should wrap bytes");
         let peer_id = PeerId::from_multihash(multihash).expect("should construct from multihash");
         NodeId::P2p(peer_id)
     }
@@ -53,9 +57,9 @@ impl NodeId {
 
 /// Used to serialize and deserialize `NodeID` where the (de)serializer isn't a human-readable type.
 #[derive(Serialize, Deserialize)]
-enum NodeIdAsBytes<'a> {
+enum NodeIdAsBytes {
     Tls(KeyFingerprint),
-    P2p(&'a [u8]),
+    P2p(Vec<u8>),
 }
 
 /// Used to serialize and deserialize `NodeID` where the (de)serializer is a human-readable type.
@@ -79,7 +83,7 @@ impl Serialize for NodeId {
 
         let helper = match self {
             NodeId::Tls(key_fingerprint) => NodeIdAsBytes::Tls(*key_fingerprint),
-            NodeId::P2p(peer_id) => NodeIdAsBytes::P2p(peer_id.as_ref()),
+            NodeId::P2p(peer_id) => NodeIdAsBytes::P2p(peer_id.to_bytes()),
         };
         helper.serialize(serializer)
     }
@@ -110,8 +114,8 @@ impl<'de> Deserialize<'de> for NodeId {
         match helper {
             NodeIdAsBytes::Tls(key_fingerprint) => Ok(NodeId::Tls(key_fingerprint)),
             NodeIdAsBytes::P2p(bytes) => {
-                let peer_id = PeerId::from_bytes(bytes.to_vec())
-                    .map_err(|_| D::Error::custom("invalid PeerId"))?;
+                let peer_id =
+                    PeerId::from_bytes(&bytes).map_err(|_| D::Error::custom("invalid PeerId"))?;
                 Ok(NodeId::P2p(peer_id))
             }
         }


### PR DESCRIPTION
This fixes security advisory on libp2p-deflate. See https://github.com/libp2p/rust-libp2p/issues/1932. Quite a lot of changes 

WIP clippy issues

```
warning: large size difference between variants
   --> node/src/reactor/joiner.rs:133:5
    |
133 |     BlockValidator(#[serde(skip_serializing)] block_validator::Event<BlockHeader, NodeId>),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this variant is 600 bytes
    |
    = note: `#[warn(clippy::large_enum_variant)]` on by default
note: and the second-largest variant is 336 bytes:
   --> node/src/reactor/joiner.rs:85:5
    |
85  |     SmallNetwork(small_network::Event<Message>),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
    |
133 |     BlockValidator(#[serde(skip_serializing)] Box<block_validator::Event<BlockHeader, NodeId>>),
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

^C  Building [=======================> ] 883/891: casper-node, casper-node
```