### PR TITLE
NDRS-797: Initial work on casper-node upgrades

### DIFF
--- a/node/src/app/cli.rs
+++ b/node/src/app/cli.rs
@@ -4,7 +4,11 @@
 
 pub mod arglang;
 
-use std::{env, fs, path::PathBuf, str::FromStr};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use anyhow::{self, bail, Context};
 use regex::Regex;
@@ -49,6 +53,24 @@ pub enum Cli {
         /// Overrides and extensions for configuration file entries in the form
         /// <SECTION>.<KEY>=<VALUE>.  For example, '-C=node.chainspec_config_path=chainspec.toml'
         config_ext: Vec<ConfigExt>,
+    },
+    /// Migrate modified values from the old config as required after an upgrade.
+    MigrateConfig {
+        /// Path to configuration file of previous version of node.
+        #[structopt(long)]
+        old_config: PathBuf,
+        /// Path to configuration file of this version of node.
+        #[structopt(long)]
+        new_config: PathBuf,
+    },
+    /// Migrate any stored data as required after an upgrade.
+    MigrateData {
+        /// Path to configuration file of previous version of node.
+        #[structopt(long)]
+        old_config: PathBuf,
+        /// Path to configuration file of this version of node.
+        #[structopt(long)]
+        new_config: PathBuf,
     },
 }
 
@@ -121,32 +143,8 @@ impl Cli {
                 // Setup UNIX signal hooks.
                 setup_signal_hooks();
 
-                // Determine the parent directory of the configuration file, if any.
-                // Otherwise, we default to `/`.
-                let root = config
-                    .parent()
-                    .map(|path| path.to_owned())
-                    .unwrap_or_else(|| "/".into());
-
-                // The app supports running without a config file, using default values.
-                let config_raw: String = fs::read_to_string(&config)
-                    .context("could not read configuration file")
-                    .with_context(|| config.display().to_string())?;
-
-                // Get the TOML table version of the config indicated from CLI args, or from a new
-                // defaulted config instance if one is not provided.
-                let mut config_table: Value = toml::from_str(&config_raw)?;
-
-                // If any command line overrides to the config values are passed, apply them.
-                for item in config_ext {
-                    item.update_toml_table(&mut config_table)?;
-                }
-
-                // Create validator config, including any overridden values.
-                let validator_config: validator::Config = config_table.try_into()?;
-                logging::init_with_config(&validator_config.logging)?;
+                let validator_config = Self::init(&config, config_ext)?;
                 info!(version = %env!("CARGO_PKG_VERSION"), "node starting up");
-                trace!("{}", config::to_string(&validator_config)?);
 
                 // We use a `ChaCha20Rng` for the production node. For one, we want to completely
                 // eliminate any chance of runtime failures, regardless of how small (these
@@ -158,7 +156,7 @@ impl Cli {
                 let registry = Registry::new();
 
                 let mut initializer_runner = Runner::<initializer::Reactor>::with_metrics(
-                    WithDir::new(root.clone(), validator_config),
+                    validator_config,
                     &mut rng,
                     &registry,
                 )
@@ -181,6 +179,10 @@ impl Cli {
                     bail!("failed to initialize successfully");
                 }
 
+                let root = config
+                    .parent()
+                    .map(|path| path.to_owned())
+                    .unwrap_or_else(|| "/".into());
                 let mut joiner_runner = Runner::<joiner::Reactor>::with_metrics(
                     WithDir::new(root, initializer),
                     &mut rng,
@@ -197,8 +199,78 @@ impl Cli {
                     Runner::<validator::Reactor>::with_metrics(config, &mut rng, &registry).await?;
                 validator_runner.run(&mut rng).await;
             }
+            Cli::MigrateConfig {
+                old_config,
+                new_config,
+            } => {
+                let new_config = Self::init(&new_config, vec![])?;
+
+                let old_root = old_config
+                    .parent()
+                    .map(|path| path.to_owned())
+                    .unwrap_or_else(|| "/".into());
+                let encoded_old_config = fs::read_to_string(&old_config)
+                    .context("could not read old configuration file")
+                    .with_context(|| old_config.display().to_string())?;
+                let old_config = toml::from_str(&encoded_old_config)?;
+
+                info!(version = %env!("CARGO_PKG_VERSION"), "migrating config");
+                casper_node::migrate_config(WithDir::new(old_root, old_config), new_config)?;
+            }
+            Cli::MigrateData {
+                old_config,
+                new_config,
+            } => {
+                let new_config = Self::init(&new_config, vec![])?;
+
+                let old_root = old_config
+                    .parent()
+                    .map(|path| path.to_owned())
+                    .unwrap_or_else(|| "/".into());
+                let encoded_old_config = fs::read_to_string(&old_config)
+                    .context("could not read old configuration file")
+                    .with_context(|| old_config.display().to_string())?;
+                let old_config = toml::from_str(&encoded_old_config)?;
+
+                info!(version = %env!("CARGO_PKG_VERSION"), "migrating data");
+                casper_node::migrate_data(WithDir::new(old_root, old_config), new_config)?;
+            }
         }
 
         Ok(())
+    }
+
+    /// Parses the config file for the current version of casper-node, and initializes logging.
+    fn init(
+        config: &Path,
+        config_ext: Vec<ConfigExt>,
+    ) -> anyhow::Result<WithDir<validator::Config>> {
+        // Determine the parent directory of the configuration file, if any.
+        // Otherwise, we default to `/`.
+        let root = config
+            .parent()
+            .map(|path| path.to_owned())
+            .unwrap_or_else(|| "/".into());
+
+        // The app supports running without a config file, using default values.
+        let encoded_config = fs::read_to_string(&config)
+            .context("could not read configuration file")
+            .with_context(|| config.display().to_string())?;
+
+        // Get the TOML table version of the config indicated from CLI args, or from a new
+        // defaulted config instance if one is not provided.
+        let mut config_table: Value = toml::from_str(&encoded_config)?;
+
+        // If any command line overrides to the config values are passed, apply them.
+        for item in config_ext {
+            item.update_toml_table(&mut config_table)?;
+        }
+
+        // Create validator config, including any overridden values.
+        let validator_config: validator::Config = config_table.try_into()?;
+        logging::init_with_config(&validator_config.logging)?;
+        trace!("{}", config::to_string(&validator_config)?);
+
+        Ok(WithDir::new(root, validator_config))
     }
 }

--- a/node/src/components/chainspec_loader/chainspec.rs
+++ b/node/src/components/chainspec_loader/chainspec.rs
@@ -392,6 +392,14 @@ impl Chainspec {
         });
         hash::hash(&serialized_chainspec)
     }
+
+    /// Returns the latest protocol version, taking into account upgrades.
+    pub fn latest_protocol_version(&self) -> Version {
+        self.upgrades
+            .last()
+            .map(|upgrade| upgrade.protocol_version.clone())
+            .unwrap_or_else(|| self.genesis.protocol_version.clone())
+    }
 }
 
 #[cfg(test)]

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -256,7 +256,7 @@ impl ItemFetcher<BlockByHeight> for Fetcher<BlockByHeight> {
         peer: NodeId,
     ) -> Effects<Event<BlockByHeight>> {
         effect_builder
-            .get_block_at_height(id)
+            .get_block_at_height_from_storage(id)
             .event(move |result| Event::GetFromStorageResult {
                 id,
                 peer,

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -337,13 +337,13 @@ where
                 }),
             Event::Request(LinearChainRequest::BlockAtHeightLocal(height, responder)) => {
                 effect_builder
-                    .get_block_at_height(height)
+                    .get_block_at_height_from_storage(height)
                     .event(move |block| {
                         Event::GetBlockByHeightResultLocal(height, block.map(Box::new), responder)
                     })
             }
             Event::Request(LinearChainRequest::BlockAtHeight(height, sender)) => effect_builder
-                .get_block_at_height(height)
+                .get_block_at_height_from_storage(height)
                 .event(move |maybe_block| {
                     Event::GetBlockByHeightResult(height, maybe_block.map(Box::new), sender)
                 }),

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -115,7 +115,7 @@ where
         match event {
             Event::RestRequest(RestRequest::GetStatus { responder }) => async move {
                 let (last_added_block, peers, chainspec_info) = join!(
-                    effect_builder.get_highest_block(),
+                    effect_builder.get_highest_block_from_storage(),
                     effect_builder.network_peers(),
                     effect_builder.get_chainspec_info()
                 );

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -198,7 +198,7 @@ where
                 maybe_id: Some(BlockIdentifier::Height(height)),
                 responder,
             }) => effect_builder
-                .get_block_at_height(height)
+                .get_block_at_height_from_storage(height)
                 .event(move |result| Event::GetBlockResult {
                     maybe_id: Some(BlockIdentifier::Height(height)),
                     result: Box::new(result),
@@ -208,7 +208,7 @@ where
                 maybe_id: None,
                 responder,
             }) => effect_builder
-                .get_highest_block()
+                .get_highest_block_from_storage()
                 .event(move |result| Event::GetBlockResult {
                     maybe_id: None,
                     result: Box::new(result),
@@ -264,7 +264,7 @@ where
                 }),
             Event::RpcRequest(RpcRequest::GetStatus { responder }) => async move {
                 let (last_added_block, peers, chainspec_info) = join!(
-                    effect_builder.get_highest_block(),
+                    effect_builder.get_highest_block_from_storage(),
                     effect_builder.network_peers(),
                     effect_builder.get_chainspec_info()
                 );

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -40,15 +40,15 @@ mod lmdb_ext;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+use std::{collections::BTreeSet, convert::TryFrom};
 use std::{
-    collections::BTreeMap,
+    collections::{btree_map::Entry, BTreeMap},
     fmt::{self, Display, Formatter},
     fs, io,
     path::PathBuf,
     sync::Arc,
 };
-#[cfg(test)]
-use std::{collections::BTreeSet, convert::TryFrom};
 
 use datasize::DataSize;
 use derive_more::From;
@@ -65,6 +65,7 @@ use super::Component;
 #[cfg(test)]
 use crate::crypto::hash::Digest;
 use crate::{
+    components::consensus::EraId,
     effect::{
         requests::{StateStoreRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects,
@@ -127,11 +128,21 @@ pub enum Error {
     /// Found a duplicate block-at-height index entry.
     #[error("duplicate entries for block at height {height}: {first} / {second}")]
     DuplicateBlockIndex {
-        /// Height at which duplication was found.
+        /// Height at which duplicate was found.
         height: u64,
         /// First block hash encountered at `height`.
         first: BlockHash,
         /// Second block hash encountered at `height`.
+        second: BlockHash,
+    },
+    /// Found a duplicate switch-block-at-era-id index entry.
+    #[error("duplicate entries for switch block at era id {era_id}: {first} / {second}")]
+    DuplicateEraIdIndex {
+        /// Era ID at which duplicate was found.
+        era_id: EraId,
+        /// First block hash encountered at `era_id`.
+        first: BlockHash,
+        /// Second block hash encountered at `era_id`.
         second: BlockHash,
     },
     /// Attempted to store a duplicate execution result.
@@ -176,8 +187,10 @@ pub struct Storage {
     /// The state storage database.
     #[data_size(skip)]
     state_store_db: Database,
-    /// Block height index.
+    /// A map of block height to block ID.
     block_height_index: BTreeMap<u64, BlockHash>,
+    /// A map of era ID to switch block ID.
+    switch_block_era_id_index: BTreeMap<EraId, BlockHash>,
     /// Chainspec cache.
     chainspec_cache: Option<Arc<Chainspec>>,
 }
@@ -250,6 +263,7 @@ impl Storage {
         // We now need to restore the block-height index. Log messages allow timing here.
         info!("reindexing block store");
         let mut block_height_index = BTreeMap::new();
+        let mut switch_block_era_id_index = BTreeMap::new();
         let block_txn = env.begin_ro_txn()?;
         let mut cursor = block_txn.open_ro_cursor(block_db)?;
 
@@ -263,15 +277,11 @@ impl Storage {
                 block.hash().as_ref(),
                 "found corrupt block in database"
             );
-            let header = block.header();
-            if let Some(duplicate) = block_height_index.insert(header.height(), *block.hash()) {
-                // A duplicated block in our backing store causes us to exit early.
-                return Err(Error::DuplicateBlockIndex {
-                    height: header.height(),
-                    first: header.hash(),
-                    second: duplicate,
-                });
-            }
+            insert_to_block_indices(
+                &mut block_height_index,
+                &mut switch_block_era_id_index,
+                &block,
+            )?;
         }
         info!("block store reindexing complete");
         drop(cursor);
@@ -286,6 +296,7 @@ impl Storage {
             transfer_db,
             state_store_db,
             block_height_index,
+            switch_block_era_id_index,
             chainspec_cache: None,
         })
     }
@@ -337,23 +348,11 @@ impl Storage {
                 let mut txn = self.env.begin_rw_txn()?;
                 let outcome = txn.put_value(self.block_db, block.hash(), &block, true)?;
                 txn.commit()?;
-
-                if outcome {
-                    // If we are attempting to insert a duplicate block, return with error.
-                    if let Some(first) = self.block_height_index.get(&block.height()) {
-                        if first != block.hash() {
-                            return Err(Error::DuplicateBlockIndex {
-                                height: block.height(),
-                                first: *first,
-                                second: *block.hash(),
-                            });
-                        }
-                    }
-                }
-
-                self.block_height_index
-                    .insert(block.height(), *block.hash());
-
+                insert_to_block_indices(
+                    &mut self.block_height_index,
+                    &mut self.switch_block_era_id_index,
+                    block.as_ref(),
+                )?;
                 responder.respond(outcome).ignore()
             }
             StorageRequest::GetBlock {
@@ -374,6 +373,24 @@ impl Storage {
                             .last()
                             .and_then(|&height| {
                                 self.get_block_by_height(&mut txn, height).transpose()
+                            })
+                            .transpose()?,
+                    )
+                    .ignore()
+            }
+            StorageRequest::GetSwitchBlockAtEraId { era_id, responder } => responder
+                .respond(self.get_switch_block_by_era_id(&mut self.env.begin_ro_txn()?, era_id)?)
+                .ignore(),
+            StorageRequest::GetHighestSwitchBlock { responder } => {
+                let mut txn = self.env.begin_ro_txn()?;
+                responder
+                    .respond(
+                        self.switch_block_era_id_index
+                            .keys()
+                            .last()
+                            .and_then(|&era_id| {
+                                self.get_switch_block_by_era_id(&mut txn, era_id)
+                                    .transpose()
                             })
                             .transpose()?,
                     )
@@ -531,6 +548,18 @@ impl Storage {
             .transpose()
     }
 
+    /// Retrieves single switch block by era ID by looking it up in the index and returning it.
+    fn get_switch_block_by_era_id<Tx: Transaction>(
+        &self,
+        tx: &mut Tx,
+        era_id: EraId,
+    ) -> Result<Option<Block>, LmdbExtError> {
+        self.switch_block_era_id_index
+            .get(&era_id)
+            .and_then(|block_hash| self.get_single_block(tx, block_hash).transpose())
+            .transpose()
+    }
+
     /// Retrieves a single block in a separate transaction from storage.
     fn get_single_block<Tx: Transaction>(
         &self,
@@ -575,6 +604,45 @@ impl Storage {
     ) -> Result<Option<Vec<Transfer>>, Error> {
         Ok(tx.get_value(self.transfer_db, block_hash)?)
     }
+}
+
+/// Inserts the relevant entries to the two indices.
+///
+/// If a duplicate entry is encountered, neither index is updated and an error is returned.
+fn insert_to_block_indices(
+    block_height_index: &mut BTreeMap<u64, BlockHash>,
+    switch_block_era_id_index: &mut BTreeMap<EraId, BlockHash>,
+    block: &Block,
+) -> Result<(), Error> {
+    if let Some(first) = block_height_index.get(&block.height()) {
+        if first != block.hash() {
+            return Err(Error::DuplicateBlockIndex {
+                height: block.height(),
+                first: *first,
+                second: *block.hash(),
+            });
+        }
+    }
+
+    if block.header().switch_block() {
+        match switch_block_era_id_index.entry(block.header().era_id()) {
+            Entry::Vacant(entry) => {
+                let _ = entry.insert(*block.hash());
+            }
+            Entry::Occupied(entry) => {
+                if entry.get() != block.hash() {
+                    return Err(Error::DuplicateEraIdIndex {
+                        era_id: block.header().era_id(),
+                        first: *entry.get(),
+                        second: *block.hash(),
+                    });
+                }
+            }
+        }
+    }
+
+    let _ = block_height_index.insert(block.height(), *block.hash());
+    Ok(())
 }
 
 /// On-disk storage configuration.

--- a/node/src/config_migration.rs
+++ b/node/src/config_migration.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+use crate::{reactor::validator::Config, utils::WithDir};
+
+// This will be changed in favour of an actual old config type when the migration is not a no-op.
+type OldConfig = Config;
+
+/// Error returned as a result of migrating the config file.
+#[derive(Debug, Error)]
+pub enum Error {}
+
+/// Migrates values from the old config file to the new one, modifying the new config file on-disk.
+///
+/// This should be executed after a new version is available, but before the casper-node has been
+/// run in validator mode using the new version.
+pub fn migrate_config(
+    _old_config: WithDir<OldConfig>,
+    _new_config: WithDir<Config>,
+) -> Result<(), Error> {
+    Ok(())
+}

--- a/node/src/data_migration.rs
+++ b/node/src/data_migration.rs
@@ -1,0 +1,336 @@
+use std::{env, fs, io, path::PathBuf};
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use toml::de::Error as TomlDecodeError;
+use tracing::info;
+
+use casper_execution_engine::shared::newtypes::Blake2bHash;
+use casper_types::{PublicKey, SecretKey, Signature};
+
+use crate::{
+    components::chainspec_loader,
+    crypto,
+    reactor::validator::Config,
+    utils::{LoadError, WithDir},
+    NodeRng,
+};
+
+// This will be changed in favour of an actual old config type when the migration is not a no-op.
+type OldConfig = Config;
+
+/// The name of the file for recording the new global state hash after a data migration.
+const POST_MIGRATION_STATE_HASH_FILENAME: &str = "post-migration-state-hash";
+/// The folder under which the post-migration-state-hash file is written.
+const CONFIG_ROOT_DIR: &str = "/etc/casper";
+/// Environment variable to override the config root dir.
+const CONFIG_ROOT_DIR_OVERRIDE: &str = "CASPER_CONFIG_DIR";
+
+/// Error returned as a result of migrating data.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Error serializing state hash info.
+    #[error("error serializing state hash info: {0}")]
+    SerializeStateHashInfo(bincode::Error),
+
+    /// Error deserializing state hash info.
+    #[error("error deserializing state hash info: {0}")]
+    DeserializeStateHashInfo(bincode::Error),
+
+    /// Error writing state hash info file.
+    #[error("error writing state hash info to {path}: {error}")]
+    WriteStateHashInfo {
+        /// The file path.
+        path: String,
+        /// The IO error.
+        error: io::Error,
+    },
+
+    /// Error reading state hash info file.
+    #[error("error reading state hash info from {path}: {error}")]
+    ReadStateHashInfo {
+        /// The file path.
+        path: String,
+        /// The IO error.
+        error: io::Error,
+    },
+
+    /// Invalid signature of state hash and version.
+    #[error("invalid signature of state hash info")]
+    InvalidSignatureOfStateHashInfo,
+
+    /// Error reading config file.
+    #[error("error reading config from {path}: {error}")]
+    ReadConfig {
+        /// The file path.
+        path: String,
+        /// The IO error.
+        error: io::Error,
+    },
+
+    /// Error decoding config file.
+    #[error("error reading config from {path}: {error}")]
+    DecodeConfig {
+        /// The file path.
+        path: String,
+        /// The TOML error.
+        error: TomlDecodeError,
+    },
+
+    /// Error loading the secret key.
+    #[error("error loading secret key: {0}")]
+    LoadSecretKey(LoadError<crypto::Error>),
+
+    /// Error loading the chainspec.
+    #[error("error loading chainspec: {0}")]
+    LoadChainspec(LoadError<chainspec_loader::Error>),
+}
+
+#[derive(Serialize, Deserialize)]
+struct PostMigrationInfo {
+    state_hash: Blake2bHash,
+    protocol_version: Version,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SignedPostMigrationInfo {
+    serialized_info: Vec<u8>,
+    signature: Signature,
+}
+
+/// Reads in the root hash of the global state after a previous run of data migration.
+///
+/// Returns `Ok(None)` if there is no saved file or if it doesn't contain the same version as
+/// `protocol_version`.  Returns `Ok(Some)` if the file can be read and it contains the same version
+/// as `protocol_version`.  Otherwise returns an error.
+// TODO - remove once used.
+#[allow(unused)]
+pub(crate) fn read_post_migration_info(
+    protocol_version: Version,
+    public_key: &PublicKey,
+) -> Result<Option<Blake2bHash>, Error> {
+    do_read_post_migration_info(protocol_version, public_key, info_path())
+}
+
+// TODO - remove once used.
+#[allow(unused)]
+fn do_read_post_migration_info(
+    protocol_version: Version,
+    public_key: &PublicKey,
+    path: PathBuf,
+) -> Result<Option<Blake2bHash>, Error> {
+    // If the file doesn't exist, return `Ok(None)`.
+    if !path.is_file() {
+        return Ok(None);
+    }
+
+    // Read the signed info.
+    let serialized_signed_info = fs::read(&path).map_err(|error| Error::ReadStateHashInfo {
+        path: path.display().to_string(),
+        error,
+    })?;
+    let signed_info: SignedPostMigrationInfo =
+        bincode::deserialize(&serialized_signed_info).map_err(Error::DeserializeStateHashInfo)?;
+
+    // Validate the signature.
+    crypto::verify(
+        &signed_info.serialized_info,
+        &signed_info.signature,
+        &public_key,
+    )
+    .map_err(|_| Error::InvalidSignatureOfStateHashInfo)?;
+
+    // Deserialize the info.
+    let info: PostMigrationInfo = bincode::deserialize(&signed_info.serialized_info)
+        .map_err(Error::DeserializeStateHashInfo)?;
+
+    if info.protocol_version == protocol_version {
+        Ok(Some(info.state_hash))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Writes the root hash of the global state and the new protocol version after data migration has
+/// completed.
+///
+/// This must be called after a data migration in order to allow the node to read in the new root
+/// state on restart.
+fn write_post_migration_info(
+    state_hash: Blake2bHash,
+    new_protocol_version: Version,
+    secret_key: &SecretKey,
+    rng: &mut NodeRng,
+    path: PathBuf,
+) -> Result<(), Error> {
+    // Serialize the info.
+    let info = PostMigrationInfo {
+        state_hash,
+        protocol_version: new_protocol_version,
+    };
+    let serialized_info = bincode::serialize(&info).map_err(Error::SerializeStateHashInfo)?;
+
+    // Sign the info.
+    let public_key = PublicKey::from(secret_key);
+    let signature = crypto::sign(&serialized_info, secret_key, &public_key, rng);
+    let signed_info = SignedPostMigrationInfo {
+        serialized_info,
+        signature,
+    };
+
+    // Write the signed info to disk.
+    let serialized_signed_info =
+        bincode::serialize(&signed_info).map_err(Error::SerializeStateHashInfo)?;
+    fs::write(&path, serialized_signed_info).map_err(|error| Error::WriteStateHashInfo {
+        path: path.display().to_string(),
+        error,
+    })?;
+
+    info!(path=%path.display(), "wrote post-migration state hash");
+    Ok(())
+}
+
+fn info_path() -> PathBuf {
+    PathBuf::from(
+        env::var(CONFIG_ROOT_DIR_OVERRIDE).unwrap_or_else(|_| CONFIG_ROOT_DIR.to_string()),
+    )
+    .join(POST_MIGRATION_STATE_HASH_FILENAME)
+}
+
+/// Migrates data from that specified in the old config file to that specified in the new one.
+pub fn migrate_data(
+    _old_config: WithDir<OldConfig>,
+    new_config: WithDir<Config>,
+) -> Result<(), Error> {
+    let (new_root, new_config) = new_config.into_parts();
+    let new_protocol_version = new_config
+        .node
+        .chainspec_config_path
+        .load(&new_root)
+        .map_err(Error::LoadChainspec)?
+        .latest_protocol_version();
+    let secret_key = new_config
+        .consensus
+        .secret_key_path
+        .load(&new_root)
+        .map_err(Error::LoadSecretKey)?;
+
+    // Get this by actually migrating the global state data.
+    let state_hash = Blake2bHash::default();
+
+    if state_hash != Blake2bHash::default() {
+        write_post_migration_info(
+            state_hash,
+            new_protocol_version,
+            &secret_key,
+            &mut crate::new_rng(),
+            info_path(),
+        )?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use super::*;
+    use crate::crypto::AsymmetricKeyExt;
+
+    #[test]
+    fn should_write_then_read_info() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let info_path = tempdir.path().join(POST_MIGRATION_STATE_HASH_FILENAME);
+
+        let mut rng = crate::new_rng();
+        let state_hash = Blake2bHash::new(&[rng.gen()]);
+        let protocol_version = Version::new(rng.gen(), rng.gen(), rng.gen());
+        let secret_key = SecretKey::random(&mut rng);
+
+        write_post_migration_info(
+            state_hash,
+            protocol_version.clone(),
+            &secret_key,
+            &mut rng,
+            info_path.clone(),
+        )
+        .unwrap();
+
+        let public_key = PublicKey::from(&secret_key);
+        let maybe_hash =
+            do_read_post_migration_info(protocol_version, &public_key, info_path).unwrap();
+        assert_eq!(maybe_hash, Some(state_hash));
+    }
+
+    #[test]
+    fn should_return_none_after_reading_info() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let info_path = tempdir.path().join(POST_MIGRATION_STATE_HASH_FILENAME);
+
+        // Should return `None` if there is no info file.
+        let protocol_version = Version::new(1, 2, 3);
+        let mut rng = crate::new_rng();
+        let secret_key = SecretKey::random(&mut rng);
+        let public_key = PublicKey::from(&secret_key);
+        let maybe_hash =
+            do_read_post_migration_info(protocol_version.clone(), &public_key, info_path.clone())
+                .unwrap();
+        assert!(maybe_hash.is_none());
+
+        // Create the info file and check we can read it.
+        let state_hash = Blake2bHash::new(&[rng.gen()]);
+        write_post_migration_info(
+            state_hash,
+            protocol_version.clone(),
+            &secret_key,
+            &mut rng,
+            info_path.clone(),
+        )
+        .unwrap();
+        assert!(
+            do_read_post_migration_info(protocol_version, &public_key, info_path.clone())
+                .unwrap()
+                .is_some()
+        );
+
+        // Should return `None` for a version different to that requested.
+        let different_version = Version::new(1, 2, 4);
+        let maybe_hash =
+            do_read_post_migration_info(different_version, &public_key, info_path).unwrap();
+        assert!(maybe_hash.is_none());
+    }
+
+    #[test]
+    fn should_fail_to_read_invalid_info() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let info_path = tempdir.path().join(POST_MIGRATION_STATE_HASH_FILENAME);
+
+        // Should return `Err` if the file can't be parsed.
+        fs::write(&info_path, "bad value".as_bytes()).unwrap();
+        let protocol_version = Version::new(1, 2, 3);
+        let mut rng = crate::new_rng();
+        let secret_key = SecretKey::random(&mut rng);
+        let public_key = PublicKey::from(&secret_key);
+        assert!(do_read_post_migration_info(
+            protocol_version.clone(),
+            &public_key,
+            info_path.clone()
+        )
+        .is_err());
+
+        // Should return `Err` if the signature is invalid.
+        let other_secret_key = SecretKey::random(&mut rng);
+        let state_hash = Blake2bHash::new(&[rng.gen()]);
+        write_post_migration_info(
+            state_hash,
+            protocol_version.clone(),
+            &other_secret_key,
+            &mut rng,
+            info_path.clone(),
+        )
+        .unwrap();
+        assert!(do_read_post_migration_info(protocol_version, &public_key, info_path).is_err());
+    }
+}

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -704,8 +704,8 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Requests block at height.
-    pub(crate) async fn get_block_at_height(self, height: u64) -> Option<Block>
+    /// Requests the block at the given height.
+    pub(crate) async fn get_block_at_height_from_storage(self, height: u64) -> Option<Block>
     where
         REv: From<StorageRequest>,
     {
@@ -717,12 +717,43 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Requests the highest block.
-    pub(crate) async fn get_highest_block(self) -> Option<Block>
+    pub(crate) async fn get_highest_block_from_storage(self) -> Option<Block>
     where
         REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetHighestBlock { responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Requests the switch block at the given era ID.
+    // TODO - remove once used.
+    #[allow(unused)]
+    pub(crate) async fn get_switch_block_at_era_id_from_storage(
+        self,
+        era_id: EraId,
+    ) -> Option<Block>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetSwitchBlockAtEraId { era_id, responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Requests the highest switch block.
+    // TODO - remove once used.
+    #[allow(unused)]
+    pub(crate) async fn get_highest_switch_block_from_storage(self) -> Option<Block>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetHighestSwitchBlock { responder },
             QueueKind::Regular,
         )
         .await
@@ -1207,7 +1238,7 @@ impl<REv> EffectBuilder<REv> {
         REv: From<ContractRuntimeRequest>,
         REv: From<StorageRequest>,
     {
-        if let Some(block) = self.get_highest_block().await {
+        if let Some(block) = self.get_highest_block_from_storage().await {
             let state_hash = (*block.state_root_hash()).into();
             let query_request = QueryRequest::new(state_hash, account_key, vec![]);
             if let Ok(QueryResult::Success { value, .. }) =
@@ -1332,8 +1363,8 @@ impl<REv> EffectBuilder<REv> {
         REv: From<ContractRuntimeRequest> + From<StorageRequest>,
     {
         let future_validators = self.get_validator_weights_by_era_id(request);
-        let future_booking_block = self.get_block_at_height(booking_block_height);
-        let future_key_block = self.get_block_at_height(key_block_height);
+        let future_booking_block = self.get_block_at_height_from_storage(booking_block_height);
+        let future_key_block = self.get_block_at_height_from_storage(key_block_height);
         join!(future_validators, future_booking_block, future_key_block)
     }
 

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -225,6 +225,18 @@ pub enum StorageRequest {
         /// Responder.
         responder: Responder<Option<Block>>,
     },
+    /// Retrieve switch block with given era ID.
+    GetSwitchBlockAtEraId {
+        /// Era ID of the switch block.
+        era_id: EraId,
+        /// Responder.
+        responder: Responder<Option<Block>>,
+    },
+    /// Retrieve highest switch block.
+    GetHighestSwitchBlock {
+        /// Responder.
+        responder: Responder<Option<Block>>,
+    },
     /// Retrieve block header with given hash.
     GetBlockHeader {
         /// Hash of block to get header of.
@@ -310,6 +322,12 @@ impl Display for StorageRequest {
                 write!(formatter, "get block at height {}", height)
             }
             StorageRequest::GetHighestBlock { .. } => write!(formatter, "get highest block"),
+            StorageRequest::GetSwitchBlockAtEraId { era_id, .. } => {
+                write!(formatter, "get switch block at era id {}", era_id)
+            }
+            StorageRequest::GetHighestSwitchBlock { .. } => {
+                write!(formatter, "get highest switch block")
+            }
             StorageRequest::GetBlockHeader { block_hash, .. } => {
                 write!(formatter, "get {}", block_hash)
             }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -25,7 +25,9 @@
 extern crate test;
 
 pub mod components;
+mod config_migration;
 pub mod crypto;
+mod data_migration;
 pub mod effect;
 pub mod logging;
 pub mod protocol;
@@ -56,6 +58,8 @@ pub use components::{
     small_network::{Config as SmallNetworkConfig, Error as SmallNetworkError},
     storage::{Config as StorageConfig, Error as StorageError},
 };
+pub use config_migration::{migrate_config, Error as ConfigMigrationError};
+pub use data_migration::{migrate_data, Error as DataMigrationError};
 pub use types::NodeRng;
 pub use utils::OS_PAGE_SIZE;
 

--- a/resources/test/valid/auction_install.wasm
+++ b/resources/test/valid/auction_install.wasm
@@ -1,1 +1,0 @@
-Auction installer bytes

--- a/resources/test/valid/mint.wasm
+++ b/resources/test/valid/mint.wasm
@@ -1,1 +1,0 @@
-Mint installer bytes

--- a/resources/test/valid/pos.wasm
+++ b/resources/test/valid/pos.wasm
@@ -1,1 +1,0 @@
-Proof of Stake installer bytes

--- a/resources/test/valid/standard_payment.wasm
+++ b/resources/test/valid/standard_payment.wasm
@@ -1,1 +1,0 @@
-Standard Payment installer bytes

--- a/resources/test/valid/upgrade.wasm
+++ b/resources/test/valid/upgrade.wasm
@@ -1,1 +1,0 @@
-Upgrade installer bytes


### PR DESCRIPTION
This PR lays the groundwork for adapting the casper-node to properly handle protocol upgrades.

The first commit adds new two new subcommands to the node: `migrate-config` and `migrate-data`.  The former will be run post-install to migrate any config changes.  The latter will be run by the casper-node-launcher just before running the node in normal mode to migrate stored data as required.

The second commit refactors storage to handle providing switch blocks by era ID.  This is required as part of the upgrade story as a newly-started node will need to be able to determine the current list of validators and their key weights.

However, this commit is also required as part of the task which @fizyk20 is currently working on, hence this PR only covers part of the changeset required to handle node upgrades.