### PR TITLE
NO-TICKET: update node readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,10 @@ This is the core application for the Casper blockchain.
 
 ### Setup
 
-Before building a node, prepare your Rust build environment, and build the required system smart contracts:
+Before building a node, prepare your Rust build environment:
 
 ```
 make setup-rs
-make build-system-contracts -j
 ```
 
 The node software can be compiled afterwards:

--- a/utils/nctl/docs/usage.md
+++ b/utils/nctl/docs/usage.md
@@ -10,7 +10,7 @@ Prior to testing a network ensure that the binary sets are available:
 nctl-compile
 ```
 
-This runs `make setup-rs` and `make build-system-contracts -j`, and compiles both `casper-node` and `casper-client` in release mode.
+This runs `make setup-rs`, and compiles both `casper-node` and `casper-client` in release mode.
 
 ## Step 1: Create network assets.
 


### PR DESCRIPTION
This removes the last instances of `make build-system-contracts` from our docs.