### PR TITLE
NDRS-876 - track metric for last block time

### DIFF
--- a/node/src/components/consensus/metrics.rs
+++ b/node/src/components/consensus/metrics.rs
@@ -10,7 +10,9 @@ pub struct ConsensusMetrics {
     /// Amount of finalized blocks.
     finalized_block_count: IntCounter,
     /// Timestamp of the most recently accepted proto block.
-    time_of_last_proposed_block: Gauge,
+    time_of_last_proposed_block: IntGauge,
+    /// Timestamp of the most recently finalized block.
+    time_of_last_finalized_block: IntGauge,
     /// The Current era.
     pub current_era: IntGauge,
     /// registry component.
@@ -25,18 +27,25 @@ impl ConsensusMetrics {
         )?;
         let finalized_block_count =
             IntCounter::new("amount_of_blocks", "the number of blocks finalized so far")?;
-        let time_of_last_proposed_block = Gauge::new(
+        let time_of_last_proposed_block = IntGauge::new(
             "time_of_last_proto_block",
             "timestamp of the most recently accepted proto block",
+        )?;
+        let time_of_last_finalized_block = IntGauge::new(
+            "time_of_last_finalized_block",
+            "timestamp of the most recently finalized block",
         )?;
         let current_era = IntGauge::new("current_era", "The current era")?;
         registry.register(Box::new(finalization_time.clone()))?;
         registry.register(Box::new(finalized_block_count.clone()))?;
         registry.register(Box::new(current_era.clone()))?;
+        registry.register(Box::new(time_of_last_proposed_block.clone()))?;
+        registry.register(Box::new(time_of_last_finalized_block.clone()))?;
         Ok(ConsensusMetrics {
             finalization_time,
             finalized_block_count,
             time_of_last_proposed_block,
+            time_of_last_finalized_block,
             current_era,
             registry: registry.clone(),
         })
@@ -46,13 +55,15 @@ impl ConsensusMetrics {
     pub(crate) fn finalized_block(&mut self, finalized_block: &FinalizedBlock) {
         let time_since_proto_block = finalized_block.timestamp().elapsed().millis() as f64;
         self.finalization_time.set(time_since_proto_block);
+        self.time_of_last_finalized_block
+            .set(finalized_block.timestamp().millis() as i64);
         self.finalized_block_count.inc();
     }
 
     /// Updates the metrics and records a newly proposed block.
     pub(crate) fn proposed_block(&mut self) {
         self.time_of_last_proposed_block
-            .set(Timestamp::now().millis() as f64 / 1000.00);
+            .set(Timestamp::now().millis() as i64);
     }
 }
 
@@ -67,5 +78,11 @@ impl Drop for ConsensusMetrics {
         self.registry
             .unregister(Box::new(self.current_era.clone()))
             .expect("did not expect deregistering current era to fail");
+        self.registry
+            .unregister(Box::new(self.time_of_last_finalized_block.clone()))
+            .expect("did not expect deregistering time_of_last_finalized_block to fail");
+        self.registry
+            .unregister(Box::new(self.time_of_last_proposed_block.clone()))
+            .expect("did not expect deregistering time_of_last_proposed_block to fail");
     }
 }

--- a/node/src/components/consensus/metrics.rs
+++ b/node/src/components/consensus/metrics.rs
@@ -1,4 +1,4 @@
-use prometheus::{Gauge, IntCounter, IntGauge, Registry};
+use prometheus::{Gauge, IntGauge, Registry};
 
 use crate::types::{FinalizedBlock, Timestamp};
 
@@ -8,7 +8,7 @@ pub struct ConsensusMetrics {
     /// Gauge to track time between proposal and finalization.
     finalization_time: Gauge,
     /// Amount of finalized blocks.
-    finalized_block_count: IntCounter,
+    finalized_block_count: IntGauge,
     /// Timestamp of the most recently accepted proto block.
     time_of_last_proposed_block: IntGauge,
     /// Timestamp of the most recently finalized block.
@@ -26,7 +26,7 @@ impl ConsensusMetrics {
             "the amount of time, in milliseconds, between proposal and finalization of a block",
         )?;
         let finalized_block_count =
-            IntCounter::new("amount_of_blocks", "the number of blocks finalized so far")?;
+            IntGauge::new("amount_of_blocks", "the number of blocks finalized so far")?;
         let time_of_last_proposed_block = IntGauge::new(
             "time_of_last_proto_block",
             "timestamp of the most recently accepted proto block",
@@ -57,7 +57,8 @@ impl ConsensusMetrics {
         self.finalization_time.set(time_since_proto_block);
         self.time_of_last_finalized_block
             .set(finalized_block.timestamp().millis() as i64);
-        self.finalized_block_count.inc();
+        self.finalized_block_count
+            .set(finalized_block.height() as i64);
     }
 
     /// Updates the metrics and records a newly proposed block.

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -475,7 +475,7 @@ impl reactor::Reactor for Reactor {
 
         let block_executor = BlockExecutor::new(genesis_state_root_hash, registry.clone());
 
-        let linear_chain = linear_chain::LinearChain::new();
+        let linear_chain = linear_chain::LinearChain::new(&registry)?;
 
         let validator_weights: BTreeMap<PublicKey, U512> = chainspec_loader
             .chainspec()

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -448,7 +448,7 @@ impl reactor::Reactor for Reactor {
         let block_executor = BlockExecutor::new(genesis_state_root_hash, registry.clone())
             .with_parent_map(latest_block);
         let (proto_block_validator, block_validator_effects) = BlockValidator::new(effect_builder);
-        let linear_chain = LinearChain::new();
+        let linear_chain = LinearChain::new(registry)?;
 
         effects.extend(reactor::wrap_effects(
             Event::ProtoBlockValidator,


### PR DESCRIPTION
Adds metrics for `time_of_last_finalized_block`, `block_completion_duration` and fixes an unregistered metric `time_of_last_proposed_block`. 

Talking with @EdHastingsCasperLabs `time_of_last_added_block` wasn't going to be meaningful, so we pivoted to instead record `block_completion_duration.`