### PR TITLE
NDRS-851: Enforce deploy's runtime args len.

### DIFF
--- a/node/src/types/chainspec/deploy_config.rs
+++ b/node/src/types/chainspec/deploy_config.rs
@@ -29,6 +29,8 @@ pub struct DeployConfig {
     pub(crate) block_max_deploy_count: u32,
     pub(crate) block_max_transfer_count: u32,
     pub(crate) block_gas_limit: u64,
+    pub(crate) payment_args_max_length: u32,
+    pub(crate) session_args_max_length: u32,
 }
 
 #[cfg(test)]
@@ -44,6 +46,8 @@ impl DeployConfig {
         let block_max_deploy_count = rng.gen();
         let block_max_transfer_count = rng.gen();
         let block_gas_limit = rng.gen_range(100_000_000_000, 1_000_000_000_000_000);
+        let payment_args_max_length = rng.gen();
+        let session_args_max_length = rng.gen();
 
         DeployConfig {
             max_payment_cost,
@@ -53,6 +57,8 @@ impl DeployConfig {
             block_max_deploy_count,
             block_max_transfer_count,
             block_gas_limit,
+            payment_args_max_length,
+            session_args_max_length,
         }
     }
 }
@@ -68,6 +74,8 @@ impl Default for DeployConfig {
             block_max_deploy_count: 10,
             block_max_transfer_count: 1000,
             block_gas_limit: 10_000_000_000_000,
+            payment_args_max_length: 1024,
+            session_args_max_length: 1024,
         }
     }
 }
@@ -82,6 +90,8 @@ impl ToBytes for DeployConfig {
         buffer.extend(self.block_max_deploy_count.to_bytes()?);
         buffer.extend(self.block_max_transfer_count.to_bytes()?);
         buffer.extend(self.block_gas_limit.to_bytes()?);
+        buffer.extend(self.payment_args_max_length.to_bytes()?);
+        buffer.extend(self.session_args_max_length.to_bytes()?);
         Ok(buffer)
     }
 
@@ -93,6 +103,8 @@ impl ToBytes for DeployConfig {
             + self.block_max_deploy_count.serialized_length()
             + self.block_max_transfer_count.serialized_length()
             + self.block_gas_limit.serialized_length()
+            + self.payment_args_max_length.serialized_length()
+            + self.session_args_max_length.serialized_length()
     }
 }
 
@@ -106,6 +118,8 @@ impl FromBytes for DeployConfig {
         let (block_max_deploy_count, remainder) = u32::from_bytes(remainder)?;
         let (block_max_transfer_count, remainder) = u32::from_bytes(remainder)?;
         let (block_gas_limit, remainder) = u64::from_bytes(remainder)?;
+        let (payment_args_max_length, remainder) = u32::from_bytes(remainder)?;
+        let (session_args_max_length, remainder) = u32::from_bytes(remainder)?;
         let config = DeployConfig {
             max_payment_cost,
             max_ttl,
@@ -114,6 +128,8 @@ impl FromBytes for DeployConfig {
             block_max_deploy_count,
             block_max_transfer_count,
             block_gas_limit,
+            payment_args_max_length,
+            session_args_max_length,
         };
         Ok((config, remainder))
     }
@@ -135,6 +151,7 @@ mod tests {
         let mut rng = crate::new_rng();
         let config = DeployConfig::random(&mut rng);
         let encoded = toml::to_string_pretty(&config).unwrap();
+        eprintln!("{}", encoded);
         let decoded = toml::from_str(&encoded).unwrap();
         assert_eq!(config, decoded);
     }

--- a/node/src/types/chainspec/deploy_config.rs
+++ b/node/src/types/chainspec/deploy_config.rs
@@ -151,7 +151,6 @@ mod tests {
         let mut rng = crate::new_rng();
         let config = DeployConfig::random(&mut rng);
         let encoded = toml::to_string_pretty(&config).unwrap();
-        eprintln!("{}", encoded);
         let decoded = toml::from_str(&encoded).unwrap();
         assert_eq!(config, decoded);
     }

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -18,7 +18,7 @@ use rand::{Rng, RngCore};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::warn;
+use tracing::{info, warn};
 
 use casper_execution_engine::{
     core::engine_state::{executable_deploy_item::ExecutableDeployItem, DeployItem},
@@ -650,10 +650,10 @@ impl Deploy {
                 got: header.ttl(),
             });
         }
-        
+
         let payment_args_length = self.payment().args().serialized_length();
         if payment_args_length > config.payment_args_max_length as usize {
-            warn!(
+            info!(
                 payment_args_length,
                 payment_args_max_length = config.payment_args_max_length,
                 "payment args excessive"
@@ -666,7 +666,7 @@ impl Deploy {
 
         let session_args_length = self.session().args().serialized_length();
         if session_args_length > config.session_args_max_length as usize {
-            warn!(
+            info!(
                 session_args_length,
                 session_args_max_length = config.session_args_max_length,
                 "session args excessive"

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -73,6 +73,10 @@ block_max_deploy_count = 100
 block_max_transfer_count = 1000
 # The upper limit of total gas of all deploys in a block.
 block_gas_limit = 10_000_000_000_000
+# The limit of length of serialized payment code arguments.
+payment_args_max_length = 1024
+# The limit of length of serialized session code arguments.
+session_args_max_length = 1024
 
 [wasm]
 # Amount of free memory (in 64kB pages) each contract can use for stack.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -73,6 +73,10 @@ block_max_deploy_count = 100
 block_max_transfer_count = 1000
 # The upper limit of total gas of all deploys in a block.
 block_gas_limit = 10_000_000_000_000
+# The limit of length of serialized payment code arguments.
+payment_args_max_length = 1024
+# The limit of length of serialized session code arguments.
+session_args_max_length = 1024
 
 [wasm]
 # Amount of free memory (in 64kB pages) each contract can use for stack.

--- a/resources/production/validation.md5
+++ b/resources/production/validation.md5
@@ -1,2 +1,2 @@
 1ce492ebe9a768f86df7016469862d0c  accounts.csv
-d92bb3992f5c1a358e3b3109089fed82  chainspec.toml
+9a10738a0c6bd8dc9b3c95e960f3d528  chainspec.toml

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -31,6 +31,8 @@ max_block_size = 12
 block_max_deploy_count = 125
 block_max_transfer_count = 1000
 block_gas_limit = 13
+payment_args_max_length = 1024
+session_args_max_length = 1024
 
 [wasm]
 max_memory = 17

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -31,6 +31,8 @@ max_block_size = 12
 block_max_deploy_count = 125
 block_max_transfer_count = 1000
 block_gas_limit = 13
+payment_args_max_length = 1024
+session_args_max_length = 1024
 
 [wasm]
 max_memory = 17


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-851

This PR adds two configuration switches to a chainspec

```diff
+ [deploys]
+ payment_args_max_length = 1024
+ session_args_max_length = 1024
```

which makes deploy acceptor verify that both payment runtime args and session runtime args are not larger than the configured values.