### PR TITLE
OP-1807: adding CARGO_FLAGS to cargo-test

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -98,8 +98,8 @@ steps:
   image: casperlabs/node-build-u1804
   commands:
   - make setup
-  - make test
-  - make test-contracts
+  - make test CARGO_FLAGS=--release
+  - make test-contracts CARGO_FLAGS=--release
 
 - name: client-ffi-tests-and-examples
   image: casperlabs/node-build-u1804


### PR DESCRIPTION
Sets `CARGO_FLAGS=--release` for the cargo-test step.

https://casperlabs.atlassian.net/browse/OP-1807