### PR TITLE
NO-TICKET: fix potential panic in ScopedInstrumenter::drop

### DIFF
--- a/execution_engine/src/core/runtime/scoped_instrumenter.rs
+++ b/execution_engine/src/core/runtime/scoped_instrumenter.rs
@@ -78,7 +78,10 @@ impl ScopedInstrumenter {
     }
 
     fn duration(&self) -> Duration {
-        self.start.elapsed() - self.pause_state.duration()
+        self.start
+            .elapsed()
+            .checked_sub(self.pause_state.duration())
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
Due to being run on systems with a non-monotonically-increasing clock, the `drop` implementation of the `ScopedInstrumenter` was seen to panic on rare occasions.

This PR resolves that issue by using a checked subtraction.

It also appears to be the only instance of `elapsed() - ` in our codebase.