### PR TITLE
NO-TICKET: Reject pings by faulty validators.

### DIFF
--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -95,10 +95,11 @@ impl<C: Context> Vertex<C> {
         }
     }
 
-    pub(crate) fn signed_wire_unit(&self) -> Option<&SignedWireUnit<C>> {
+    pub(crate) fn creator(&self) -> Option<ValidatorIndex> {
         match self {
-            Vertex::Unit(signed_wire_unit) => Some(signed_wire_unit),
-            _ => None,
+            Vertex::Unit(signed_wire_unit) => Some(signed_wire_unit.wire_unit().creator),
+            Vertex::Ping(ping) => Some(ping.creator),
+            Vertex::Evidence(_) | Vertex::Endorsements(_) => None,
         }
     }
 

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -421,11 +421,8 @@ where
                         .collect();
                     }
                 };
-                let is_faulty = match pvv.inner().signed_wire_unit() {
-                    Some(signed_wire_unit) => self
-                        .highway
-                        .state()
-                        .is_faulty(signed_wire_unit.wire_unit().creator),
+                let is_faulty = match pvv.inner().creator() {
+                    Some(creator) => self.highway.state().is_faulty(creator),
                     None => false,
                 };
 


### PR DESCRIPTION
We don't count faulty validators towards the "online" ones anyway, so there's no point processing their pings.