### PR TITLE
NDRS-803: Add an integration test for a new node joining the network.

### DIFF
--- a/utils/nctl/activate
+++ b/utils/nctl/activate
@@ -67,6 +67,7 @@ alias nctl-view-chain-era='source $NCTL/sh/views/view_chain_era.sh'
 alias nctl-view-chain-era-info='source $NCTL/sh/views/view_chain_era_info.sh'
 alias nctl-view-chain-height='source $NCTL/sh/views/view_chain_height.sh'
 alias nctl-view-chain-state-root-hash='source $NCTL/sh/views/view_chain_state_root_hash.sh'
+alias nctl-view-chain-lfb='source $NCTL/sh/views/view_chain_lfb.sh'
 alias nctl-view-chain-spec='source $NCTL/sh/views/view_chain_spec.sh'
 alias nctl-view-chain-spec-accounts='source $NCTL/sh/views/view_chain_spec_accounts.sh'
 

--- a/utils/nctl/sh/node/svc_systemd.sh
+++ b/utils/nctl/sh/node/svc_systemd.sh
@@ -11,7 +11,7 @@
 function do_node_start()
 {
     local NODE_ID=${1}
-    local TRUSTED_HASH=${3:-}
+    local TRUSTED_HASH=${2:-}
     local PATH_TO_NET
     local PATH_TO_NET_CHAINSPEC
     local PATH_TO_NODE

--- a/utils/nctl/sh/scenarios/sync_test.sh
+++ b/utils/nctl/sh/scenarios/sync_test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+source "$NCTL"/sh/utils/main.sh
+source "$NCTL"/sh/views/utils.sh
+source "$NCTL"/sh/node/svc_"$NCTL_DAEMON_TYPE".sh
+
+# Exit if any of the commands fail.
+set -e
+
+#######################################
+# Runs an integration tests that tries to sync a new node
+# to an already running network.
+#
+# Arguments:
+#   `node=XXX` ID of a new node.
+#   `timeout=XXX` timeout (in seconds) when syncing.
+#######################################
+function main() {
+    log "------------------------------------------------------------"
+    log "Syncing node begins"
+    log "------------------------------------------------------------"
+
+    do_await_genesis_era_to_complete
+
+    # 1. Send batch of Wasm deploys
+    do_send_wasm_deploys
+    # 2. Send batch of native transfers
+    do_send_transfers
+    # 3. Wait until they're all included in the chain.
+    do_await_deploy_inclusion
+    # 4. Take a note of the last finalized block hash
+    do_read_lfb_hash
+    # 5. Send batch of Wasm deploys
+    do_send_wasm_deploys
+    # 6. Send batch of native transfers
+    do_send_transfers
+    # 7. Wait until they're all included in the chain.
+    # 8. Start the node in sync mode using hash from 4)
+    do_start_new_node "$NEW_NODE_ID"
+    # 9. Wait until it's synchronized.
+    # 10. Verify that its last finalized block matches other nodes'.
+    # nctl-view-chain-root-hash
+    do_await_full_synchronization "$NEW_NODE_ID"
+
+    log "------------------------------------------------------------"
+    log "Syncing node complete"
+    log "------------------------------------------------------------"
+}
+
+function log_step() {
+    local COMMENT=${1}
+    log "------------------------------------------------------------"
+    log "STEP $STEP: $COMMENT"
+    STEP=$((STEP + 1))
+}
+
+function do_await_genesis_era_to_complete() {
+    log_step "awaiting genesis era to complete"
+    while [ "$(get_chain_era)" -lt 1 ]; do
+        sleep 1.0
+    done
+}
+
+function do_send_wasm_deploys() {
+    # NOTE: Maybe make these arguments to the test?
+    local BATCH_COUNT=2
+    local BATCH_SIZE=10
+    local TRANSFER_AMOUNT=10000
+    log_step "sending Wasm deploys"
+    # prepare wasm batch
+    prepare_wasm_batch "$TRANSFER_AMOUNT" "$BATCH_COUNT" "$BATCH_SIZE"
+    # dispatch wasm batches
+    for BATCH_ID in $(seq 1 $BATCH_COUNT); do
+        dispatch_wasm_batch "$BATCH_ID"
+    done
+}
+
+function do_send_transfers() {
+    log_step "sending native transfers"
+    # NOTE: Maybe make these arguments to the test?
+    local AMOUNT=1000
+    local TRANSFERS_COUNT=10
+    local NODE_ID="random"
+
+    # Enumerate set of users.
+    for USER_ID in $(seq 1 "$(get_count_of_users)"); do
+        dispatch_native "$AMOUNT" "$USER_ID" "$TRANSFERS_COUNT" "$NODE_ID"
+    done
+}
+
+function do_await_deploy_inclusion() {
+    # Should be enough to await for two eras.
+    log_step "awaiting two eras…"
+    await_n_eras 1
+}
+
+function do_read_lfb_hash() {
+    local NODE_ID=${1}
+    LFB_HASH=$(render_last_finalized_block_hash "$NODE_ID" | cut -f2 -d= | cut -f2 -d ' ')
+    echo "$LFB_HASH"
+}
+
+function do_start_new_node() {
+    local NODE_ID=${1}
+    log_step "starting new node-$NODE_ID. Syncing from hash=${LFB_HASH}"
+    export RUST_LOG="info,casper_node::components::linear_chain_sync=trace"
+    # TODO: Do not hardcode.
+    do_node_start "$NODE_ID" "$LFB_HASH"
+}
+
+function do_await_full_synchronization() {
+    local NODE_ID=${1}
+    local WAIT_TIME_SEC=0
+    log_step "awaiting full synchronization of the new node=${NODE_ID}…"
+    while [ "$(do_read_lfb_hash "$NODE_ID")" != "$(do_read_lfb_hash 1)" ]; do
+        if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
+            log "ERROR: Failed to synchronize in ${SYNC_TIMEOUT_SEC} seconds"
+            exit 1
+        fi
+        WAIT_TIME_SEC=$((WAIT_TIME_SEC + 1))
+        sleep 1.0
+    done
+}
+
+function dispatch_native() {
+    local AMOUNT=${1}
+    local USER_ID=${2}
+    local TRANSFERS=${3}
+    local NODE_ID=${4}
+
+    source "$NCTL"/sh/contracts-transfers/do_dispatch_native.sh amount="$AMOUNT" \
+        user="$USER_ID" \
+        transfers="$TRANSFERS" \
+        node="$NODE_ID"
+}
+
+function dispatch_wasm_batch() {
+    local BATCH_ID=${1:-1}
+    local INTERVAL=${2:-0.01}
+    local NODE_ID=${3:-"random"}
+
+    source "$NCTL"/sh/contracts-transfers/do_dispatch_wasm_batch.sh batch="$BATCH_ID" \
+        interval="$INTERVAL" \
+        node="$NODE_ID"
+}
+
+function prepare_wasm_batch() {
+    local AMOUNT=${1}
+    local BATCH_COUNT=${2}
+    local BATCH_SIZE=${3}
+
+    source "$NCTL"/sh/contracts-transfers/do_prepare_wasm_batch.sh amount="$AMOUNT" \
+        count="$BATCH_COUNT" \
+        size="$BATCH_SIZE"
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset NEW_NODE_ID
+unset SYNC_TIMEOUT_SEC
+unset LFB_HASH
+STEP=0
+
+for ARGUMENT in "$@"; do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        node) NEW_NODE_ID=${VALUE} ;;
+        timeout) SYNC_TIMEOUT_SEC=${VALUE} ;;
+        *) ;;
+    esac
+done
+
+NEW_NODE_ID=${NEW_NODE_ID:-"6"}
+SYNC_TIMEOUT_SEC=${SYNC_TIMEOUT_SEC:-"300"}
+
+main "$NEW_NODE_ID"

--- a/utils/nctl/sh/utils/infra.sh
+++ b/utils/nctl/sh/utils/infra.sh
@@ -137,7 +137,7 @@ function get_node_address_rpc_for_curl()
 }
 
 #######################################
-# Returns ordinal identifier of a validator node able to be used for deploy dispatch.
+# Returns ordinal identifier of a random validator node able to be used for deploy dispatch.
 # Arguments:
 #   Network ordinal identifier.
 #######################################

--- a/utils/nctl/sh/utils/queries.sh
+++ b/utils/nctl/sh/utils/queries.sh
@@ -53,13 +53,24 @@ function get_chain_name()
 }
 
 #######################################
-# Returns latest block finalized at a node.
+# Returns hash of latest block finalized at a node.
 #######################################
 function get_chain_latest_block_hash()
 {
     $(get_path_to_client) get-block \
         --node-address "$(get_node_address_rpc)" \
         | jq '.result.block.hash' \
+        | sed -e 's/^"//' -e 's/"$//'
+}
+
+#######################################
+# Returns latest block finalized at a node.
+#######################################
+function get_chain_latest_block()
+{
+    $(get_path_to_client) get-block \
+        --node-address "$(get_node_address_rpc)" \
+        | jq '.result.block' \
         | sed -e 's/^"//' -e 's/"$//'
 }
 

--- a/utils/nctl/sh/views/utils.sh
+++ b/utils/nctl/sh/views/utils.sh
@@ -163,3 +163,24 @@ function render_chain_state_root_hash()
 
     log "state root hash @ node-$NODE_ID = ${STATE_ROOT_HASH:-'N/A'}"
 }
+
+#######################################
+# Renders a last finalized block hash at a certain node.
+# Globals:
+#   NCTL - path to nctl home directory.
+# Arguments:
+#   Node ordinal identifier.
+#######################################
+function render_last_finalized_block_hash()
+{
+    local NODE_ID=${1}
+    local NODE_IS_UP
+    local LFB_HASH
+
+    NODE_IS_UP=$(get_node_is_up "$NODE_ID")
+    if [ "$NODE_IS_UP" = true ]; then
+        LFB_HASH=$(get_chain_latest_block_hash "$NODE_ID")
+    fi
+
+    log "last finalized block hash @ node-$NODE_ID = ${LFB_HASH:-'N/A'}"
+}

--- a/utils/nctl/sh/views/view_chain_lfb.sh
+++ b/utils/nctl/sh/views/view_chain_lfb.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+source "$NCTL"/sh/utils/main.sh
+source "$NCTL"/sh/views/utils.sh
+
+#######################################
+# Renders last finalized block at specified node(s).
+# Arguments:
+#   Node ordinal identifier.
+#######################################
+function main()
+{
+    local NODE_ID=${1}
+    local BLOCK_HASH=${2}
+
+    if [ "$NODE_ID" = "all" ]; then
+        for NODE_ID in $(seq 1 "$(get_count_of_nodes)")
+        do
+            render_last_finalized_block_hash "$NODE_ID"
+        done
+    else
+        render_last_finalized_block_hash "$NODE_ID"
+    fi
+}
+
+# ----------------------------------------------------------------
+# ENTRY POINT
+# ----------------------------------------------------------------
+
+unset BLOCK_HASH
+unset NODE_ID
+
+for ARGUMENT in "$@"
+do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+        node) NODE_ID=${VALUE} ;;
+        *)
+    esac
+done
+
+main "${NODE_ID:-"all"}"


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-803

Adds an integration test that exercises a scenario where a new node is joining an already running network.

Test scenario:
1. Send a batch of Wasm transfers.
2. Send a batch of native transfers.
3. Take a note of the LFB hash.
4. Send a batch of Wasm transfers.
5. Send a batch of native transfers.
6. Start a new node and join the network using LFB hash from **3)**
7. Verify that eventually, the LFB hash on the new node matches the hash on one of the old nodes.

This PR also adds new nctl command `nctl-view-chain-lfb` which will query nodes for the hash of the last finalized block.

Note that this requires `nctl` set up (as described in the `nctl` directory) and that there's an already running network.

Example usage:
```shell
nctl-assets-setup # generates chainspec, accounts.csv etc.
nctl-start # by default starts 5 nodes
source sync_test.sh node=6 timeout=500
```