### PR TITLE
HWY-239: Pause if too much stake is offline

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -27,6 +27,11 @@ impl BlockContext {
     pub(crate) fn timestamp(&self) -> Timestamp {
         self.timestamp
     }
+
+    #[cfg(test)]
+    pub(crate) fn height(&self) -> u64 {
+        self.height
+    }
 }
 
 /// Equivocation and reward information to be included in the terminal finalized block.

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -10,8 +10,8 @@ use tracing::{error, info, trace, warn};
 use super::{
     endorsement::{Endorsement, SignedEndorsement},
     evidence::Evidence,
-    highway::{Endorsements, ValidVertex, Vertex, WireUnit},
-    state::{self, Panorama, State, Unit},
+    highway::{Endorsements, Ping, ValidVertex, Vertex, WireUnit},
+    state::{self, Panorama, State, Unit, Weight},
     validators::ValidatorIndex,
 };
 
@@ -73,6 +73,9 @@ pub(crate) struct ActiveValidator<C: Context> {
     unit_hash_file: Option<PathBuf>,
     /// The hash of the last known unit created by us.
     own_last_unit: Option<C::Hash>,
+    /// The target fault tolerance threshold. The validator pauses (i.e. doesn't create new units)
+    /// if not enough validators are online to finalize values at this FTT.
+    target_ftt: Weight,
 }
 
 impl<C: Context> Debug for ActiveValidator<C> {
@@ -93,6 +96,7 @@ impl<C: Context> ActiveValidator<C> {
         start_time: Timestamp,
         state: &State<C>,
         unit_hash_file: Option<PathBuf>,
+        target_ftt: Weight,
     ) -> (Self, Vec<Effect<C>>) {
         let own_last_unit = unit_hash_file
             .as_ref()
@@ -115,6 +119,7 @@ impl<C: Context> ActiveValidator<C> {
             next_proposal: None,
             unit_hash_file,
             own_last_unit,
+            target_ftt,
         };
         let effects = av.schedule_timer(start_time, state);
         (av, effects)
@@ -180,19 +185,41 @@ impl<C: Context> ActiveValidator<C> {
         let r_exp = self.round_exp(state, timestamp);
         let r_id = state::round_id(timestamp, r_exp);
         let r_len = state::round_len(r_exp);
-        if timestamp == r_id && state.leader(r_id) == self.vidx {
-            effects.extend(self.request_new_block(state, instance_id, timestamp, rng))
-        } else if timestamp == r_id + self.witness_offset(r_len) {
-            let panorama = self.panorama_at(state, timestamp);
-            if panorama.has_correct() {
-                if let Some(witness_unit) =
-                    self.new_unit(panorama, timestamp, None, state, instance_id, rng)
-                {
-                    effects.push(Effect::NewVertex(ValidVertex(Vertex::Unit(witness_unit))))
+        // Only create new units if enough validators are online.
+        if self.enough_validators_online(state, timestamp) {
+            if timestamp == r_id && state.leader(r_id) == self.vidx {
+                effects.extend(self.request_new_block(state, instance_id, timestamp, rng));
+                return effects;
+            } else if timestamp == r_id + self.witness_offset(r_len) {
+                let panorama = self.panorama_at(state, timestamp);
+                if panorama.has_correct() {
+                    if let Some(witness_unit) =
+                        self.new_unit(panorama, timestamp, None, state, instance_id, rng)
+                    {
+                        effects.push(Effect::NewVertex(ValidVertex(Vertex::Unit(witness_unit))));
+                        return effects;
+                    }
                 }
             }
         }
+        // We are not creating a new unit. Send a ping if necessary, to show that we're online.
+        if !state.has_ping(self.vidx, timestamp) {
+            warn!(%timestamp, "too many validators offline, sending ping");
+            let ping = Ping::new(self.vidx, timestamp, &self.secret, rng);
+            effects.push(Effect::NewVertex(ValidVertex(Vertex::Ping(ping))));
+        }
         effects
+    }
+
+    /// Returns whether enough validators are online to finalize values with the target fault
+    /// tolerance threshold, always counting this validator as online.
+    fn enough_validators_online(&self, state: &State<C>, timestamp: Timestamp) -> bool {
+        let target_quorum = (state.total_weight() + self.target_ftt) / 2;
+        let mut weight = state.online_and_honest_weight(timestamp);
+        if !state.is_online_and_honest(self.vidx, timestamp) {
+            weight += state.weight(self.vidx); // We know we are online.
+        }
+        weight > target_quorum
     }
 
     /// Returns actions a validator needs to take upon receiving a new unit.
@@ -556,6 +583,9 @@ impl<C: Context> ActiveValidator<C> {
                 endorsements.endorsers.iter().any(is_ours)
                     && !state.has_endorsement(endorsements.unit(), self.vidx)
             }
+            Vertex::Ping(ping) => {
+                ping.creator() == self.vidx && !state.has_ping(self.vidx, ping.timestamp())
+            }
             Vertex::Evidence(_) => false,
         }
     }
@@ -620,12 +650,13 @@ mod tests {
             } else {
                 current_round_id + (1 << state.params().init_round_exp()).into()
             };
+            let target_ftt = state.total_weight() / 3;
             let active_validators = validators
                 .into_iter()
                 .map(|vidx| {
                     let secret = TestSecret(vidx.0);
                     let (av, effects) =
-                        ActiveValidator::new(vidx, secret, start_time, &state, None);
+                        ActiveValidator::new(vidx, secret, start_time, &state, None, target_ftt);
                     let timestamp = unwrap_single(&effects).unwrap_timer();
                     if state.leader(earliest_round_start) == vidx {
                         assert_eq!(

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -162,6 +162,11 @@ impl<C: Context> FinalityDetector<C> {
     pub(crate) fn last_finalized(&self) -> Option<&C::Hash> {
         self.last_finalized.as_ref()
     }
+
+    /// Returns the configured fault tolerance threshold of this detector.
+    pub(crate) fn fault_tolerance_threshold(&self) -> Weight {
+        self.ftt
+    }
 }
 
 #[allow(unused_qualifications)] // This is to suppress warnings originating in the test macros.

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -79,7 +79,7 @@ impl<C: Context> Vertex<C> {
         matches!(self, Vertex::Evidence(_))
     }
 
-    /// Returns a `Timestamp` provided the vertex is a `Vertex::Unit`
+    /// Returns a `Timestamp` provided the vertex is a `Vertex::Unit` or `Vertex::Ping`.
     pub(crate) fn timestamp(&self) -> Option<Timestamp> {
         match self {
             Vertex::Unit(signed_wire_unit) => Some(signed_wire_unit.wire_unit().timestamp),

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -222,7 +222,7 @@ impl HighwayValidator {
         msg: HighwayMessage,
     ) -> Vec<HighwayMessage> {
         match self.fault.as_ref() {
-            Some(DesFault::Mute { from, till })
+            Some(DesFault::TemporarilyMute { from, till })
                 if *from <= delivery_time && delivery_time <= *till =>
             {
                 // For mute validators we add it to the state but not gossip, if the delivery time
@@ -238,7 +238,7 @@ impl HighwayValidator {
                     }
                 }
             }
-            None | Some(DesFault::Mute { .. }) => {
+            None | Some(DesFault::TemporarilyMute { .. }) | Some(DesFault::PermanentlyMute) => {
                 // Honest validator.
                 match &msg {
                     HighwayMessage::NewVertex(_)
@@ -1172,7 +1172,7 @@ mod test_harness {
         let mut highway_test_harness = HighwayTestHarnessBuilder::new()
             .max_faulty_validators(3)
             .faulty_weight_perc(fault_perc)
-            .fault_type(DesFault::always_mute())
+            .fault_type(DesFault::PermanentlyMute)
             .consensus_values_count(cv_count)
             .weight_limits(100, 120)
             .build(&mut rng)
@@ -1276,7 +1276,7 @@ mod test_harness {
         let mut test_harness = HighwayTestHarnessBuilder::new()
             .max_faulty_validators(3)
             .faulty_weight_perc(40) // Too many mute validators to be live...
-            .fault_type(DesFault::Mute {
+            .fault_type(DesFault::TemporarilyMute {
                 from: start_mute,
                 till: stop_mute,
             }) // ...but just temporarily mute.

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -215,20 +215,16 @@ impl HighwayValidator {
         Ok(self.finality_detector.run(&self.highway)?.collect())
     }
 
-    fn post_hook(&mut self, rng: &mut NodeRng, msg: HighwayMessage) -> Vec<HighwayMessage> {
+    fn post_hook(
+        &mut self,
+        rng: &mut NodeRng,
+        delivery_time: Timestamp,
+        msg: HighwayMessage,
+    ) -> Vec<HighwayMessage> {
         match self.fault.as_ref() {
-            None => {
-                // Honest validator.
-                match &msg {
-                    HighwayMessage::NewVertex(_)
-                    | HighwayMessage::Timer(_)
-                    | HighwayMessage::RequestBlock(_) => vec![msg],
-                    HighwayMessage::WeAreFaulty(ev) => {
-                        panic!("validator equivocated unexpectedly: {:?}", ev);
-                    }
-                }
-            }
-            Some(DesFault::Mute) => {
+            Some(DesFault::Mute(from, till))
+                if *from <= delivery_time && delivery_time <= *till =>
+            {
                 // For mute validators we add it to the state but not gossip.
                 match msg {
                     HighwayMessage::NewVertex(_) => {
@@ -236,6 +232,17 @@ impl HighwayValidator {
                         vec![]
                     }
                     HighwayMessage::Timer(_) | HighwayMessage::RequestBlock(_) => vec![msg],
+                    HighwayMessage::WeAreFaulty(ev) => {
+                        panic!("validator equivocated unexpectedly: {:?}", ev);
+                    }
+                }
+            }
+            None | Some(DesFault::Mute(_, _)) => {
+                // Honest validator.
+                match &msg {
+                    HighwayMessage::NewVertex(_)
+                    | HighwayMessage::Timer(_)
+                    | HighwayMessage::RequestBlock(_) => vec![msg],
                     HighwayMessage::WeAreFaulty(ev) => {
                         panic!("validator equivocated unexpectedly: {:?}", ev);
                     }
@@ -275,6 +282,12 @@ impl HighwayValidator {
 type HighwayNode = Node<ConsensusValue, HighwayMessage, HighwayValidator>;
 
 type HighwayNet = VirtualNet<ConsensusValue, HighwayMessage, HighwayValidator>;
+
+impl HighwayNode {
+    fn unit_count(&self) -> usize {
+        self.validator().highway.state().unit_count()
+    }
+}
 
 struct HighwayTestHarness<DS>
 where
@@ -353,8 +366,11 @@ where
         Ok(())
     }
 
-    fn next_consensus_value(&mut self) -> ConsensusValue {
-        self.consensus_values.pop_front().unwrap_or_default()
+    fn next_consensus_value(&mut self, height: u64) -> ConsensusValue {
+        self.consensus_values
+            .get(height as usize)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Helper for getting validator from the underlying virtual net.
@@ -367,6 +383,7 @@ where
     fn call_validator<F>(
         &mut self,
         rng: &mut NodeRng,
+        delivery_time: Timestamp,
         validator_id: &ValidatorId,
         f: F,
     ) -> TestResult<Vec<HighwayMessage>>
@@ -378,9 +395,11 @@ where
         let messages = res
             .into_iter()
             .flat_map(|eff| {
-                validator_node
-                    .validator_mut()
-                    .post_hook(rng, HighwayMessage::from(eff))
+                validator_node.validator_mut().post_hook(
+                    rng,
+                    delivery_time,
+                    HighwayMessage::from(eff),
+                )
             })
             .collect();
         Ok(messages)
@@ -406,7 +425,7 @@ where
 
             match hwm {
                 HighwayMessage::Timer(timestamp) => {
-                    self.call_validator(rng, &validator_id, |consensus, rng| {
+                    self.call_validator(rng, delivery_time, &validator_id, |consensus, rng| {
                         consensus.highway_mut().handle_timer(timestamp, rng)
                     })?
                 }
@@ -434,9 +453,9 @@ where
                     }
                 }
                 HighwayMessage::RequestBlock(block_context) => {
-                    let consensus_value = self.next_consensus_value();
+                    let consensus_value = self.next_consensus_value(block_context.height());
 
-                    self.call_validator(rng, &validator_id, |consensus, rng| {
+                    self.call_validator(rng, delivery_time, &validator_id, |consensus, rng| {
                         consensus
                             .highway_mut()
                             .propose(consensus_value, block_context, rng)
@@ -531,10 +550,12 @@ where
                         .validate_vertex(prevalidated_vertex)
                     {
                         Err((pvv, error)) => return Ok(Err((pvv.into_vertex(), error))),
-                        Ok(valid_vertex) => self.call_validator(rng, &recipient, |v, rng| {
-                            v.highway_mut()
-                                .add_valid_vertex(valid_vertex, rng, delivery_time)
-                        })?,
+                        Ok(valid_vertex) => {
+                            self.call_validator(rng, delivery_time, &recipient, |v, rng| {
+                                v.highway_mut()
+                                    .add_valid_vertex(valid_vertex, rng, delivery_time)
+                            })?
+                        }
                     }
                 };
 
@@ -590,7 +611,6 @@ where
     // If validator has missing dependencies then we have to add them first.
     // We don't want to test synchronization, and the Highway theory assumes
     // that when units are added then all their dependencies are satisfied.
-    #[allow(clippy::type_complexity)]
     fn synchronize_dependency(
         &mut self,
         rng: &mut NodeRng,
@@ -622,17 +642,40 @@ where
 }
 
 fn crank_until<F, DS: DeliveryStrategy>(
-    htt: &mut HighwayTestHarness<DS>,
+    hth: &mut HighwayTestHarness<DS>,
     rng: &mut NodeRng,
     f: F,
 ) -> TestResult<()>
 where
     F: Fn(&HighwayTestHarness<DS>) -> bool,
 {
-    while !f(htt) {
-        htt.crank(rng)?;
+    while !f(hth) {
+        hth.crank(rng)?;
     }
     Ok(())
+}
+
+fn crank_until_finalized<DS: DeliveryStrategy>(
+    hth: &mut HighwayTestHarness<DS>,
+    rng: &mut NodeRng,
+    cv_count: usize,
+) -> TestResult<()> {
+    crank_until(hth, rng, |hth| {
+        let has_all_finalized = |v: &HighwayNode| v.finalized_count() == cv_count;
+        hth.virtual_net.validators().all(has_all_finalized)
+    })
+}
+
+fn crank_until_time<DS: DeliveryStrategy>(
+    hth: &mut HighwayTestHarness<DS>,
+    rng: &mut NodeRng,
+    timestamp: Timestamp,
+) -> TestResult<()> {
+    crank_until(hth, rng, |hth| {
+        hth.virtual_net
+            .peek_message()
+            .map_or(true, |qe| qe.delivery_time > timestamp)
+    })
 }
 
 struct MutableHandle<'a, DS: DeliveryStrategy>(&'a mut HighwayTestHarness<DS>);
@@ -646,11 +689,33 @@ impl<'a, DS: DeliveryStrategy> MutableHandle<'a, DS> {
     fn validators(&self) -> impl Iterator<Item = &HighwayNode> {
         self.0.virtual_net.validators()
     }
+
+    fn correct_validators(&self) -> impl Iterator<Item = &HighwayNode> {
+        self.0
+            .virtual_net
+            .validators()
+            .filter(|v| v.validator().fault.is_none())
+    }
 }
 
+fn test_params() -> Params {
+    Params::new(
+        0, // random seed
+        TEST_BLOCK_REWARD,
+        TEST_REDUCED_BLOCK_REWARD,
+        TEST_MIN_ROUND_EXP,
+        TEST_MAX_ROUND_EXP,
+        TEST_MIN_ROUND_EXP,
+        TEST_END_HEIGHT,
+        Timestamp::zero(),
+        Timestamp::zero(), // Length depends only on block number.
+        TEST_ENDORSEMENT_EVIDENCE_LIMIT,
+    )
+}
+
+#[derive(Debug)]
 enum BuilderError {
     WeightLimits,
-    TooManyFaultyNodes(String),
 }
 
 struct HighwayTestHarnessBuilder<DS: DeliveryStrategy> {
@@ -679,9 +744,8 @@ struct HighwayTestHarnessBuilder<DS: DeliveryStrategy> {
     /// Type of discrete distribution of validators' weights.
     /// Defaults to uniform.
     weight_distribution: Distribution,
-    /// Seed for `Highway`.
-    /// Defaults to 0.
-    seed: u64,
+    /// Highway parameters.
+    params: Params,
 }
 
 // Default strategy for message delivery.
@@ -721,7 +785,7 @@ impl HighwayTestHarnessBuilder<InstantDeliveryNoDropping> {
             weight_limits: (1, 100),
             start_time: Timestamp::zero(),
             weight_distribution: Distribution::Uniform,
-            seed: 0,
+            params: test_params(),
         }
     }
 }
@@ -759,13 +823,17 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
         self
     }
 
+    fn params(mut self, params: Params) -> Self {
+        self.params = params;
+        self
+    }
+
     fn build(self, rng: &mut NodeRng) -> Result<HighwayTestHarness<DS>, BuilderError> {
         let consensus_values = (0..self.consensus_values_count as u32)
             .map(|el| vec![el])
             .collect::<VecDeque<ConsensusValue>>();
 
         let instance_id = 0;
-        let seed = self.seed;
         let start_time = self.start_time;
 
         let (lower, upper) = {
@@ -777,13 +845,6 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
         };
 
         let (faulty_weights, honest_weights): (Vec<Weight>, Vec<Weight>) = {
-            if self.faulty_percent > 33 {
-                return Err(BuilderError::TooManyFaultyNodes(
-                    "Total weight of all malicious validators cannot be more than 33% of all network weight."
-                        .to_string(),
-                ));
-            }
-
             if self.faulty_percent == 0 {
                 // All validators are honest.
                 let validators_num = rng.gen_range(2, self.max_faulty_validators + 1);
@@ -855,25 +916,14 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
             .ftt
             .map(|p| p * weights_sum.0 / 100)
             .unwrap_or_else(|| (weights_sum.0 - 1) / 3);
+        let params = self.params;
 
         // Local function creating an instance of `HighwayConsensus` for a single validator.
         let highway_consensus =
             |(vid, secrets): (ValidatorId, &mut HashMap<ValidatorId, TestSecret>)| {
                 let v_sec = secrets.remove(&vid).expect("Secret key should exist.");
 
-                let params = Params::new(
-                    seed,
-                    TEST_BLOCK_REWARD,
-                    TEST_REDUCED_BLOCK_REWARD,
-                    TEST_MIN_ROUND_EXP,
-                    TEST_MAX_ROUND_EXP,
-                    TEST_MIN_ROUND_EXP,
-                    TEST_END_HEIGHT,
-                    Timestamp::zero(),
-                    Timestamp::zero(), // Length depends only on block number.
-                    TEST_ENDORSEMENT_EVIDENCE_LIMIT,
-                );
-                let mut highway = Highway::new(instance_id, validators.clone(), params);
+                let mut highway = Highway::new(instance_id, validators.clone(), params.clone());
                 let effects = highway.activate_validator(vid, v_sec, start_time, None, Weight(ftt));
 
                 let finality_detector = FinalityDetector::new(Weight(ftt));
@@ -1003,13 +1053,20 @@ impl Context for TestContext {
 mod test_harness {
     use std::{collections::HashSet, fmt::Debug};
 
+    use itertools::Itertools;
+
     use super::{
-        crank_until, ConsensusValue, HighwayTestHarness, HighwayTestHarnessBuilder,
-        InstantDeliveryNoDropping, TestRunError,
+        crank_until, crank_until_finalized, crank_until_time, test_params, ConsensusValue,
+        HighwayTestHarness, HighwayTestHarnessBuilder, InstantDeliveryNoDropping, TestRunError,
+        TEST_MIN_ROUND_EXP,
     };
     use crate::{
-        components::consensus::tests::consensus_des_testing::{Fault as DesFault, ValidatorId},
+        components::consensus::{
+            highway_core::state,
+            tests::consensus_des_testing::{Fault as DesFault, ValidatorId},
+        },
         logging,
+        types::Timestamp,
     };
     use logging::{LoggingConfig, LoggingFormat};
 
@@ -1021,7 +1078,6 @@ mod test_harness {
                 .consensus_values_count(1)
                 .weight_limits(100, 120)
                 .build(&mut rng)
-                .ok()
                 .expect("Construction was successful");
 
         highway_test_harness.mutable_handle().clear_message_queue();
@@ -1053,7 +1109,6 @@ mod test_harness {
             .consensus_values_count(cv_count)
             .weight_limits(100, 120)
             .build(&mut rng)
-            .ok()
             .expect("Construction was successful");
 
         crank_until(&mut highway_test_harness, &mut rng, |hth| {
@@ -1116,11 +1171,10 @@ mod test_harness {
         let mut highway_test_harness = HighwayTestHarnessBuilder::new()
             .max_faulty_validators(3)
             .faulty_weight_perc(fault_perc)
-            .fault_type(DesFault::Mute)
+            .fault_type(DesFault::Mute(Timestamp::zero(), u64::MAX.into()))
             .consensus_values_count(cv_count)
             .weight_limits(100, 120)
             .build(&mut rng)
-            .ok()
             .expect("Construction was successful");
 
         crank_until(&mut highway_test_harness, &mut rng, |hth| {
@@ -1161,7 +1215,6 @@ mod test_harness {
             .consensus_values_count(cv_count)
             .weight_limits(100, 150)
             .build(&mut rng)
-            .ok()
             .expect("Construction was successful");
 
         crank_until(&mut highway_test_harness, &mut rng, |hth| {
@@ -1200,6 +1253,72 @@ mod test_harness {
         assert_eq_vectors(
             equivocators_seen,
             "Nodes saw different set of equivocators.",
+        );
+    }
+
+    #[test]
+    fn pause_if_too_many_are_offline() {
+        let _ = logging::init_with_config(&LoggingConfig::new(LoggingFormat::Text, true, true));
+
+        let mut rng = crate::new_rng();
+        let cv_count = 10u8;
+        let max_round_exp = TEST_MIN_ROUND_EXP + 1;
+        let max_round_len = state::round_len(max_round_exp);
+
+        let start_mute = Timestamp::zero() + max_round_len * 2;
+        let should_start_pause = start_mute + max_round_len * 4;
+        let stop_mute = should_start_pause + max_round_len * 3;
+
+        let params = test_params()
+            .with_max_round_exp(max_round_exp)
+            .with_end_height(cv_count as u64);
+        let mut test_harness = HighwayTestHarnessBuilder::new()
+            .max_faulty_validators(3)
+            .faulty_weight_perc(40) // Too many mute validators to be live...
+            .fault_type(DesFault::Mute(start_mute, stop_mute)) // ...but just temporarily mute.
+            .consensus_values_count(cv_count)
+            .weight_limits(100, 120)
+            .params(params)
+            .build(&mut rng)
+            .expect("Construction was successful");
+
+        // Three max-length rounds after 40% went silent, the honest validators should stop voting.
+        crank_until_time(&mut test_harness, &mut rng, should_start_pause).unwrap();
+
+        // They should all see the same number of finalized blocks.
+        let handle = test_harness.mutable_handle();
+        let first_validator = handle.correct_validators().next().unwrap();
+        let finalized_before_pause = first_validator.finalized_count();
+        let unit_count_before_pause = first_validator.unit_count();
+        assert_ne!(finalized_before_pause, 0);
+        assert!(finalized_before_pause < cv_count as usize);
+        for v in handle.correct_validators() {
+            assert_eq!(finalized_before_pause, v.finalized_count());
+            assert_eq!(unit_count_before_pause, v.unit_count());
+        }
+
+        // Much later, just before the missing 40% come back online...
+        crank_until_time(&mut test_harness, &mut rng, stop_mute).unwrap();
+
+        // ...there should still be no new unit yet.
+        for v in test_harness.mutable_handle().correct_validators() {
+            assert_eq!(finalized_before_pause, v.finalized_count());
+            assert_eq!(unit_count_before_pause, v.unit_count());
+        }
+
+        // After that, however, the network should resume...
+        crank_until_finalized(&mut test_harness, &mut rng, cv_count as usize).unwrap();
+
+        // ...and finalize the remaining blocks.
+        let finalized_values = test_harness
+            .mutable_handle()
+            .validators()
+            .map(|v| v.finalized_values().cloned().collect_vec())
+            .collect_vec();
+
+        assert_eq_vectors(
+            finalized_values,
+            "Nodes finalized different consensus values.",
         );
     }
 }

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -874,7 +874,7 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
                     TEST_ENDORSEMENT_EVIDENCE_LIMIT,
                 );
                 let mut highway = Highway::new(instance_id, validators.clone(), params);
-                let effects = highway.activate_validator(vid, v_sec, start_time, None);
+                let effects = highway.activate_validator(vid, v_sec, start_time, None, Weight(ftt));
 
                 let finality_detector = FinalityDetector::new(Weight(ftt));
 

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -864,6 +864,12 @@ impl<C: Context> State<C> {
         self.units.is_empty()
     }
 
+    /// Returns the number of units received.
+    #[cfg(test)]
+    pub(crate) fn unit_count(&self) -> usize {
+        self.units.len()
+    }
+
     /// Returns the set of units (by hash) that are endorsed and seen from the panorama.
     pub(crate) fn seen_endorsed(&self, pan: &Panorama<C>) -> BTreeSet<C::Hash> {
         // First we collect all units that were already seen as endorsed by earlier units.

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -505,20 +505,11 @@ impl<C: Context> State<C> {
         self.pings[creator] + max_round_len > timestamp
     }
 
-    /// Returns whether the validator is honest and the latest unit or ping is at most
-    /// `PING_TIMEOUT` maximum round lengths old.
-    pub(crate) fn is_online_and_honest(&self, vidx: ValidatorIndex, now: Timestamp) -> bool {
+    /// Returns whether the validator's latest unit or ping is at most `PING_TIMEOUT` maximum round
+    /// lengths old.
+    pub(crate) fn is_online(&self, vidx: ValidatorIndex, now: Timestamp) -> bool {
         let max_round_len = round_len(self.params.max_round_exp());
-        !self.is_faulty(vidx) && self.pings[vidx] + max_round_len * PING_TIMEOUT >= now
-    }
-
-    /// Returns the total weight of all honest and online validators.
-    pub(crate) fn online_and_honest_weight(&self, now: Timestamp) -> Weight {
-        self.weights
-            .enumerate()
-            .filter(|(vidx, _)| self.is_online_and_honest(*vidx, now))
-            .map(|(_, w)| *w)
-            .sum()
+        self.pings[vidx] + max_round_len * PING_TIMEOUT >= now
     }
 
     /// Creates new `Evidence` if the new endorsements contain any that conflict with existing

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -51,6 +51,10 @@ use tallies::Tallies;
 // endorsements again.
 pub(super) const TODO_ENDORSEMENT_EVIDENCE_DISABLED: bool = true;
 
+/// Number of maximum-length rounds after which a validator counts as offline, if we haven't heard
+/// from them.
+const PING_TIMEOUT: u64 = 3;
+
 #[derive(Debug, Error, PartialEq, Clone)]
 pub(crate) enum UnitError {
     #[error("The unit is a ballot but doesn't cite any block.")]
@@ -162,6 +166,8 @@ pub(crate) struct State<C: Context> {
     /// Signatures are stored in a map so that a single validator sending lots of signatures for
     /// different units doesn't cause us to allocate a lot of memory.
     incomplete_endorsements: HashMap<C::Hash, BTreeMap<ValidatorIndex, C::Signature>>,
+    /// Timestamp of the last ping or unit we received from each validator.
+    pings: ValidatorMap<Timestamp>,
     /// Clock to measure time spent in fork choice computation.
     clock: Clock,
 }
@@ -194,6 +200,9 @@ impl<C: Context> State<C> {
             );
             panorama[*idx] = Observation::Faulty;
         }
+        let pings = iter::repeat(params.start_timestamp())
+            .take(weights.len())
+            .collect();
         State {
             params,
             weights,
@@ -204,6 +213,7 @@ impl<C: Context> State<C> {
             panorama,
             endorsements: HashMap::new(),
             incomplete_endorsements: HashMap::new(),
+            pings,
             clock: Clock::new(),
         }
     }
@@ -387,6 +397,7 @@ impl<C: Context> State<C> {
             let block = Block::new(fork_choice, value, self);
             self.blocks.insert(hash, block);
         }
+        self.add_ping(unit.creator, unit.timestamp);
         self.units.insert(hash, unit);
 
         // Update the panorama.
@@ -477,6 +488,37 @@ impl<C: Context> State<C> {
                 .get(uhash)
                 .map(|ends| ends.contains_key(&vidx))
                 .unwrap_or(false)
+    }
+
+    /// Updates `self.pings` with the given timestamp.
+    pub(crate) fn add_ping(&mut self, creator: ValidatorIndex, timestamp: Timestamp) {
+        self.pings[creator] = self.pings[creator].max(timestamp);
+    }
+
+    /// Returns `true` if the latest timestamp we have is less than one maximum round length older
+    /// than the given timestamp.
+    ///
+    /// This is to prevent ping spam: If the incoming ping is only slightly newer than a unit or
+    /// ping we have already received, we drop it without forwarding it to our peers.
+    pub(crate) fn has_ping(&self, creator: ValidatorIndex, timestamp: Timestamp) -> bool {
+        let max_round_len = round_len(self.params.max_round_exp());
+        self.pings[creator] + max_round_len > timestamp
+    }
+
+    /// Returns whether the validator is honest and the latest unit or ping is at most
+    /// `PING_TIMEOUT` maximum round lengths old.
+    pub(crate) fn is_online_and_honest(&self, vidx: ValidatorIndex, now: Timestamp) -> bool {
+        let max_round_len = round_len(self.params.max_round_exp());
+        !self.is_faulty(vidx) && self.pings[vidx] + max_round_len * PING_TIMEOUT >= now
+    }
+
+    /// Returns the total weight of all honest and online validators.
+    pub(crate) fn online_and_honest_weight(&self, now: Timestamp) -> Weight {
+        self.weights
+            .enumerate()
+            .filter(|(vidx, _)| self.is_online_and_honest(*vidx, now))
+            .map(|(_, w)| *w)
+            .sum()
     }
 
     /// Creates new `Evidence` if the new endorsements contain any that conflict with existing

--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -119,11 +119,22 @@ impl Params {
     pub(crate) fn endorsement_evidence_limit(&self) -> u64 {
         self.endorsement_evidence_limit
     }
+}
 
-    /// Returns new `Params` with the update endorsement evidence limit.
-    #[cfg(test)]
+#[cfg(test)]
+impl Params {
     pub(crate) fn with_endorsement_evidence_limit(mut self, new_limit: u64) -> Params {
         self.endorsement_evidence_limit = new_limit;
+        self
+    }
+
+    pub(crate) fn with_max_round_exp(mut self, new_max_round_exp: u8) -> Params {
+        self.max_round_exp = new_max_round_exp;
+        self
+    }
+
+    pub(crate) fn with_end_height(mut self, new_end_height: u64) -> Params {
+        self.end_height = new_end_height;
         self
     }
 }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -657,9 +657,10 @@ where
         timestamp: Timestamp,
         unit_hash_file: Option<PathBuf>,
     ) -> ProtocolOutcomes<I, C> {
-        let av_effects = self
-            .highway
-            .activate_validator(our_id, secret, timestamp, unit_hash_file);
+        let ftt = self.finality_detector.fault_tolerance_threshold();
+        let av_effects =
+            self.highway
+                .activate_validator(our_id, secret, timestamp, unit_hash_file, ftt);
         self.process_av_effects(av_effects)
     }
 

--- a/node/src/components/consensus/tests/consensus_des_testing.rs
+++ b/node/src/components/consensus/tests/consensus_des_testing.rs
@@ -62,8 +62,20 @@ impl Display for ValidatorId {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Fault {
-    Mute(Timestamp, Timestamp),
+    /// The validator does not send any messages within the interval between the timestamps.
+    Mute { from: Timestamp, till: Timestamp },
+    /// The validator is actively malicious.
     Equivocate,
+}
+
+impl Fault {
+    /// Returns a `Fault::Mute` that is always mute, not only within a limited interval.
+    pub(crate) fn always_mute() -> Fault {
+        Fault::Mute {
+            from: Timestamp::zero(),
+            till: u64::MAX.into(),
+        }
+    }
 }
 
 /// A validator in the test network.

--- a/node/src/components/consensus/tests/consensus_des_testing.rs
+++ b/node/src/components/consensus/tests/consensus_des_testing.rs
@@ -62,7 +62,7 @@ impl Display for ValidatorId {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Fault {
-    Mute,
+    Mute(Timestamp, Timestamp),
     Equivocate,
 }
 
@@ -210,6 +210,12 @@ where
     /// It's a message with the earliest delivery time.
     pub(crate) fn pop_message(&mut self) -> Option<QueueEntry<M>> {
         self.msg_queue.pop()
+    }
+
+    /// Returns a reference to the next message from the queue without removing it.
+    /// It's a message with the earliest delivery time.
+    pub(crate) fn peek_message(&self) -> Option<&QueueEntry<M>> {
+        self.msg_queue.peek()
     }
 
     pub(crate) fn validators_ids(&self) -> impl Iterator<Item = &ValidatorId> {

--- a/node/src/components/consensus/tests/consensus_des_testing.rs
+++ b/node/src/components/consensus/tests/consensus_des_testing.rs
@@ -63,19 +63,11 @@ impl Display for ValidatorId {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Fault {
     /// The validator does not send any messages within the interval between the timestamps.
-    Mute { from: Timestamp, till: Timestamp },
+    TemporarilyMute { from: Timestamp, till: Timestamp },
+    /// The validator does not send any messages ever.
+    PermanentlyMute,
     /// The validator is actively malicious.
     Equivocate,
-}
-
-impl Fault {
-    /// Returns a `Fault::Mute` that is always mute, not only within a limited interval.
-    pub(crate) fn always_mute() -> Fault {
-        Fault::Mute {
-            from: Timestamp::zero(),
-            till: u64::MAX.into(),
-        }
-    }
 }
 
 /// A validator in the test network.

--- a/node/src/components/consensus/tests/queue.rs
+++ b/node/src/components/consensus/tests/queue.rs
@@ -105,6 +105,12 @@ where
         self.0.pop()
     }
 
+    /// Returns a reference to next message without removing it.
+    /// Returns `None` if there aren't any.
+    pub(crate) fn peek(&self) -> Option<&QueueEntry<M>> {
+        self.0.peek()
+    }
+
     /// Pushes new message to the queue.
     pub(crate) fn push(&mut self, item: QueueEntry<M>) {
         self.0.push(item)


### PR DESCRIPTION
This prevents the remaining validators from creating more and more units (increasing the protocol state size, and thus memory usage) while too many validators are offline to finalize anything. E.g. if there's a 34% fault tolerance threshold, we need more than 67% = 50% + 34% / 2 online for liveness, so if 33% or more are offline, the other validators will pause.

During a pause, instead of units, they gossip new `Ping` messages, so that others can keep track of who's still online. Once enough validators are back online again, they resume.

https://casperlabs.atlassian.net/browse/HWY-239