### PR TITLE
NO-TICKET: Revert changes in finality signatures

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{BTreeMap, HashMap},
     convert::Infallible,
     fmt::{self, Display, Formatter},
     marker::PhantomData,
@@ -10,7 +10,7 @@ use derive_more::From;
 use itertools::Itertools;
 use tracing::{debug, error, info, warn};
 
-use casper_types::{ExecutionResult, ProtocolVersion, PublicKey, SemVer};
+use casper_types::{ExecutionResult, ProtocolVersion, PublicKey, SemVer, Signature};
 
 use super::{consensus::EraId, Component};
 use crate::{
@@ -23,7 +23,7 @@ use crate::{
         EffectBuilder, EffectExt, EffectOptionExt, EffectResultExt, Effects, Responder,
     },
     protocol::Message,
-    types::{Block, BlockByHeight, BlockHash, BlockSignatures, DeployHash, FinalitySignature},
+    types::{Block, BlockByHeight, BlockHash, BlockHeader, DeployHash, FinalitySignature},
     NodeRng,
 };
 
@@ -67,13 +67,13 @@ pub enum Event<I> {
         /// The deploys' execution results.
         execution_results: HashMap<DeployHash, ExecutionResult>,
     },
-    /// The result of requesting finality signatures from storage to add pending signatures.
-    GetStoredFinalitySignaturesResult(Box<FinalitySignature>, Option<Box<BlockSignatures>>),
+    /// The result of requesting a block from storage to add a finality signature to it.
+    GetBlockForFinalitySignaturesResult(Box<FinalitySignature>, Option<Box<Block>>),
     /// Check if validator is bonded in the future era.
     /// Validator's public key and the block's era are part of the finality signature.
-    IsBondedFutureEra(Option<Box<BlockSignatures>>, Box<FinalitySignature>),
+    IsBondedFutureEra(Option<Box<Block>>, Box<FinalitySignature>),
     /// Result of testing if creator of the finality signature is bonded validator.
-    IsBonded(Option<Box<BlockSignatures>>, Box<FinalitySignature>, bool),
+    IsBonded(Option<Box<Block>>, Box<FinalitySignature>, bool),
 }
 
 impl<I: Display> Display for Event<I> {
@@ -109,12 +109,12 @@ impl<I: Display> Display for Event<I> {
                 height,
                 block.is_some()
             ),
-            Event::GetStoredFinalitySignaturesResult(finality_signature, maybe_signatures) => {
+            Event::GetBlockForFinalitySignaturesResult(finality_signature, maybe_block) => {
                 write!(
                     f,
-                    "linear chain get-stored-finality-signatures result for {} found: {}",
+                    "linear chain get-block-for-finality-signatures-result for {} found: {}",
                     finality_signature.block_hash,
-                    maybe_signatures.is_some(),
+                    maybe_block.is_some()
                 )
             }
             Event::IsBonded(_block, fs, is_bonded) => {
@@ -135,61 +135,54 @@ impl<I: Display> Display for Event<I> {
     }
 }
 
+// Cache for blocks.
+// Blocks are invalidated when a block for newer era is inserted.
 #[derive(DataSize, Debug)]
-struct SignatureCache {
+struct BlockCache {
     curr_era: EraId,
-    signatures: HashMap<BlockHash, BlockSignatures>,
+    blocks: HashMap<BlockHash, BlockHeader>,
+    proofs: HashMap<BlockHash, BTreeMap<PublicKey, Signature>>,
 }
 
-impl SignatureCache {
+impl BlockCache {
     fn new() -> Self {
-        SignatureCache {
+        BlockCache {
             curr_era: EraId(0),
-            signatures: Default::default(),
+            blocks: Default::default(),
+            proofs: Default::default(),
         }
     }
 
-    fn get(&mut self, hash: &BlockHash, _era_id: EraId) -> Option<BlockSignatures> {
-        self.signatures.get(hash).cloned()
-    }
-
-    fn insert(&mut self, block_signature: BlockSignatures) {
-        // We optimistically assume that most of the signatures that arrive in close temporal
-        // proximity refer to the same era.
-        if self.curr_era < block_signature.era_id {
-            self.signatures.clear();
-            self.curr_era = block_signature.era_id;
-        }
-        match self.signatures.entry(block_signature.block_hash) {
-            Entry::Occupied(mut entry) => {
-                entry.get_mut().proofs.extend(block_signature.proofs);
-            }
-            Entry::Vacant(_) => {
-                self.signatures
-                    .insert(block_signature.block_hash, block_signature);
+    fn get(&self, hash: &BlockHash) -> Option<Block> {
+        let block_header = self.blocks.get(hash)?;
+        let mut block = Block::from_header(block_header.clone());
+        if let Some(proofs) = self.proofs.get(hash) {
+            for (pub_key, sig) in proofs {
+                block.append_proof(*pub_key, *sig);
             }
         }
+        Some(block)
     }
 
-    /// Get signatures from the cache to be updated.
-    /// If there are no signatures, create an empty signature to be updated.
-    fn get_known_signatures(&self, block_hash: &BlockHash, block_era: EraId) -> BlockSignatures {
-        match self.signatures.get(block_hash) {
-            Some(signatures) => signatures.clone(),
-            None => BlockSignatures::new(*block_hash, block_era),
+    /// Inserts new block to the cache.
+    /// Caches block's finality signatures as well.
+    /// If we receive a block from a new era, old era blocks are removed.
+    fn insert(&mut self, block: Block) {
+        let new_block_era = block.header().era_id();
+        if self.curr_era < new_block_era {
+            // We optimistically assume that most of the signatures that arrive in close temporal
+            // proximity refer to the same era.
+            self.blocks.clear();
+            self.proofs.clear();
+            self.curr_era = new_block_era;
         }
-    }
-
-    /// Returns whether finality signature is known already.
-    fn known_signature(&self, fs: &FinalitySignature) -> bool {
-        let FinalitySignature {
-            block_hash,
-            public_key,
-            ..
-        } = fs;
-        self.signatures
-            .get(block_hash)
-            .map_or(false, |bs| bs.has_proof(public_key))
+        if !block.proofs().is_empty() {
+            let entry = self.proofs.entry(*block.hash()).or_default();
+            for (pk, sig) in block.proofs() {
+                entry.insert(*pk, *sig);
+            }
+        }
+        self.blocks.insert(*block.hash(), block.take_header());
     }
 }
 
@@ -199,7 +192,7 @@ pub(crate) struct LinearChain<I> {
     latest_block: Option<Block>,
     /// Finality signatures to be inserted in a block once it is available.
     pending_finality_signatures: HashMap<PublicKey, HashMap<BlockHash, FinalitySignature>>,
-    signature_cache: SignatureCache,
+    block_cache: BlockCache,
     _marker: PhantomData<I>,
 }
 
@@ -208,7 +201,7 @@ impl<I> LinearChain<I> {
         LinearChain {
             latest_block: None,
             pending_finality_signatures: HashMap::new(),
-            signature_cache: SignatureCache::new(),
+            block_cache: BlockCache::new(),
             _marker: PhantomData,
         }
     }
@@ -237,10 +230,9 @@ impl<I> LinearChain<I> {
     /// them, and the updated block.
     fn collect_pending_finality_signatures<REv>(
         &mut self,
-        block_hash: &BlockHash,
-        block_era: EraId,
+        mut block: Block,
         effect_builder: EffectBuilder<REv>,
-    ) -> (BlockSignatures, Effects<Event<I>>)
+    ) -> (Block, Effects<Event<I>>)
     where
         REv: From<StorageRequest>
             + From<ConsensusRequest>
@@ -250,16 +242,15 @@ impl<I> LinearChain<I> {
         I: Display + Send + 'static,
     {
         let mut effects = Effects::new();
-        let mut known_signatures = self
-            .signature_cache
-            .get_known_signatures(block_hash, block_era);
+        let block_hash = block.hash();
         let pending_sigs = self
             .pending_finality_signatures
             .values_mut()
             .filter_map(|sigs| sigs.remove(&block_hash).map(Box::new))
-            .filter(|fs| !known_signatures.proofs.contains_key(&fs.public_key))
+            .filter(|fs| !block.proofs().contains_key(&fs.public_key))
             .collect_vec();
         self.remove_empty_entries();
+        let block_era = block.header().era_id();
         // Add new signatures and send the updated block to storage.
         for fs in pending_sigs {
             if fs.era_id != block_era {
@@ -267,16 +258,16 @@ impl<I> LinearChain<I> {
                 // TODO: disconnect from the sender.
                 continue;
             }
-            if known_signatures.proofs.contains_key(&fs.public_key) {
+            if block.proofs().contains_key(&fs.public_key) {
                 // Don't send finality signatures we already know of.
                 continue;
             }
-            known_signatures.insert_proof(fs.public_key, fs.signature);
+            block.append_proof(fs.public_key, fs.signature);
             let message = Message::FinalitySignature(fs.clone());
             effects.extend(effect_builder.broadcast_message(message).ignore());
             effects.extend(effect_builder.announce_finality_signature(fs).ignore());
         }
-        (known_signatures, effects)
+        (block, effects)
     }
 
     /// Adds finality signature to the collection of pending finality signatures.
@@ -392,14 +383,11 @@ where
                 block,
                 execution_results,
             } => {
-                let (signatures, mut effects) = self.collect_pending_finality_signatures(
-                    block.hash(),
-                    block.header().era_id(),
-                    effect_builder,
-                );
-                // Cache the signature as we expect more finality signatures to arrive soon.
-                self.signature_cache.insert(signatures.clone());
-                effects.extend(effect_builder.put_signatures_to_storage(signatures).ignore());
+                let (block, mut effects) =
+                    self.collect_pending_finality_signatures(*block, effect_builder);
+                // Cache the block as we expect more finality signatures to arrive soon.
+                self.block_cache.insert(block.clone());
+                let block = Box::new(block);
                 effects.extend(effect_builder.put_block_to_storage(block.clone()).event(
                     move |_| Event::PutBlockResult {
                         block,
@@ -438,7 +426,6 @@ where
                 let FinalitySignature {
                     block_hash,
                     public_key,
-                    era_id,
                     ..
                 } = *fs;
                 if let Err(err) = fs.verify() {
@@ -450,60 +437,53 @@ where
                         "finality signature already pending");
                     return Effects::new();
                 }
-                if self.signature_cache.known_signature(&fs) {
-                    debug!(block_hash=%fs.block_hash, public_key=%fs.public_key,
-                        "finality signature is already known");
-                    return Effects::new();
-                }
                 self.add_pending_finality_signature(*fs.clone());
-                match self.signature_cache.get(&block_hash, era_id) {
-                    None => effect_builder
-                        .get_signatures_from_storage(block_hash)
-                        .event(move |maybe_signatures| {
-                            let maybe_box_signatures = maybe_signatures.map(Box::new);
-                            Event::GetStoredFinalitySignaturesResult(fs, maybe_box_signatures)
-                        }),
-                    Some(signatures) => effect_builder.immediately().event(move |_| {
-                        Event::GetStoredFinalitySignaturesResult(fs, Some(Box::new(signatures)))
+                match self.block_cache.get(&block_hash) {
+                    None => effect_builder.get_block_from_storage(block_hash).event(
+                        move |maybe_block| {
+                            let maybe_box_block = maybe_block.map(Box::new);
+                            Event::GetBlockForFinalitySignaturesResult(fs, maybe_box_block)
+                        },
+                    ),
+                    Some(block) => effect_builder.immediately().event(move |_| {
+                        Event::GetBlockForFinalitySignaturesResult(fs, Some(Box::new(block)))
                     }),
                 }
             }
-            Event::GetStoredFinalitySignaturesResult(fs, maybe_signatures) => {
-                if let Some(signatures) = &maybe_signatures {
-                    if signatures.era_id != fs.era_id {
-                        warn!(public_key=%fs.public_key, expected=%signatures.era_id, got=%fs.era_id,
-                            "finality signature with invalid era id.");
+            Event::GetBlockForFinalitySignaturesResult(fs, maybe_block) => {
+                if let Some(block) = &maybe_block {
+                    if block.header().era_id() != fs.era_id {
+                        warn!(public_key=%fs.public_key, "Finality signature with invalid era id.");
                         // TODO: Disconnect from the sender.
-                        self.remove_from_pending_fs(&*fs);
                         return Effects::new();
                     }
                     // Populate cache so that next finality signatures don't have to read from the
-                    // storage. If signature is already from cache then this will be a noop.
-                    self.signature_cache.insert(*signatures.clone());
+                    // storage. If block is already from cache then this will be a noop.
+                    self.block_cache.insert(*block.clone())
                 }
-                // Check if the validator is bonded in the era in which the block was created.
+                // Check if validator is bonded in the era in which the block was created.
                 effect_builder
                     .is_bonded_validator(fs.era_id, fs.public_key)
                     .map(|is_bonded| {
                         if is_bonded {
-                            Ok((maybe_signatures, fs, is_bonded))
+                            Ok((maybe_block, fs, is_bonded))
                         } else {
-                            Err((maybe_signatures, fs))
+                            // If it's not bonded in that era, we will check if it's bonded in the
+                            // future era.
+                            Err((maybe_block, fs))
                         }
                     })
             }
             .result(
-                |(maybe_signatures, fs, is_bonded)| {
-                    Event::IsBonded(maybe_signatures, fs, is_bonded)
-                },
-                |(maybe_signatures, fs)| Event::IsBondedFutureEra(maybe_signatures, fs),
+                |(maybe_block, fs, is_bonded)| Event::IsBonded(maybe_block, fs, is_bonded),
+                |(maybe_block, fs)| Event::IsBondedFutureEra(maybe_block, fs),
             ),
-            Event::IsBondedFutureEra(maybe_signatures, fs) => {
+            Event::IsBondedFutureEra(maybe_block, fs) => {
                 match self.latest_block.as_ref() {
                     // If we don't have any block yet, we cannot determine who is bonded or not.
                     None => effect_builder
                         .immediately()
-                        .event(move |_| Event::IsBonded(maybe_signatures, fs, false)),
+                        .event(move |_| Event::IsBonded(maybe_block, fs, false)),
                     Some(block) => {
                         let latest_header = block.header();
                         let state_root_hash = latest_header.state_root_hash();
@@ -526,7 +506,7 @@ where
                                 }
                             })
                             .result(
-                                |is_bonded| Event::IsBonded(maybe_signatures, fs, is_bonded),
+                                |is_bonded| Event::IsBonded(maybe_block, fs, is_bonded),
                                 |error| {
                                     error!(%error, "is_bonded_in_future_era returned an error.");
                                     panic!("couldn't check if validator is bonded")
@@ -535,17 +515,16 @@ where
                     }
                 }
             }
-            Event::IsBonded(Some(mut signatures), fs, true) => {
+            Event::IsBonded(Some(mut block), fs, true) => {
                 // Known block and signature from a bonded validator.
                 // Check if we had already seen this signature before.
-                let signature_known = signatures
-                    .proofs
+                let signature_known = block
+                    .proofs()
                     .get(&fs.public_key)
                     .iter()
                     .any(|sig| *sig == &fs.signature);
                 // If new, gossip and store.
                 if signature_known {
-                    self.remove_from_pending_fs(&*fs);
                     Effects::new()
                 } else {
                     let message = Message::FinalitySignature(fs.clone());
@@ -555,17 +534,11 @@ where
                             .announce_finality_signature(fs.clone())
                             .ignore(),
                     );
-                    signatures.insert_proof(fs.public_key, fs.signature);
+                    block.append_proof(fs.public_key, fs.signature);
                     // Cache the results in case we receive the same finality signature before we
                     // manage to store it in the database.
-                    self.signature_cache.insert(*signatures.clone());
-                    debug!(hash=%signatures.block_hash, "storing finality signatures");
-                    self.remove_from_pending_fs(&*fs);
-                    effects.extend(
-                        effect_builder
-                            .put_signatures_to_storage(*signatures)
-                            .ignore(),
-                    );
+                    self.block_cache.insert(*block.clone());
+                    effects.extend(effect_builder.put_block_to_storage(block).ignore());
                     effects
                 }
             }

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -188,7 +188,7 @@ where
                 maybe_id: Some(BlockIdentifier::Hash(hash)),
                 responder,
             }) => effect_builder
-                .get_block_with_metadata_from_storage(hash)
+                .get_block_from_storage(hash)
                 .event(move |result| Event::GetBlockResult {
                     maybe_id: Some(BlockIdentifier::Hash(hash)),
                     result: Box::new(result),
@@ -198,7 +198,7 @@ where
                 maybe_id: Some(BlockIdentifier::Height(height)),
                 responder,
             }) => effect_builder
-                .get_block_at_height_with_metadata_from_storage(height)
+                .get_block_at_height_from_storage(height)
                 .event(move |result| Event::GetBlockResult {
                     maybe_id: Some(BlockIdentifier::Height(height)),
                     result: Box::new(result),
@@ -208,7 +208,7 @@ where
                 maybe_id: None,
                 responder,
             }) => effect_builder
-                .get_highest_block_with_metadata_from_storage()
+                .get_highest_block_from_storage()
                 .event(move |result| Event::GetBlockResult {
                     maybe_id: None,
                     result: Box::new(result),

--- a/node/src/components/rpc_server/event.rs
+++ b/node/src/components/rpc_server/event.rs
@@ -14,7 +14,7 @@ use casper_types::{auction::EraValidators, Transfer};
 use crate::{
     effect::{requests::RpcRequest, Responder},
     rpcs::chain::BlockIdentifier,
-    types::{Block, BlockHash, BlockSignatures, Deploy, DeployHash, DeployMetadata, NodeId},
+    types::{Block, BlockHash, Deploy, DeployHash, DeployMetadata, NodeId},
 };
 
 #[derive(Debug, From)]
@@ -23,8 +23,8 @@ pub enum Event {
     RpcRequest(RpcRequest<NodeId>),
     GetBlockResult {
         maybe_id: Option<BlockIdentifier>,
-        result: Box<Option<(Block, BlockSignatures)>>,
-        main_responder: Responder<Option<(Block, BlockSignatures)>>,
+        result: Box<Option<Block>>,
+        main_responder: Responder<Option<Block>>,
     },
     GetBlockTransfersResult {
         block_hash: BlockHash,

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -29,7 +29,7 @@ use crate::{
     effect::EffectBuilder,
     reactor::QueueKind,
     rpcs::common::{self},
-    types::{Block, BlockHash, BlockSignatures, Item, JsonBlock},
+    types::{Block, BlockHash, Item, JsonBlock},
 };
 pub use era_summary::EraSummary;
 use era_summary::ERA_SUMMARY;
@@ -39,7 +39,7 @@ static GET_BLOCK_PARAMS: Lazy<GetBlockParams> = Lazy::new(|| GetBlockParams {
 });
 static GET_BLOCK_RESULT: Lazy<GetBlockResult> = Lazy::new(|| GetBlockResult {
     api_version: CLIENT_API_VERSION.clone(),
-    block: Some(JsonBlock::doc_example().clone()),
+    block: Some(Block::doc_example().clone().into()),
 });
 static GET_BLOCK_TRANSFERS_PARAMS: Lazy<GetBlockTransfersParams> =
     Lazy::new(|| GetBlockTransfersParams {
@@ -127,25 +127,15 @@ impl RpcWithOptionalParamsExt for GetBlock {
         async move {
             // Get the block.
             let maybe_block_id = maybe_params.map(|params| params.block_identifier);
-            let (block, signatures) =
-                match get_block_with_metadata(maybe_block_id, effect_builder).await {
-                    Ok(Some((block, signatures))) => (block, signatures),
-                    Ok(None) => {
-                        let error = warp_json_rpc::Error::custom(
-                            ErrorCode::NoSuchBlock as i64,
-                            "block not known",
-                        );
-                        return Ok(response_builder.error(error)?);
-                    }
-                    Err(error) => return Ok(response_builder.error(error)?),
-                };
-
-            let json_block = JsonBlock::new(block, signatures);
+            let maybe_block = match get_block(maybe_block_id, effect_builder).await {
+                Ok(maybe_block) => maybe_block,
+                Err(error) => return Ok(response_builder.error(error)?),
+            };
 
             // Return the result.
             let result = Self::ResponseResult {
                 api_version: CLIENT_API_VERSION.clone(),
-                block: Some(json_block),
+                block: maybe_block.map(Into::into),
             };
             Ok(response_builder.success(result)?)
         }
@@ -436,25 +426,9 @@ async fn get_block<REv: ReactorEventT>(
     maybe_id: Option<BlockIdentifier>,
     effect_builder: EffectBuilder<REv>,
 ) -> Result<Option<Block>, warp_json_rpc::Error> {
-    match get_block_with_metadata(maybe_id, effect_builder).await {
-        Ok(Some((block, _))) => Ok(Some(block)),
-        Ok(None) => {
-            return Err(warp_json_rpc::Error::custom(
-                ErrorCode::NoSuchBlock as i64,
-                "block not known",
-            ))
-        }
-        Err(error) => Err(error),
-    }
-}
-
-async fn get_block_with_metadata<REv: ReactorEventT>(
-    maybe_id: Option<BlockIdentifier>,
-    effect_builder: EffectBuilder<REv>,
-) -> Result<Option<(Block, BlockSignatures)>, warp_json_rpc::Error> {
     // Get the block from storage or the latest from the linear chain.
     let getting_specific_block = maybe_id.is_some();
-    let maybe_result = effect_builder
+    let maybe_block = effect_builder
         .make_request(
             |responder| RpcRequest::GetBlock {
                 maybe_id,
@@ -464,7 +438,7 @@ async fn get_block_with_metadata<REv: ReactorEventT>(
         )
         .await;
 
-    if maybe_result.is_none() && getting_specific_block {
+    if maybe_block.is_none() && getting_specific_block {
         info!("failed to get {:?} from storage", maybe_id.unwrap());
         return Err(warp_json_rpc::Error::custom(
             ErrorCode::NoSuchBlock as i64,
@@ -472,5 +446,5 @@ async fn get_block_with_metadata<REv: ReactorEventT>(
         ));
     }
 
-    Ok(maybe_result)
+    Ok(maybe_block)
 }

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -341,7 +341,7 @@ impl RpcWithoutParamsExt for GetAuctionInfo {
                             error_msg,
                         ))?);
                     }
-                    Some((block, _)) => block,
+                    Some(block) => block,
                 }
             };
 

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -71,7 +71,7 @@ use crate::{
         EffectBuilder, EffectExt, Effects,
     },
     fatal,
-    types::{Block, BlockHash, BlockSignatures, Chainspec, Deploy, DeployHash, DeployMetadata},
+    types::{Block, BlockHash, Chainspec, Deploy, DeployHash, DeployMetadata},
     utils::WithDir,
     NodeRng,
 };
@@ -175,9 +175,6 @@ pub struct Storage {
     /// The block database.
     #[data_size(skip)]
     block_db: Database,
-    /// The block metadata db.
-    #[data_size(skip)]
-    block_metadata_db: Database,
     /// The deploy database.
     #[data_size(skip)]
     deploy_db: Database,
@@ -258,7 +255,6 @@ impl Storage {
             .open(&root.join(STORAGE_DB_FILENAME))?;
 
         let block_db = env.create_db(Some("blocks"), DatabaseFlags::empty())?;
-        let block_metadata_db = env.create_db(Some("block_metadata"), DatabaseFlags::empty())?;
         let deploy_db = env.create_db(Some("deploys"), DatabaseFlags::empty())?;
         let deploy_metadata_db = env.create_db(Some("deploy_metadata"), DatabaseFlags::empty())?;
         let transfer_db = env.create_db(Some("transfer"), DatabaseFlags::empty())?;
@@ -295,7 +291,6 @@ impl Storage {
             root,
             env,
             block_db,
-            block_metadata_db,
             deploy_db,
             deploy_metadata_db,
             transfer_db,
@@ -526,69 +521,6 @@ impl Storage {
                     .unwrap_or_default();
                 responder.respond(Some((deploy, metadata))).ignore()
             }
-            StorageRequest::GetBlockAndMetadataByHash {
-                block_hash,
-                responder,
-            } => {
-                let mut txn = self.env.begin_ro_txn()?;
-
-                let block: Block = if let Some(block) =
-                    self.get_single_block(&mut self.env.begin_ro_txn()?, &block_hash)?
-                {
-                    block
-                } else {
-                    return Ok(responder.respond(None).ignore());
-                };
-                // Check that the hash of the block retrieved is correct.
-                assert_eq!(&block_hash, block.hash());
-                let signatures = match self.get_finality_signatures(&mut txn, &block_hash)? {
-                    Some(signatures) => signatures,
-                    None => BlockSignatures::new(block_hash, block.header().era_id()),
-                };
-                responder.respond(Some((block, signatures))).ignore()
-            }
-            StorageRequest::GetBlockAndMetadataByHeight {
-                block_height,
-                responder,
-            } => {
-                let mut txn = self.env.begin_ro_txn()?;
-
-                let block: Block =
-                    if let Some(block) = self.get_block_by_height(&mut txn, block_height)? {
-                        block
-                    } else {
-                        return Ok(responder.respond(None).ignore());
-                    };
-
-                let hash = block.hash();
-                let signatures = match self.get_finality_signatures(&mut txn, hash)? {
-                    Some(signatures) => signatures,
-                    None => BlockSignatures::new(*hash, block.header().era_id()),
-                };
-                responder.respond(Some((block, signatures))).ignore()
-            }
-            StorageRequest::GetHighestBlockWithMetadata { responder } => {
-                let mut txn = self.env.begin_ro_txn()?;
-                let highest_block: Block = if let Some(block) = self
-                    .block_height_index
-                    .keys()
-                    .last()
-                    .and_then(|&height| self.get_block_by_height(&mut txn, height).transpose())
-                    .transpose()?
-                {
-                    block
-                } else {
-                    return Ok(responder.respond(None).ignore());
-                };
-                let hash = highest_block.hash();
-                let signatures = match self.get_finality_signatures(&mut txn, hash)? {
-                    Some(signatures) => signatures,
-                    None => BlockSignatures::new(*hash, highest_block.header().era_id()),
-                };
-                responder
-                    .respond(Some((highest_block, signatures)))
-                    .ignore()
-            }
             StorageRequest::PutChainspec {
                 chainspec,
                 responder,
@@ -601,39 +533,6 @@ impl Storage {
                 version: _version,
                 responder,
             } => responder.respond(self.chainspec_cache.clone()).ignore(),
-            StorageRequest::PutBlockSignatures {
-                signatures,
-                responder,
-            } => {
-                let mut txn = self.env.begin_rw_txn()?;
-                let old_data: Option<BlockSignatures> =
-                    txn.get_value(self.block_metadata_db, &signatures.block_hash)?;
-                let new_data = match old_data {
-                    None => signatures,
-                    Some(mut data) => {
-                        for (pk, sig) in signatures.proofs {
-                            data.insert_proof(pk, sig);
-                        }
-                        data
-                    }
-                };
-                let outcome = txn.put_value(
-                    self.block_metadata_db,
-                    &new_data.block_hash,
-                    &new_data,
-                    true,
-                )?;
-                txn.commit()?;
-                responder.respond(outcome).ignore()
-            }
-            StorageRequest::GetBlockSignatures {
-                block_hash,
-                responder,
-            } => {
-                let result =
-                    self.get_finality_signatures(&mut self.env.begin_ro_txn()?, &block_hash)?;
-                responder.respond(result).ignore()
-            }
         })
     }
 
@@ -704,15 +603,6 @@ impl Storage {
         block_hash: &BlockHash,
     ) -> Result<Option<Vec<Transfer>>, Error> {
         Ok(tx.get_value(self.transfer_db, block_hash)?)
-    }
-
-    /// Retrieves finality signatures for a block with a given block hash
-    fn get_finality_signatures<Tx: Transaction>(
-        &self,
-        tx: &mut Tx,
-        block_hash: &BlockHash,
-    ) -> Result<Option<BlockSignatures>, Error> {
-        Ok(tx.get_value(self.block_metadata_db, block_hash)?)
     }
 }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -111,9 +111,9 @@ use crate::{
     effect::requests::LinearChainRequest,
     reactor::{EventQueueHandle, QueueKind},
     types::{
-        ActivationPoint, Block, BlockByHeight, BlockHash, BlockHeader, BlockLike, BlockSignatures,
-        Chainspec, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
-        FinalizedBlock, Item, ProtoBlock, Timestamp,
+        ActivationPoint, Block, BlockByHeight, BlockHash, BlockHeader, BlockLike, Chainspec,
+        Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature, FinalizedBlock, Item,
+        ProtoBlock, Timestamp,
     },
     utils::Source,
 };
@@ -685,39 +685,6 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Gets the requested signatures for a given block hash.
-    pub(crate) async fn get_signatures_from_storage(
-        self,
-        block_hash: BlockHash,
-    ) -> Option<BlockSignatures>
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::GetBlockSignatures {
-                block_hash,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    /// Puts the requested finality signatures into storage.
-    pub(crate) async fn put_signatures_to_storage(self, signatures: BlockSignatures) -> bool
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::PutBlockSignatures {
-                signatures,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
     /// Gets the requested block's transfers from storage.
     pub(crate) async fn get_block_transfers_from_storage(
         self,
@@ -885,56 +852,6 @@ impl<REv> EffectBuilder<REv> {
                 deploy_hash,
                 responder,
             },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    /// Gets the requested block and its associated metadata.
-    pub(crate) async fn get_block_at_height_with_metadata_from_storage(
-        self,
-        block_height: u64,
-    ) -> Option<(Block, BlockSignatures)>
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::GetBlockAndMetadataByHeight {
-                block_height,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    /// Gets the requested block by hash with its associated metadata.
-    pub(crate) async fn get_block_with_metadata_from_storage(
-        self,
-        block_hash: BlockHash,
-    ) -> Option<(Block, BlockSignatures)>
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::GetBlockAndMetadataByHash {
-                block_hash,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    /// Get the highest block with its associated metadata.
-    pub(crate) async fn get_highest_block_with_metadata_from_storage(
-        self,
-    ) -> Option<(Block, BlockSignatures)>
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::GetHighestBlockWithMetadata { responder },
             QueueKind::Regular,
         )
         .await

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -47,9 +47,9 @@ use crate::{
     crypto::hash::Digest,
     rpcs::chain::BlockIdentifier,
     types::{
-        ActivationPoint, Block as LinearBlock, Block, BlockHash, BlockHeader, BlockSignatures,
-        Chainspec, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
-        FinalizedBlock, Item, ProtoBlock, StatusFeed, Timestamp,
+        ActivationPoint, Block as LinearBlock, Block, BlockHash, BlockHeader, Chainspec, Deploy,
+        DeployHash, DeployHeader, DeployMetadata, FinalitySignature, FinalizedBlock, Item,
+        ProtoBlock, StatusFeed, Timestamp,
     },
     utils::DisplayIter,
 };
@@ -298,25 +298,6 @@ pub enum StorageRequest {
         /// Responder to call with the results.
         responder: Responder<Option<(Deploy, DeployMetadata)>>,
     },
-    /// Retrieve block and its metadata by its hash.
-    GetBlockAndMetadataByHash {
-        /// The hash of the block.
-        block_hash: BlockHash,
-        /// The responder to call with the results.
-        responder: Responder<Option<(Block, BlockSignatures)>>,
-    },
-    /// Retrieve block and its metadata at a given height.
-    GetBlockAndMetadataByHeight {
-        /// The height of the block.
-        block_height: BlockHeight,
-        /// The responder to call with the results.
-        responder: Responder<Option<(Block, BlockSignatures)>>,
-    },
-    /// Get the highest block and its metadata.
-    GetHighestBlockWithMetadata {
-        /// The responder to call the results with.
-        responder: Responder<Option<(Block, BlockSignatures)>>,
-    },
     /// Store given chainspec.
     PutChainspec {
         /// Chainspec.
@@ -330,21 +311,6 @@ pub enum StorageRequest {
         version: Version,
         /// Responder to call with the result.
         responder: Responder<Option<Arc<Chainspec>>>,
-    },
-    /// Get finality signatures for a Block hash.
-    GetBlockSignatures {
-        /// The hash for the request
-        block_hash: BlockHash,
-        /// Responder to call with the result.
-        responder: Responder<Option<BlockSignatures>>,
-    },
-    /// Store finality signatures.
-    PutBlockSignatures {
-        /// Signatures that are to be stored.
-        signatures: BlockSignatures,
-        /// Responder to call with the result, if true then the signatures were successfully
-        /// stored.
-        responder: Responder<bool>,
     },
 }
 
@@ -384,23 +350,6 @@ impl Display for StorageRequest {
             StorageRequest::GetDeployAndMetadata { deploy_hash, .. } => {
                 write!(formatter, "get deploy and metadata for {}", deploy_hash)
             }
-            StorageRequest::GetBlockAndMetadataByHash { block_hash, .. } => {
-                write!(
-                    formatter,
-                    "get block and metadata for block with hash: {}",
-                    block_hash
-                )
-            }
-            StorageRequest::GetBlockAndMetadataByHeight { block_height, .. } => {
-                write!(
-                    formatter,
-                    "get block and metadata for block at height: {}",
-                    block_height
-                )
-            }
-            StorageRequest::GetHighestBlockWithMetadata { .. } => {
-                write!(formatter, "get highest block with metadata")
-            }
             StorageRequest::PutChainspec { chainspec, .. } => {
                 write!(
                     formatter,
@@ -410,16 +359,6 @@ impl Display for StorageRequest {
             }
             StorageRequest::GetChainspec { version, .. } => {
                 write!(formatter, "get chainspec {}", version)
-            }
-            StorageRequest::GetBlockSignatures { block_hash, .. } => {
-                write!(
-                    formatter,
-                    "get finality signatures for block hash {}",
-                    block_hash
-                )
-            }
-            StorageRequest::PutBlockSignatures { .. } => {
-                write!(formatter, "put finality signatures")
             }
         }
     }
@@ -520,13 +459,13 @@ pub enum RpcRequest<I> {
         /// Responder to call.
         responder: Responder<Result<(), Error>>,
     },
-    /// If `maybe_identifier` is `Some`, return the specified block if it exists, else `None`.  If
-    /// `maybe_identifier` is `None`, return the latest block.
+    /// If `maybe_hash` is `Some`, return the specified block if it exists, else `None`.  If
+    /// `maybe_hash` is `None`, return the latest block.
     GetBlock {
-        /// The identifier (can either be a hash or the height) of the block to be retrieved.
+        /// The hash of the block to be retrieved.
         maybe_id: Option<BlockIdentifier>,
         /// Responder to call with the result.
-        responder: Responder<Option<(LinearBlock, BlockSignatures)>>,
+        responder: Responder<Option<LinearBlock>>,
     },
     /// Return transfers for block by hash (if any).
     GetBlockTransfers {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -73,7 +73,6 @@ use crate::{
 use memory_metrics::MemoryMetrics;
 
 /// Top-level event for the reactor.
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, From, Serialize)]
 #[must_use]
 pub enum Event {

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -16,8 +16,8 @@ use rand::{CryptoRng, RngCore};
 use rand_chacha::ChaCha20Rng;
 
 pub use block::{
-    json_compatibility::JsonBlock, Block, BlockHash, BlockHeader, BlockSignatures,
-    BlockValidationError, FinalitySignature,
+    json_compatibility::JsonBlock, Block, BlockHash, BlockHeader, BlockValidationError,
+    FinalitySignature,
 };
 pub(crate) use block::{BlockByHeight, BlockLike, FinalizedBlock, ProtoBlock};
 pub(crate) use chainspec::ActivationPoint;


### PR DESCRIPTION
Reverted changes made by NDRS-767: Remove Finality Signatures from Block