### PR TITLE
NO-TICKET: update RPC server

### DIFF
--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -1,17 +1,46 @@
 use std::{convert::Infallible, time::Duration};
 
-use futures::future::{self};
-use hyper::server::{conn::AddrIncoming, Builder};
+use futures::future;
+use http::{Response, StatusCode};
+use hyper::{
+    server::{conn::AddrIncoming, Builder},
+    Body,
+};
+use serde::Serialize;
 use tokio::sync::oneshot;
 use tower::builder::ServiceBuilder;
 use tracing::{info, trace};
-use warp::Filter;
+use warp::{Filter, Rejection};
 
 use super::{
-    rpcs::{self, RpcWithOptionalParamsExt, RpcWithParamsExt, RpcWithoutParamsExt},
+    rpcs::{self, RpcWithOptionalParamsExt, RpcWithParamsExt, RpcWithoutParamsExt, RPC_API_PATH},
     ReactorEventT,
 };
 use crate::effect::EffectBuilder;
+
+// This is a workaround for not being able to create a `warp_json_rpc::Response` without a
+// `warp_json_rpc::Builder`.
+fn new_error_response(error: warp_json_rpc::Error) -> Response<Body> {
+    #[derive(Serialize)]
+    struct JsonRpcErrorResponse {
+        jsonrpc: String,
+        id: Option<()>,
+        error: warp_json_rpc::Error,
+    }
+
+    let json_response = JsonRpcErrorResponse {
+        jsonrpc: "2.0".to_string(),
+        id: None,
+        error,
+    };
+
+    let body = Body::from(serde_json::to_vec(&json_response).unwrap());
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .unwrap()
+}
 
 /// Run the JSON-RPC server.
 pub(super) async fn run<REv: ReactorEventT>(
@@ -33,6 +62,24 @@ pub(super) async fn run<REv: ReactorEventT>(
     let rpc_get_auction_info = rpcs::state::GetAuctionInfo::create_filter(effect_builder);
     let rpc_get_rpcs = rpcs::docs::ListRpcs::create_filter(effect_builder);
 
+    // Catch requests where the method is not one we handle.
+    let unknown_method = warp::path(RPC_API_PATH)
+        .and(warp_json_rpc::filters::json_rpc())
+        .and_then(move |response_builder: warp_json_rpc::Builder| async move {
+            response_builder
+                .error(warp_json_rpc::Error::METHOD_NOT_FOUND)
+                .map_err(|_| warp::reject())
+        });
+
+    // Catch requests which don't parse as JSON.
+    let parse_failure = warp::path(RPC_API_PATH).and_then(move || async move {
+        let error_response = new_error_response(warp_json_rpc::Error::PARSE_ERROR);
+        Ok::<_, Rejection>(error_response)
+    });
+
+    // TODO - we can't catch cases where we should return `warp_json_rpc::Error::INVALID_REQUEST`
+    //        (i.e. where the request is JSON, but not valid JSON-RPC).  This will require an
+    //        update to or move away from warp_json_rpc.
     let service = warp_json_rpc::service(
         rpc_put_deploy
             .or(rpc_get_block)
@@ -45,7 +92,9 @@ pub(super) async fn run<REv: ReactorEventT>(
             .or(rpc_get_status)
             .or(rpc_get_era_info)
             .or(rpc_get_auction_info)
-            .or(rpc_get_rpcs),
+            .or(rpc_get_rpcs)
+            .or(unknown_method)
+            .or(parse_failure),
     );
 
     // Start the server, passing a oneshot receiver to allow the server to be shut down gracefully.


### PR DESCRIPTION
This PR brings the JSON-RPC server more in line with [the error object as defined in the specs](https://www.jsonrpc.org/specification#error_object).

* -32601, "Method not found" is now handled correctly
* -32602, "Invalid params" is now handled correctly
* -32603, "Internal error" is not required
* our server error codes have been negated to fit the range -32000 to -32099

Due to shortcomings in a third-party crate, we're not able to distinguish between an error due to the request containing invalid JSON, or the request containing valid JSON, but not a valid JSON-RPC request.  As such our server returns -32700, "Parse error" for both cases.