### PR TITLE
EE-1163: Refactor `engine_state::mod.rs` file. [NFC]

### DIFF
--- a/execution_engine/src/core/engine_state/macros.rs
+++ b/execution_engine/src/core/engine_state/macros.rs
@@ -28,6 +28,7 @@ macro_rules! tracking_copy {
 }
 
 /// Returns system module for the given TrackingCopy and Preprocessor instances.
+/// If not present, returns precondition failure.
 macro_rules! system_module {
     ($tracking_copy: ident, $preprocessor: expr) => {{
         match $tracking_copy.borrow_mut().get_system_module($preprocessor) {
@@ -53,3 +54,18 @@ macro_rules! get_contract {
     }};
 }
 
+/// Matches on the result and returns early with en error if it's not valid.
+macro_rules! fail_precondition {
+    ($result: expr) => {{
+        match $result {
+            Ok(value) => value,
+            Err(error) => return Ok(ExecutionResult::precondition_failure(error.into())),
+        }
+    }};
+    ($maybe: expr, $cause: expr) => {{
+        match $maybe {
+            Some(value) => value,
+            None => return Ok(ExecutionResult::precondition_failure($cause)),
+        }
+    }};
+}

--- a/execution_engine/src/core/engine_state/macros.rs
+++ b/execution_engine/src/core/engine_state/macros.rs
@@ -38,3 +38,18 @@ macro_rules! system_module {
         }
     }};
 }
+
+/// Returns a contract under specified hash.
+/// If not present, returns precondition failure.
+macro_rules! get_contract {
+    ($tracking_copy: ident, $contract_hash: expr, $correlation_id: ident) => {{
+        match $tracking_copy
+            .borrow_mut()
+            .get_contract($correlation_id, $contract_hash)
+        {
+            Ok(contract) => contract,
+            Err(error) => return Ok(ExecutionResult::precondition_failure(error.into())),
+        }
+    }};
+}
+

--- a/execution_engine/src/core/engine_state/macros.rs
+++ b/execution_engine/src/core/engine_state/macros.rs
@@ -15,3 +15,14 @@ macro_rules! protocol_data {
         }
     }};
 }
+
+/// Returns tracking copy at specific state hash.
+macro_rules! tracking_copy {
+    ($self: expr, $prestate_hash: ident) => {{
+        match $self.tracking_copy($prestate_hash) {
+            Err(error) => return Ok(ExecutionResult::precondition_failure(error)),
+            Ok(None) => return Err(RootNotFound::new($prestate_hash)),
+            Ok(Some(tracking_copy)) => Rc::new(RefCell::new(tracking_copy)),
+        }
+    }};
+}

--- a/execution_engine/src/core/engine_state/macros.rs
+++ b/execution_engine/src/core/engine_state/macros.rs
@@ -26,3 +26,15 @@ macro_rules! tracking_copy {
         }
     }};
 }
+
+/// Returns system module for the given TrackingCopy and Preprocessor instances.
+macro_rules! system_module {
+    ($tracking_copy: ident, $preprocessor: expr) => {{
+        match $tracking_copy.borrow_mut().get_system_module($preprocessor) {
+            Ok(module) => module,
+            Err(error) => {
+                return Ok(ExecutionResult::precondition_failure(error.into()));
+            }
+        }
+    }};
+}

--- a/execution_engine/src/core/engine_state/macros.rs
+++ b/execution_engine/src/core/engine_state/macros.rs
@@ -1,0 +1,17 @@
+/// Returns a ProtocolData instance that's valid for specific protocol version.
+macro_rules! protocol_data {
+    ($state: expr, $protocol_version: ident) => {{
+        match $state.get_protocol_data($protocol_version) {
+            Ok(Some(protocol_data)) => protocol_data,
+            Ok(None) => {
+                let error = Error::InvalidProtocolVersion($protocol_version);
+                return Ok(ExecutionResult::precondition_failure(error));
+            }
+            Err(error) => {
+                return Ok(ExecutionResult::precondition_failure(Error::Exec(
+                    error.into(),
+                )));
+            }
+        }
+    }};
+}

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -532,14 +532,7 @@ where
         // do this second; as there is no reason to proceed if the prestate hash is invalid
         let tracking_copy = tracking_copy!(self, prestate_hash);
 
-        let system_module = {
-            match tracking_copy.borrow_mut().get_system_module(&preprocessor) {
-                Ok(module) => module,
-                Err(error) => {
-                    return Ok(ExecutionResult::precondition_failure(error.into()));
-                }
-            }
-        };
+        let system_module = system_module!(tracking_copy, &preprocessor);
 
         let base_key = Key::Account(deploy_item.address);
 
@@ -1089,14 +1082,7 @@ where
         // do this second; as there is no reason to proceed if the prestate hash is invalid
         let tracking_copy = tracking_copy!(self, prestate_hash);
 
-        let system_module = {
-            match tracking_copy.borrow_mut().get_system_module(&preprocessor) {
-                Ok(module) => module,
-                Err(error) => {
-                    return Ok(ExecutionResult::precondition_failure(error.into()));
-                }
-            }
-        };
+        let system_module = system_module!(tracking_copy, &preprocessor);
 
         // vestigial system_contract_cache
         self.system_contract_cache

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -553,29 +553,17 @@ where
             Err(e) => return Ok(ExecutionResult::precondition_failure(e)),
         };
 
-        let mint_contract = match tracking_copy
-            .borrow_mut()
-            .get_contract(correlation_id, protocol_data.mint())
-        {
-            Ok(contract) => contract,
-            Err(error) => {
-                return Ok(ExecutionResult::precondition_failure(error.into()));
-            }
-        };
+        let mint_contract = get_contract!(tracking_copy, protocol_data.mint(), correlation_id);
 
         let mut mint_named_keys = mint_contract.named_keys().to_owned();
         let mut mint_extra_keys: Vec<Key> = vec![];
         let mint_base_key = Key::from(protocol_data.mint());
 
-        let pos_contract = match tracking_copy
-            .borrow_mut()
-            .get_contract(correlation_id, protocol_data.proof_of_stake())
-        {
-            Ok(contract) => contract,
-            Err(error) => {
-                return Ok(ExecutionResult::precondition_failure(error.into()));
-            }
-        };
+        let pos_contract = get_contract!(
+            tracking_copy,
+            protocol_data.proof_of_stake(),
+            correlation_id
+        );
 
         let mut pos_named_keys = pos_contract.named_keys().to_owned();
         let pos_extra_keys: Vec<Key> = vec![];
@@ -1312,15 +1300,11 @@ where
         let payment_purse_balance: Motes = {
             // Get proof of stake system contract details
             // payment_code_spec_6: system contract validity
-            let proof_of_stake_contract = match tracking_copy
-                .borrow_mut()
-                .get_contract(correlation_id, protocol_data.proof_of_stake())
-            {
-                Ok(contract) => contract,
-                Err(error) => {
-                    return Ok(ExecutionResult::precondition_failure(error.into()));
-                }
-            };
+            let proof_of_stake_contract = get_contract!(
+                tracking_copy,
+                protocol_data.proof_of_stake(),
+                correlation_id
+            );
 
             // Get payment purse Key from proof of stake contract
             // payment_code_spec_6: system contract validity
@@ -1578,13 +1562,11 @@ where
 
             // The PoS keys may have changed because of effects during payment and/or
             // session, so we need to look them up again from the tracking copy
-            let proof_of_stake_contract = match finalization_tc
-                .borrow_mut()
-                .get_contract(correlation_id, protocol_data.proof_of_stake())
-            {
-                Ok(info) => info,
-                Err(error) => return Ok(ExecutionResult::precondition_failure(error.into())),
-            };
+            let proof_of_stake_contract = get_contract!(
+                finalization_tc,
+                protocol_data.proof_of_stake(),
+                correlation_id
+            );
 
             let mut proof_of_stake_keys = proof_of_stake_contract.named_keys().to_owned();
 

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -143,8 +143,7 @@ where
             Err(error) => return Err(error),
         };
 
-        let wasm_config = ee_config.wasm_config();
-        let preprocessor = Preprocessor::new(*wasm_config);
+        let preprocessor = Preprocessor::new(*ee_config.wasm_config());
 
         let system_module = tracking_copy
             .borrow_mut()
@@ -182,7 +181,7 @@ where
         // Associate given CostTable with given ProtocolVersion.
         {
             let protocol_data = ProtocolData::new(
-                *wasm_config,
+                *ee_config.wasm_config(),
                 *system_config,
                 mint_hash,
                 proof_of_stake_hash,
@@ -522,10 +521,7 @@ where
     ) -> Result<ExecutionResult, RootNotFound> {
         let protocol_data: ProtocolData = protocol_data!(self.state, protocol_version);
 
-        let preprocessor = {
-            let wasm_config = protocol_data.wasm_config();
-            Preprocessor::new(*wasm_config)
-        };
+        let preprocessor = Preprocessor::new(*protocol_data.wasm_config());
 
         // Create tracking copy (which functions as a deploy context)
         // validation_spec_2: prestate_hash check
@@ -1072,10 +1068,7 @@ where
         // do this first, as there is no reason to proceed if protocol version is invalid
         let protocol_data: ProtocolData = protocol_data!(self.state, protocol_version);
 
-        let preprocessor = {
-            let wasm_config = protocol_data.wasm_config();
-            Preprocessor::new(*wasm_config)
-        };
+        let preprocessor = Preprocessor::new(*protocol_data.wasm_config());
 
         // Create tracking copy (which functions as a deploy context)
         // validation_spec_2: prestate_hash check
@@ -1799,10 +1792,7 @@ where
 
         let executor = Executor::new(self.config);
 
-        let preprocessor = {
-            let wasm_config = protocol_data.wasm_config();
-            Preprocessor::new(*wasm_config)
-        };
+        let preprocessor = Preprocessor::new(*protocol_data.wasm_config());
 
         let auction_hash = protocol_data.auction();
 

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -1794,17 +1794,10 @@ where
 
         let preprocessor = Preprocessor::new(*protocol_data.wasm_config());
 
-        let auction_hash = protocol_data.auction();
-
-        let auction_contract = match tracking_copy
+        let auction_contract = tracking_copy
             .borrow_mut()
-            .get_contract(correlation_id, auction_hash)
-        {
-            Ok(contract) => contract,
-            Err(_) => {
-                return Ok(StepResult::PreconditionError);
-            }
-        };
+            .get_contract(correlation_id, protocol_data.auction())
+            .map_err(Error::from)?;
 
         let system_module = match tracking_copy.borrow_mut().get_system_module(&preprocessor) {
             Ok(module) => module,

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -527,16 +527,10 @@ where
             Preprocessor::new(*wasm_config)
         };
 
-        let tracking_copy = match self.tracking_copy(prestate_hash) {
-            Err(error) => return Ok(ExecutionResult::precondition_failure(error)),
-            Ok(None) => return Err(RootNotFound::new(prestate_hash)),
-            Ok(Some(tracking_copy)) => Rc::new(RefCell::new(tracking_copy)),
-        };
-
-        let preprocessor = {
-            let wasm_config = protocol_data.wasm_config();
-            Preprocessor::new(*wasm_config)
-        };
+        // Create tracking copy (which functions as a deploy context)
+        // validation_spec_2: prestate_hash check
+        // do this second; as there is no reason to proceed if the prestate hash is invalid
+        let tracking_copy = tracking_copy!(self, prestate_hash);
 
         let system_module = {
             match tracking_copy.borrow_mut().get_system_module(&preprocessor) {
@@ -1093,11 +1087,7 @@ where
         // Create tracking copy (which functions as a deploy context)
         // validation_spec_2: prestate_hash check
         // do this second; as there is no reason to proceed if the prestate hash is invalid
-        let tracking_copy = match self.tracking_copy(prestate_hash) {
-            Err(error) => return Ok(ExecutionResult::precondition_failure(error)),
-            Ok(None) => return Err(RootNotFound::new(prestate_hash)),
-            Ok(Some(tracking_copy)) => Rc::new(RefCell::new(tracking_copy)),
-        };
+        let tracking_copy = tracking_copy!(self, prestate_hash);
 
         let system_module = {
             match tracking_copy.borrow_mut().get_system_module(&preprocessor) {


### PR DESCRIPTION
This PR deduplicates some of the code between `deploy` and `transfer` methods by extracting the code to macros. It couldn't be a function b/c we need to return early in error cases so we need to "expand" the `return` logic on the call side.