### PR TITLE
NDRS-841: avoid generating the client ffi header in the source tree

### DIFF
--- a/client/build.rs
+++ b/client/build.rs
@@ -5,6 +5,11 @@ fn main() {
 
         use cbindgen::{Builder, Language};
 
+        let output_file = format!(
+            "{}/../../../../headers/casper_client.h",
+            env::var("OUT_DIR").expect("should have env var OUT_DIR set"),
+        );
+
         let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
         Builder::new()
             .with_crate(crate_dir)
@@ -23,6 +28,6 @@ fn main() {
             .include_item("casper_session_params_t")
             .generate()
             .expect("Unable to generate bindings")
-            .write_to_file("headers/casper_client.h");
+            .write_to_file(&output_file);
     }
 }

--- a/client/examples/ffi/CMakeLists.txt
+++ b/client/examples/ffi/CMakeLists.txt
@@ -21,7 +21,7 @@ set(ClientBuiltLibSource "${CMAKE_CURRENT_LIST_DIR}/../../../target/${TARGET_DIR
 # The location of the casper_client library after being moved to the ffi examples build directory.
 set(ClientBuiltLibTarget "${InstallPath}/lib/${ClientLibName}")
 # The initial location of the generated header for the casper_client library.
-set(ClientHeadersDirSource "${CMAKE_CURRENT_LIST_DIR}/../../headers")
+set(ClientHeadersDirSource "${CMAKE_CURRENT_LIST_DIR}/../../../target/headers")
 # The location of the casper_client header after being moved to the ffi examples build directory.
 set(ClientHeadersDirTarget "${InstallPath}/include")
 

--- a/client/examples/ffi/README.md
+++ b/client/examples/ffi/README.md
@@ -14,8 +14,8 @@ cmake --build target/build
 
 In the `target/build` directory which was created, you should see the binaries for the examples that have been compiled.
 
-The build also produces a shared library in `target/build/lib/libcasper_client.so` and its header file in
-`target/build/headers/casper_client.h`.
+The build also produces a shared library in `target/build/installed/lib/libcasper_client.so` and its header file in
+`target/build/installed/include/casper_client.h`.
 
 ```
 #include "casper_client.h


### PR DESCRIPTION
Ref: [NDRS-841](https://casperlabs.atlassian.net/browse/NDRS-841).

This PR makes bindgen generate the C header of our client FFI in the project's target folder rather than the client's source tree.  This allows `cargo publish` to function as expected.