### PR TITLE
NO-TICKET: fix short-circuit in Runtime::transfer_to_account

### DIFF
--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -2943,7 +2943,7 @@ where
             }
             Some(StoredValue::Account(account)) => {
                 let target_uref = account.main_purse_add_only();
-                if source == target_uref {
+                if source.with_access_rights(AccessRights::ADD) == target_uref {
                     return Ok(Ok(TransferredTo::ExistingAccount));
                 }
                 // If an account exists, transfer the amount to its purse


### PR DESCRIPTION
No functional changes here, just joticed that this check wasn't correctly factoring in access rights so that we weren't actually short-circuiting when transferring from a given source to itself. 