### PR TITLE
HWY-250: Use `ConsensusValue`'s hash as a key in map.

### DIFF
--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -9,7 +9,7 @@ use casper_types::PublicKey;
 
 use crate::{
     components::consensus::traits::ConsensusValueT,
-    crypto::hash::Digest, 
+    crypto::hash::Digest,
     types::{ProtoBlock, Timestamp},
 };
 
@@ -76,7 +76,7 @@ impl ConsensusValueT for CandidateBlock {
         });
         result.into()
     }
-    
+
     fn needs_validation(&self) -> bool {
         !self.proto_block.wasm_deploys().is_empty() || !self.proto_block.transfers().is_empty()
     }

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -1,9 +1,15 @@
+use blake2::{
+    digest::{Update, VariableOutput},
+    VarBlake2b,
+};
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 use casper_types::PublicKey;
 
-use crate::{components::consensus::traits::ConsensusValueT, types::ProtoBlock};
+use crate::{
+    components::consensus::traits::ConsensusValueT, crypto::hash::Digest, types::ProtoBlock,
+};
 
 /// A proposed block. Once the consensus protocol reaches agreement on it, it will be converted to
 /// a `FinalizedBlock`.
@@ -40,6 +46,21 @@ impl From<CandidateBlock> for ProtoBlock {
 }
 
 impl ConsensusValueT for CandidateBlock {
+    type Hash = Digest;
+
+    fn hash(&self) -> Self::Hash {
+        let mut result = [0; Digest::LENGTH];
+
+        let mut hasher = VarBlake2b::new(Digest::LENGTH).expect("should create hasher");
+        hasher.update(self.proto_block.hash().inner());
+        hasher
+            .update(bincode::serialize(self.accusations()).expect("should serialize accusations"));
+        hasher.finalize_variable(|slice| {
+            result.copy_from_slice(slice);
+        });
+        result.into()
+    }
+    
     fn needs_validation(&self) -> bool {
         !self.proto_block.wasm_deploys().is_empty() || !self.proto_block.transfers().is_empty()
     }

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -40,11 +40,19 @@ use crate::{
     NodeRng,
 };
 
-type ConsensusValue = Vec<u32>;
+type ConsensusValue = Vec<u8>;
 
 impl ConsensusValueT for ConsensusValue {
+    type Hash = u64;
+
     fn needs_validation(&self) -> bool {
         !self.is_empty()
+    }
+
+    fn hash(&self) -> Self::Hash {
+        let mut hasher = DefaultHasher::new();
+        std::hash::Hash::hash(&self, &mut hasher);
+        hasher.finish()
     }
 }
 
@@ -831,7 +839,7 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
     }
 
     fn build(self, rng: &mut NodeRng) -> Result<HighwayTestHarness<DS>, BuilderError> {
-        let consensus_values = (0..self.consensus_values_count as u32)
+        let consensus_values = (0..self.consensus_values_count)
             .map(|el| vec![el])
             .collect::<VecDeque<ConsensusValue>>();
 

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -65,6 +65,12 @@ impl ConsensusValueT for u32 {
     fn needs_validation(&self) -> bool {
         false
     }
+
+    type Hash = u32;
+
+    fn hash(&self) -> Self::Hash {
+        *self
+    }
 }
 
 impl Context for TestContext {

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -19,6 +19,11 @@ impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash + Send
 pub(crate) trait ConsensusValueT:
     Eq + Clone + Debug + Hash + Serialize + DeserializeOwned + Send + DataSize
 {
+    type Hash: HashT;
+
+    /// Returns hash of self.
+    fn hash(&self) -> Self::Hash;
+
     /// Returns whether the consensus value needs validation.
     fn needs_validation(&self) -> bool;
 }


### PR DESCRIPTION
Instead of storing the whole `ConsensusValue` as a key in the map (where `ConsensusValue` is a set of all deploys that the block includes), we will store a hash of `ConsensusValue`. This will improve memory management.

https://casperlabs.atlassian.net/browse/HWY-250