### PR TITLE
NO-TICKET: generate node version consistently

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,13 +24,7 @@ casper-node-macros = { version = "0.7.0", path = "../node_macros" }
 casper-types = { version = "0.7.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 csv = "1.1.3"
-datasize = { version = "0.2.6", features = [
-    "detailed",
-    "fake_clock-types",
-    "futures-types",
-    "smallvec-types",
-    "tokio-types",
-] }
+datasize = { version = "0.2.6", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types", "tokio-types"] }
 derive_more = "0.99.7"
 derp = "0.0.14"
 directories = "3.0.1"

--- a/node/build.rs
+++ b/node/build.rs
@@ -4,7 +4,6 @@ use vergen::ConstantsFlags;
 
 fn main() {
     let mut flags = ConstantsFlags::empty();
-    flags.toggle(ConstantsFlags::SEMVER_LIGHTWEIGHT);
     flags.toggle(ConstantsFlags::SHA_SHORT);
     flags.toggle(ConstantsFlags::REBUILD_ON_HEAD_CHANGE);
     vergen::generate_cargo_keys(flags).expect("should generate the cargo keys");

--- a/node/src/app/cli.rs
+++ b/node/src/app/cli.rs
@@ -144,7 +144,7 @@ impl Cli {
                 setup_signal_hooks();
 
                 let validator_config = Self::init(&config, config_ext)?;
-                info!(version = %env!("CARGO_PKG_VERSION"), "node starting up");
+                info!(version = %casper_node::VERSION_STRING.as_str(), "node starting up");
 
                 // We use a `ChaCha20Rng` for the production node. For one, we want to completely
                 // eliminate any chance of runtime failures, regardless of how small (these

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -66,15 +66,7 @@ pub use utils::OS_PAGE_SIZE;
 pub const MAX_THREAD_COUNT: usize = 512;
 
 fn version_string(color: bool) -> String {
-    let mut version = if env!("VERGEN_SEMVER_LIGHTWEIGHT") == "UNKNOWN" {
-        env!("CARGO_PKG_VERSION").to_string()
-    } else {
-        format!(
-            "{}-{}",
-            env!("VERGEN_SEMVER_LIGHTWEIGHT"),
-            env!("VERGEN_SHA_SHORT"),
-        )
-    };
+    let mut version = format!("{}-{}", env!("CARGO_PKG_VERSION"), env!("VERGEN_SHA_SHORT"));
 
     // Add a `@DEBUG` (or similar) tag to release string on non-release builds.
     if env!("NODE_BUILD_PROFILE") != "release" {


### PR DESCRIPTION
When building from a repo where the git tags were not up to date, the version the node reported was highly misleading, using the latest git tag rather than the version specified in `Cargo.toml`.  This misleading version is used to populate the output when running the node with `-h` or `-V` and is also reported via the status endpoints.  However, when the node first starts, a further version is output which is based upon the value in `Cargo.toml`.

This PR ensures the proper crate version as specified in the `Cargo.toml` is used in all these cases.