### PR TITLE
NO_TICKET ensure transfers are included in block limited only by bloc…

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -429,7 +429,7 @@ impl BlockProposerReady {
         for (hash, deploy_type) in self.sets.pending.iter() {
             let at_max_transfers = transfers.len() == max_transfers;
             let at_max_deploys = wasm_deploys.len() == max_deploys
-                || (deploy_type.is_other()
+                || (deploy_type.is_wasm()
                     && block_size_running_total + DEPLOY_APPROX_MIN_SIZE >= max_block_size_bytes);
 
             if at_max_deploys && at_max_transfers {
@@ -450,7 +450,7 @@ impl BlockProposerReady {
             // always include wasm-less transfers if we are under the max for them
             if deploy_type.is_transfer() && !at_max_transfers {
                 transfers.push(*hash);
-            } else if deploy_type.is_other() && !at_max_deploys {
+            } else if deploy_type.is_wasm() && !at_max_deploys {
                 if block_size_running_total + deploy_type.size() > max_block_size_bytes {
                     continue;
                 }

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -428,14 +428,11 @@ impl BlockProposerReady {
 
         for (hash, deploy_type) in self.sets.pending.iter() {
             let at_max_transfers = transfers.len() == max_transfers;
-            let at_max_deploys = wasm_deploys.len() == max_deploys;
+            let at_max_deploys = wasm_deploys.len() == max_deploys
+                || (deploy_type.is_other()
+                    && block_size_running_total + DEPLOY_APPROX_MIN_SIZE >= max_block_size_bytes);
 
-            // Early exit if block limits are met.
-            // TODO: break early if gas total is met, but only once we have a constant for the cost
-            // of wasm-less transfers. if block_gas_running_total >= block_gas_limit
-            if block_size_running_total + DEPLOY_APPROX_MIN_SIZE >= max_block_size_bytes
-                || (at_max_deploys && at_max_transfers)
-            {
+            if at_max_deploys && at_max_transfers {
                 break;
             }
 
@@ -446,42 +443,43 @@ impl BlockProposerReady {
                 &past_deploys,
             ) || past_deploys.contains(hash)
                 || self.sets.finalized_deploys.contains_key(hash)
-                || block_size_running_total + deploy_type.size() > max_block_size_bytes
             {
                 continue;
             }
 
-            let payment_amount_gas = match Gas::from_motes(
-                deploy_type.payment_amount(),
-                deploy_type.header().gas_price(),
-            ) {
-                Some(value) => value,
-                None => {
-                    error!("payment_amount couldn't be converted from motes to gas");
-                    continue;
-                }
-            };
-
-            let gas_running_total = if let Some(gas_running_total) =
-                block_gas_running_total.checked_add(payment_amount_gas)
-            {
-                gas_running_total
-            } else {
-                warn!("block gas would overflow");
-                continue;
-            };
-
-            if gas_running_total > block_gas_limit {
-                continue;
-            }
+            // always include wasm-less transfers if we are under the max for them
             if deploy_type.is_transfer() && !at_max_transfers {
                 transfers.push(*hash);
-            } else if !at_max_deploys {
-                wasm_deploys.push(*hash);
-            }
-            block_gas_running_total = gas_running_total;
+            } else if deploy_type.is_other() && !at_max_deploys {
+                if block_size_running_total + deploy_type.size() > max_block_size_bytes {
+                    continue;
+                }
+                let payment_amount_gas = match Gas::from_motes(
+                    deploy_type.payment_amount(),
+                    deploy_type.header().gas_price(),
+                ) {
+                    Some(value) => value,
+                    None => {
+                        error!("payment_amount couldn't be converted from motes to gas");
+                        continue;
+                    }
+                };
+                let gas_running_total = if let Some(gas_running_total) =
+                    block_gas_running_total.checked_add(payment_amount_gas)
+                {
+                    gas_running_total
+                } else {
+                    warn!("block gas would overflow");
+                    continue;
+                };
 
-            block_size_running_total += deploy_type.size();
+                if gas_running_total > block_gas_limit {
+                    continue;
+                }
+                wasm_deploys.push(*hash);
+                block_gas_running_total = gas_running_total;
+                block_size_running_total += deploy_type.size();
+            }
         }
 
         ProtoBlock::new(wasm_deploys, transfers, random_bit)

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -72,7 +72,7 @@ impl DeployType {
     }
 
     /// Asks if the variant is Wasm.
-    pub fn is_wasm(&self) -> bool {
+    pub fn is_other(&self) -> bool {
         matches!(self, DeployType::Other { .. })
     }
 }

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -72,7 +72,7 @@ impl DeployType {
     }
 
     /// Asks if the variant is Wasm.
-    pub fn is_other(&self) -> bool {
+    pub fn is_wasm(&self) -> bool {
         matches!(self, DeployType::Other { .. })
     }
 }

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -487,7 +487,6 @@ fn should_not_propose_deploy_if_block_size_limit_passed() {
         proposed_count: 4,
         remaining_pending_count: 1,
         max_block_size: Some(2 * DEPLOY_APPROX_MIN_SIZE),
-        ..Default::default()
     });
 }
 

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -433,20 +433,6 @@ fn should_respect_limits_for_gas_cost() {
 }
 
 #[test]
-fn should_respect_block_gas_limit_for_transfers() {
-    test_proposer_with(TestArgs {
-        // transfers are effectively free until we have a payment_amount for them
-        transfer_count: 15,
-        payment_amount: default_gas_payment(),
-        block_gas_limit: 1,
-        max_transfer_count: 15,
-        proposed_count: 15,
-        remaining_pending_count: 0,
-        ..Default::default()
-    });
-}
-
-#[test]
 fn should_respect_block_gas_limit_for_deploys() {
     test_proposer_with(TestArgs {
         deploy_count: 15,
@@ -483,8 +469,8 @@ fn should_not_propose_deploy_if_block_size_limit_within_threshold() {
         block_gas_limit: 10,
         max_transfer_count: 3,
         max_deploy_count: 3,
-        proposed_count: 2,
-        remaining_pending_count: 2,
+        proposed_count: 4,
+        remaining_pending_count: 0,
         max_block_size: Some(2 * DEPLOY_APPROX_MIN_SIZE),
     });
 }
@@ -492,14 +478,15 @@ fn should_not_propose_deploy_if_block_size_limit_within_threshold() {
 #[test]
 fn should_not_propose_deploy_if_block_size_limit_passed() {
     test_proposer_with(TestArgs {
-        deploy_count: 0,
-        transfer_count: 1,
+        deploy_count: 3,
+        transfer_count: 2, // transfers should -not- count towards the block size limit
         payment_amount: default_gas_payment(),
-        block_gas_limit: 10,
+        block_gas_limit: 100,
         max_transfer_count: 5,
-        proposed_count: 0,
+        max_deploy_count: 5,
+        proposed_count: 4,
         remaining_pending_count: 1,
-        max_block_size: Some(100usize),
+        max_block_size: Some(2 * DEPLOY_APPROX_MIN_SIZE),
         ..Default::default()
     });
 }
@@ -571,10 +558,6 @@ fn test_proposer_with(
     }
     for _ in 0..transfer_count {
         let transfer = generate_transfer(&mut rng, creation_time, ttl, vec![], payment_amount);
-        println!(
-            "generated transfer with size {}",
-            transfer.serialized_length()
-        );
         proposer.add_deploy_or_transfer(
             creation_time,
             *transfer.id(),
@@ -585,6 +568,8 @@ fn test_proposer_with(
     let block = proposer.propose_proto_block(config, test_time, past_deploys, true);
     let all_deploys = BlockLike::deploys(&block);
     proposer.finalized_deploys(all_deploys.iter().map(|hash| **hash));
+    println!("proposed deploys {}", block.wasm_deploys().len());
+    println!("proposed transfers {}", block.transfers().len());
     assert_eq!(
         all_deploys.len(),
         proposed_count,

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -490,6 +490,21 @@ fn should_not_propose_deploy_if_block_size_limit_passed() {
     });
 }
 
+#[test]
+fn should_allow_transfers_to_exceed_block_size_limit() {
+    test_proposer_with(TestArgs {
+        deploy_count: 3,
+        transfer_count: 60,
+        payment_amount: default_gas_payment(),
+        block_gas_limit: 100,
+        max_transfer_count: 40,
+        max_deploy_count: 5,
+        proposed_count: 42,
+        remaining_pending_count: 21,
+        max_block_size: Some(2 * DEPLOY_APPROX_MIN_SIZE),
+    });
+}
+
 #[derive(Default)]
 struct TestArgs {
     /// Number of deploys to create.


### PR DESCRIPTION
This PR is intended to ensure that transfers are included in block limited only by `block_max_transfer_limit`. @EdHastingsCasperLabs asked for this change in our testing meeting today.