### PR TITLE
NDRS-840: replace hard-coded prococol versions

### DIFF
--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -23,7 +23,7 @@ mod event;
 mod filters;
 mod http_server;
 
-use std::{convert::Infallible, fmt::Debug};
+use std::{convert::Infallible, fmt::Debug, sync::Arc};
 
 use datasize::DataSize;
 use futures::{future::BoxFuture, join, FutureExt};
@@ -37,7 +37,7 @@ use crate::{
         EffectBuilder, EffectExt, Effects,
     },
     reactor::Finalize,
-    types::{NodeId, StatusFeed},
+    types::{Chainspec, NodeId, StatusFeed},
     utils::{self, ListeningError},
     NodeRng,
 };
@@ -76,12 +76,14 @@ pub(crate) struct RestServer {
     shutdown_sender: oneshot::Sender<()>,
     /// The task handle which will only join once the server loop has exited.
     server_join_handle: Option<JoinHandle<()>>,
+    chainspec: Arc<Chainspec>,
 }
 
 impl RestServer {
     pub(crate) fn new<REv>(
         config: Config,
         effect_builder: EffectBuilder<REv>,
+        chainspec: Arc<Chainspec>,
     ) -> Result<Self, ListeningError>
     where
         REv: ReactorEventT,
@@ -99,6 +101,7 @@ impl RestServer {
         Ok(RestServer {
             shutdown_sender,
             server_join_handle: Some(server_join_handle),
+            chainspec,
         })
     }
 }

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -30,7 +30,7 @@ pub use item::{Item, Tag};
 pub use node_config::NodeConfig;
 pub(crate) use node_id::NodeId;
 pub use peers_map::PeersMap;
-pub use status_feed::{GetStatusResult, StatusFeed};
+pub use status_feed::{ChainspecInfo, GetStatusResult, StatusFeed};
 pub use timestamp::{TimeDiff, Timestamp};
 
 /// An object-safe RNG trait that requires a cryptographically strong random number generator.

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -57,6 +57,9 @@ pub struct Chainspec {
     pub(crate) wasm_config: WasmConfig,
     #[serde(rename = "system_costs")]
     pub(crate) system_costs_config: SystemConfig,
+    #[serde(skip)]
+    /// The state root hash after running EE genesis/upgrade process.
+    pub(crate) state_root_hash: Option<Digest>,
 }
 
 impl Chainspec {


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-860

This PR provides the next upgrade activation point in the status endpoints.

Manual testing via nctl showed that the status endpoints showed correct values for the activation point (`null` at start, then a valid era ID, then an updated era ID).  Example output:

```json
{
  "api_version": "1.0.0",
  "chainspec_name": "casper-net-1",
  "genesis_root_hash": "d166..3f9c",
  "peers": [
    {
      "node_id": "NodeId::P2p(Adei..Pu9v)",
      "address": "/ip4/127.0.0.1/tcp/56468"
    },
    {
      "node_id": "NodeId::P2p(DxxP..FXfi)",
      "address": "/ip4/127.0.0.1/tcp/56440"
    },
    {
      "node_id": "NodeId::P2p(GFf9..5xrb)",
      "address": "/ip4/127.0.0.1/tcp/56492"
    },
    {
      "node_id": "NodeId::P2p(HLDJ..nSvx)",
      "address": "/ip4/127.0.0.1/tcp/56452"
    }
  ],
  "last_added_block_info": {
    "hash": "e7e38f70cd955eb56b87bd8a26499d6c32dce85a74492eb6b973ebadd4afa7c1",
    "timestamp": "2021-02-06T00:50:02.368Z",
    "era_id": 1,
    "height": 19,
    "state_root_hash": "c805380b4d56135523a484ef5ce5e4bbde187ef8be05c434213e7bc1b42b667d",
    "creator": "0164fc6d2faf121bb212e9c2399f10960ee75586ca85f1c7044b5daa6db06b8f59"
  },
  "next_upgrade_activation_point": 42,
  "build_version": "v0.7.0-40-g3b5ea971-3b5ea971"
}
```
Tagging @momipsl & @zie1ony for info due to changed API.