### PR TITLE
HWY-251: BlockValidator accepts alternative sources of data.

### DIFF
--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -232,7 +232,7 @@ where
                 self.validation_states.retain(|key, state| {
                     if state.missing_deploys.contains(&deploy_hash) {
                         match state.source() {
-                            Some(peer) => { 
+                            Some(peer) => {
                                 info!(%deploy_hash, ?peer, "trying the next peer");
                                 // There's still hope to download the deploy.
                                 let (chainspec, block_timestamp) = &state.context;
@@ -255,7 +255,7 @@ where
                         true
                     }
                 });
-                
+
                 if retried {
                     // If we retried, we need to increase this counter.
                     self.in_flight.inc(&deploy_hash);
@@ -263,7 +263,8 @@ where
             }
             Event::DeployInvalid(deploy_hash) => {
                 info!(%deploy_hash, "deploy invalid");
-                // Deploy is invalid. There's no point waiting for other in-flight requests to finish.
+                // Deploy is invalid. There's no point waiting for other in-flight requests to
+                // finish.
                 self.in_flight.dec(&deploy_hash);
 
                 self.validation_states.retain(|key, state| {

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -189,8 +189,7 @@ where
                             missing_deploys,
                             responders: smallvec![responder],
                             sources: VecDeque::new(), /* This is empty b/c we create the first
-                                                       * request
-                                                       * using `sender`. */
+                                                       * request using `sender`. */
                             context: (chainspec, block_timestamp),
                         });
                     }
@@ -230,13 +229,21 @@ where
                 let mut retried = false;
 
                 self.validation_states.retain(|key, state| {
-                    if state.missing_deploys.contains(&deploy_hash) {
+                    if !state.missing_deploys.contains(&deploy_hash) {
+                        true
+                    } else {
                         match state.source() {
                             Some(peer) => {
                                 info!(%deploy_hash, ?peer, "trying the next peer");
                                 // There's still hope to download the deploy.
                                 let (chainspec, block_timestamp) = &state.context;
-                                effects.extend(fetch_deploy(effect_builder, Arc::clone(chainspec), *block_timestamp, deploy_hash, peer));
+                                effects.extend(
+                                    fetch_deploy(effect_builder,
+                                        Arc::clone(chainspec),
+                                        *block_timestamp,
+                                        deploy_hash,
+                                        peer,
+                                    ));
                                 retried = true;
                                 true
                             },
@@ -251,8 +258,6 @@ where
                                 false
                             }
                         }
-                    } else {
-                        true
                     }
                 });
 

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -229,8 +229,6 @@ where
                 self.validation_states.retain(|key, state| {
                     if state.missing_deploys.contains(&deploy_hash) {
                         match state.source() {
-                            // If deploy is invalid there's no point in trying alternative sources.
-                            // Retry only on timeout.
                             Some(peer) => {
                                 info!(%deploy_hash, ?peer, "trying the next peer");
                                 // There's still hope to download the deploy.
@@ -239,7 +237,7 @@ where
                                 true
                             },
                             None => {
-                                // Otherwise notify everyone still waiting on it that all is lost.
+                                // Notify everyone still waiting on it that all is lost.
                                 info!(block=?key, %deploy_hash, "could not validate the deploy. block is invalid");
                                 // This validation state contains a failed deploy hash, it can never
                                 // succeed.


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/HWY-251

After this PR, if fetching a `Deploy` fails due to a timeout then `BlockValidator` will retry downloading a deploy from an alternative source.