### PR TITLE
EE-1163: Native transfer error charge

### DIFF
--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -34,6 +34,8 @@ pub enum Error {
     Authorization,
     #[error("Insufficient payment")]
     InsufficientPayment,
+    #[error("Gas conversion overflow")]
+    GasConversionOverflow,
     #[error("Deploy error")]
     Deploy,
     #[error("Payment finalization error")]

--- a/execution_engine/src/core/engine_state/execution_result.rs
+++ b/execution_engine/src/core/engine_state/execution_result.rs
@@ -76,6 +76,8 @@ pub type ExecutionResults = VecDeque<ExecutionResult>;
 pub enum ForcedTransferResult {
     /// Payment code ran out of gas during execution
     InsufficientPayment,
+    /// Gas conversion overflow
+    GasConversionOverflow,
     /// Payment code execution resulted in an error
     PaymentFailure,
 }
@@ -227,9 +229,7 @@ impl ExecutionResult {
     ) -> Option<ForcedTransferResult> {
         let payment_result_cost = match Motes::from_gas(self.cost(), gas_price) {
             Some(cost) => cost,
-            // Multiplying cost by gas_price overflowed the U512 range
-            // TODO: Add a specific error variant to represent gas to motes conversion overflow.
-            None => return Some(ForcedTransferResult::InsufficientPayment),
+            None => return Some(ForcedTransferResult::GasConversionOverflow),
         };
         // payment_code_spec_3_b_ii: if (balance of PoS pay purse) < (gas spent during
         // payment code execution) * gas_price, no session

--- a/execution_engine_testing/test_support/src/internal/mod.rs
+++ b/execution_engine_testing/test_support/src/internal/mod.rs
@@ -54,7 +54,7 @@ pub const DEFAULT_ROUND_SEIGNIORAGE_RATE: Ratio<u64> = Ratio::new_raw(6414, 6234
 pub const DEFAULT_CHAIN_NAME: &str = "gerald";
 pub const DEFAULT_GENESIS_TIMESTAMP_MILLIS: u64 = 0;
 pub const DEFAULT_BLOCK_TIME: u64 = 0;
-pub const DEFAULT_GAS_PRICE: u64 = 10;
+pub const DEFAULT_GAS_PRICE: u64 = 1;
 pub const MOCKED_ACCOUNT_ADDRESS: AccountHash = AccountHash::new([48u8; 32]);
 
 pub const ARG_AMOUNT: &str = "amount";

--- a/execution_engine_testing/test_support/src/internal/mod.rs
+++ b/execution_engine_testing/test_support/src/internal/mod.rs
@@ -54,7 +54,7 @@ pub const DEFAULT_ROUND_SEIGNIORAGE_RATE: Ratio<u64> = Ratio::new_raw(6414, 6234
 pub const DEFAULT_CHAIN_NAME: &str = "gerald";
 pub const DEFAULT_GENESIS_TIMESTAMP_MILLIS: u64 = 0;
 pub const DEFAULT_BLOCK_TIME: u64 = 0;
-pub const DEFAULT_GAS_PRICE: u64 = 1;
+pub const DEFAULT_GAS_PRICE: u64 = 10;
 pub const MOCKED_ACCOUNT_ADDRESS: AccountHash = AccountHash::new([48u8; 32]);
 
 pub const ARG_AMOUNT: &str = "amount";

--- a/execution_engine_testing/tests/src/test/regression/ee_1160.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1160.rs
@@ -1,11 +1,12 @@
 use casper_engine_test_support::{
     internal::{
-        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_GAS_PRICE,
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
         DEFAULT_RUN_GENESIS_REQUEST,
     },
     AccountHash, DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
 use casper_execution_engine::{
+    core::engine_state::WASMLESS_TRANSFER_FIXED_GAS_PRICE,
     shared::{gas::Gas, motes::Motes},
     storage::protocol_data::DEFAULT_WASMLESS_TRANSFER_COST,
 };
@@ -17,8 +18,11 @@ const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 #[test]
 fn ee_1160_wasmless_transfer_should_empty_account() {
     let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
-    let wasmless_transfer_cost =
-        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+    let wasmless_transfer_cost = Motes::from_gas(
+        wasmless_transfer_gas_cost,
+        WASMLESS_TRANSFER_FIXED_GAS_PRICE,
+    )
+    .expect("gas overflow");
 
     let transfer_amount =
         U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE) - wasmless_transfer_cost.value();
@@ -106,8 +110,11 @@ fn ee_1160_transfer_larger_than_balance_should_fail() {
     let balance_after = builder.get_purse_balance(default_account.main_purse());
 
     let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
-    let wasmless_transfer_motes =
-        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+    let wasmless_transfer_motes = Motes::from_gas(
+        wasmless_transfer_gas_cost,
+        WASMLESS_TRANSFER_FIXED_GAS_PRICE,
+    )
+    .expect("gas overflow");
 
     let last_result = builder.get_exec_result(0).unwrap().clone();
     let last_result = &last_result[0];
@@ -163,8 +170,11 @@ fn ee_1160_large_wasmless_transfer_should_avoid_overflow() {
     let balance_after = builder.get_purse_balance(default_account.main_purse());
 
     let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
-    let wasmless_transfer_motes =
-        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+    let wasmless_transfer_motes = Motes::from_gas(
+        wasmless_transfer_gas_cost,
+        WASMLESS_TRANSFER_FIXED_GAS_PRICE,
+    )
+    .expect("gas overflow");
 
     assert_eq!(
         balance_before - wasmless_transfer_motes.value(),

--- a/execution_engine_testing/tests/src/test/regression/ee_1163.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1163.rs
@@ -1,0 +1,175 @@
+use casper_engine_test_support::{
+    internal::{
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_GAS_PRICE,
+        DEFAULT_RUN_GENESIS_REQUEST,
+    },
+    AccountHash, DEFAULT_ACCOUNT_ADDR,
+};
+use casper_execution_engine::{
+    core::{
+        engine_state::{Error, ExecuteRequest},
+        execution,
+    },
+    shared::{gas::Gas, motes::Motes},
+    storage::protocol_data::DEFAULT_WASMLESS_TRANSFER_COST,
+};
+use casper_types::{mint, proof_of_stake, runtime_args, ApiError, RuntimeArgs, U512};
+
+const PRIORITIZED_GAS_PRICE: u64 = DEFAULT_GAS_PRICE * 7;
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
+
+fn setup() -> InMemoryWasmTestBuilder {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&*DEFAULT_RUN_GENESIS_REQUEST);
+    builder
+}
+
+fn expect_charge_for_error(
+    builder: &mut InMemoryWasmTestBuilder,
+    request: ExecuteRequest,
+) -> Error {
+    let transfer_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
+    let transfer_cost_motes =
+        Motes::from_gas(transfer_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+
+    let default_account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have default account");
+    let main_purse = default_account.main_purse();
+    let purse_balance_before = builder.get_purse_balance(main_purse);
+    let proposer_purse_balance_before = builder.get_proposer_purse_balance();
+
+    builder.exec(request).commit();
+
+    let purse_balance_after = builder.get_purse_balance(main_purse);
+    let proposer_purse_balance_after = builder.get_proposer_purse_balance();
+
+    let response = builder
+        .get_exec_result(0)
+        .expect("should have result")
+        .get(0)
+        .expect("should have first result");
+    assert_eq!(response.cost(), transfer_cost);
+    assert_eq!(
+        purse_balance_before - transfer_cost_motes.value(),
+        purse_balance_after
+    );
+    assert_eq!(
+        proposer_purse_balance_before + transfer_cost_motes.value(),
+        proposer_purse_balance_after
+    );
+
+    // Verify PoS postconditions
+
+    let pos = builder.get_pos_contract();
+    let payment_purse = pos
+        .named_keys()
+        .get(proof_of_stake::POS_PAYMENT_PURSE)
+        .expect("should have pos payment purse")
+        .into_uref()
+        .expect("should have uref");
+    let payment_purse_balance = builder.get_purse_balance(payment_purse);
+
+    assert_eq!(payment_purse_balance, U512::zero());
+
+    response.as_error().cloned().expect("should have error")
+}
+
+#[ignore]
+#[test]
+fn should_properly_charge_with_nondefault_gas_price() {
+    let transfer_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
+    let transfer_cost_motes =
+        Motes::from_gas(transfer_cost, PRIORITIZED_GAS_PRICE).expect("gas overflow");
+    let transfer_amount = Motes::new(U512::one());
+
+    let id: Option<u64> = None;
+
+    let transfer_args = runtime_args! {
+        mint::ARG_TARGET => ACCOUNT_1_ADDR,
+        mint::ARG_AMOUNT => transfer_amount.value(),
+        mint::ARG_ID => id,
+    };
+    let transfer_request = {
+        let deploy_item = DeployItemBuilder::new()
+            .with_address(*DEFAULT_ACCOUNT_ADDR)
+            .with_empty_payment_bytes(runtime_args! {})
+            .with_transfer_args(transfer_args)
+            .with_authorization_keys(&[*DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash([42; 32])
+            .with_gas_price(PRIORITIZED_GAS_PRICE)
+            .build();
+        ExecuteRequestBuilder::from_deploy_item(deploy_item).build()
+    };
+
+    let mut builder = setup();
+    let default_account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have default account");
+    let main_purse = default_account.main_purse();
+    let purse_balance_before = builder.get_purse_balance(main_purse);
+    let proposer_purse_balance_before = builder.get_proposer_purse_balance();
+
+    builder.exec(transfer_request).commit();
+
+    let purse_balance_after = builder.get_purse_balance(main_purse);
+    let proposer_purse_balance_after = builder.get_proposer_purse_balance();
+
+    let response = builder
+        .get_exec_result(0)
+        .expect("should have result")
+        .get(0)
+        .expect("should have first result");
+    assert_eq!(response.cost(), transfer_cost);
+    assert_eq!(
+        purse_balance_before - transfer_cost_motes.value() - transfer_amount.value(),
+        purse_balance_after
+    );
+    assert_eq!(
+        proposer_purse_balance_before + transfer_cost_motes.value(),
+        proposer_purse_balance_after
+    );
+}
+
+#[ignore]
+#[test]
+fn should_charge_for_wasmless_transfer_missing_args() {
+    let transfer_args = RuntimeArgs::new();
+    let transfer_request =
+        ExecuteRequestBuilder::transfer(*DEFAULT_ACCOUNT_ADDR, transfer_args).build();
+
+    let mut builder = setup();
+    let error = expect_charge_for_error(&mut builder, transfer_request);
+
+    assert!(matches!(
+        error,
+        Error::Exec(execution::Error::Revert(ApiError::MissingArgument))
+    ));
+}
+
+#[ignore]
+#[test]
+fn should_charge_for_wasmless_transfer_invalid_purse() {
+    let mut builder = setup();
+    let default_account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have default account");
+    let main_purse = default_account.main_purse();
+
+    let id: Option<u64> = None;
+
+    let transfer_args = runtime_args! {
+        mint::ARG_TARGET => main_purse,
+        mint::ARG_AMOUNT => U512::one(),
+        mint::ARG_ID => id,
+    };
+
+    let transfer_request =
+        ExecuteRequestBuilder::transfer(*DEFAULT_ACCOUNT_ADDR, transfer_args).build();
+
+    let error = expect_charge_for_error(&mut builder, transfer_request);
+    assert!(matches!(
+        error,
+        Error::Exec(execution::Error::Revert(ApiError::InvalidPurse))
+    ));
+}

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -6,6 +6,7 @@ mod ee_1120;
 mod ee_1129;
 mod ee_1152;
 mod ee_1160;
+mod ee_1163;
 mod ee_221;
 mod ee_401;
 mod ee_441;

--- a/execution_engine_testing/tests/src/test/wasmless_transfer.rs
+++ b/execution_engine_testing/tests/src/test/wasmless_transfer.rs
@@ -1,7 +1,7 @@
 use casper_engine_test_support::{
     internal::{
         DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
-        DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST,
+        DEFAULT_GAS_PRICE, DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST,
     },
     DEFAULT_ACCOUNT_ADDR,
 };
@@ -10,10 +10,14 @@ use casper_execution_engine::{
         engine_state::{upgrade::ActivationPoint, Error as CoreError},
         execution::Error as ExecError,
     },
-    shared::system_config::{
-        auction_costs::AuctionCosts, mint_costs::MintCosts,
-        proof_of_stake_costs::ProofOfStakeCosts, standard_payment_costs::StandardPaymentCosts,
-        SystemConfig,
+    shared::{
+        gas::Gas,
+        motes::Motes,
+        system_config::{
+            auction_costs::AuctionCosts, mint_costs::MintCosts,
+            proof_of_stake_costs::ProofOfStakeCosts, standard_payment_costs::StandardPaymentCosts,
+            SystemConfig,
+        },
     },
     storage::protocol_data::DEFAULT_WASMLESS_TRANSFER_COST,
 };
@@ -143,8 +147,12 @@ fn transfer_wasmless(wasmless_transfer: WasmlessTransfer) {
         .expect_success()
         .commit();
 
+    let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
+    let wasmless_transfer_cost =
+        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+
     assert_eq!(
-        account_1_starting_balance - transfer_amount - U512::from(DEFAULT_WASMLESS_TRANSFER_COST),
+        account_1_starting_balance - transfer_amount - wasmless_transfer_cost.value(),
         builder.get_purse_balance(account_1_purse),
         "account 1 ending balance incorrect"
     );
@@ -518,6 +526,10 @@ fn invalid_transfer_wasmless(invalid_wasmless_transfer: InvalidWasmlessTransfer)
 #[ignore]
 #[test]
 fn transfer_wasmless_should_create_target_if_it_doesnt_exist() {
+    let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
+    let wasmless_transfer_cost =
+        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+
     let create_account_2: bool = false;
     let mut builder = init_wasmless_transform_builder(create_account_2);
     let transfer_amount: U512 = U512::from(1000);
@@ -563,7 +575,7 @@ fn transfer_wasmless_should_create_target_if_it_doesnt_exist() {
     let account_2_starting_balance = builder.get_purse_balance(account_2.main_purse());
 
     assert_eq!(
-        account_1_starting_balance - transfer_amount - U512::from(DEFAULT_WASMLESS_TRANSFER_COST),
+        account_1_starting_balance - transfer_amount - wasmless_transfer_cost.value(),
         builder.get_purse_balance(account_1_purse),
         "account 1 ending balance incorrect"
     );
@@ -633,6 +645,10 @@ fn init_wasmless_transform_builder(create_account_2: bool) -> InMemoryWasmTestBu
 #[ignore]
 #[test]
 fn transfer_wasmless_should_fail_without_main_purse_minimum_balance() {
+    let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
+    let wasmless_transfer_cost =
+        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+
     let create_account_2: bool = false;
     let mut builder = init_wasmless_transform_builder(create_account_2);
     let account_1_to_account_2_amount: U512 =
@@ -680,9 +696,7 @@ fn transfer_wasmless_should_fail_without_main_purse_minimum_balance() {
     let account_2_starting_balance = builder.get_purse_balance(account_2.main_purse());
 
     assert_eq!(
-        account_1_starting_balance
-            - account_1_to_account_2_amount
-            - U512::from(DEFAULT_WASMLESS_TRANSFER_COST),
+        account_1_starting_balance - account_1_to_account_2_amount - wasmless_transfer_cost.value(),
         builder.get_purse_balance(account_1_purse),
         "account 1 ending balance incorrect"
     );
@@ -692,7 +706,7 @@ fn transfer_wasmless_should_fail_without_main_purse_minimum_balance() {
     );
 
     // Another transfer but this time created account tries to do a transfer
-    assert!(account_2_to_account_1_amount < U512::from(DEFAULT_WASMLESS_TRANSFER_COST));
+    assert!(account_2_to_account_1_amount < wasmless_transfer_cost.value());
     let runtime_args = runtime_args! {
        mint::ARG_TARGET => ACCOUNT_1_ADDR,
        mint::ARG_AMOUNT => account_2_to_account_1_amount,
@@ -725,10 +739,13 @@ fn transfer_wasmless_should_fail_without_main_purse_minimum_balance() {
 #[ignore]
 #[test]
 fn transfer_wasmless_should_transfer_funds_after_paying_for_transfer() {
+    let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
+    let wasmless_transfer_cost =
+        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+
     let create_account_2: bool = false;
     let mut builder = init_wasmless_transform_builder(create_account_2);
-    let account_1_to_account_2_amount: U512 =
-        U512::from(DEFAULT_WASMLESS_TRANSFER_COST) + U512::one();
+    let account_1_to_account_2_amount: U512 = wasmless_transfer_cost.value() + U512::one();
     // This transfer should succeed as after paying for execution of wasmless transfer account_2's
     // main purse would contain exactly 1 token.
     let account_2_to_account_1_amount: U512 = U512::one();
@@ -774,9 +791,7 @@ fn transfer_wasmless_should_transfer_funds_after_paying_for_transfer() {
     let account_2_starting_balance = builder.get_purse_balance(account_2.main_purse());
 
     assert_eq!(
-        account_1_starting_balance
-            - account_1_to_account_2_amount
-            - U512::from(DEFAULT_WASMLESS_TRANSFER_COST),
+        account_1_starting_balance - account_1_to_account_2_amount - wasmless_transfer_cost.value(),
         builder.get_purse_balance(account_1_purse),
         "account 1 ending balance incorrect"
     );
@@ -786,7 +801,7 @@ fn transfer_wasmless_should_transfer_funds_after_paying_for_transfer() {
     );
 
     // Another transfer but this time created account tries to do a transfer
-    assert!(account_2_to_account_1_amount <= U512::from(DEFAULT_WASMLESS_TRANSFER_COST));
+    assert!(account_2_to_account_1_amount <= wasmless_transfer_cost.value());
     let runtime_args = runtime_args! {
        mint::ARG_TARGET => ACCOUNT_1_ADDR,
        mint::ARG_AMOUNT => account_2_to_account_1_amount,
@@ -871,17 +886,22 @@ fn transfer_wasmless_should_fail_with_secondary_purse_insufficient_funds() {
 #[ignore]
 #[test]
 fn transfer_wasmless_should_observe_upgraded_cost() {
+    let new_wasmless_transfer_cost_value = DEFAULT_WASMLESS_TRANSFER_COST * 2;
+
+    let new_wasmless_transfer_gas_cost = Gas::from(new_wasmless_transfer_cost_value);
+    let new_wasmless_transfer_cost =
+        Motes::from_gas(new_wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+
     let transfer_amount = U512::one();
     const DEFAULT_ACTIVATION_POINT: ActivationPoint = 1;
 
-    let new_wasmless_transfer_cost = DEFAULT_WASMLESS_TRANSFER_COST * 2;
     let new_auction_costs = AuctionCosts::default();
     let new_mint_costs = MintCosts::default();
     let new_proof_of_stake_costs = ProofOfStakeCosts::default();
     let new_standard_payment_costs = StandardPaymentCosts::default();
 
     let new_system_config = SystemConfig::new(
-        new_wasmless_transfer_cost,
+        new_wasmless_transfer_cost_value,
         new_auction_costs,
         new_mint_costs,
         new_proof_of_stake_costs,
@@ -941,7 +961,7 @@ fn transfer_wasmless_should_observe_upgraded_cost() {
     let default_account_balance_after = builder.get_purse_balance(default_account.main_purse());
 
     assert_eq!(
-        default_account_balance_before - transfer_amount - new_wasmless_transfer_cost,
+        default_account_balance_before - transfer_amount - new_wasmless_transfer_cost.value(),
         default_account_balance_after,
         "expected wasmless transfer cost to be {} but it was {}",
         new_wasmless_transfer_cost,

--- a/execution_engine_testing/tests/src/test/wasmless_transfer.rs
+++ b/execution_engine_testing/tests/src/test/wasmless_transfer.rs
@@ -1,13 +1,15 @@
 use casper_engine_test_support::{
     internal::{
         DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
-        DEFAULT_GAS_PRICE, DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST,
+        DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, DEFAULT_RUN_GENESIS_REQUEST,
     },
     DEFAULT_ACCOUNT_ADDR,
 };
 use casper_execution_engine::{
     core::{
-        engine_state::{upgrade::ActivationPoint, Error as CoreError},
+        engine_state::{
+            upgrade::ActivationPoint, Error as CoreError, WASMLESS_TRANSFER_FIXED_GAS_PRICE,
+        },
         execution::Error as ExecError,
     },
     shared::{
@@ -148,8 +150,11 @@ fn transfer_wasmless(wasmless_transfer: WasmlessTransfer) {
         .commit();
 
     let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
-    let wasmless_transfer_cost =
-        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+    let wasmless_transfer_cost = Motes::from_gas(
+        wasmless_transfer_gas_cost,
+        WASMLESS_TRANSFER_FIXED_GAS_PRICE,
+    )
+    .expect("gas overflow");
 
     assert_eq!(
         account_1_starting_balance - transfer_amount - wasmless_transfer_cost.value(),
@@ -527,8 +532,11 @@ fn invalid_transfer_wasmless(invalid_wasmless_transfer: InvalidWasmlessTransfer)
 #[test]
 fn transfer_wasmless_should_create_target_if_it_doesnt_exist() {
     let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
-    let wasmless_transfer_cost =
-        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+    let wasmless_transfer_cost = Motes::from_gas(
+        wasmless_transfer_gas_cost,
+        WASMLESS_TRANSFER_FIXED_GAS_PRICE,
+    )
+    .expect("gas overflow");
 
     let create_account_2: bool = false;
     let mut builder = init_wasmless_transform_builder(create_account_2);
@@ -646,8 +654,11 @@ fn init_wasmless_transform_builder(create_account_2: bool) -> InMemoryWasmTestBu
 #[test]
 fn transfer_wasmless_should_fail_without_main_purse_minimum_balance() {
     let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
-    let wasmless_transfer_cost =
-        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+    let wasmless_transfer_cost = Motes::from_gas(
+        wasmless_transfer_gas_cost,
+        WASMLESS_TRANSFER_FIXED_GAS_PRICE,
+    )
+    .expect("gas overflow");
 
     let create_account_2: bool = false;
     let mut builder = init_wasmless_transform_builder(create_account_2);
@@ -740,8 +751,11 @@ fn transfer_wasmless_should_fail_without_main_purse_minimum_balance() {
 #[test]
 fn transfer_wasmless_should_transfer_funds_after_paying_for_transfer() {
     let wasmless_transfer_gas_cost = Gas::from(DEFAULT_WASMLESS_TRANSFER_COST);
-    let wasmless_transfer_cost =
-        Motes::from_gas(wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+    let wasmless_transfer_cost = Motes::from_gas(
+        wasmless_transfer_gas_cost,
+        WASMLESS_TRANSFER_FIXED_GAS_PRICE,
+    )
+    .expect("gas overflow");
 
     let create_account_2: bool = false;
     let mut builder = init_wasmless_transform_builder(create_account_2);
@@ -889,8 +903,11 @@ fn transfer_wasmless_should_observe_upgraded_cost() {
     let new_wasmless_transfer_cost_value = DEFAULT_WASMLESS_TRANSFER_COST * 2;
 
     let new_wasmless_transfer_gas_cost = Gas::from(new_wasmless_transfer_cost_value);
-    let new_wasmless_transfer_cost =
-        Motes::from_gas(new_wasmless_transfer_gas_cost, DEFAULT_GAS_PRICE).expect("gas overflow");
+    let new_wasmless_transfer_cost = Motes::from_gas(
+        new_wasmless_transfer_gas_cost,
+        WASMLESS_TRANSFER_FIXED_GAS_PRICE,
+    )
+    .expect("gas overflow");
 
     let transfer_amount = U512::one();
     const DEFAULT_ACTIVATION_POINT: ActivationPoint = 1;


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1163

- This PR will now use a precomputed finalization result for user errors (https://github.com/CasperLabs/casperlabs-node/blob/4ad2e250ac839c41c9761e1aaba3281b17e34bb2/execution_engine/src/core/engine_state/execution_result.rs#L254-L275) in native transfer instead of early exit with 0 cost.
- During refactor I noticed I used wrong field for charging cost of wasmless transfer
- I also verified other test correctness in the meantime by changing default gas price to >1 and corrected failing tests.