### PR TITLE
NO-TICKET/networking metrics

### DIFF
--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -22,9 +22,9 @@ pub(crate) mod rpc_server;
 // The `in_memory_network` is public for use in doctests.
 #[cfg(test)]
 pub mod in_memory_network;
-
 pub(crate) mod metrics;
 pub(crate) mod network;
+pub(crate) mod networking_metrics;
 pub(crate) mod small_network;
 pub(crate) mod storage;
 

--- a/node/src/components/networking_metrics.rs
+++ b/node/src/components/networking_metrics.rs
@@ -7,7 +7,7 @@ pub(crate) struct NetworkingMetrics {
     /// How often a request to send a message directly to a peer was made.
     pub(crate) direct_message_requests: IntCounter,
     /// Current number of open connections.
-    pub(crate) open_connnections: IntGauge,
+    pub(crate) open_connections: IntGauge,
     /// Number of messages still waiting to be broadcast.
     pub(crate) queued_broadcast_messages: IntGauge,
     /// Number of messages still waiting to be sent out.
@@ -48,7 +48,7 @@ impl NetworkingMetrics {
         Ok(NetworkingMetrics {
             broadcast_requests,
             direct_message_requests,
-            open_connnections,
+            open_connections: open_connnections,
             queued_broadcast_messages,
             queued_direct_messages,
             registry: registry.clone(),
@@ -65,7 +65,7 @@ impl Drop for NetworkingMetrics {
             .unregister(Box::new(self.direct_message_requests.clone()))
             .expect("did not expect deregistering direct_message_requests to fail");
         self.registry
-            .unregister(Box::new(self.open_connnections.clone()))
+            .unregister(Box::new(self.open_connections.clone()))
             .expect("did not expect deregistering open_connnections to fail");
         self.registry
             .unregister(Box::new(self.queued_broadcast_messages.clone()))

--- a/node/src/components/networking_metrics.rs
+++ b/node/src/components/networking_metrics.rs
@@ -1,0 +1,99 @@
+use prometheus::{IntCounter, IntGauge, Registry};
+
+/// Network-type agnostic networking metrics.
+pub(crate) struct NetworkingMetrics {
+    /// How often a request was made a component to broadcast.
+    pub(crate) broadcast_requests: IntCounter,
+    /// How often a request to send a message directly to a peer was made.
+    pub(crate) direct_message_requests: IntCounter,
+    /// Number of messages received via gossip.
+    pub(crate) incoming_gossip_messages: IntCounter,
+    /// Number of messages received directly.
+    pub(crate) incoming_direct_messages: IntCounter,
+    /// Current number of open connections.
+    pub(crate) open_connnections: IntGauge,
+    /// Number of messages still waiting to be broadcast.
+    pub(crate) queued_broadcast_messages: IntGauge,
+    /// Number of messages still waiting to be sent out.
+    pub(crate) queued_direct_messages: IntGauge,
+
+    /// Registry instance,
+    registry: Registry,
+}
+
+impl NetworkingMetrics {
+    /// Creates a new instance of networking metrics.
+    pub fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
+        let broadcast_requests =
+            IntCounter::new("net_broadcast_requests", "number of broadcasting requests")?;
+        let direct_message_requests = IntCounter::new(
+            "net_direct_message_requests",
+            "How often a request to send a message directly to a peer was made.",
+        )?;
+        let incoming_gossip_messages = IntCounter::new(
+            "net_incoming_gossip_messages",
+            "Number of messages received via gossip.",
+        )?;
+        let incoming_direct_messages = IntCounter::new(
+            "net_incoming_direct_messages",
+            "Number of messages received directly.",
+        )?;
+        let open_connnections = IntGauge::new(
+            "net_open_connnections",
+            "Current number of open connections.",
+        )?;
+        let queued_broadcast_messages = IntGauge::new(
+            "net_queued_broadcast_messages",
+            "Number of messages still waiting to be broadcast.",
+        )?;
+        let queued_direct_messages = IntGauge::new(
+            "net_queued_direct_messages",
+            "Number of messages still waiting to be sent out.",
+        )?;
+
+        registry.register(Box::new(broadcast_requests.clone()))?;
+        registry.register(Box::new(direct_message_requests.clone()))?;
+        registry.register(Box::new(incoming_gossip_messages.clone()))?;
+        registry.register(Box::new(incoming_direct_messages.clone()))?;
+        registry.register(Box::new(open_connnections.clone()))?;
+        registry.register(Box::new(queued_broadcast_messages.clone()))?;
+        registry.register(Box::new(queued_direct_messages.clone()))?;
+
+        Ok(NetworkingMetrics {
+            broadcast_requests,
+            direct_message_requests,
+            incoming_gossip_messages,
+            incoming_direct_messages,
+            open_connnections,
+            queued_broadcast_messages,
+            queued_direct_messages,
+            registry: registry.clone(),
+        })
+    }
+}
+
+impl Drop for NetworkingMetrics {
+    fn drop(&mut self) {
+        self.registry
+            .unregister(Box::new(self.broadcast_requests.clone()))
+            .expect("did not expect deregistering broadcast_requests to fail");
+        self.registry
+            .unregister(Box::new(self.direct_message_requests.clone()))
+            .expect("did not expect deregistering direct_message_requests to fail");
+        self.registry
+            .unregister(Box::new(self.incoming_gossip_messages.clone()))
+            .expect("did not expect deregistering incoming_gossip_messages to fail");
+        self.registry
+            .unregister(Box::new(self.incoming_direct_messages.clone()))
+            .expect("did not expect deregistering incoming_direct_messages to fail");
+        self.registry
+            .unregister(Box::new(self.open_connnections.clone()))
+            .expect("did not expect deregistering open_connnections to fail");
+        self.registry
+            .unregister(Box::new(self.queued_broadcast_messages.clone()))
+            .expect("did not expect deregistering queued_broadcast_messages to fail");
+        self.registry
+            .unregister(Box::new(self.queued_direct_messages.clone()))
+            .expect("did not expect deregistering queued_direct_messages to fail");
+    }
+}

--- a/node/src/components/networking_metrics.rs
+++ b/node/src/components/networking_metrics.rs
@@ -13,7 +13,7 @@ pub(crate) struct NetworkingMetrics {
     /// Number of messages still waiting to be sent out.
     pub(crate) queued_direct_messages: IntGauge,
 
-    /// Registry instance,
+    /// Registry instance.
     registry: Registry,
 }
 

--- a/node/src/components/networking_metrics.rs
+++ b/node/src/components/networking_metrics.rs
@@ -8,10 +8,8 @@ pub(crate) struct NetworkingMetrics {
     pub(crate) direct_message_requests: IntCounter,
     /// Current number of open connections.
     pub(crate) open_connections: IntGauge,
-    /// Number of messages still waiting to be broadcast.
-    pub(crate) queued_broadcast_messages: IntGauge,
-    /// Number of messages still waiting to be sent out.
-    pub(crate) queued_direct_messages: IntGauge,
+    /// Number of messages still waiting to be sent out (broadcast and direct).
+    pub(crate) queued_messages: IntGauge,
 
     /// Registry instance.
     registry: Registry,
@@ -26,31 +24,25 @@ impl NetworkingMetrics {
             "net_direct_message_requests",
             "How often a request to send a message directly to a peer was made.",
         )?;
-        let open_connnections = IntGauge::new(
+        let open_connections = IntGauge::new(
             "net_open_connnections",
             "Current number of open connections.",
         )?;
-        let queued_broadcast_messages = IntGauge::new(
-            "net_queued_broadcast_messages",
-            "Number of messages still waiting to be broadcast.",
-        )?;
-        let queued_direct_messages = IntGauge::new(
+        let queued_messages = IntGauge::new(
             "net_queued_direct_messages",
             "Number of messages still waiting to be sent out.",
         )?;
 
         registry.register(Box::new(broadcast_requests.clone()))?;
         registry.register(Box::new(direct_message_requests.clone()))?;
-        registry.register(Box::new(open_connnections.clone()))?;
-        registry.register(Box::new(queued_broadcast_messages.clone()))?;
-        registry.register(Box::new(queued_direct_messages.clone()))?;
+        registry.register(Box::new(open_connections.clone()))?;
+        registry.register(Box::new(queued_messages.clone()))?;
 
         Ok(NetworkingMetrics {
             broadcast_requests,
             direct_message_requests,
-            open_connections: open_connnections,
-            queued_broadcast_messages,
-            queued_direct_messages,
+            open_connections,
+            queued_messages,
             registry: registry.clone(),
         })
     }
@@ -68,10 +60,7 @@ impl Drop for NetworkingMetrics {
             .unregister(Box::new(self.open_connections.clone()))
             .expect("did not expect deregistering open_connnections to fail");
         self.registry
-            .unregister(Box::new(self.queued_broadcast_messages.clone()))
-            .expect("did not expect deregistering queued_broadcast_messages to fail");
-        self.registry
-            .unregister(Box::new(self.queued_direct_messages.clone()))
+            .unregister(Box::new(self.queued_messages.clone()))
             .expect("did not expect deregistering queued_direct_messages to fail");
     }
 }

--- a/node/src/components/networking_metrics.rs
+++ b/node/src/components/networking_metrics.rs
@@ -6,10 +6,6 @@ pub(crate) struct NetworkingMetrics {
     pub(crate) broadcast_requests: IntCounter,
     /// How often a request to send a message directly to a peer was made.
     pub(crate) direct_message_requests: IntCounter,
-    /// Number of messages received via gossip.
-    pub(crate) incoming_gossip_messages: IntCounter,
-    /// Number of messages received directly.
-    pub(crate) incoming_direct_messages: IntCounter,
     /// Current number of open connections.
     pub(crate) open_connnections: IntGauge,
     /// Number of messages still waiting to be broadcast.
@@ -30,14 +26,6 @@ impl NetworkingMetrics {
             "net_direct_message_requests",
             "How often a request to send a message directly to a peer was made.",
         )?;
-        let incoming_gossip_messages = IntCounter::new(
-            "net_incoming_gossip_messages",
-            "Number of messages received via gossip.",
-        )?;
-        let incoming_direct_messages = IntCounter::new(
-            "net_incoming_direct_messages",
-            "Number of messages received directly.",
-        )?;
         let open_connnections = IntGauge::new(
             "net_open_connnections",
             "Current number of open connections.",
@@ -53,8 +41,6 @@ impl NetworkingMetrics {
 
         registry.register(Box::new(broadcast_requests.clone()))?;
         registry.register(Box::new(direct_message_requests.clone()))?;
-        registry.register(Box::new(incoming_gossip_messages.clone()))?;
-        registry.register(Box::new(incoming_direct_messages.clone()))?;
         registry.register(Box::new(open_connnections.clone()))?;
         registry.register(Box::new(queued_broadcast_messages.clone()))?;
         registry.register(Box::new(queued_direct_messages.clone()))?;
@@ -62,8 +48,6 @@ impl NetworkingMetrics {
         Ok(NetworkingMetrics {
             broadcast_requests,
             direct_message_requests,
-            incoming_gossip_messages,
-            incoming_direct_messages,
             open_connnections,
             queued_broadcast_messages,
             queued_direct_messages,
@@ -80,12 +64,6 @@ impl Drop for NetworkingMetrics {
         self.registry
             .unregister(Box::new(self.direct_message_requests.clone()))
             .expect("did not expect deregistering direct_message_requests to fail");
-        self.registry
-            .unregister(Box::new(self.incoming_gossip_messages.clone()))
-            .expect("did not expect deregistering incoming_gossip_messages to fail");
-        self.registry
-            .unregister(Box::new(self.incoming_direct_messages.clone()))
-            .expect("did not expect deregistering incoming_direct_messages to fail");
         self.registry
             .unregister(Box::new(self.open_connnections.clone()))
             .expect("did not expect deregistering open_connnections to fail");

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -118,4 +118,11 @@ pub enum Error {
     /// Server has stopped.
     #[error("failed to create outgoing connection as server has stopped")]
     ServerStopped,
+    #[error(transparent)]
+    /// Instantiating metrics failed.
+    MetricsError(
+        #[serde(skip_serializing)]
+        #[from]
+        prometheus::Error,
+    ),
 }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -117,6 +117,7 @@ impl Reactor for TestReactor {
         let (net, effects) = SmallNetwork::new(
             event_queue,
             cfg,
+            registry,
             small_network_identity,
             Digest::default(),
             false,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -403,6 +403,7 @@ impl reactor::Reactor for Reactor {
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network.clone(),
+            registry,
             small_network_identity,
             genesis_config_hash,
             false,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -384,6 +384,7 @@ impl reactor::Reactor for Reactor {
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network,
+            registry,
             small_network_identity,
             genesis_config_hash,
             true,


### PR DESCRIPTION
This adds generic networking metrics, counting queued message and requests for outgoing broadcasts, as well as direct messages.

Currently only implemented for `small_net` due to some time constraints, but the same structure should be used for the libp2p `networking` component. Having the same metrics on both will allow for some comparability.

These metrics should be especially useful when tweaking the chattiness of consensus.