### PR TITLE
HWY-249: Add the timestamp to `CandidateBlock`.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -95,6 +95,7 @@ pub enum Event<I> {
         era_id: EraId,
         sender: I,
         proto_block: ProtoBlock,
+        timestamp: Timestamp,
         valid: bool,
     },
     /// Deactivate the era with the given ID, unless the number of faulty validators increases.
@@ -184,11 +185,13 @@ impl<I: Debug> Display for Event<I> {
                 era_id,
                 sender,
                 proto_block,
+                timestamp,
                 valid,
             } => write!(
                 f,
-                "Proto-block received from {:?} for {} is {}: {:?}",
+                "Proto-block received from {:?} at {} for {} is {}: {:?}",
                 sender,
+                timestamp,
                 era_id,
                 if *valid { "valid" } else { "invalid" },
                 proto_block
@@ -286,8 +289,9 @@ where
                 era_id,
                 sender,
                 proto_block,
+                timestamp,
                 valid,
-            } => handling_es.resolve_validity(era_id, sender, proto_block, valid),
+            } => handling_es.resolve_validity(era_id, sender, proto_block, timestamp, valid),
             Event::DeactivateEra {
                 era_id,
                 faulty_num,

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -3,21 +3,30 @@ use serde::{Deserialize, Serialize};
 
 use casper_types::PublicKey;
 
-use crate::{components::consensus::traits::ConsensusValueT, types::ProtoBlock};
+use crate::{
+    components::consensus::traits::ConsensusValueT,
+    types::{ProtoBlock, Timestamp},
+};
 
 /// A proposed block. Once the consensus protocol reaches agreement on it, it will be converted to
 /// a `FinalizedBlock`.
 #[derive(Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) struct CandidateBlock {
     proto_block: ProtoBlock,
+    timestamp: Timestamp,
     accusations: Vec<PublicKey>,
 }
 
 impl CandidateBlock {
     /// Creates a new candidate block, wrapping a proto block and accusing the given validators.
-    pub(crate) fn new(proto_block: ProtoBlock, accusations: Vec<PublicKey>) -> Self {
+    pub(crate) fn new(
+        proto_block: ProtoBlock,
+        timestamp: Timestamp,
+        accusations: Vec<PublicKey>,
+    ) -> Self {
         CandidateBlock {
             proto_block,
+            timestamp,
             accusations,
         }
     }
@@ -25,6 +34,11 @@ impl CandidateBlock {
     /// Returns the proto block containing the deploys.
     pub(crate) fn proto_block(&self) -> &ProtoBlock {
         &self.proto_block
+    }
+
+    /// Returns the candidate block's timestamp.
+    pub(crate) fn timestamp(&self) -> Timestamp {
+        self.timestamp
     }
 
     /// Returns the validators accused by this block.

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -38,7 +38,7 @@ impl CandidateBlock {
 
     /// Returns the candidate block's timestamp, i.e. when the block was proposed.
     ///
-    /// This is idential to the timestamp of the Highway unit, and the timestamp of the `Block`,
+    /// This is identical to the timestamp of the Highway unit, and the timestamp of the `Block`,
     /// if it gets finalized.
     pub(crate) fn timestamp(&self) -> Timestamp {
         self.timestamp

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -36,7 +36,10 @@ impl CandidateBlock {
         &self.proto_block
     }
 
-    /// Returns the candidate block's timestamp.
+    /// Returns the candidate block's timestamp, i.e. when the block was proposed.
+    ///
+    /// This is idential to the timestamp of the Highway unit, and the timestamp of the `Block`,
+    /// if it gets finalized.
     pub(crate) fn timestamp(&self) -> Timestamp {
         self.timestamp
     }

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -180,16 +180,18 @@ fn send_a_valid_wire_unit() {
     let panorama: Panorama<ClContext> = Panorama::from(vec![N]);
     let seq_number = panorama.next_seq_num(&state, creator);
     let mut rng = TestRng::new();
+    let timestamp = 0.into();
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
         creator,
         instance_id: ClContext::hash(INSTANCE_ID_DATA),
         value: Some(CandidateBlock::new(
             ProtoBlock::new(vec![], vec![], false),
+            timestamp,
             vec![],
         )),
         seq_number,
-        timestamp: 0.into(),
+        timestamp,
         round_exp: 14,
         endorsed: BTreeSet::new(),
     };
@@ -223,14 +225,15 @@ fn detect_doppelganger() {
     let mut rng = TestRng::new();
     let instance_id = ClContext::hash(INSTANCE_ID_DATA);
     let round_exp = 14;
-    let value = CandidateBlock::new(ProtoBlock::new(vec![], vec![], false), vec![]);
+    let timestamp = 0.into();
+    let value = CandidateBlock::new(ProtoBlock::new(vec![], vec![], false), timestamp, vec![]);
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
         creator,
         instance_id,
         value: Some(value),
         seq_number,
-        timestamp: 0.into(),
+        timestamp,
         round_exp,
         endorsed: BTreeSet::new(),
     };


### PR DESCRIPTION
Validity of a proto block depends on the timestamp. If there are two different candidate blocks (belonging to different units) with the same proto block, we must not apply the validity result to both.

https://casperlabs.atlassian.net/browse/HWY-249