### PR TITLE
NDRS-834: Extend upgrade points

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -368,6 +368,11 @@ where
                 .write(locked_funds_period_key, value);
         }
 
+        // apply the arbitrary modifications
+        for (key, value) in upgrade_config.global_state_update() {
+            tracking_copy.borrow_mut().write(*key, value.clone());
+        }
+
         let effects = tracking_copy.borrow().effect();
 
         // commit

--- a/execution_engine/src/core/engine_state/upgrade.rs
+++ b/execution_engine/src/core/engine_state/upgrade.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, fmt, rc::Rc};
+use std::{cell::RefCell, collections::BTreeMap, fmt, rc::Rc};
 
 use num_rational::Ratio;
 use thiserror::Error;
@@ -88,6 +88,7 @@ pub struct UpgradeConfig {
     new_locked_funds_period: Option<EraId>,
     new_round_seigniorage_rate: Option<Ratio<u64>>,
     new_unbonding_delay: Option<EraId>,
+    global_state_update: BTreeMap<Key, StoredValue>,
 }
 
 impl UpgradeConfig {
@@ -104,6 +105,7 @@ impl UpgradeConfig {
         new_locked_funds_period: Option<EraId>,
         new_round_seigniorage_rate: Option<Ratio<u64>>,
         new_unbonding_delay: Option<EraId>,
+        global_state_update: BTreeMap<Key, StoredValue>,
     ) -> Self {
         UpgradeConfig {
             pre_state_hash,
@@ -117,6 +119,7 @@ impl UpgradeConfig {
             new_locked_funds_period,
             new_round_seigniorage_rate,
             new_unbonding_delay,
+            global_state_update,
         }
     }
 
@@ -162,6 +165,10 @@ impl UpgradeConfig {
 
     pub fn new_unbonding_delay(&self) -> Option<EraId> {
         self.new_unbonding_delay
+    }
+
+    pub fn global_state_update(&self) -> &BTreeMap<Key, StoredValue> {
+        &self.global_state_update
     }
 
     pub fn with_pre_state_hash(&mut self, pre_state_hash: Blake2bHash) {

--- a/execution_engine_testing/test_support/src/internal/upgrade_request_builder.rs
+++ b/execution_engine_testing/test_support/src/internal/upgrade_request_builder.rs
@@ -1,10 +1,15 @@
+use std::collections::BTreeMap;
+
 use num_rational::Ratio;
 
 use casper_execution_engine::{
     core::engine_state::{upgrade::ActivationPoint, UpgradeConfig},
-    shared::{newtypes::Blake2bHash, system_config::SystemConfig, wasm_config::WasmConfig},
+    shared::{
+        newtypes::Blake2bHash, stored_value::StoredValue, system_config::SystemConfig,
+        wasm_config::WasmConfig,
+    },
 };
-use casper_types::{auction::EraId, ProtocolVersion};
+use casper_types::{auction::EraId, Key, ProtocolVersion};
 
 #[derive(Default)]
 pub struct UpgradeRequestBuilder {
@@ -19,6 +24,7 @@ pub struct UpgradeRequestBuilder {
     new_locked_funds_period: Option<EraId>,
     new_round_seigniorage_rate: Option<Ratio<u64>>,
     new_unbonding_delay: Option<EraId>,
+    global_state_update: BTreeMap<Key, StoredValue>,
 }
 
 impl UpgradeRequestBuilder {
@@ -75,6 +81,14 @@ impl UpgradeRequestBuilder {
         self
     }
 
+    pub fn with_global_state_update(
+        mut self,
+        global_state_update: BTreeMap<Key, StoredValue>,
+    ) -> Self {
+        self.global_state_update = global_state_update;
+        self
+    }
+
     pub fn with_activation_point(mut self, height: u64) -> Self {
         self.activation_point = Some(height);
         self
@@ -93,6 +107,7 @@ impl UpgradeRequestBuilder {
             self.new_locked_funds_period,
             self.new_round_seigniorage_rate,
             self.new_unbonding_delay,
+            self.global_state_update,
         )
     }
 }

--- a/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use casper_engine_test_support::internal::{
     InMemoryWasmTestBuilder, UpgradeRequestBuilder, DEFAULT_RUN_GENESIS_REQUEST,
     DEFAULT_UNBONDING_DELAY, DEFAULT_WASM_CONFIG,
@@ -16,6 +18,7 @@ use casper_execution_engine::{
             DEFAULT_UNREACHABLE_COST,
         },
         storage_costs::StorageCosts,
+        stored_value::StoredValue,
         wasm_config::{WasmConfig, DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY},
     },
 };
@@ -24,7 +27,7 @@ use casper_types::{
         EraId, AUCTION_DELAY_KEY, LOCKED_FUNDS_PERIOD_KEY, UNBONDING_DELAY_KEY, VALIDATOR_SLOTS_KEY,
     },
     mint::ROUND_SEIGNIORAGE_RATE_KEY,
-    ProtocolVersion, U512,
+    CLValue, ProtocolVersion, U512,
 };
 use num_rational::Ratio;
 
@@ -563,5 +566,69 @@ fn should_upgrade_only_unbonding_delay() {
     assert_eq!(
         new_unbonding_delay, after_unbonding_delay,
         "Should have upgraded locked funds period"
+    );
+}
+
+#[ignore]
+#[test]
+fn should_apply_global_state_upgrade() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    let sem_ver = PROTOCOL_VERSION.value();
+    let new_protocol_version =
+        ProtocolVersion::from_parts(sem_ver.major, sem_ver.minor, sem_ver.patch + 1);
+
+    // We'll try writing directly to this key.
+    let unbonding_delay_key = builder
+        .get_contract(builder.get_auction_contract_hash())
+        .expect("auction should exist")
+        .named_keys()[UNBONDING_DELAY_KEY];
+
+    let before_unbonding_delay: EraId = builder
+        .query(None, unbonding_delay_key, &[])
+        .expect("should have locked funds period")
+        .as_cl_value()
+        .expect("should be a CLValue")
+        .clone()
+        .into_t()
+        .expect("should be u64");
+
+    let new_unbonding_delay: EraId = DEFAULT_UNBONDING_DELAY + 5;
+
+    let mut update_map = BTreeMap::new();
+    update_map.insert(
+        unbonding_delay_key,
+        StoredValue::from(CLValue::from_t(new_unbonding_delay).expect("should create a CLValue")),
+    );
+
+    let mut upgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(PROTOCOL_VERSION)
+            .with_new_protocol_version(new_protocol_version)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .with_global_state_update(update_map)
+            .build()
+    };
+
+    builder
+        .upgrade_with_upgrade_request(&mut upgrade_request)
+        .expect_upgrade_success();
+
+    let after_unbonding_delay: EraId = builder
+        .query(None, unbonding_delay_key, &[])
+        .expect("should have locked funds period")
+        .as_cl_value()
+        .expect("should be a CLValue")
+        .clone()
+        .into_t()
+        .expect("should be u64");
+
+    assert_ne!(before_unbonding_delay, new_unbonding_delay);
+
+    assert_eq!(
+        new_unbonding_delay, after_unbonding_delay,
+        "Should have modified locked funds period"
     );
 }

--- a/types/src/access_rights.rs
+++ b/types/src/access_rights.rs
@@ -2,6 +2,10 @@ use alloc::vec::Vec;
 
 use bitflags::bitflags;
 use datasize::DataSize;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::bytesrepr;
@@ -108,6 +112,22 @@ impl<'de> Deserialize<'de> for AccessRights {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let bits = u8::deserialize(deserializer)?;
         AccessRights::from_bits(bits).ok_or_else(|| SerdeError::custom("invalid bits"))
+    }
+}
+
+impl Distribution<AccessRights> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AccessRights {
+        let mut result = AccessRights::NONE;
+        if rng.gen() {
+            result |= AccessRights::READ;
+        }
+        if rng.gen() {
+            result |= AccessRights::WRITE;
+        }
+        if rng.gen() {
+            result |= AccessRights::ADD;
+        }
+        result
     }
 }
 

--- a/types/src/access_rights.rs
+++ b/types/src/access_rights.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 
 use bitflags::bitflags;
+use datasize::DataSize;
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::bytesrepr;
@@ -12,6 +13,7 @@ bitflags! {
     /// A struct which behaves like a set of bitflags to define access rights associated with a
     /// [`URef`](crate::URef).
     #[allow(clippy::derive_hash_xor_eq)]
+    #[derive(DataSize)]
     pub struct AccessRights: u8 {
         /// No permissions
         const NONE = 0;

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -16,6 +16,10 @@ use blake2::{
 };
 use datasize::DataSize;
 use failure::Fail;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 #[cfg(feature = "std")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
@@ -382,6 +386,12 @@ impl FromBytes for AccountHash {
 impl AsRef<[u8]> for AccountHash {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl Distribution<AccountHash> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AccountHash {
+        AccountHash::new(rng.gen())
     }
 }
 

--- a/types/src/bytesrepr/bytes.rs
+++ b/types/src/bytesrepr/bytes.rs
@@ -11,6 +11,10 @@ use core::{
 };
 
 use datasize::DataSize;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{
     de::{Error as SerdeError, SeqAccess, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
@@ -195,6 +199,19 @@ impl DataSize for Bytes {
 
     fn estimate_heap_size(&self) -> usize {
         self.0.capacity() * mem::size_of::<u8>()
+    }
+}
+
+const RANDOM_BYTES_MAX_LENGTH: usize = 100;
+
+impl Distribution<Bytes> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Bytes {
+        let len = rng.gen_range(0, RANDOM_BYTES_MAX_LENGTH);
+        let mut result = Vec::with_capacity(len);
+        for _ in 0..len {
+            result.push(rng.gen());
+        }
+        result.into()
     }
 }
 

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -11,6 +11,10 @@ use core::{
 
 use datasize::DataSize;
 use hex_fmt::HexFmt;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
@@ -376,6 +380,20 @@ impl FromBytes for Key {
                 Ok((Key::EraInfo(era_id), rem))
             }
             _ => Err(Error::Formatting),
+        }
+    }
+}
+
+impl Distribution<Key> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Key {
+        match rng.gen_range(0, 6) {
+            0 => Key::Account(rng.gen()),
+            1 => Key::Hash(rng.gen()),
+            2 => Key::URef(rng.gen()),
+            3 => Key::Transfer(rng.gen()),
+            4 => Key::DeployInfo(rng.gen()),
+            5 => Key::EraInfo(rng.gen()),
+            _ => unreachable!(),
         }
     }
 }

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -9,6 +9,7 @@ use core::{
     fmt::{self, Debug, Display, Formatter},
 };
 
+use datasize::DataSize;
 use hex_fmt::HexFmt;
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -62,7 +63,7 @@ impl From<HashAddr> for Key {
 /// The type under which data (e.g. [`CLValue`](crate::CLValue)s, smart contracts, user accounts)
 /// are indexed on the network.
 #[repr(C)]
-#[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
+#[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash, DataSize)]
 pub enum Key {
     /// A `Key` under which a user account is stored.
     Account(AccountHash),

--- a/types/src/transfer.rs
+++ b/types/src/transfer.rs
@@ -9,6 +9,10 @@ use core::{
 };
 
 use datasize::DataSize;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 #[cfg(feature = "std")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
@@ -97,6 +101,12 @@ impl<'de> Deserialize<'de> for DeployHash {
             <[u8; DEPLOY_HASH_LENGTH]>::deserialize(deserializer)?
         };
         Ok(DeployHash(bytes))
+    }
+}
+
+impl Distribution<DeployHash> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> DeployHash {
+        DeployHash::new(rng.gen())
     }
 }
 
@@ -372,6 +382,12 @@ impl FromBytes for TransferAddr {
 impl AsRef<[u8]> for TransferAddr {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl Distribution<TransferAddr> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> TransferAddr {
+        TransferAddr::new(rng.gen())
     }
 }
 

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -11,6 +11,10 @@ use core::{
 
 use datasize::DataSize;
 use hex_fmt::HexFmt;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 #[cfg(feature = "std")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
@@ -258,6 +262,12 @@ impl TryFrom<Key> for URef {
         } else {
             Err(ApiError::UnexpectedKeyVariant)
         }
+    }
+}
+
+impl Distribution<URef> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> URef {
+        URef::new(rng.gen(), rng.gen())
     }
 }
 

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -9,6 +9,7 @@ use core::{
     num::ParseIntError,
 };
 
+use datasize::DataSize;
 use hex_fmt::HexFmt;
 #[cfg(feature = "std")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
@@ -87,7 +88,7 @@ impl Display for FromStrError {
 /// the [`AccessRights`] of the reference.
 ///
 /// A `URef` can be used to index entities such as [`CLValue`](crate::CLValue)s, or smart contracts.
-#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default, DataSize)]
 pub struct URef(URefAddr, AccessRights);
 
 impl URef {


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-834

Currently there are no upgrade points per se - the chainspec as a whole is kind of an upgrade point. So maybe the `global_state_update` doesn't really belong in `ProtocolConfig` - could be an additional field in the chainspec itself, maybe? I'm open to moving it somewhere else.