### PR TITLE
NO-TICKET: enable libp2p component by default

### DIFF
--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -67,8 +67,8 @@ use crate::{
     NodeRng,
 };
 
-/// Env var which, if it's defined at runtime, enables the libp2p server.
-pub(crate) const ENABLE_LIBP2P_ENV_VAR: &str = "CASPER_ENABLE_LIBP2P";
+/// Env var which, if it's defined at runtime, enables the small_network component.
+pub(crate) const ENABLE_SMALL_NET_ENV_VAR: &str = "CASPER_ENABLE_LEGACY_NET";
 
 /// A helper trait whose bounds represent the requirements for a payload that `Network` can
 /// work with.
@@ -167,8 +167,8 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
         let (gossip_message_sender, gossip_message_receiver) = mpsc::unbounded_channel();
         let (server_shutdown_sender, server_shutdown_receiver) = watch::channel(());
 
-        // If the env var "CASPER_ENABLE_LIBP2P" is not defined, exit without starting the server.
-        if env::var(ENABLE_LIBP2P_ENV_VAR).is_err() {
+        // If the env var "CASPER_ENABLE_LEGACY_NET" is defined, exit without starting the server.
+        if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
             let network = Network {
                 our_id,
                 peers: HashMap::new(),
@@ -742,7 +742,7 @@ impl<REv: Send + 'static, P: Send + 'static> Finalize for Network<REv, P> {
                     Ok(_) => debug!("{}: server exited cleanly", self.our_id),
                     Err(err) => error!(%err, "{}: could not join server task cleanly", self.our_id),
                 }
-            } else if env::var(ENABLE_LIBP2P_ENV_VAR).is_ok() {
+            } else if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
                 warn!("{}: server shutdown while already shut down", self.our_id)
             }
         }

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -11,7 +11,7 @@ use prometheus::Registry;
 use serde::Serialize;
 use tracing::{debug, info};
 
-use super::{Config, Event as NetworkEvent, Network as NetworkComponent, ENABLE_LIBP2P_ENV_VAR};
+use super::{Config, Event as NetworkEvent, Network as NetworkComponent, ENABLE_SMALL_NET_ENV_VAR};
 use crate::{
     components::{chainspec_loader::Chainspec, Component},
     effect::{
@@ -173,8 +173,8 @@ fn network_started(net: &Network<TestReactor>) -> bool {
 /// Ensures that network cleanup and basic networking works.
 #[tokio::test]
 async fn run_two_node_network_five_times() {
-    // If the env var "CASPER_ENABLE_LIBP2P" is not defined, exit without running the test.
-    if env::var(ENABLE_LIBP2P_ENV_VAR).is_err() {
+    // If the env var "CASPER_ENABLE_LEGACY_NET" is defined, exit without running the test.
+    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
         return;
     }
 
@@ -239,8 +239,8 @@ async fn run_two_node_network_five_times() {
 /// Very unlikely to ever fail on a real machine.
 #[tokio::test]
 async fn bind_to_real_network_interface() {
-    // If the env var "CASPER_ENABLE_LIBP2P" is not defined, exit without running the test.
-    if env::var(ENABLE_LIBP2P_ENV_VAR).is_err() {
+    // If the env var "CASPER_ENABLE_LEGACY_NET" is defined, exit without running the test.
+    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
         return;
     }
 
@@ -284,8 +284,8 @@ async fn bind_to_real_network_interface() {
 /// Check that a network of varying sizes will connect all nodes properly.
 #[tokio::test]
 async fn check_varying_size_network_connects() {
-    // If the env var "CASPER_ENABLE_LIBP2P" is not defined, exit without running the test.
-    if env::var(ENABLE_LIBP2P_ENV_VAR).is_err() {
+    // If the env var "CASPER_ENABLE_LEGACY_NET" is defined, exit without running the test.
+    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
         return;
     }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -81,7 +81,7 @@ use tracing::{debug, error, info, trace, warn};
 use self::error::Result;
 pub(crate) use self::{event::Event, gossiped_address::GossipedAddress, message::Message};
 use crate::{
-    components::{network::ENABLE_LIBP2P_ENV_VAR, Component},
+    components::{network::ENABLE_SMALL_NET_ENV_VAR, Component},
     crypto::hash::Digest,
     effect::{
         announcements::NetworkAnnouncement,
@@ -197,8 +197,9 @@ where
         let certificate = Arc::new(tls::validate_cert(cert).map_err(Error::OwnCertificateInvalid)?);
         let our_id = NodeId::from(certificate.public_key_fingerprint());
 
-        // If the env var "CASPER_ENABLE_LIBP2P" is defined, exit without starting the server.
-        if env::var(ENABLE_LIBP2P_ENV_VAR).is_ok() {
+        // If the env var "CASPER_ENABLE_LEGACY_NET" is not defined, exit without starting the
+        // server.
+        if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
             let model = SmallNetwork {
                 certificate,
                 secret_key: Arc::new(secret_key),
@@ -788,7 +789,7 @@ where
                     Ok(_) => debug!(our_id=%self.our_id, "server exited cleanly"),
                     Err(err) => error!(%self.our_id,%err, "could not join server task cleanly"),
                 }
-            } else if env::var(ENABLE_LIBP2P_ENV_VAR).is_err() {
+            } else if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
                 warn!(our_id=%self.our_id, "server shutdown while already shut down")
             }
         }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -20,7 +20,7 @@ use super::{Config, Event as SmallNetworkEvent, GossipedAddress, SmallNetwork};
 use crate::{
     components::{
         gossiper::{self, Gossiper},
-        network::ENABLE_LIBP2P_ENV_VAR,
+        network::ENABLE_SMALL_NET_ENV_VAR,
         Component,
     },
     crypto::hash::Digest,
@@ -249,8 +249,8 @@ fn network_started(net: &Network<TestReactor>) -> bool {
 /// Ensures that network cleanup and basic networking works.
 #[tokio::test]
 async fn run_two_node_network_five_times() {
-    // If the env var "CASPER_ENABLE_LIBP2P" is defined, exit without running the test.
-    if env::var(ENABLE_LIBP2P_ENV_VAR).is_ok() {
+    // If the env var "CASPER_ENABLE_LEGACY_NET" is not defined, exit without running the test.
+    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
         return;
     }
 
@@ -315,8 +315,8 @@ async fn run_two_node_network_five_times() {
 /// Very unlikely to ever fail on a real machine.
 #[tokio::test]
 async fn bind_to_real_network_interface() {
-    // If the env var "CASPER_ENABLE_LIBP2P" is defined, exit without running the test.
-    if env::var(ENABLE_LIBP2P_ENV_VAR).is_ok() {
+    // If the env var "CASPER_ENABLE_LEGACY_NET" is not defined, exit without running the test.
+    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
         return;
     }
 
@@ -360,8 +360,8 @@ async fn bind_to_real_network_interface() {
 /// Check that a network of varying sizes will connect all nodes properly.
 #[tokio::test]
 async fn check_varying_size_network_connects() {
-    // If the env var "CASPER_ENABLE_LIBP2P" is defined, exit without running the test.
-    if env::var(ENABLE_LIBP2P_ENV_VAR).is_ok() {
+    // If the env var "CASPER_ENABLE_LEGACY_NET" is not defined, exit without running the test.
+    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
         return;
     }
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -38,7 +38,7 @@ use crate::{
         gossiper::{self, Gossiper},
         linear_chain,
         metrics::Metrics,
-        network::{self, Network, ENABLE_LIBP2P_ENV_VAR},
+        network::{self, Network, ENABLE_SMALL_NET_ENV_VAR},
         rest_server::{self, RestServer},
         small_network::{self, GossipedAddress, SmallNetwork},
         storage::{self, Storage},
@@ -227,7 +227,7 @@ impl From<StorageRequest> for Event {
 
 impl From<NetworkRequest<NodeId, Message>> for Event {
     fn from(request: NetworkRequest<NodeId, Message>) -> Self {
-        if env::var(ENABLE_LIBP2P_ENV_VAR).is_ok() {
+        if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
             Event::Network(network::Event::from(request))
         } else {
             Event::SmallNetwork(small_network::Event::from(request))
@@ -844,7 +844,7 @@ impl reactor::Reactor for Reactor {
                 self.dispatch_event(effect_builder, rng, Event::ChainspecLoader(req.into()))
             }
             Event::NetworkInfoRequest(req) => {
-                let event = if env::var(ENABLE_LIBP2P_ENV_VAR).is_ok() {
+                let event = if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
                     Event::Network(network::Event::from(req))
                 } else {
                     Event::SmallNetwork(small_network::Event::from(req))

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -36,7 +36,7 @@ use crate::{
         gossiper::{self, Gossiper},
         linear_chain,
         metrics::Metrics,
-        network::{self, Network, ENABLE_LIBP2P_ENV_VAR},
+        network::{self, Network, ENABLE_SMALL_NET_ENV_VAR},
         rest_server::{self, RestServer},
         rpc_server::{self, RpcServer},
         small_network::{self, GossipedAddress, SmallNetwork},
@@ -556,7 +556,7 @@ impl reactor::Reactor for Reactor {
 
             // Requests:
             Event::NetworkRequest(req) => {
-                let event = if env::var(ENABLE_LIBP2P_ENV_VAR).is_ok() {
+                let event = if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
                     Event::Network(network::Event::from(req))
                 } else {
                     Event::SmallNetwork(small_network::Event::from(req))
@@ -564,7 +564,7 @@ impl reactor::Reactor for Reactor {
                 self.dispatch_event(effect_builder, rng, event)
             }
             Event::NetworkInfoRequest(req) => {
-                let event = if env::var(ENABLE_LIBP2P_ENV_VAR).is_ok() {
+                let event = if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
                     Event::Network(network::Event::from(req))
                 } else {
                     Event::SmallNetwork(small_network::Event::from(req))
@@ -894,7 +894,7 @@ impl reactor::Reactor for Reactor {
 impl NetworkedReactor for Reactor {
     type NodeId = NodeId;
     fn node_id(&self) -> Self::NodeId {
-        if env::var(ENABLE_LIBP2P_ENV_VAR).is_ok() {
+        if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
             self.network.node_id()
         } else {
             self.small_network.node_id()

--- a/resources/maintainer_scripts/casper_node/casper-node.service
+++ b/resources/maintainer_scripts/casper_node/casper-node.service
@@ -8,8 +8,6 @@ After=network-online.target
 
 [Service]
 Type=simple
-# Enabling new network for testing, value is not important, just that env var exists
-Environment="CASPER_ENABLE_LIBP2P=TRUE"
 ExecStartPre=/etc/casper/systemd_pre_start.sh
 #StandardOutput can only append log files from systemd version 240 + (Ubuntu 20.04). Use ExecStart with redirection as workaround.
 #seperate stderr logging as it outputs non-JSON stack traces


### PR DESCRIPTION
This PR reverses the behaviour of which networking component is chosen by default: now libp2p is the default, and users need to set the env var `CASPER_ENABLE_LEGACY_NET` to enable the old `small_network` component.