### PR TITLE
NDRS-860: include next upgrade activation point in status endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,10 +175,11 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1679af9a1ab4bea16f228b05d18f8363f8327b1fa8db00d2760cfafc6b61e"
+checksum = "f2475b58cd94eb4f70159f4fd8844ba3b807532fe3131b3373fae060bbe30396"
 dependencies = [
+ "bstr",
  "doc-comment",
  "predicates",
  "predicates-core",
@@ -188,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "assert_matches"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695579f0f2520f3774bb40461e5adb066459d4e0af4d59d20175484fb8e9edf1"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-channel"
@@ -243,7 +244,7 @@ dependencies = [
  "fastrand",
  "futures-lite",
  "libc",
- "log 0.4.13",
+ "log 0.4.14",
  "nb-connect",
  "once_cell",
  "parking",
@@ -288,7 +289,7 @@ dependencies = [
  "futures-lite",
  "gloo-timers",
  "kv-log-macro",
- "log 0.4.13",
+ "log 0.4.14",
  "memchr",
  "num_cpus",
  "once_cell",
@@ -586,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07aa6688c702439a1be0307b6a94dffe1168569e45b9500c1372bc580740d59"
+checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
 
 [[package]]
 name = "byte-tools"
@@ -680,7 +681,7 @@ dependencies = [
  "casper-execution-engine",
  "casper-types",
  "lmdb",
- "log 0.4.13",
+ "log 0.4.14",
  "num-rational 0.3.2",
  "num-traits",
  "once_cell",
@@ -703,7 +704,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel 0.5.0",
  "env_logger",
- "log 0.4.13",
+ "log 0.4.14",
  "num-rational 0.3.2",
  "num-traits",
  "once_cell",
@@ -735,7 +736,7 @@ dependencies = [
  "libc",
  "linked-hash-map",
  "lmdb",
- "log 0.4.13",
+ "log 0.4.14",
  "num",
  "num-derive",
  "num-rational 0.3.2",
@@ -800,7 +801,7 @@ dependencies = [
  "libp2p",
  "linked-hash-map",
  "lmdb",
- "log 0.4.13",
+ "log 0.4.14",
  "multihash",
  "num",
  "num-derive",
@@ -927,7 +928,7 @@ dependencies = [
  "clap",
  "heck",
  "indexmap",
- "log 0.4.13",
+ "log 0.4.14",
  "proc-macro2",
  "quote",
  "serde",
@@ -1387,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bcb9d7dcbf7002aaffbb53eac22906b64cdcc127971dcc387d8eb7c95d5560"
+checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
 dependencies = [
  "quote",
  "syn",
@@ -1421,15 +1422,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "datasize"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c7ae8d503c8e459b16a59846025e61e29427d102558a14112c43ff0c4dd543"
+checksum = "a29aa9e31c464bc82c5965d92a28ff5895df6e5e35b2831fe679ced73c63d908"
 dependencies = [
  "datasize_derive",
  "fake_instant",
@@ -1441,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "datasize_derive"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0deff99fdcea9b202a00910ae90127d96b4bfc68b4a408901481b16581ec8b20"
+checksum = "72ae1242652da371636ee090f259c142d82bd6cbf00496fdf3093fda61683175"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1632,7 +1633,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_bytes",
- "sha2 0.9.2",
+ "sha2 0.9.3",
  "zeroize",
 ]
 
@@ -1820,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.26"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1863,7 +1864,7 @@ checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.13",
+ "log 0.4.14",
  "regex",
  "termcolor",
 ]
@@ -1958,9 +1959,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -2236,7 +2237,7 @@ checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.1+wasi-snapshot-preview1",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2457,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
 
 [[package]]
 name = "httpdate"
@@ -2475,9 +2476,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -2489,7 +2490,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "socket2",
  "tokio",
  "tower-service",
@@ -2512,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -2689,7 +2690,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.9.2",
+ "sha2 0.9.3",
 ]
 
 [[package]]
@@ -2722,7 +2723,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -2739,9 +2740,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
 
 [[package]]
 name = "libp2p"
@@ -2773,7 +2774,7 @@ dependencies = [
  "multihash",
  "parity-multiaddr",
  "parking_lot 0.11.1",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "smallvec",
  "wasm-timer",
 ]
@@ -2793,18 +2794,18 @@ dependencies = [
  "futures-timer",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.13",
+ "log 0.4.14",
  "multihash",
  "multistream-select",
  "parity-multiaddr",
  "parking_lot 0.11.1",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.2",
+ "sha2 0.9.3",
  "smallvec",
  "thiserror",
  "unsigned-varint",
@@ -2841,7 +2842,7 @@ checksum = "436280f5fe21a58fcaff82c2606945579241f32bc0eaf2d39321aa4624a66e7f"
 dependencies = [
  "futures",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -2855,7 +2856,7 @@ dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2877,12 +2878,12 @@ dependencies = [
  "hex_fmt",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "lru_time_cache",
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.2",
+ "sha2 0.9.3",
  "smallvec",
  "unsigned-varint",
  "wasm-timer",
@@ -2897,7 +2898,7 @@ dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "prost",
  "prost-build",
  "smallvec",
@@ -2918,12 +2919,12 @@ dependencies = [
  "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "multihash",
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.2",
+ "sha2 0.9.3",
  "smallvec",
  "uint",
  "unsigned-varint",
@@ -2944,7 +2945,7 @@ dependencies = [
  "lazy_static",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "net2",
  "rand 0.7.3",
  "smallvec",
@@ -2963,7 +2964,7 @@ dependencies = [
  "futures",
  "futures_codec",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
  "nohash-hasher",
  "parking_lot 0.11.1",
  "rand 0.7.3",
@@ -2982,11 +2983,11 @@ dependencies = [
  "futures",
  "lazy_static",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.2",
+ "sha2 0.9.3",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -3002,7 +3003,7 @@ dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "rand 0.7.3",
  "void",
  "wasm-timer",
@@ -3019,7 +3020,7 @@ dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.13",
+ "log 0.4.14",
  "lru",
  "minicbor",
  "rand 0.7.3",
@@ -3037,7 +3038,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
  "rand 0.7.3",
  "smallvec",
  "void",
@@ -3055,7 +3056,7 @@ dependencies = [
  "if-addrs",
  "ipnet",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
  "socket2",
  "tokio",
 ]
@@ -3069,7 +3070,7 @@ dependencies = [
  "async-std",
  "futures",
  "libp2p-core",
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -3161,33 +3162,34 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.13",
+ "log 0.4.14",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
+ "value-bag",
 ]
 
 [[package]]
 name = "lru"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aae342b73d57ad0b8b364bd12584819f2c1fe9114285dfcf8b0722607671635"
+checksum = "fe2382d8ed3918ea4ba70d98d5b74e47a168e0331965f3f17cdbc748bdebc5a3"
 dependencies = [
  "hashbrown",
 ]
 
 [[package]]
 name = "lru_time_cache"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f957950068c53af3b32a1b3a6e69f6dd3c19fa6f0dcc1168b846662d5e10b1"
+checksum = "a559ce34615abd3145e6ca99df0e33ac069dc5298d1bfecfcc1ca821803f0cb2"
 
 [[package]]
 name = "mach"
@@ -3351,7 +3353,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.13",
+ "log 0.4.14",
  "miow",
  "net2",
  "slab",
@@ -3379,8 +3381,8 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "digest 0.9.0",
- "sha-1 0.9.2",
- "sha2 0.9.2",
+ "sha-1 0.9.3",
+ "sha2 0.9.3",
  "sha3",
  "unsigned-varint",
 ]
@@ -3399,7 +3401,7 @@ checksum = "d050aeedc89243f5347c3e237e3e13dc76fbe4ae3742a57b94dc14f69acf76d4"
 dependencies = [
  "buf_redux",
  "httparse",
- "log 0.4.13",
+ "log 0.4.14",
  "mime",
  "mime_guess",
  "quick-error",
@@ -3417,8 +3419,8 @@ checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
 dependencies = [
  "bytes 0.5.6",
  "futures",
- "log 0.4.13",
- "pin-project 1.0.4",
+ "log 0.4.14",
+ "pin-project 1.0.5",
  "smallvec",
  "unsigned-varint",
 ]
@@ -3447,7 +3449,7 @@ checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.13",
+ "log 0.4.14",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -3836,11 +3838,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
+checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 1.0.4",
+ "pin-project-internal 1.0.5",
 ]
 
 [[package]]
@@ -3856,9 +3858,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
+checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4013,7 +4015,7 @@ checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "log 0.4.13",
+ "log 0.4.14",
  "wepoll-sys",
  "winapi 0.3.9",
 ]
@@ -4071,9 +4073,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "predicates"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73dd9b7b200044694dfede9edf907c1ca19630908443e9447e624993700c6932"
+checksum = "eeb433456c1a57cc93554dea3ce40b4c19c4057e41c55d4a0f3d84ea71c325aa"
 dependencies = [
  "difference",
  "predicates-core",
@@ -4081,15 +4083,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3dbeaaf793584e29c58c7e3a82bbb3c7c06b63cea68d13b0e3cddc124104dc"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee95d988ee893cb35c06b148c80ed2cd52c8eea927f50ba7a0be1a786aeab73"
+checksum = "15f553275e5721409451eb85e15fd9a860a6e5ab4496eb215987502b5f5391f2"
 dependencies = [
  "predicates-core",
  "treeline",
@@ -4194,7 +4196,7 @@ dependencies = [
  "bytes 0.5.6",
  "heck",
  "itertools 0.8.2",
- "log 0.4.13",
+ "log 0.4.14",
  "multimap",
  "petgraph",
  "prost",
@@ -4274,7 +4276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
 dependencies = [
  "byteorder",
- "log 0.4.13",
+ "log 0.4.14",
  "parity-wasm 0.41.0",
 ]
 
@@ -4285,7 +4287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c8ac87af529432d3a4f0e2b3bbf08af49f28f09cc73ed7e551161bdaef5f78d"
 dependencies = [
  "byteorder",
- "log 0.4.13",
+ "log 0.4.14",
  "parity-wasm 0.41.0",
 ]
 
@@ -4542,7 +4544,7 @@ dependencies = [
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.13",
+ "log 0.4.14",
  "mime",
  "mime_guess",
  "native-tls",
@@ -4570,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.19"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
@@ -4585,9 +4587,9 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f10b46df14cf1ee1ac7baa4d2fbc2c52c0622a4b82fa8740e37bc452ac0184f"
+checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -4865,9 +4867,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
  "itoa",
  "ryu",
@@ -4932,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
+checksum = "f4b312c3731e3fe78a185e6b9b911a7aa715b8e31cce117975219aab2acf285d"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -4957,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -5055,7 +5057,7 @@ dependencies = [
  "rand_core 0.5.1",
  "ring",
  "rustc_version",
- "sha2 0.9.2",
+ "sha2 0.9.3",
  "subtle 2.4.0",
  "x25519-dalek",
 ]
@@ -5313,9 +5315,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
 ]
@@ -5357,9 +5359,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -5426,7 +5428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
 dependencies = [
  "futures-util",
- "log 0.4.13",
+ "log 0.4.14",
  "pin-project 0.4.27",
  "tokio",
  "tungstenite",
@@ -5441,7 +5443,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log 0.4.13",
+ "log 0.4.14",
  "pin-project-lite 0.1.11",
  "tokio",
 ]
@@ -5525,7 +5527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
 dependencies = [
  "futures-core",
- "log 0.4.13",
+ "log 0.4.14",
  "pin-project 0.4.27",
  "tokio",
  "tower-discover",
@@ -5589,12 +5591,12 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.13",
+ "log 0.4.14",
  "pin-project-lite 0.2.4",
  "tracing-attributes",
  "tracing-core",
@@ -5602,9 +5604,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5637,7 +5639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 dependencies = [
  "lazy_static",
- "log 0.4.13",
+ "log 0.4.14",
  "tracing-core",
 ]
 
@@ -5821,9 +5823,9 @@ dependencies = [
  "http",
  "httparse",
  "input_buffer",
- "log 0.4.13",
+ "log 0.4.14",
  "rand 0.7.3",
- "sha-1 0.9.2",
+ "sha-1 0.9.3",
  "url",
  "utf-8",
 ]
@@ -5983,6 +5985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.0.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
+dependencies = [
+ "ctor",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6069,7 +6080,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.13",
+ "log 0.4.14",
  "try-lock",
 ]
 
@@ -6084,7 +6095,7 @@ dependencies = [
  "headers",
  "http",
  "hyper",
- "log 0.4.13",
+ "log 0.4.14",
  "mime",
  "mime_guess",
  "multipart",
@@ -6113,7 +6124,7 @@ dependencies = [
  "http",
  "hyper",
  "lazycell",
- "log 0.4.13",
+ "log 0.4.14",
  "serde",
  "serde_json",
  "warp",
@@ -6127,9 +6138,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.1+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
@@ -6151,7 +6162,7 @@ checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.13",
+ "log 0.4.14",
  "proc-macro2",
  "quote",
  "syn",
@@ -6387,7 +6398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
 dependencies = [
  "futures",
- "log 0.4.13",
+ "log 0.4.14",
  "nohash-hasher",
  "parking_lot 0.11.1",
  "rand 0.7.3",

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -7,6 +7,9 @@
 //! <https://casperlabs.atlassian.net/wiki/spaces/EN/pages/135528449/Genesis+Process+Specification>
 //! for full details.
 
+// TODO - remove once schemars stops causing warning.
+#![allow(clippy::field_reassign_with_default)]
+
 use std::{
     fmt::{self, Display, Formatter},
     fs,
@@ -17,6 +20,7 @@ use std::{
 use datasize::DataSize;
 use derive_more::From;
 use once_cell::sync::Lazy;
+use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use tokio::task;
@@ -27,7 +31,7 @@ use casper_execution_engine::core::engine_state::{self, genesis::GenesisResult};
 #[cfg(test)]
 use crate::utils::RESOURCES_PATH;
 use crate::{
-    components::Component,
+    components::{consensus::EraId, Component},
     crypto::hash::Digest,
     effect::{
         announcements::ChainspecLoaderAnnouncement,
@@ -43,9 +47,16 @@ use crate::{
     NodeRng,
 };
 
-static CHAINSPEC_INFO: Lazy<ChainspecInfo> = Lazy::new(|| ChainspecInfo {
-    name: String::from("casper-example"),
-    root_hash: Some(Digest::from([2u8; Digest::LENGTH])),
+static CHAINSPEC_INFO: Lazy<ChainspecInfo> = Lazy::new(|| {
+    let next_upgrade = NextUpgrade {
+        activation_point: ActivationPoint { era_id: EraId(42) },
+        protocol_version: Version::new(2, 0, 1),
+    };
+    ChainspecInfo {
+        name: String::from("casper-example"),
+        root_hash: Some(Digest::from([2u8; Digest::LENGTH])),
+        next_upgrade: Some(next_upgrade),
+    }
 });
 
 /// `ChainspecHandler` events.
@@ -54,9 +65,9 @@ pub enum Event {
     #[from]
     Request(ChainspecLoaderRequest),
     /// Check config dir to see if an upgrade activation point is available, and if so announce it.
-    CheckUpgradeActivationPoint,
-    /// If the result of checking for an upgrade activation point is successful, it is passed here.
-    GotUpgradeActivationPoint(ActivationPoint),
+    CheckForNextUpgrade,
+    /// If the result of checking for an upgrade is successful, it is passed here.
+    GotNextUpgrade(NextUpgrade),
     /// The result of the `ChainspecHandler` putting a `Chainspec` to the storage component.
     PutToStorage { version: Version },
     /// The result of contract runtime running the genesis process.
@@ -67,11 +78,11 @@ impl Display for Event {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Event::Request(_) => write!(formatter, "chainspec_loader request"),
-            Event::CheckUpgradeActivationPoint => {
-                write!(formatter, "check for upgrade activation point")
+            Event::CheckForNextUpgrade => {
+                write!(formatter, "check for next upgrade")
             }
-            Event::GotUpgradeActivationPoint(activation_point) => {
-                write!(formatter, "got {}", activation_point)
+            Event::GotNextUpgrade(next_upgrade) => {
+                write!(formatter, "got {}", next_upgrade)
             }
             Event::PutToStorage { version } => {
                 write!(formatter, "put chainspec {} to storage", version)
@@ -86,17 +97,61 @@ impl Display for Event {
     }
 }
 
+/// Information about the next protocol upgrade.
+#[derive(PartialEq, Eq, DataSize, Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct NextUpgrade {
+    activation_point: ActivationPoint,
+    #[data_size(skip)]
+    #[schemars(with = "String")]
+    protocol_version: Version,
+}
+
+impl NextUpgrade {
+    pub(crate) fn activation_point(&self) -> ActivationPoint {
+        self.activation_point
+    }
+}
+
+impl From<ProtocolConfig> for NextUpgrade {
+    fn from(protocol_config: ProtocolConfig) -> Self {
+        NextUpgrade {
+            activation_point: protocol_config.activation_point,
+            protocol_version: protocol_config.version,
+        }
+    }
+}
+
+impl Display for NextUpgrade {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "next upgrade to {} at start of era {}",
+            self.protocol_version, self.activation_point.era_id
+        )
+    }
+}
+
+/// Information about the chainspec.
 #[derive(DataSize, Debug, Serialize, Deserialize, Clone)]
 pub struct ChainspecInfo {
-    // Name of the chainspec.
+    /// Name of the chainspec.
     name: String,
-    // If `Some` then genesis process returned a valid post state hash.
+    /// If `Some` then genesis process returned a valid post state hash.
     root_hash: Option<Digest>,
+    next_upgrade: Option<NextUpgrade>,
 }
 
 impl ChainspecInfo {
-    pub(crate) fn new(name: String, root_hash: Option<Digest>) -> ChainspecInfo {
-        ChainspecInfo { name, root_hash }
+    pub(crate) fn new(
+        name: String,
+        root_hash: Option<Digest>,
+        next_upgrade: Option<NextUpgrade>,
+    ) -> ChainspecInfo {
+        ChainspecInfo {
+            name,
+            root_hash,
+            next_upgrade,
+        }
     }
 
     pub fn name(&self) -> String {
@@ -106,20 +161,15 @@ impl ChainspecInfo {
     pub fn root_hash(&self) -> Option<Digest> {
         self.root_hash
     }
+
+    pub fn next_upgrade(&self) -> Option<NextUpgrade> {
+        self.next_upgrade.clone()
+    }
 }
 
 impl DocExample for ChainspecInfo {
     fn doc_example() -> &'static Self {
         &*CHAINSPEC_INFO
-    }
-}
-
-impl From<ChainspecLoader> for ChainspecInfo {
-    fn from(chainspec_loader: ChainspecLoader) -> Self {
-        ChainspecInfo::new(
-            chainspec_loader.chainspec.network_config.name.clone(),
-            chainspec_loader.genesis_state_root_hash,
-        )
     }
 }
 
@@ -133,7 +183,7 @@ pub struct ChainspecLoader {
     completed_successfully: Option<bool>,
     /// If `Some` then genesis process returned a valid state root hash.
     genesis_state_root_hash: Option<Digest>,
-    upgrade_activation_point: Option<ActivationPoint>,
+    next_upgrade: Option<NextUpgrade>,
 }
 
 impl ChainspecLoader {
@@ -190,7 +240,7 @@ impl ChainspecLoader {
             root_dir,
             completed_successfully: None,
             genesis_state_root_hash: None,
-            upgrade_activation_point: None,
+            next_upgrade: None,
         };
 
         (chainspec_loader, effects)
@@ -232,39 +282,44 @@ where
     ) -> Effects<Self::Event> {
         match event {
             Event::Request(ChainspecLoaderRequest::GetChainspecInfo(responder)) => {
-                responder.respond(self.clone().into()).ignore()
+                let chainspec_info = ChainspecInfo::new(
+                    self.chainspec.network_config.name.clone(),
+                    self.genesis_state_root_hash,
+                    self.next_upgrade.clone(),
+                );
+                responder.respond(chainspec_info).ignore()
             }
-            Event::Request(ChainspecLoaderRequest::GetUpgradeActivationPoint(responder)) => {
-                responder.respond(self.upgrade_activation_point).ignore()
-            }
-            Event::CheckUpgradeActivationPoint => {
+            Event::CheckForNextUpgrade => {
                 let root_dir = self.root_dir.clone();
                 let current_version = self.chainspec.protocol_config.version.clone();
                 async move {
-                    let maybe_upgrade_activation_point = task::spawn_blocking(move || {
-                        next_activation_point(root_dir, current_version)
-                    })
-                    .await
-                    .unwrap_or_else(|error| {
-                        warn!(%error, "failed to join tokio task");
-                        None
-                    });
-                    if let Some(activation_point) = maybe_upgrade_activation_point {
+                    let maybe_next_upgrade =
+                        task::spawn_blocking(move || next_upgrade(root_dir, current_version))
+                            .await
+                            .unwrap_or_else(|error| {
+                                warn!(%error, "failed to join tokio task");
+                                None
+                            });
+                    if let Some(next_upgrade) = maybe_next_upgrade {
                         effect_builder
-                            .announce_upgrade_activation_point_read(activation_point)
+                            .announce_upgrade_activation_point_read(next_upgrade)
                             .await
                     }
                 }
                 .ignore()
             }
-            Event::GotUpgradeActivationPoint(activation_point) => {
-                debug!("got {}", activation_point);
-                if let Some(ref current_point) = self.upgrade_activation_point {
-                    if activation_point != *current_point {
-                        info!(new_point=%activation_point, %current_point, "changing upgrade activation point");
+            Event::GotNextUpgrade(next_upgrade) => {
+                debug!("got {}", next_upgrade);
+                if let Some(ref current_point) = self.next_upgrade {
+                    if next_upgrade != *current_point {
+                        info!(
+                            new_point=%next_upgrade.activation_point,
+                            %current_point,
+                            "changing upgrade activation point"
+                        );
                     }
                 }
-                self.upgrade_activation_point = Some(activation_point);
+                self.next_upgrade = Some(next_upgrade);
                 Effects::new()
             }
             Event::PutToStorage { version } => {
@@ -306,8 +361,8 @@ where
 }
 
 /// This struct can be parsed from a TOML-encoded chainspec file.  It means that as the
-/// chainspec format changes over versions, as long as we maintain the protocol config in this
-/// form at the top of the chainspec file, it can continue to be parsed as an `UpgradePoint`.
+/// chainspec format changes over versions, as long as we maintain the protocol config in this form
+/// in the chainspec file, it can continue to be parsed as an `UpgradePoint`.
 #[derive(Deserialize)]
 struct UpgradePoint {
     #[serde(rename = "protocol")]
@@ -374,9 +429,9 @@ fn max_installed_version(dir: &Path) -> Result<Version, Error> {
 }
 
 /// Uses `max_installed_version()` to find the latest versioned subdir.  If this is greater than
-/// `current_version`, reads the UpgradePoint file from there and returns its activation point.
-/// Returns `None` if there is no greater version available, or if any step errors.
-fn next_activation_point(dir: PathBuf, current_version: Version) -> Option<ActivationPoint> {
+/// `current_version`, reads the UpgradePoint file from there and returns its version and activation
+/// point.  Returns `None` if there is no greater version available, or if any step errors.
+fn next_upgrade(dir: PathBuf, current_version: Version) -> Option<NextUpgrade> {
     let max_version = match max_installed_version(&dir) {
         Ok(version) => version,
         Err(error) => {
@@ -407,7 +462,7 @@ fn next_activation_point(dir: PathBuf, current_version: Version) -> Option<Activ
         return None;
     }
 
-    Some(upgrade_point.protocol_config.activation_point)
+    Some(NextUpgrade::from(upgrade_point.protocol_config))
 }
 
 #[cfg(test)]
@@ -506,11 +561,11 @@ mod tests {
     }
 
     #[test]
-    fn should_get_next_activation_point() {
+    fn should_get_next_upgrade() {
         let tempdir = tempfile::tempdir().expect("should create temp dir");
 
         let max_point = |current_version: &Version| {
-            next_activation_point(tempdir.path().to_path_buf(), current_version.clone()).unwrap()
+            next_upgrade(tempdir.path().to_path_buf(), current_version.clone()).unwrap()
         };
 
         let mut rng = crate::new_rng();
@@ -518,26 +573,20 @@ mod tests {
         let mut current = Version::new(0, 9, 9);
         let v1_0_0 = Version::new(1, 0, 0);
         let chainspec_v1_0_0 = install_chainspec(&mut rng, tempdir.path(), &v1_0_0);
-        assert_eq!(
-            max_point(&current),
-            chainspec_v1_0_0.protocol_config.activation_point
-        );
+        assert_eq!(max_point(&current), chainspec_v1_0_0.protocol_config.into());
 
         current = v1_0_0;
         let v1_0_3 = Version::new(1, 0, 3);
         let chainspec_v1_0_3 = install_chainspec(&mut rng, tempdir.path(), &v1_0_3);
-        assert_eq!(
-            max_point(&current),
-            chainspec_v1_0_3.protocol_config.activation_point
-        );
+        assert_eq!(max_point(&current), chainspec_v1_0_3.protocol_config.into());
     }
 
     #[test]
-    fn should_not_get_old_or_invalid_activation_points() {
+    fn should_not_get_old_or_invalid_upgrade() {
         let tempdir = tempfile::tempdir().expect("should create temp dir");
 
         let maybe_max_point = |current_version: &Version| {
-            next_activation_point(tempdir.path().to_path_buf(), current_version.clone())
+            next_upgrade(tempdir.path().to_path_buf(), current_version.clone())
         };
 
         let mut rng = crate::new_rng();

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -115,8 +115,8 @@ pub enum Event<I> {
     Shutdown,
     /// An event fired when the joiner reactor transitions into validator.
     FinishedJoining(Timestamp),
-    /// Got the result of checking for the next upgrade activation point.
-    GotUpgradeActivationPoint(Option<ActivationPoint>),
+    /// Got the result of checking for an upgrade activation point.
+    GotUpgradeActivationPoint(ActivationPoint),
 }
 
 impl Debug for ConsensusMessage {

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -23,7 +23,7 @@ use datasize::DataSize;
 use itertools::Itertools;
 use prometheus::Registry;
 use rand::Rng;
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use casper_types::{AsymmetricType, PublicKey, SecretKey, U512};
 
@@ -495,12 +495,6 @@ where
         block_header: BlockHeader,
         responder: Responder<Option<FinalitySignature>>,
     ) -> Effects<Event<I>> {
-        // Try to get the next upgrade activation point.
-        let mut effects = self
-            .effect_builder
-            .next_upgrade_activation_point()
-            .event(Event::GotUpgradeActivationPoint);
-
         let our_pk = self.era_supervisor.public_signing_key;
         let our_sk = self.era_supervisor.secret_signing_key.clone();
         let era_id = block_header.era_id();
@@ -516,7 +510,7 @@ where
         } else {
             None
         };
-        effects.extend(responder.respond(maybe_fin_sig).ignore());
+        let mut effects = responder.respond(maybe_fin_sig).ignore();
         if era_id < self.era_supervisor.current_era {
             trace!(era = era_id.0, "executed block in old era");
             return effects;
@@ -893,27 +887,13 @@ where
         self.handle_consensus_results(self.era_supervisor.current_era, results)
     }
 
-    /// Handles registering a new upgrade activation point.
+    /// Handles registering an upgrade activation point.
     pub(super) fn got_upgrade_activation_point(
         &mut self,
-        maybe_activation_point: Option<ActivationPoint>,
+        activation_point: ActivationPoint,
     ) -> Effects<Event<I>> {
-        match (
-            maybe_activation_point,
-            &self.era_supervisor.next_upgrade_activation_point,
-        ) {
-            (Some(new_point), Some(current_point)) => {
-                if new_point != *current_point {
-                    info!(%new_point, %current_point, "changing upgrade activation point");
-                }
-                self.era_supervisor.next_upgrade_activation_point = Some(new_point);
-            }
-            (Some(new_point), None) => {
-                info!(activation_point=%new_point, "new upgrade activation point");
-                self.era_supervisor.next_upgrade_activation_point = Some(new_point);
-            }
-            (None, Some(_)) | (None, None) => (),
-        }
+        debug!("got {}", activation_point);
+        self.era_supervisor.next_upgrade_activation_point = Some(activation_point);
         Effects::new()
     }
 

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -1,4 +1,6 @@
 #![cfg(test)]
+#![allow(unreachable_code)]
+
 use std::sync::{Arc, Mutex};
 
 use casper_node_macros::reactor;
@@ -96,6 +98,7 @@ reactor!(Reactor {
         // Currently the RpcServerAnnouncement is misnamed - it solely tells of new deploys arriving
         // from a client.
         RpcServerAnnouncement -> [deploy_acceptor];
+        ChainspecLoaderAnnouncement -> [!];
     }
 });
 

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -118,14 +118,12 @@ where
     ) -> Effects<Self::Event> {
         match event {
             Event::RestRequest(RestRequest::GetStatus { responder }) => async move {
-                let (last_added_block, peers, chainspec_info, activation_point) = join!(
+                let (last_added_block, peers, chainspec_info) = join!(
                     effect_builder.get_highest_block_from_storage(),
                     effect_builder.network_peers(),
                     effect_builder.get_chainspec_info(),
-                    effect_builder.get_upgrade_activation_point(),
                 );
-                let status_feed =
-                    StatusFeed::new(last_added_block, peers, chainspec_info, activation_point);
+                let status_feed = StatusFeed::new(last_added_block, peers, chainspec_info);
                 responder.respond(status_feed).await;
             }
             .ignore(),

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -118,12 +118,14 @@ where
     ) -> Effects<Self::Event> {
         match event {
             Event::RestRequest(RestRequest::GetStatus { responder }) => async move {
-                let (last_added_block, peers, chainspec_info) = join!(
+                let (last_added_block, peers, chainspec_info, activation_point) = join!(
                     effect_builder.get_highest_block_from_storage(),
                     effect_builder.network_peers(),
-                    effect_builder.get_chainspec_info()
+                    effect_builder.get_chainspec_info(),
+                    effect_builder.get_upgrade_activation_point(),
                 );
-                let status_feed = StatusFeed::new(last_added_block, peers, chainspec_info);
+                let status_feed =
+                    StatusFeed::new(last_added_block, peers, chainspec_info, activation_point);
                 responder.respond(status_feed).await;
             }
             .ignore(),

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -263,14 +263,12 @@ where
                     main_responder: responder,
                 }),
             Event::RpcRequest(RpcRequest::GetStatus { responder }) => async move {
-                let (last_added_block, peers, chainspec_info, activation_point) = join!(
+                let (last_added_block, peers, chainspec_info) = join!(
                     effect_builder.get_highest_block_from_storage(),
                     effect_builder.network_peers(),
                     effect_builder.get_chainspec_info(),
-                    effect_builder.get_upgrade_activation_point(),
                 );
-                let status_feed =
-                    StatusFeed::new(last_added_block, peers, chainspec_info, activation_point);
+                let status_feed = StatusFeed::new(last_added_block, peers, chainspec_info);
                 responder.respond(status_feed).await;
             }
             .ignore(),

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -263,12 +263,14 @@ where
                     main_responder: responder,
                 }),
             Event::RpcRequest(RpcRequest::GetStatus { responder }) => async move {
-                let (last_added_block, peers, chainspec_info) = join!(
+                let (last_added_block, peers, chainspec_info, activation_point) = join!(
                     effect_builder.get_highest_block_from_storage(),
                     effect_builder.network_peers(),
-                    effect_builder.get_chainspec_info()
+                    effect_builder.get_chainspec_info(),
+                    effect_builder.get_upgrade_activation_point(),
                 );
-                let status_feed = StatusFeed::new(last_added_block, peers, chainspec_info);
+                let status_feed =
+                    StatusFeed::new(last_added_block, peers, chainspec_info, activation_point);
                 responder.respond(status_feed).await;
             }
             .ignore(),

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -100,7 +100,7 @@ use casper_types::{
 
 use crate::{
     components::{
-        chainspec_loader::ChainspecInfo,
+        chainspec_loader::{ChainspecInfo, NextUpgrade},
         consensus::{BlockContext, EraId},
         contract_runtime::EraValidatorsRequest,
         deploy_acceptor,
@@ -111,9 +111,9 @@ use crate::{
     effect::requests::LinearChainRequest,
     reactor::{EventQueueHandle, QueueKind},
     types::{
-        ActivationPoint, Block, BlockByHeight, BlockHash, BlockHeader, BlockLike, BlockSignatures,
-        Chainspec, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
-        FinalizedBlock, Item, ProtoBlock, Timestamp,
+        Block, BlockByHeight, BlockHash, BlockHeader, BlockLike, BlockSignatures, Chainspec,
+        Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature, FinalizedBlock, Item,
+        ProtoBlock, Timestamp,
     },
     utils::Source,
 };
@@ -660,15 +660,13 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Announce upgrade activation point read.
-    pub(crate) async fn announce_upgrade_activation_point_read(
-        self,
-        activation_point: ActivationPoint,
-    ) where
+    pub(crate) async fn announce_upgrade_activation_point_read(self, next_upgrade: NextUpgrade)
+    where
         REv: From<ChainspecLoaderAnnouncement>,
     {
         self.0
             .schedule(
-                ChainspecLoaderAnnouncement::UpgradeActivationPointRead(activation_point),
+                ChainspecLoaderAnnouncement::UpgradeActivationPointRead(next_upgrade),
                 QueueKind::Regular,
             )
             .await
@@ -1225,18 +1223,6 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(ChainspecLoaderRequest::GetChainspecInfo, QueueKind::Regular)
             .await
-    }
-
-    /// Requests the current upgrade activation point from the chainspec loader.
-    pub(crate) async fn get_upgrade_activation_point(self) -> Option<ActivationPoint>
-    where
-        REv: From<ChainspecLoaderRequest> + Send,
-    {
-        self.make_request(
-            ChainspecLoaderRequest::GetUpgradeActivationPoint,
-            QueueKind::Regular,
-        )
-        .await
     }
 
     /// Loads potentially previously stored state from storage.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -118,8 +118,9 @@ use crate::{
     utils::Source,
 };
 use announcements::{
-    BlockExecutorAnnouncement, ConsensusAnnouncement, DeployAcceptorAnnouncement,
-    GossiperAnnouncement, LinearChainAnnouncement, NetworkAnnouncement, RpcServerAnnouncement,
+    BlockExecutorAnnouncement, ChainspecLoaderAnnouncement, ConsensusAnnouncement,
+    DeployAcceptorAnnouncement, GossiperAnnouncement, LinearChainAnnouncement, NetworkAnnouncement,
+    RpcServerAnnouncement,
 };
 use casper_execution_engine::core::engine_state::put_trie::InsertedTrieKeyAndMissingDescendants;
 use requests::{
@@ -653,6 +654,21 @@ impl<REv> EffectBuilder<REv> {
                     block,
                     execution_results,
                 },
+                QueueKind::Regular,
+            )
+            .await
+    }
+
+    /// Announce upgrade activation point read.
+    pub(crate) async fn announce_upgrade_activation_point_read(
+        self,
+        activation_point: ActivationPoint,
+    ) where
+        REv: From<ChainspecLoaderAnnouncement>,
+    {
+        self.0
+            .schedule(
+                ChainspecLoaderAnnouncement::UpgradeActivationPointRead(activation_point),
                 QueueKind::Regular,
             )
             .await
@@ -1211,16 +1227,13 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
-    /// Requests to check config dir to see if a new upgrade point is available, and if so, returns
-    /// its activation point.
-    // TODO - remove once used.
-    #[allow(unused)]
-    pub(crate) async fn next_upgrade_activation_point(self) -> Option<ActivationPoint>
+    /// Requests the current upgrade activation point from the chainspec loader.
+    pub(crate) async fn get_upgrade_activation_point(self) -> Option<ActivationPoint>
     where
         REv: From<ChainspecLoaderRequest> + Send,
     {
         self.make_request(
-            ChainspecLoaderRequest::NextUpgradeActivationPoint,
+            ChainspecLoaderRequest::GetUpgradeActivationPoint,
             QueueKind::Regular,
         )
         .await

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -13,11 +13,14 @@ use serde::Serialize;
 use casper_types::{ExecutionResult, PublicKey};
 
 use crate::{
-    components::{consensus::EraId, deploy_acceptor::Error, small_network::GossipedAddress},
+    components::{
+        chainspec_loader::NextUpgrade, consensus::EraId, deploy_acceptor::Error,
+        small_network::GossipedAddress,
+    },
     effect::Responder,
     types::{
-        ActivationPoint, Block, BlockHash, BlockHeader, Deploy, DeployHash, DeployHeader,
-        FinalitySignature, FinalizedBlock, Item, Timestamp,
+        Block, BlockHash, BlockHeader, Deploy, DeployHash, DeployHeader, FinalitySignature,
+        FinalizedBlock, Item, Timestamp,
     },
     utils::Source,
 };
@@ -239,14 +242,14 @@ impl Display for LinearChainAnnouncement {
 #[derive(Debug, Serialize)]
 pub enum ChainspecLoaderAnnouncement {
     /// New finality signature received.
-    UpgradeActivationPointRead(ActivationPoint),
+    UpgradeActivationPointRead(NextUpgrade),
 }
 
 impl Display for ChainspecLoaderAnnouncement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ChainspecLoaderAnnouncement::UpgradeActivationPointRead(activation_point) => {
-                write!(f, "read {}", activation_point)
+            ChainspecLoaderAnnouncement::UpgradeActivationPointRead(next_upgrade) => {
+                write!(f, "read {}", next_upgrade)
             }
         }
     }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -16,8 +16,8 @@ use crate::{
     components::{consensus::EraId, deploy_acceptor::Error, small_network::GossipedAddress},
     effect::Responder,
     types::{
-        Block, BlockHash, BlockHeader, Deploy, DeployHash, DeployHeader, FinalitySignature,
-        FinalizedBlock, Item, Timestamp,
+        ActivationPoint, Block, BlockHash, BlockHeader, Deploy, DeployHash, DeployHeader,
+        FinalitySignature, FinalizedBlock, Item, Timestamp,
     },
     utils::Source,
 };
@@ -230,6 +230,23 @@ impl Display for LinearChainAnnouncement {
             }
             LinearChainAnnouncement::NewFinalitySignature(fs) => {
                 write!(f, "new finality signature {}", fs.block_hash)
+            }
+        }
+    }
+}
+
+/// A chainspec loader announcement.
+#[derive(Debug, Serialize)]
+pub enum ChainspecLoaderAnnouncement {
+    /// New finality signature received.
+    UpgradeActivationPointRead(ActivationPoint),
+}
+
+impl Display for ChainspecLoaderAnnouncement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ChainspecLoaderAnnouncement::UpgradeActivationPointRead(activation_point) => {
+                write!(f, "read {}", activation_point)
             }
         }
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -47,9 +47,9 @@ use crate::{
     crypto::hash::Digest,
     rpcs::chain::BlockIdentifier,
     types::{
-        ActivationPoint, Block as LinearBlock, Block, BlockHash, BlockHeader, BlockSignatures,
-        Chainspec, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
-        FinalizedBlock, Item, ProtoBlock, StatusFeed, Timestamp,
+        Block as LinearBlock, Block, BlockHash, BlockHeader, BlockSignatures, Chainspec, Deploy,
+        DeployHash, DeployHeader, DeployMetadata, FinalitySignature, FinalizedBlock, Item,
+        ProtoBlock, StatusFeed, Timestamp,
     },
     utils::DisplayIter,
 };
@@ -981,17 +981,12 @@ pub enum ConsensusRequest {
 pub enum ChainspecLoaderRequest {
     /// Chainspec info request.
     GetChainspecInfo(Responder<ChainspecInfo>),
-    /// Request for the cached upgrade activation point.
-    GetUpgradeActivationPoint(Responder<Option<ActivationPoint>>),
 }
 
 impl Display for ChainspecLoaderRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ChainspecLoaderRequest::GetChainspecInfo(_) => write!(f, "get chainspec info"),
-            ChainspecLoaderRequest::GetUpgradeActivationPoint(_) => {
-                write!(f, "get activation point")
-            }
         }
     }
 }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -981,16 +981,15 @@ pub enum ConsensusRequest {
 pub enum ChainspecLoaderRequest {
     /// Chainspec info request.
     GetChainspecInfo(Responder<ChainspecInfo>),
-    /// Request to check config dir to see if a new upgrade point is available, and if so, return
-    /// its activation point.
-    NextUpgradeActivationPoint(Responder<Option<ActivationPoint>>),
+    /// Request for the cached upgrade activation point.
+    GetUpgradeActivationPoint(Responder<Option<ActivationPoint>>),
 }
 
 impl Display for ChainspecLoaderRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ChainspecLoaderRequest::GetChainspecInfo(_) => write!(f, "get chainspec info"),
-            ChainspecLoaderRequest::NextUpgradeActivationPoint(_) => {
+            ChainspecLoaderRequest::GetUpgradeActivationPoint(_) => {
                 write!(f, "get activation point")
             }
         }

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -20,6 +20,7 @@ use crate::{
         Component,
     },
     effect::{
+        announcements::ChainspecLoaderAnnouncement,
         requests::{ContractRuntimeRequest, NetworkRequest, StorageRequest},
         EffectBuilder, Effects,
     },
@@ -62,6 +63,12 @@ impl From<ContractRuntimeRequest> for Event {
 impl From<NetworkRequest<NodeId, Message>> for Event {
     fn from(_request: NetworkRequest<NodeId, Message>) -> Self {
         unreachable!("no network traffic happens during initialization")
+    }
+}
+
+impl From<ChainspecLoaderAnnouncement> for Event {
+    fn from(_announcement: ChainspecLoaderAnnouncement) -> Self {
+        unreachable!("no chainspec announcements happen during initialization")
     }
 }
 

--- a/node/src/reactor/initializer2.rs
+++ b/node/src/reactor/initializer2.rs
@@ -1,4 +1,5 @@
 //! Reactor used to initialize a node.
+#![allow(unreachable_code)]
 
 use casper_node_macros::reactor;
 
@@ -8,7 +9,7 @@ reactor!(Initializer {
   type Config = WithDir<validator::Config>;
 
   components: {
-    chainspec = has_effects ChainspecLoader(cfg.dir(), effect_builder);
+    chainspec_loader = has_effects ChainspecLoader(cfg.dir(), effect_builder);
     storage = Storage(&cfg.map_ref(|cfg| cfg.storage.clone()));
     contract_runtime = ContractRuntime(cfg.map_ref(|cfg| cfg.storage.clone()),
 &cfg.value().contract_runtime, registry);   }
@@ -25,7 +26,7 @@ reactor!(Initializer {
   }
 
   announcements: {
-    // We neither send nor process announcements.
+    ChainspecLoaderAnnouncement -> [!];
   }
 });
 
@@ -35,6 +36,6 @@ reactor!(Initializer {
 impl Initializer {
     /// Returns whether the initialization process completed successfully or not.
     pub fn stopped_successfully(&self) -> bool {
-        self.chainspec.stopped_successfully()
+        self.chainspec_loader.stopped_successfully()
     }
 }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -865,15 +865,15 @@ impl reactor::Reactor for Reactor {
                 self.dispatch_event(effect_builder, rng, event)
             }
             Event::ChainspecLoaderAnnouncement(
-                ChainspecLoaderAnnouncement::UpgradeActivationPointRead(activation_point),
+                ChainspecLoaderAnnouncement::UpgradeActivationPointRead(next_upgrade),
             ) => {
                 let reactor_event = Event::ChainspecLoader(
-                    chainspec_loader::Event::GotUpgradeActivationPoint(activation_point),
+                    chainspec_loader::Event::GotNextUpgrade(next_upgrade.clone()),
                 );
                 let mut effects = self.dispatch_event(effect_builder, rng, reactor_event);
 
                 let reactor_event = Event::Consensus(consensus::Event::GotUpgradeActivationPoint(
-                    activation_point,
+                    next_upgrade.activation_point(),
                 ));
                 effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                 effects

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -46,8 +46,9 @@ use crate::{
     },
     effect::{
         announcements::{
-            BlockExecutorAnnouncement, ConsensusAnnouncement, DeployAcceptorAnnouncement,
-            GossiperAnnouncement, LinearChainAnnouncement, NetworkAnnouncement,
+            BlockExecutorAnnouncement, ChainspecLoaderAnnouncement, ConsensusAnnouncement,
+            DeployAcceptorAnnouncement, GossiperAnnouncement, LinearChainAnnouncement,
+            NetworkAnnouncement,
         },
         requests::{
             BlockExecutorRequest, BlockProposerRequest, BlockValidationRequest,
@@ -212,6 +213,10 @@ pub enum Event {
     /// Linear chain announcement.
     #[from]
     LinearChainAnnouncement(#[serde(skip_serializing)] LinearChainAnnouncement),
+
+    /// Chainspec loader announcement.
+    #[from]
+    ChainspecLoaderAnnouncement(#[serde(skip_serializing)] ChainspecLoaderAnnouncement),
 }
 
 impl From<LinearChainRequest<NodeId>> for Event {
@@ -314,6 +319,9 @@ impl Display for Event {
             }
             Event::DeployAcceptor(event) => write!(f, "deploy acceptor: {}", event),
             Event::LinearChainAnnouncement(ann) => write!(f, "linear chain announcement: {}", ann),
+            Event::ChainspecLoaderAnnouncement(ann) => {
+                write!(f, "chainspec loader announcement: {}", ann)
+            }
         }
     }
 }
@@ -855,6 +863,20 @@ impl reactor::Reactor for Reactor {
                     Event::SmallNetwork(small_network::Event::from(req))
                 };
                 self.dispatch_event(effect_builder, rng, event)
+            }
+            Event::ChainspecLoaderAnnouncement(
+                ChainspecLoaderAnnouncement::UpgradeActivationPointRead(activation_point),
+            ) => {
+                let reactor_event = Event::ChainspecLoader(
+                    chainspec_loader::Event::GotUpgradeActivationPoint(activation_point),
+                );
+                let mut effects = self.dispatch_event(effect_builder, rng, reactor_event);
+
+                let reactor_event = Event::Consensus(consensus::Event::GotUpgradeActivationPoint(
+                    activation_point,
+                ));
+                effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
+                effects
             }
         }
     }

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -811,9 +811,8 @@ impl reactor::Reactor for Reactor {
                             });
                         let mut effects = self.dispatch_event(effect_builder, rng, reactor_event);
 
-                        let reactor_event = Event::ChainspecLoader(
-                            chainspec_loader::Event::CheckUpgradeActivationPoint,
-                        );
+                        let reactor_event =
+                            Event::ChainspecLoader(chainspec_loader::Event::CheckForNextUpgrade);
                         effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                         effects
                     }
@@ -899,15 +898,15 @@ impl reactor::Reactor for Reactor {
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
             Event::ChainspecLoaderAnnouncement(
-                ChainspecLoaderAnnouncement::UpgradeActivationPointRead(activation_point),
+                ChainspecLoaderAnnouncement::UpgradeActivationPointRead(next_upgrade),
             ) => {
                 let reactor_event = Event::ChainspecLoader(
-                    chainspec_loader::Event::GotUpgradeActivationPoint(activation_point),
+                    chainspec_loader::Event::GotNextUpgrade(next_upgrade.clone()),
                 );
                 let mut effects = self.dispatch_event(effect_builder, rng, reactor_event);
 
                 let reactor_event = Event::Consensus(consensus::Event::GotUpgradeActivationPoint(
-                    activation_point,
+                    next_upgrade.activation_point(),
                 ));
                 effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                 effects

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -45,9 +45,9 @@ use crate::{
     },
     effect::{
         announcements::{
-            BlockExecutorAnnouncement, ConsensusAnnouncement, DeployAcceptorAnnouncement,
-            GossiperAnnouncement, LinearChainAnnouncement, NetworkAnnouncement,
-            RpcServerAnnouncement,
+            BlockExecutorAnnouncement, ChainspecLoaderAnnouncement, ConsensusAnnouncement,
+            DeployAcceptorAnnouncement, GossiperAnnouncement, LinearChainAnnouncement,
+            NetworkAnnouncement, RpcServerAnnouncement,
         },
         requests::{
             BlockExecutorRequest, BlockProposerRequest, BlockValidationRequest,
@@ -183,6 +183,9 @@ pub enum Event {
     /// Linear chain announcement.
     #[from]
     LinearChainAnnouncement(#[serde(skip_serializing)] LinearChainAnnouncement),
+    /// Chainspec loader announcement.
+    #[from]
+    ChainspecLoaderAnnouncement(#[serde(skip_serializing)] ChainspecLoaderAnnouncement),
 }
 
 impl From<RpcRequest<NodeId>> for Event {
@@ -279,6 +282,9 @@ impl Display for Event {
                 write!(f, "address gossiper announcement: {}", ann)
             }
             Event::LinearChainAnnouncement(ann) => write!(f, "linear chain announcement: {}", ann),
+            Event::ChainspecLoaderAnnouncement(ann) => {
+                write!(f, "chainspec loader announcement: {}", ann)
+            }
         }
     }
 }
@@ -796,17 +802,19 @@ impl reactor::Reactor for Reactor {
                 source: _,
             }) => Effects::new(),
             Event::ConsensusAnnouncement(consensus_announcement) => {
-                let mut reactor_event_dispatch = |dbe: block_proposer::Event| {
-                    self.dispatch_event(effect_builder, rng, Event::BlockProposer(dbe))
-                };
-
                 match consensus_announcement {
                     ConsensusAnnouncement::Finalized(block) => {
-                        let effects =
-                            reactor_event_dispatch(block_proposer::Event::FinalizedProtoBlock {
+                        let reactor_event =
+                            Event::BlockProposer(block_proposer::Event::FinalizedProtoBlock {
                                 block: block.proto_block().clone(),
                                 height: block.height(),
                             });
+                        let mut effects = self.dispatch_event(effect_builder, rng, reactor_event);
+
+                        let reactor_event = Event::ChainspecLoader(
+                            chainspec_loader::Event::CheckUpgradeActivationPoint,
+                        );
+                        effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                         effects
                     }
                     ConsensusAnnouncement::Handled(_) => {
@@ -889,6 +897,20 @@ impl reactor::Reactor for Reactor {
                 let reactor_event =
                     Event::EventStreamServer(event_stream_server::Event::FinalitySignature(fs));
                 self.dispatch_event(effect_builder, rng, reactor_event)
+            }
+            Event::ChainspecLoaderAnnouncement(
+                ChainspecLoaderAnnouncement::UpgradeActivationPointRead(activation_point),
+            ) => {
+                let reactor_event = Event::ChainspecLoader(
+                    chainspec_loader::Event::GotUpgradeActivationPoint(activation_point),
+                );
+                let mut effects = self.dispatch_event(effect_builder, rng, reactor_event);
+
+                let reactor_event = Event::Consensus(consensus::Event::GotUpgradeActivationPoint(
+                    activation_point,
+                ));
+                effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
+                effects
             }
         }
     }

--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -1,8 +1,12 @@
+// TODO - remove once schemars stops causing warning.
+#![allow(clippy::field_reassign_with_default)]
+
 use std::fmt::{self, Display, Formatter};
 
 use datasize::DataSize;
 #[cfg(test)]
 use rand::Rng;
+use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +17,7 @@ use crate::components::consensus::EraId;
 use crate::testing::TestRng;
 
 /// The era whose end will trigger the upgrade process.
-#[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct ActivationPoint {
     pub(crate) era_id: EraId,
 }

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -19,7 +19,7 @@ use crate::{
         chainspec_loader::ChainspecInfo, consensus::EraId, rpc_server::rpcs::docs::DocExample,
     },
     crypto::hash::Digest,
-    types::{Block, BlockHash, NodeId, PeersMap, Timestamp},
+    types::{ActivationPoint, Block, BlockHash, NodeId, PeersMap, Timestamp},
 };
 
 static GET_STATUS_RESULT: Lazy<GetStatusResult> = Lazy::new(|| {
@@ -31,6 +31,7 @@ static GET_STATUS_RESULT: Lazy<GetStatusResult> = Lazy::new(|| {
         last_added_block: Some(Block::doc_example().clone()),
         peers,
         chainspec_info: ChainspecInfo::doc_example().clone(),
+        upgrade_activation_point: Some(ActivationPoint { era_id: EraId(42) }),
         version: crate::VERSION_STRING.as_str(),
     };
     GetStatusResult::from(status_feed)
@@ -46,6 +47,8 @@ pub struct StatusFeed<I> {
     pub peers: BTreeMap<I, String>,
     /// The chainspec info for this node.
     pub chainspec_info: ChainspecInfo,
+    /// The next upgrade activation point.
+    pub upgrade_activation_point: Option<ActivationPoint>,
     /// The compiled node version.
     pub version: &'static str,
 }
@@ -55,11 +58,13 @@ impl<I> StatusFeed<I> {
         last_added_block: Option<Block>,
         peers: BTreeMap<I, String>,
         chainspec_info: ChainspecInfo,
+        upgrade_activation_point: Option<ActivationPoint>,
     ) -> Self {
         StatusFeed {
             last_added_block,
             peers,
             chainspec_info,
+            upgrade_activation_point,
             version: crate::VERSION_STRING.as_str(),
         }
     }
@@ -105,6 +110,8 @@ pub struct GetStatusResult {
     pub peers: PeersMap,
     /// The minimal info of the last block from the linear chain.
     pub last_added_block_info: Option<MinimalBlockInfo>,
+    /// The next upgrade activation point.
+    pub next_upgrade_activation_point: Option<EraId>,
     /// The compiled node version.
     pub build_version: String,
 }
@@ -133,6 +140,9 @@ impl From<StatusFeed<NodeId>> for GetStatusResult {
         let api_version = Version::from((0, 0, 0));
         let peers = PeersMap::from(status_feed.peers);
         let last_added_block_info = status_feed.last_added_block.map(Into::into);
+        let next_upgrade_activation_point = status_feed
+            .upgrade_activation_point
+            .map(|point| point.era_id);
         let build_version = crate::VERSION_STRING.clone();
         GetStatusResult {
             api_version,
@@ -140,6 +150,7 @@ impl From<StatusFeed<NodeId>> for GetStatusResult {
             genesis_root_hash,
             peers,
             last_added_block_info,
+            next_upgrade_activation_point,
             build_version,
         }
     }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-860

This PR provides the next upgrade activation point in the status endpoints.

Manual testing via nctl showed that the status endpoints showed correct values for the activation point (`null` at start, then a valid era ID, then an updated era ID).  Example output:

```json
{
  "api_version": "1.0.0",
  "chainspec_name": "casper-net-1",
  "genesis_root_hash": "4ae2..e47d",
  "peers": [
    {
      "node_id": "NodeId::P2p(A5Rc..k9qM)",
      "address": "/ip4/127.0.0.1/tcp/49474"
    },
    {
      "node_id": "NodeId::P2p(HzXd..yzFM)",
      "address": "/ip4/127.0.0.1/tcp/49428"
    },
    {
      "node_id": "NodeId::P2p(NCPU..Hsim)",
      "address": "/ip4/127.0.0.1/tcp/49442"
    },
    {
      "node_id": "NodeId::P2p(PBzu..AfgF)",
      "address": "/ip4/127.0.0.1/tcp/49458"
    }
  ],
  "last_added_block_info": {
    "hash": "cdf9cb9158517ff2e0e60009ceb29013d1cba6d6b5fc0e7027a7de914662ef08",
    "timestamp": "2021-02-06T23:14:37.184Z",
    "era_id": 6,
    "height": 71,
    "state_root_hash": "c1fe6c87961339bc54e7304a182074de83e4fe8b34bc17f560afb29670855cd2",
    "creator": "01579e108b2b1e9c8f24282e9342d7679e32154e4807e1c123be3ac6a8ad78681f"
  },
  "next_upgrade": {
    "activation_point": {
      "era_id": 7
    },
    "protocol_version": "2.0.0"
  },
  "build_version": "v0.7.0-46-g73c86004-73c86004"
}
```
Tagging @momipsl & @zie1ony for info due to changed API.