### PR TITLE
HWY-238: Highway synchronizer unit test

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -5,6 +5,7 @@ mod cl_context;
 mod config;
 mod consensus_protocol;
 mod era_supervisor;
+#[macro_use]
 mod highway_core;
 mod metrics;
 mod protocols;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -689,7 +689,7 @@ where
                 .send_message(to, era_id.message(out_msg).into())
                 .ignore(),
             ProtocolOutcome::ScheduleTimer(timestamp, timer_id) => {
-                let timediff = timestamp.saturating_sub(Timestamp::now());
+                let timediff = timestamp.saturating_diff(Timestamp::now());
                 self.effect_builder
                     .set_timeout(timediff.into())
                     .event(move |_| Event::Timer {
@@ -761,7 +761,7 @@ where
                 self.era_supervisor.next_block_height = finalized_block.height() + 1;
                 if finalized_block.era_end().is_some() {
                     // This was the era's last block. Schedule deactivating this era.
-                    let delay = Timestamp::now().saturating_sub(timestamp).into();
+                    let delay = Timestamp::now().saturating_diff(timestamp).into();
                     let faulty_num = era.consensus.validators_with_evidence().len();
                     let deactivate_era = move |_| Event::DeactivateEra {
                         era_id,

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -656,7 +656,7 @@ pub(crate) mod tests {
         types::Timestamp,
     };
 
-    fn test_validators() -> Validators<u32> {
+    pub(crate) fn test_validators() -> Validators<u32> {
         let vid_weights: Vec<(u32, u64)> =
             vec![(ALICE_SEC, ALICE), (BOB_SEC, BOB), (CAROL_SEC, CAROL)]
                 .into_iter()

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -121,7 +121,7 @@ impl<C: Context> SignedWireUnit<C> {
     }
 }
 
-fn test_params(seed: u64) -> Params {
+pub(crate) fn test_params(seed: u64) -> Params {
     Params::new(
         seed,
         TEST_BLOCK_REWARD,

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -460,7 +460,7 @@ where
                         // If it's not from an equivocator and from the future, add to queue
                         trace!("received a vertex from the future; storing for later");
                         self.synchronizer
-                            .store_vertex_for_addition_later(timestamp, sender, pvv);
+                            .store_vertex_for_addition_later(timestamp, now, sender, pvv);
                         let timer_id = TIMER_ID_VERTEX_WITH_FUTURE_TIMESTAMP;
                         vec![ProtocolOutcome::ScheduleTimer(timestamp, timer_id)]
                     }
@@ -468,7 +468,7 @@ where
                         // If it's not from an equivocator or it is a transitive dependency, add the
                         // vertex
                         trace!("received a valid vertex");
-                        let pv = PendingVertex::new(sender, pvv);
+                        let pv = PendingVertex::new(sender, pvv, now);
                         self.synchronizer.schedule_add_vertices(iter::once(pv))
                     }
                 }
@@ -574,7 +574,7 @@ where
                 self.synchronizer.add_past_due_stored_vertices(timestamp)
             }
             TIMER_ID_PURGE_VERTICES => {
-                self.synchronizer.purge_vertices();
+                self.synchronizer.purge_vertices(timestamp);
                 let next_time = Timestamp::now() + self.synchronizer.pending_vertex_timeout();
                 vec![ProtocolOutcome::ScheduleTimer(next_time, timer_id)]
             }

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashSet},
     fmt::Debug,
+    iter,
 };
 
 use datasize::DataSize;
@@ -15,7 +16,10 @@ use crate::{
     types::{TimeDiff, Timestamp},
 };
 
-use super::{ProtocolOutcomes, ACTION_ID_VERTEX};
+use super::{HighwayMessage, ProtocolOutcomes, ACTION_ID_VERTEX};
+
+#[cfg(test)]
+mod tests;
 
 /// An incoming pre-validated vertex that we haven't added to the protocol state yet.
 #[derive(DataSize, Debug)]
@@ -143,18 +147,15 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
         results
     }
 
-    /// Schedules vertices to be added to the protocol state.
-    pub(crate) fn schedule_add_vertices<T>(&mut self, pending_vertices: T) -> ProtocolOutcomes<I, C>
-    where
-        T: IntoIterator<Item = PendingVertex<I, C>>,
-    {
-        let was_empty = self.vertices_to_be_added.is_empty();
-        self.vertices_to_be_added.extend(pending_vertices);
-        if was_empty && !self.vertices_to_be_added.is_empty() {
-            vec![ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]
-        } else {
-            Vec::new()
-        }
+    /// Schedules a vertex to be added to the protocol state.
+    pub(crate) fn schedule_add_vertex(
+        &mut self,
+        sender: I,
+        pvv: PreValidatedVertex<C>,
+        now: Timestamp,
+    ) -> ProtocolOutcomes<I, C> {
+        let pv = PendingVertex::new(sender, pvv, now);
+        self.schedule_add_vertices(iter::once(pv))
     }
 
     /// Moves all vertices whose known missing dependency is now satisfied into the
@@ -175,25 +176,35 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
 
     /// Pops and returns the next entry from `vertices_to_be_added` that is not yet in the protocol
     /// state. Also returns a `ProtocolOutcome` that schedules the next action to add a vertex,
-    /// unless the queue is empty.
+    /// unless the queue is empty, and `ProtocolOutcome`s to request missing dependencies.
     pub(crate) fn pop_vertex_to_add(
         &mut self,
         highway: &Highway<C>,
-    ) -> Option<(PendingVertex<I, C>, ProtocolOutcomes<I, C>)> {
-        // Get the next vertex to be added; skip the ones that are already in the protocol state.
-        let pv = loop {
-            let pv = self.vertices_to_be_added.pop()?;
-            if highway.has_vertex(pv.vertex()) {
-                continue; // This vertex was already added. Try the next one.
+    ) -> (Option<PendingVertex<I, C>>, ProtocolOutcomes<I, C>) {
+        let mut outcomes = Vec::new();
+        // Get the next vertex to be added; skip the ones that are already in the protocol state,
+        // and the ones that are still missing dependencies.
+        loop {
+            let pv = match self.vertices_to_be_added.pop() {
+                None => return (None, outcomes),
+                Some(pv) if highway.has_vertex(pv.vertex()) => continue,
+                Some(pv) => pv,
+            };
+            if let Some(dep) = highway.missing_dependency(pv.pvv()) {
+                // We are still missing a dependency. Store the vertex in the map and request
+                // the dependency from the sender.
+                let sender = pv.sender().clone();
+                self.add_missing_dependency(dep.clone(), pv);
+                let ser_msg = HighwayMessage::RequestDependency(dep).serialize();
+                outcomes.push(ProtocolOutcome::CreatedTargetedMessage(ser_msg, sender));
+                continue;
             }
-            break pv;
-        };
-        if self.vertices_to_be_added.is_empty() {
-            // Found next vertex, but the queue is empty: No need to schedule another call.
-            Some((pv, Vec::new()))
-        } else {
-            // There are still vertices in the queue: schedule next call.
-            Some((pv, vec![ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]))
+            // We found the next vertex to add.
+            if !self.vertices_to_be_added.is_empty() {
+                // There are still vertices in the queue: schedule next call.
+                outcomes.push(ProtocolOutcome::QueueAction(ACTION_ID_VERTEX));
+            }
+            return (Some(pv), outcomes);
         }
     }
 
@@ -233,6 +244,20 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
             senders.extend(new_senders);
         }
         senders
+    }
+
+    /// Schedules vertices to be added to the protocol state.
+    fn schedule_add_vertices<T>(&mut self, pending_vertices: T) -> ProtocolOutcomes<I, C>
+    where
+        T: IntoIterator<Item = PendingVertex<I, C>>,
+    {
+        let was_empty = self.vertices_to_be_added.is_empty();
+        self.vertices_to_be_added.extend(pending_vertices);
+        if was_empty && !self.vertices_to_be_added.is_empty() {
+            vec![ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]
+        } else {
+            Vec::new()
+        }
     }
 
     /// Drops all vertices that have the specified direct dependencies, and returns their IDs and

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -1,0 +1,109 @@
+use super::*;
+
+use crate::components::consensus::{
+    highway_core::{
+        highway::tests::test_validators,
+        highway_testing::TEST_INSTANCE_ID,
+        state::{tests::*, State},
+    },
+    protocols::highway::tests::NodeId,
+};
+
+#[test]
+fn purge_vertices() {
+    let params = test_params(0);
+    let mut state = State::new(WEIGHTS, params.clone(), vec![]);
+    let mut rng = crate::new_rng();
+
+    // We use round exponent 4u8, so a round is 0x10 ms. With seed 0, Carol is the first leader.
+    //
+    // time:  0x00 0x0A 0x1A 0x2A 0x3A
+    //
+    // Carol   c0 — c1 — c2
+    //            \
+    // Bob          ————————— b0 — b1
+    let c0 = add_unit!(state, rng, CAROL, 0x00, 4u8, 0xA; N, N, N).unwrap();
+    let c1 = add_unit!(state, rng, CAROL, 0x0A, 4u8, None; N, N, c0).unwrap();
+    let c2 = add_unit!(state, rng, CAROL, 0x1A, 4u8, None; N, N, c1).unwrap();
+    let b0 = add_unit!(state, rng, BOB, 0x2A, 4u8, None; N, N, c0).unwrap();
+    let b1 = add_unit!(state, rng, BOB, 0x3A, 4u8, None; N, b0, c0).unwrap();
+
+    // A Highway instance that's just used to create PreValidatedVertex instances below.
+    let util_highway =
+        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params.clone());
+
+    // Returns the WireUnit with the specified hash.
+    let unit = |hash: u64| Vertex::Unit(state.wire_unit(&hash, TEST_INSTANCE_ID).unwrap());
+    // Returns the PreValidatedVertex with the specified hash.
+    let pvv = |hash: u64| util_highway.pre_validate_vertex(unit(hash)).unwrap();
+
+    let peer0 = NodeId(0);
+
+    // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
+    let mut sync = Synchronizer::<NodeId, TestContext>::new(0x20.into());
+    let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
+
+    // At time 0x20, we receive c2, b0 and b1 — the latter ahead of their timestamp.
+    // Since c2 is the first entry in the main queue, processing is scheduled.
+    let now = 0x20.into();
+    assert!(matches!(
+        *sync.schedule_add_vertex(peer0, pvv(c2), now),
+        [ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]
+    ));
+    sync.store_vertex_for_addition_later(unit(b1).timestamp().unwrap(), now, peer0, pvv(b1));
+    sync.store_vertex_for_addition_later(unit(b0).timestamp().unwrap(), now, peer0, pvv(b0));
+
+    // At time 0x21, we receive c1.
+    let now = 0x21.into();
+    assert!(sync.schedule_add_vertex(peer0, pvv(c1), now).is_empty());
+
+    // No new vertices can be added yet, because all are missing dependencies.
+    // The missing dependencies of c1 and c2 are requested.
+    let (maybe_pv, outcomes) = sync.pop_vertex_to_add(&highway);
+    assert!(maybe_pv.is_none());
+    assert!(matches!(
+        *outcomes,
+        [
+            ProtocolOutcome::CreatedTargetedMessage(_, NodeId(0)),
+            ProtocolOutcome::CreatedTargetedMessage(_, NodeId(0)),
+        ]
+    ));
+
+    // At 0x23, c0 gets enqueued and added.
+    // That puts c1 back into the main queue, since its dependency is satisfied.
+    let now = 0x23.into();
+    let outcomes = sync.schedule_add_vertex(peer0, pvv(c0), now);
+    assert!(
+        matches!(*outcomes, [ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]),
+        "unexpected outcomes: {:?}",
+        outcomes
+    );
+    let (maybe_pv, outcomes) = sync.pop_vertex_to_add(&highway);
+    assert_eq!(Dependency::Unit(c0), maybe_pv.unwrap().vertex().id());
+    assert!(outcomes.is_empty());
+    let vv_c0 = highway.validate_vertex(pvv(c0)).expect("c0 is valid");
+    highway.add_valid_vertex(vv_c0, &mut rng, now);
+    let outcomes = sync.remove_satisfied_deps(&highway);
+    assert!(
+        matches!(*outcomes, [ProtocolOutcome::QueueAction(ACTION_ID_VERTEX)]),
+        "unexpected outcomes: {:?}",
+        outcomes
+    );
+
+    // At time 0x2A, the vertex b0 moves into the main queue.
+    let now = 0x2A.into();
+    assert!(sync.add_past_due_stored_vertices(now).is_empty());
+
+    // At 0x41, all vertices received at 0x20 are expired, but c1 (received at 0x21) isn't.
+    // This will remove:
+    // * b1: still postponed due to future timestamp
+    // * b0: in the main queue
+    // * c2: waiting for dependency c1 to be added
+    sync.purge_vertices(0x41.into());
+
+    // The main queue should now contain only c1. If we remove it, the synchronizer is empty.
+    let (maybe_pv, outcomes) = sync.pop_vertex_to_add(&highway);
+    assert_eq!(Dependency::Unit(c1), maybe_pv.unwrap().vertex().id());
+    assert!(outcomes.is_empty());
+    assert!(sync.is_empty());
+}

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -27,7 +27,7 @@ use crate::{
     types::{ProtoBlock, Timestamp},
 };
 
-#[derive(DataSize, Debug, Ord, PartialOrd, Clone, Display, Hash, Eq, PartialEq)]
+#[derive(DataSize, Debug, Ord, PartialOrd, Copy, Clone, Display, Hash, Eq, PartialEq)]
 pub(crate) struct NodeId(pub u8);
 
 /// Returns a new `State` with `ClContext` parameters suitable for tests.

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -60,8 +60,13 @@ impl Timestamp {
     }
 
     /// Returns the difference between `self` and `other`, or `0` if `self` is earlier than `other`.
-    pub fn saturating_sub(self, other: Timestamp) -> TimeDiff {
+    pub fn saturating_diff(self, other: Timestamp) -> TimeDiff {
         TimeDiff(self.0.saturating_sub(other.0))
+    }
+
+    /// Returns the difference between `self` and `other`, or `0` if that would be before the epoch.
+    pub fn saturating_sub(self, other: TimeDiff) -> Timestamp {
+        Timestamp(self.0.saturating_sub(other.0))
     }
 
     /// Returns the number of trailing zeros in the number of milliseconds since the epoch.


### PR DESCRIPTION
This removes all `Timestamp::now()` calls from the synchronizer and adds a unit test that doesn't use the wall clock. The test purges vertices from all three queues, and in the process also exercises pushing and popping vertices, and enqueueing vertices with a future timestamp.

https://casperlabs.atlassian.net/browse/HWY-238