### PR TITLE
NDRS-837: Add account-address subcommand

### DIFF
--- a/client/src/account_address.rs
+++ b/client/src/account_address.rs
@@ -1,0 +1,89 @@
+use std::{fs, str};
+
+use clap::{App, Arg, ArgMatches, SubCommand};
+
+use casper_types::{AsymmetricType, PublicKey};
+
+use crate::{command::ClientCommand, common};
+
+/// This struct defines the order in which the args are shown for this subcommand's help message.
+enum DisplayOrder {
+    Verbose,
+    Key,
+}
+
+/// Handles providing the arg for and retrieval of the key.
+mod key {
+    use casper_node::crypto::AsymmetricKeyExt;
+    use casper_types::AsymmetricType;
+
+    use super::*;
+
+    const ARG_NAME: &str = "public-key";
+    const ARG_SHORT: &str = "pk";
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
+    const ARG_HELP: &str = "Path to the public key or the formatted hex string";
+
+    pub(super) fn arg() -> Arg<'static, 'static> {
+        Arg::with_name(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(true)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::Key as usize)
+    }
+
+    pub(super) fn get(matches: &ArgMatches) -> String {
+        let value = matches
+            .value_of(ARG_NAME)
+            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME));
+
+        if let Ok(public_key) = PublicKey::from_file(value) {
+            return public_key.to_hex();
+        }
+
+        if let Ok(hex_public_key) = fs::read_to_string(value).map(|contents| {
+            PublicKey::from_hex(&contents).unwrap_or_else(|error| {
+                panic!(
+                    "failed to parse '{}' as a hex-encoded public key file: {}",
+                    value, error
+                )
+            });
+            contents
+        }) {
+            return hex_public_key;
+        }
+
+        value.to_string()
+    }
+}
+
+pub struct GenerateAccountHash {}
+
+impl<'a, 'b> ClientCommand<'a, 'b> for GenerateAccountHash {
+    const NAME: &'static str = "account-address";
+    const ABOUT: &'static str = "Generate an account hash from a given public key";
+
+    fn build(display_order: usize) -> App<'a, 'b> {
+        SubCommand::with_name(Self::NAME)
+            .about(Self::ABOUT)
+            .display_order(display_order)
+            .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
+            .arg(key::arg())
+    }
+
+    fn run(matches: &ArgMatches<'_>) {
+        let mut verbosity_level = common::verbose::get(matches);
+        let key_string = key::get(matches);
+        let public_key = PublicKey::from_hex(key_string)
+            .unwrap_or_else(|error| panic!("error in retrieving public key: {}", error));
+        let account_hash = public_key.to_account_hash();
+
+        if verbosity_level == 0 {
+            verbosity_level += 1
+        }
+
+        casper_client::pretty_print_at_level(&account_hash, verbosity_level)
+    }
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,3 +1,4 @@
+mod account_address;
 mod block;
 mod command;
 mod common;
@@ -23,6 +24,7 @@ use casper_node::rpcs::{
 
 use deploy::{ListDeploys, MakeDeploy, SendDeploy, SignDeploy};
 
+use account_address::GenerateAccountHash as AccountAddress;
 use command::ClientCommand;
 use deploy::Transfer;
 use generate_completion::GenerateCompletion;
@@ -49,6 +51,7 @@ enum DisplayOrder {
     Keygen,
     GenerateCompletion,
     GetRpcs,
+    AccountAddress,
 }
 
 fn cli<'a, 'b>() -> App<'a, 'b> {
@@ -80,6 +83,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
             DisplayOrder::GenerateCompletion as usize,
         ))
         .subcommand(ListRpcs::build(DisplayOrder::GetRpcs as usize))
+        .subcommand(AccountAddress::build(DisplayOrder::AccountAddress as usize))
 }
 
 #[tokio::main]
@@ -103,6 +107,7 @@ async fn main() {
         (Keygen::NAME, Some(matches)) => Keygen::run(matches),
         (GenerateCompletion::NAME, Some(matches)) => GenerateCompletion::run(matches),
         (ListRpcs::NAME, Some(matches)) => ListRpcs::run(matches),
+        (AccountAddress::NAME, Some(matches)) => AccountAddress::run(matches),
         _ => {
             let _ = cli().print_long_help();
             println!();


### PR DESCRIPTION
REF: https://casperlabs.atlassian.net/browse/NDRS-837

CHANGELOG:

- Added a new sub-command called `account-address` with a single arg `--public-key` which takes a hex formatted public key or a path to a key and outputs the associated account-hash for the public key

Sample Output:
![Screenshot from 2021-02-10 10-56-44](https://user-images.githubusercontent.com/42871449/107543848-3b0af000-6b8f-11eb-9736-d32ab090bd3d.png)
