### PR TITLE
NO-TICKET: Make eras last for at least one maximum round length after the first block

### DIFF
--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -115,10 +115,9 @@ impl Params {
         self.end_timestamp
     }
 
-    /// Returns the timestamp corresponding to one round with maximum possible length having passed
-    /// since the start of the era.
-    pub(crate) fn one_max_round_after(&self, timestamp: Timestamp) -> Timestamp {
-        timestamp + TimeDiff::from(1 << self.max_round_exp)
+    /// Returns the maximum round length, corresponding to the maximum round exponent.
+    pub(crate) fn max_round_length(&self) -> TimeDiff {
+        TimeDiff::from(1 << self.max_round_exp)
     }
 
     /// Returns the maximum number of additional units included in evidence for conflicting

--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -1,6 +1,6 @@
 use datasize::DataSize;
 
-use super::Timestamp;
+use super::{TimeDiff, Timestamp};
 
 /// Protocol parameters for Highway.
 #[derive(Debug, DataSize, Clone)]
@@ -113,6 +113,12 @@ impl Params {
     /// Returns the minimum timestamp of the last block.
     pub(crate) fn end_timestamp(&self) -> Timestamp {
         self.end_timestamp
+    }
+
+    /// Returns the timestamp corresponding to one round with maximum possible length having passed
+    /// since the start of the era.
+    pub(crate) fn one_max_round_after(&self, timestamp: Timestamp) -> Timestamp {
+        timestamp + TimeDiff::from(1 << self.max_round_exp)
     }
 
     /// Returns the maximum number of additional units included in evidence for conflicting

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -780,6 +780,7 @@ fn is_terminal_block_min_round_len() -> Result<(), AddUnitError<TestContext>> {
     let a2 = add_unit!(state, rng, ALICE, None; a1, b0, c0)?;
     let a3 = add_unit!(state, rng, ALICE, 0x04; a2, b0, c0)?;
     assert!(!state.is_terminal_block(&a3));
+    assert!(state.maybe_block(&a3).is_some());
     Ok(())
 }
 

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -743,7 +743,8 @@ fn validate_lnc_four_forks() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn is_terminal_block() -> Result<(), AddUnitError<TestContext>> {
-    let mut state = State::new_test(WEIGHTS, 0);
+    let params = test_params(0).with_max_round_exp(TEST_MIN_ROUND_EXP + 1);
+    let mut state = State::new(WEIGHTS, params, vec![]);
     let mut rng = crate::new_rng();
 
     let a0 = add_unit!(state, rng, ALICE, 0x00; N, N, N)?;
@@ -761,6 +762,24 @@ fn is_terminal_block() -> Result<(), AddUnitError<TestContext>> {
     assert_eq!(TEST_ERA_HEIGHT - 1, state.block(&a3).height);
     let a4 = add_unit!(state, rng, ALICE, None; a3, b0, c0)?;
     assert!(!state.is_terminal_block(&a4)); // not a block
+    Ok(())
+}
+
+#[test]
+fn is_terminal_block_min_round_len() -> Result<(), AddUnitError<TestContext>> {
+    let params = test_params(0).with_max_round_exp(TEST_MIN_ROUND_EXP + 5);
+    let mut state = State::new(WEIGHTS, params, vec![]);
+    let mut rng = crate::new_rng();
+
+    // This is identical to the previous test, but with a higher maximum round length. This time a3
+    // will not be a terminal block because less than one max round length has passed since a0.
+    let a0 = add_unit!(state, rng, ALICE, 0x00; N, N, N)?;
+    let b0 = add_unit!(state, rng, BOB, 0x01; a0, N, N)?;
+    let c0 = add_unit!(state, rng, CAROL, 0x02; a0, b0, N)?;
+    let a1 = add_unit!(state, rng, ALICE, 0x03; a0, b0, c0)?;
+    let a2 = add_unit!(state, rng, ALICE, None; a1, b0, c0)?;
+    let a3 = add_unit!(state, rng, ALICE, 0x04; a2, b0, c0)?;
+    assert!(!state.is_terminal_block(&a3));
     Ok(())
 }
 

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -71,8 +71,10 @@ impl TestChain {
         // Make the genesis timestamp 45 seconds from now, to allow for all validators to start up.
         chainspec.network_config.timestamp = Timestamp::now() + 45000.into();
 
-        chainspec.core_config.minimum_era_height = 4;
+        chainspec.core_config.minimum_era_height = 1;
         chainspec.highway_config.finality_threshold_fraction = Ratio::new(34, 100);
+        chainspec.highway_config.maximum_round_exponent =
+            chainspec.highway_config.minimum_round_exponent;
         chainspec.core_config.era_duration = 10.into();
 
         TestChain {
@@ -207,7 +209,6 @@ async fn run_validator_network() {
         .await;
 }
 
-// TODO: fix this test
 #[tokio::test]
 async fn run_equivocator_network() {
     testing::init_logging();

--- a/node/src/testing/multi_stage_test_reactor/test_chain.rs
+++ b/node/src/testing/multi_stage_test_reactor/test_chain.rs
@@ -110,6 +110,8 @@ impl TestChain {
 
         chainspec.core_config.minimum_era_height = 4;
         chainspec.highway_config.finality_threshold_fraction = Ratio::new(34, 100);
+        chainspec.highway_config.maximum_round_exponent =
+            chainspec.highway_config.minimum_round_exponent;
         chainspec.core_config.era_duration = 10.into();
 
         // Assign a port for the first node (TODO: this has a race condition)


### PR DESCRIPTION
This is to prevent validators being evicted by mistake because of the network giving them no chance to create even a single unit.