### PR TITLE
NO-TICKET: Don't evict validators if era was too short to produce a unit.

### DIFF
--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -11,7 +11,7 @@ use crate::{
         consensus_protocol::{FinalizedBlock, TerminalBlockData},
         highway_core::{
             highway::Highway,
-            state::{Observation, State, Weight},
+            state::{Observation, State, Unit, Weight},
             validators::ValidatorIndex,
         },
         traits::Context,
@@ -65,18 +65,9 @@ impl<C: Context> FinalityDetector<C> {
             let to_id = |vidx: ValidatorIndex| highway.validators().id(vidx).unwrap().clone();
             let block = state.block(bhash);
             let unit = state.unit(bhash);
-            let terminal_block_data = if state.is_terminal_block(bhash) {
-                let rewards = rewards::compute_rewards(state, bhash);
-                let rewards_iter = rewards.enumerate();
-                let rewards = rewards_iter.map(|(vidx, r)| (to_id(vidx), *r)).collect();
-                let inactive_validators = unit.panorama.iter_none().map(to_id).collect();
-                Some(TerminalBlockData {
-                    rewards,
-                    inactive_validators,
-                })
-            } else {
-                None
-            };
+            let terminal_block_data = state
+                .is_terminal_block(bhash)
+                .then(|| Self::create_terminal_block_data(bhash, unit, highway));
             let finalized_block = FinalizedBlock {
                 value: block.value.clone(),
                 timestamp: unit.timestamp,
@@ -170,6 +161,26 @@ impl<C: Context> FinalityDetector<C> {
     /// Returns the configured fault tolerance threshold of this detector.
     pub(crate) fn fault_tolerance_threshold(&self) -> Weight {
         self.ftt
+    }
+
+    /// Creates the information for the terminal block: which validators were inactive, and how
+    /// rewards should be distributed.
+    fn create_terminal_block_data(
+        bhash: &C::Hash,
+        unit: &Unit<C>,
+        highway: &Highway<C>,
+    ) -> TerminalBlockData<C> {
+        let state = highway.state();
+        // Index exists, since we have units from them.
+        let to_id = |vidx: ValidatorIndex| highway.validators().id(vidx).unwrap().clone();
+        let rewards = rewards::compute_rewards(state, bhash);
+        let rewards_iter = rewards.enumerate();
+        let rewards = rewards_iter.map(|(vidx, r)| (to_id(vidx), *r)).collect();
+        let inactive_validators = unit.panorama.iter_none().map(to_id).collect();
+        TerminalBlockData {
+            rewards,
+            inactive_validators,
+        }
     }
 }
 

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -509,15 +509,13 @@ impl<C: Context> State<C> {
     /// This is to prevent ping spam: If the incoming ping is only slightly newer than a unit or
     /// ping we have already received, we drop it without forwarding it to our peers.
     pub(crate) fn has_ping(&self, creator: ValidatorIndex, timestamp: Timestamp) -> bool {
-        let max_round_len = round_len(self.params.max_round_exp());
-        self.pings[creator] + max_round_len > timestamp
+        self.pings[creator] + self.params.max_round_length() > timestamp
     }
 
     /// Returns whether the validator's latest unit or ping is at most `PING_TIMEOUT` maximum round
     /// lengths old.
     pub(crate) fn is_online(&self, vidx: ValidatorIndex, now: Timestamp) -> bool {
-        let max_round_len = round_len(self.params.max_round_exp());
-        self.pings[vidx] + max_round_len * PING_TIMEOUT >= now
+        self.pings[vidx] + self.params.max_round_length() * PING_TIMEOUT >= now
     }
 
     /// Creates new `Evidence` if the new endorsements contain any that conflict with existing

--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -1,6 +1,6 @@
 use datasize::DataSize;
 
-use super::Timestamp;
+use super::{round_len, TimeDiff, Timestamp};
 
 /// Protocol parameters for Highway.
 #[derive(Debug, DataSize, Clone)]
@@ -93,6 +93,11 @@ impl Params {
     /// round length.
     pub(crate) fn max_round_exp(&self) -> u8 {
         self.max_round_exp
+    }
+
+    /// Returns the maximum round length, corresponding to the maximum round exponent.
+    pub(crate) fn max_round_length(&self) -> TimeDiff {
+        round_len(self.max_round_exp)
     }
 
     /// Returns the initial round exponent.

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -71,7 +71,7 @@ impl TestChain {
         // Make the genesis timestamp 45 seconds from now, to allow for all validators to start up.
         chainspec.network_config.timestamp = Timestamp::now() + 45000.into();
 
-        chainspec.core_config.minimum_era_height = 4;
+        chainspec.core_config.minimum_era_height = 1;
         chainspec.highway_config.finality_threshold_fraction = Ratio::new(34, 100);
         chainspec.core_config.era_duration = 10.into();
 


### PR DESCRIPTION
In practice, with reasonably long eras, this won't make any difference, but in some tests with single-block eras we observed that everyone got evicted because they did not have a chance to create a unit before the last (and only) block.

This PR makes Highway only report a validator as inactive if there was enough time before the first and last block of an era for them to create a unit.