### PR TITLE
NO-TICKET: Make the small_net a default networking layer.

### DIFF
--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -68,7 +68,7 @@ use crate::{
 };
 
 /// Env var which, if it's defined at runtime, enables the small_network component.
-pub(crate) const ENABLE_SMALL_NET_ENV_VAR: &str = "CASPER_ENABLE_LEGACY_NET";
+pub(crate) const ENABLE_LIBP2P_NET_ENV_VAR: &str = "CASPER_ENABLE_LIBP2P_NET";
 
 /// How long to sleep before reconnecting
 const RECONNECT_DELAY: Duration = Duration::from_millis(500);
@@ -179,8 +179,8 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
         let (gossip_message_sender, gossip_message_receiver) = mpsc::unbounded_channel();
         let (server_shutdown_sender, server_shutdown_receiver) = watch::channel(());
 
-        // If the env var "CASPER_ENABLE_LEGACY_NET" is defined, exit without starting the server.
-        if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
+        // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, start the server and exit.
+        if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
             let network = Network {
                 network_identity,
                 our_id,
@@ -808,7 +808,7 @@ impl<REv: Send + 'static, P: Send + 'static> Finalize for Network<REv, P> {
                     Ok(_) => debug!("{}: server exited cleanly", self.our_id),
                     Err(err) => error!(%err, "{}: could not join server task cleanly", self.our_id),
                 }
-            } else if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
+            } else if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
                 warn!("{}: server shutdown while already shut down", self.our_id)
             }
         }

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -67,7 +67,7 @@ use crate::{
     NodeRng,
 };
 
-/// Env var which, if it's defined at runtime, enables the small_network component.
+/// Env var which, if it's defined at runtime, enables the network (libp2p based) component.
 pub(crate) const ENABLE_LIBP2P_NET_ENV_VAR: &str = "CASPER_ENABLE_LIBP2P_NET";
 
 /// How long to sleep before reconnecting

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -13,7 +13,7 @@ use tracing::{debug, info};
 
 use super::{
     network_is_isolated, Config, Event as NetworkEvent, Network as NetworkComponent,
-    ENABLE_SMALL_NET_ENV_VAR,
+    ENABLE_LIBP2P_NET_ENV_VAR,
 };
 use crate::{
     components::{network::NetworkIdentity, Component},
@@ -182,8 +182,8 @@ fn network_started(net: &Network<TestReactor>) -> bool {
 /// Ensures that network cleanup and basic networking works.
 #[tokio::test]
 async fn run_two_node_network_five_times() {
-    // If the env var "CASPER_ENABLE_LEGACY_NET" is defined, exit without running the test.
-    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without running the test.
+    if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
         return;
     }
 
@@ -248,8 +248,8 @@ async fn run_two_node_network_five_times() {
 /// Very unlikely to ever fail on a real machine.
 #[tokio::test]
 async fn bind_to_real_network_interface() {
-    // If the env var "CASPER_ENABLE_LEGACY_NET" is defined, exit without running the test.
-    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without running the test.
+    if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
         return;
     }
 
@@ -293,8 +293,8 @@ async fn bind_to_real_network_interface() {
 /// Check that a network of varying sizes will connect all nodes properly.
 #[tokio::test]
 async fn check_varying_size_network_connects() {
-    // If the env var "CASPER_ENABLE_LEGACY_NET" is defined, exit without running the test.
-    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without running the test.
+    if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
         return;
     }
 

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -182,7 +182,7 @@ fn network_started(net: &Network<TestReactor>) -> bool {
 /// Ensures that network cleanup and basic networking works.
 #[tokio::test]
 async fn run_two_node_network_five_times() {
-    // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without running the test.
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without running the test.
     if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
         return;
     }
@@ -248,7 +248,7 @@ async fn run_two_node_network_five_times() {
 /// Very unlikely to ever fail on a real machine.
 #[tokio::test]
 async fn bind_to_real_network_interface() {
-    // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without running the test.
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without running the test.
     if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
         return;
     }
@@ -293,7 +293,7 @@ async fn bind_to_real_network_interface() {
 /// Check that a network of varying sizes will connect all nodes properly.
 #[tokio::test]
 async fn check_varying_size_network_connects() {
-    // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without running the test.
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without running the test.
     if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
         return;
     }

--- a/node/src/components/network/tests_bulk_gossip.rs
+++ b/node/src/components/network/tests_bulk_gossip.rs
@@ -13,7 +13,7 @@ use tracing::info;
 
 use casper_node_macros::reactor;
 
-use super::ENABLE_SMALL_NET_ENV_VAR;
+use super::ENABLE_LIBP2P_NET_ENV_VAR;
 use crate::{
     components::{
         collector::Collectable,
@@ -133,8 +133,8 @@ impl Display for DummyPayload {
 async fn send_large_message_across_network() {
     testing::init_logging();
 
-    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
-        eprintln!("{} set, skipping test", ENABLE_SMALL_NET_ENV_VAR);
+    if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
+        eprintln!("{} set, skipping test", ENABLE_LIBP2P_NET_ENV_VAR);
         return;
     }
 

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -209,7 +209,7 @@ where
 
         let net_metrics = NetworkingMetrics::new(&registry)?;
 
-        // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without starting the
+        // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without starting the
         // server.
         if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
             let model = SmallNetwork {

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -85,7 +85,7 @@ use self::error::Result;
 pub(crate) use self::{event::Event, gossiped_address::GossipedAddress, message::Message};
 use crate::{
     components::{
-        network::ENABLE_SMALL_NET_ENV_VAR, networking_metrics::NetworkingMetrics, Component,
+        network::ENABLE_LIBP2P_NET_ENV_VAR, networking_metrics::NetworkingMetrics, Component,
     },
     crypto::hash::Digest,
     effect::{
@@ -209,9 +209,9 @@ where
 
         let net_metrics = NetworkingMetrics::new(&registry)?;
 
-        // If the env var "CASPER_ENABLE_LEGACY_NET" is not defined, exit without starting the
+        // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without starting the
         // server.
-        if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
+        if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
             let model = SmallNetwork {
                 certificate,
                 secret_key,
@@ -817,7 +817,7 @@ where
                     Ok(_) => debug!(our_id=%self.our_id, "server exited cleanly"),
                     Err(err) => error!(%self.our_id,%err, "could not join server task cleanly"),
                 }
-            } else if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
+            } else if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
                 warn!(our_id=%self.our_id, "server shutdown while already shut down")
             }
         }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -20,7 +20,7 @@ use super::{Config, Event as SmallNetworkEvent, GossipedAddress, SmallNetwork};
 use crate::{
     components::{
         gossiper::{self, Gossiper},
-        network::ENABLE_SMALL_NET_ENV_VAR,
+        network::ENABLE_LIBP2P_NET_ENV_VAR,
         small_network::SmallNetworkIdentity,
         Component,
     },
@@ -258,8 +258,8 @@ fn network_started(net: &Network<TestReactor>) -> bool {
 /// Ensures that network cleanup and basic networking works.
 #[tokio::test]
 async fn run_two_node_network_five_times() {
-    // If the env var "CASPER_ENABLE_LEGACY_NET" is not defined, exit without running the test.
-    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without running the test.
+    if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
         return;
     }
 
@@ -324,8 +324,8 @@ async fn run_two_node_network_five_times() {
 /// Very unlikely to ever fail on a real machine.
 #[tokio::test]
 async fn bind_to_real_network_interface() {
-    // If the env var "CASPER_ENABLE_LEGACY_NET" is not defined, exit without running the test.
-    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without running the test.
+    if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
         return;
     }
 
@@ -369,8 +369,8 @@ async fn bind_to_real_network_interface() {
 /// Check that a network of varying sizes will connect all nodes properly.
 #[tokio::test]
 async fn check_varying_size_network_connects() {
-    // If the env var "CASPER_ENABLE_LEGACY_NET" is not defined, exit without running the test.
-    if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without running the test.
+    if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
         return;
     }
 

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -258,7 +258,7 @@ fn network_started(net: &Network<TestReactor>) -> bool {
 /// Ensures that network cleanup and basic networking works.
 #[tokio::test]
 async fn run_two_node_network_five_times() {
-    // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without running the test.
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without running the test.
     if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
         return;
     }
@@ -324,7 +324,7 @@ async fn run_two_node_network_five_times() {
 /// Very unlikely to ever fail on a real machine.
 #[tokio::test]
 async fn bind_to_real_network_interface() {
-    // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without running the test.
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without running the test.
     if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
         return;
     }
@@ -369,7 +369,7 @@ async fn bind_to_real_network_interface() {
 /// Check that a network of varying sizes will connect all nodes properly.
 #[tokio::test]
 async fn check_varying_size_network_connects() {
-    // If the env var "CASPER_ENABLE_LIBP2P_NET" is not defined, exit without running the test.
+    // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without running the test.
     if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
         return;
     }

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 
 #[cfg(test)]
 use crate::{
-    components::network::ENABLE_SMALL_NET_ENV_VAR, testing::network::NetworkedReactor,
+    components::network::ENABLE_LIBP2P_NET_ENV_VAR, testing::network::NetworkedReactor,
     types::Chainspec,
 };
 use crate::{
@@ -236,7 +236,7 @@ impl reactor::Reactor for Reactor {
 impl NetworkedReactor for Reactor {
     type NodeId = NodeId;
     fn node_id(&self) -> Self::NodeId {
-        if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
+        if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
             NodeId::from(&self.small_network_identity)
         } else {
             NodeId::from(&self.network_identity)

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -38,7 +38,7 @@ use crate::{
         gossiper::{self, Gossiper},
         linear_chain,
         metrics::Metrics,
-        network::{self, Network, NetworkIdentity, ENABLE_SMALL_NET_ENV_VAR},
+        network::{self, Network, NetworkIdentity, ENABLE_LIBP2P_NET_ENV_VAR},
         rest_server::{self, RestServer},
         small_network::{self, GossipedAddress, SmallNetwork, SmallNetworkIdentity},
         storage::{self, Storage},
@@ -233,7 +233,7 @@ impl From<StorageRequest> for Event {
 
 impl From<NetworkRequest<NodeId, Message>> for Event {
     fn from(request: NetworkRequest<NodeId, Message>) -> Self {
-        if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
+        if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
             Event::Network(network::Event::from(request))
         } else {
             Event::SmallNetwork(small_network::Event::from(request))
@@ -858,7 +858,7 @@ impl reactor::Reactor for Reactor {
                 self.dispatch_event(effect_builder, rng, Event::ChainspecLoader(req.into()))
             }
             Event::NetworkInfoRequest(req) => {
-                let event = if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
+                let event = if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
                     Event::Network(network::Event::from(req))
                 } else {
                     Event::SmallNetwork(small_network::Event::from(req))

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -925,7 +925,7 @@ impl Reactor {
 impl NetworkedReactor for Reactor {
     type NodeId = NodeId;
     fn node_id(&self) -> Self::NodeId {
-        if env::var(ENABLE_SMALL_NET_ENV_VAR).is_ok() {
+        if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
             self.small_network.node_id()
         } else {
             self.network.node_id()

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -36,7 +36,7 @@ use crate::{
         gossiper::{self, Gossiper},
         linear_chain,
         metrics::Metrics,
-        network::{self, Network, NetworkIdentity, ENABLE_SMALL_NET_ENV_VAR},
+        network::{self, Network, NetworkIdentity, ENABLE_LIBP2P_NET_ENV_VAR},
         rest_server::{self, RestServer},
         rpc_server::{self, RpcServer},
         small_network::{self, GossipedAddress, SmallNetwork, SmallNetworkIdentity},
@@ -573,7 +573,7 @@ impl reactor::Reactor for Reactor {
 
             // Requests:
             Event::NetworkRequest(req) => {
-                let event = if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
+                let event = if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
                     Event::Network(network::Event::from(req))
                 } else {
                     Event::SmallNetwork(small_network::Event::from(req))
@@ -581,7 +581,7 @@ impl reactor::Reactor for Reactor {
                 self.dispatch_event(effect_builder, rng, event)
             }
             Event::NetworkInfoRequest(req) => {
-                let event = if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
+                let event = if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
                     Event::Network(network::Event::from(req))
                 } else {
                     Event::SmallNetwork(small_network::Event::from(req))
@@ -930,7 +930,7 @@ impl reactor::Reactor for Reactor {
 impl NetworkedReactor for Reactor {
     type NodeId = NodeId;
     fn node_id(&self) -> Self::NodeId {
-        if env::var(ENABLE_SMALL_NET_ENV_VAR).is_err() {
+        if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
             self.network.node_id()
         } else {
             self.small_network.node_id()


### PR DESCRIPTION
Make the `small_net` the default networking component.

In order to enable the libp2p-based version, one has to export `CASPER_ENABLE_LIBP2P_NET` variable.