### PR TITLE
OP-1820: Building upgrade package release candidates and staging on S3.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -182,6 +182,27 @@ steps:
     event:
     - push
 
+- name: build-upgrade-package
+  image: casperlabs/node-build-u1804
+  commands:
+    - "./ci/build_update_package.sh"
+
+- name: put-upgrade_package-s3
+  image: casperlabs/s3cmd-build:latest
+  commands:
+    - ./ci/upgrade_package_s3_storage.sh put $(pwd)/target/upgrade_package/
+  environment:
+    CL_VAULT_TOKEN:
+      from_secret: vault_token
+    CL_VAULT_HOST:
+      from_secret: vault_host
+  when:
+    branch:
+      - master
+      - "release-*"
+    event:
+      - push
+
 depends_on:
   - pre-checks
 
@@ -224,6 +245,7 @@ steps:
   # bors should make sure, that it has passed on staging or trying branches
 - name: publish-test-bintray
   image: casperlabs/node-build-u1804
+  # Keeping casper-node from int test publish to allow networks stood up without casper-node-launcher for now.
   commands:
     - "./upload.sh --repo-name casper-debian-tests --package-name casper-node"
     - "./upload.sh --repo-name casper-debian-tests --package-name casper-client"
@@ -267,6 +289,23 @@ steps:
   image: casperlabs/s3cmd-build:latest
   commands:
     - ./ci/drone_s3_storage.sh del
+  environment:
+    CL_VAULT_TOKEN:
+      from_secret: vault_token
+    CL_VAULT_HOST:
+      from_secret: vault_host
+  when:
+    branch:
+      - master
+      - "release-*"
+    event:
+      - push
+
+# Build failed so remove the update_package candidate
+- name: del-upgrade_package-s3
+  image: casperlabs/s3cmd-build:latest
+  commands:
+    - ./ci/upgrade_package_s3_storage.sh del
   environment:
     CL_VAULT_TOKEN:
       from_secret: vault_token
@@ -325,14 +364,19 @@ steps:
 
 - name: publish-prod-bintray
   image: casperlabs/node-build-u1804
+  # Removed casper-node from tag publish as we not longer ship this way.
   commands:
-  - "./upload.sh --repo-name debian --package-name casper-node --package-tag true"
   - "./upload.sh --repo-name debian --package-name casper-client --package-tag true"
   environment:
     CL_VAULT_TOKEN:
       from_secret: vault_token
     CL_VAULT_HOST:
       from_secret: vault_host
+
+- name: build-upgrade-package
+  image: casperlabs/node-build-u1804
+  commands:
+    - "./ci/build_update_package.sh"
 
 - name: publish-github-pre-release
   image: plugins/github-release
@@ -344,6 +388,7 @@ steps:
     - md5
     files:
     - "./target/debian/*.deb"
+    - "./target/upgrade_build/*.gz
     prerelease:
     - true
   when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -190,7 +190,7 @@ steps:
 - name: put-upgrade_package-s3
   image: casperlabs/s3cmd-build:latest
   commands:
-    - ./ci/upgrade_package_s3_storage.sh put $(pwd)/target/upgrade_package/
+    - "./ci/upgrade_package_s3_storage.sh put $(pwd)/target/upgrade_package/"
   environment:
     CL_VAULT_TOKEN:
       from_secret: vault_token
@@ -388,7 +388,7 @@ steps:
     - md5
     files:
     - "./target/debian/*.deb"
-    - "./target/upgrade_build/*.gz
+    - "./target/upgrade_build/*.gz"
     prerelease:
     - true
   when:

--- a/ci/build_update_package.sh
+++ b/ci/build_update_package.sh
@@ -28,30 +28,46 @@ protocol_version() {
 }
 
 build_casper_node() {
+    echo "Building casper-node"
     cd "$NODE_BUILD_DIR"
     cargo build --release
 }
 
+make_bin_readme() {
+    mkdir -p "$BIN_DIR"
+    echo "Generating bin README.md"
+    local readme="$BIN_DIR/README.md"
+    {
+      echo "Build for Ubuntu 18.04."
+      echo ""
+      echo "To run on other platforms, build from https://github.com/CasperLabs/casper-node"
+      echo " cd node"
+      echo " cargo build --release"
+      echo ""
+      echo "git commit hash: $(git rev-parse HEAD)"
+    } > "$readme"
+}
+
 package_bin_tar_gz() {
-    printf "Packaging bin.tar.gz"
+    printf "Packaging ${PROTOCOL_VERSION}_bin.tar.gz"
     mkdir -p "$BIN_DIR"
     cp "$NODE_BUILD_TARGET" "$BIN_DIR"
     # To get no path in tar, need to cd in.
     cd "$BIN_DIR"
-    tar -czvf "../$PROTOCOL_VERSION/bin.tar.gz" .
+    tar -czvf "../${PROTOCOL_VERSION}_bin.tar.gz" .
     cd ..
     rm -rf "$BIN_DIR"
 }
 
 package_config_tar_gz() {
-    printf "Packaging config.tar.gz"
+    printf "Packaging ${PROTOCOL_VERSION}_config.tar.gz"
     mkdir -p "$CONFIG_DIR"
     cp "$GENESIS_FILES_DIR/chainspec.toml" "$CONFIG_DIR"
     cp "$GENESIS_FILES_DIR/config-example.toml" "$CONFIG_DIR"
     cp "$GENESIS_FILES_DIR/accounts.csv" "$CONFIG_DIR"
     # To get no path in tar, need to cd in.
     cd "$CONFIG_DIR"
-    tar -czvf "../$PROTOCOL_VERSION/config.tar.gz" .
+    tar -czvf "../${PROTOCOL_VERSION}_config.tar.gz" .
     cd ..
     rm -rf "$CONFIG_DIR"
 }
@@ -59,9 +75,8 @@ package_config_tar_gz() {
 check_python_has_toml
 protocol_version
 
-mkdir -p "$UPGRADE_DIR/$PROTOCOL_VERSION"
-
 build_casper_node
+make_bin_readme
 package_bin_tar_gz
 package_config_tar_gz
 

--- a/ci/build_update_package.sh
+++ b/ci/build_update_package.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+NODE_BUILD_TARGET="$ROOT_DIR/target/release/casper-node"
+UPGRADE_DIR="$ROOT_DIR/target/upgrade_build"
+BIN_DIR="$UPGRADE_DIR/bin"
+CONFIG_DIR="$UPGRADE_DIR/config"
+NODE_BUILD_DIR="$ROOT_DIR/node"
+GENESIS_FILES_DIR="$ROOT_DIR/resources/production"
+
+check_python_has_toml() {
+    set +e
+    python3 -c "import toml" 2>/dev/null
+    if [[ $? -ne 0 ]]; then
+        printf "Ensure you have 'toml' installed for Python3\n"
+        printf "e.g. run\n"
+        printf "    pip3 install toml --user\n\n"
+        exit 3
+    fi
+    set -e
+}
+
+protocol_version() {
+    PROTOCOL_VERSION=$(cat "$GENESIS_FILES_DIR/chainspec.toml" | python3 -c "import sys, toml; print(toml.load(sys.stdin)['protocol']['version'].replace('.','_'))")
+    printf "Protocol version: %s\n" $PROTOCOL_VERSION
+}
+
+build_casper_node() {
+    cd "$NODE_BUILD_DIR"
+    cargo build --release
+}
+
+package_bin_tar_gz() {
+    printf "Packaging bin.tar.gz"
+    mkdir -p "$BIN_DIR"
+    cp "$NODE_BUILD_TARGET" "$BIN_DIR"
+    # To get no path in tar, need to cd in.
+    cd "$BIN_DIR"
+    tar -czvf "../$PROTOCOL_VERSION/bin.tar.gz" .
+    cd ..
+    rm -rf "$BIN_DIR"
+}
+
+package_config_tar_gz() {
+    printf "Packaging config.tar.gz"
+    mkdir -p "$CONFIG_DIR"
+    cp "$GENESIS_FILES_DIR/chainspec.toml" "$CONFIG_DIR"
+    cp "$GENESIS_FILES_DIR/config-example.toml" "$CONFIG_DIR"
+    cp "$GENESIS_FILES_DIR/accounts.csv" "$CONFIG_DIR"
+    # To get no path in tar, need to cd in.
+    cd "$CONFIG_DIR"
+    tar -czvf "../$PROTOCOL_VERSION/config.tar.gz" .
+    cd ..
+    rm -rf "$CONFIG_DIR"
+}
+
+check_python_has_toml
+protocol_version
+
+mkdir -p "$UPGRADE_DIR/$PROTOCOL_VERSION"
+
+build_casper_node
+package_bin_tar_gz
+package_config_tar_gz
+
+

--- a/ci/build_update_package.sh
+++ b/ci/build_update_package.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# This script will build bin.tar.gz and config.tar.gz in target/upgrade_build
+
 set -e
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
@@ -10,73 +12,39 @@ CONFIG_DIR="$UPGRADE_DIR/config"
 NODE_BUILD_DIR="$ROOT_DIR/node"
 GENESIS_FILES_DIR="$ROOT_DIR/resources/production"
 
-check_python_has_toml() {
-    set +e
-    python3 -c "import toml" 2>/dev/null
-    if [[ $? -ne 0 ]]; then
-        printf "Ensure you have 'toml' installed for Python3\n"
-        printf "e.g. run\n"
-        printf "    pip3 install toml --user\n\n"
-        exit 3
-    fi
-    set -e
-}
+echo "Building casper-node"
+cd "$NODE_BUILD_DIR"
+cargo build --release
 
-protocol_version() {
-    PROTOCOL_VERSION=$(cat "$GENESIS_FILES_DIR/chainspec.toml" | python3 -c "import sys, toml; print(toml.load(sys.stdin)['protocol']['version'].replace('.','_'))")
-    printf "Protocol version: %s\n" $PROTOCOL_VERSION
-}
+echo "Generating bin README.md"
+mkdir -p "$BIN_DIR"
+readme="$BIN_DIR/README.md"
+{
+  echo "Build for Ubuntu 18.04."
+  echo ""
+  echo "To run on other platforms, build from https://github.com/CasperLabs/casper-node"
+  echo " cd node"
+  echo " cargo build --release"
+  echo ""
+  echo "git commit hash: $(git rev-parse HEAD)"
+} > "$readme"
 
-build_casper_node() {
-    echo "Building casper-node"
-    cd "$NODE_BUILD_DIR"
-    cargo build --release
-}
+echo "Packaging bin.tar.gz"
+mkdir -p "$BIN_DIR"
+cp "$NODE_BUILD_TARGET" "$BIN_DIR"
+# To get no path in tar, need to cd in.
+cd "$BIN_DIR"
+tar -czvf "../bin.tar.gz" .
+cd ..
+rm -rf "$BIN_DIR"
 
-make_bin_readme() {
-    echo "Generating bin README.md"
-    mkdir -p "$BIN_DIR"
-    local readme="$BIN_DIR/README.md"
-    {
-      echo "Build for Ubuntu 18.04."
-      echo ""
-      echo "To run on other platforms, build from https://github.com/CasperLabs/casper-node"
-      echo " cd node"
-      echo " cargo build --release"
-      echo ""
-      echo "git commit hash: $(git rev-parse HEAD)"
-    } > "$readme"
-}
-
-package_bin_tar_gz() {
-    printf "Packaging ${PROTOCOL_VERSION}_bin.tar.gz"
-    mkdir -p "$BIN_DIR"
-    cp "$NODE_BUILD_TARGET" "$BIN_DIR"
-    # To get no path in tar, need to cd in.
-    cd "$BIN_DIR"
-    tar -czvf "../${PROTOCOL_VERSION}_bin.tar.gz" .
-    cd ..
-    rm -rf "$BIN_DIR"
-}
-
-package_config_tar_gz() {
-    printf "Packaging ${PROTOCOL_VERSION}_config.tar.gz"
-    mkdir -p "$CONFIG_DIR"
-    cp "$GENESIS_FILES_DIR/chainspec.toml" "$CONFIG_DIR"
-    cp "$GENESIS_FILES_DIR/config-example.toml" "$CONFIG_DIR"
-    cp "$GENESIS_FILES_DIR/accounts.csv" "$CONFIG_DIR"
-    # To get no path in tar, need to cd in.
-    cd "$CONFIG_DIR"
-    tar -czvf "../${PROTOCOL_VERSION}_config.tar.gz" .
-    cd ..
-    rm -rf "$CONFIG_DIR"
-}
-
-check_python_has_toml
-protocol_version
-
-build_casper_node
-make_bin_readme
-package_bin_tar_gz
-package_config_tar_gz
-
+echo "Packaging config.tar.gz"
+mkdir -p "$CONFIG_DIR"
+cp "$GENESIS_FILES_DIR/chainspec.toml" "$CONFIG_DIR"
+cp "$GENESIS_FILES_DIR/config-example.toml" "$CONFIG_DIR"
+cp "$GENESIS_FILES_DIR/accounts.csv" "$CONFIG_DIR"
+# To get no path in tar, need to cd in.
+cd "$CONFIG_DIR"
+tar -czvf "../config.tar.gz" .
+cd ..
+rm -rf "$CONFIG_DIR"

--- a/ci/build_update_package.sh
+++ b/ci/build_update_package.sh
@@ -34,8 +34,8 @@ build_casper_node() {
 }
 
 make_bin_readme() {
-    mkdir -p "$BIN_DIR"
     echo "Generating bin README.md"
+    mkdir -p "$BIN_DIR"
     local readme="$BIN_DIR/README.md"
     {
       echo "Build for Ubuntu 18.04."
@@ -79,5 +79,4 @@ build_casper_node
 make_bin_readme
 package_bin_tar_gz
 package_config_tar_gz
-
 

--- a/ci/upgrade_package_s3_storage.sh
+++ b/ci/upgrade_package_s3_storage.sh
@@ -19,6 +19,9 @@ if [[ $? -ne 0 ]]; then
 fi
 set -e
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+GENESIS_FILES_DIR="$ROOT_DIR/resources/production"
+
 PROTOCOL_VERSION=$(cat "$GENESIS_FILES_DIR/chainspec.toml" | python3 -c "import sys, toml; print(toml.load(sys.stdin)['protocol']['version'].replace('.','_'))")
 echo "Protocol version: $PROTOCOL_VERSION"
 GIT_HASH=$(git rev-parse HEAD)
@@ -35,16 +38,11 @@ if [[ " ${valid_commands[*]} " != *" $ACTION "* ]]; then
   exit 1
 fi
 
-if [[ "$ACTION" == "del" ]]; then
+if [[ "$ACTION" != "del" ]]; then
   LOCAL=$2
 
   if [ -z "$LOCAL" ]; then
-    echo "Source not provided"
-    exit 1
-  fi
-
-  if [ -z "$LOCAL" ]; then
-    echo "Target not provided"
+    echo "Local path not provided"
     exit 1
   fi
 fi

--- a/ci/upgrade_package_s3_storage.sh
+++ b/ci/upgrade_package_s3_storage.sh
@@ -1,11 +1,28 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 # This script allows uploading, downloading and purging of files to genesis.casperlabs.io s3 for storing
 # possible upgrade package releases to promote to a network or use for testing.
 
-# Using DRONE_BUILD_NUMBER as s3 bucket location
+# Using drone/GIT_HASH/PROTOCOL_VERSION as s3 bucket location in genesis.casperlabs.io
+
+# Check python has toml for getting PROTOCOL_VERSION
+set +e
+python3 -c "import toml" 2>/dev/null
+if [[ $? -ne 0 ]]; then
+  echo "Ensure you have 'toml' installed for Python3"
+  echo "e.g. run"
+  echo "    python3 -m pip install toml --user"
+  echo ""
+  exit 3
+fi
+set -e
+
+PROTOCOL_VERSION=$(cat "$GENESIS_FILES_DIR/chainspec.toml" | python3 -c "import sys, toml; print(toml.load(sys.stdin)['protocol']['version'].replace('.','_'))")
+echo "Protocol version: $PROTOCOL_VERSION"
+GIT_HASH=$(git rev-parse HEAD)
+echo "Git hash: $GIT_HASH"
 
 valid_commands=("put" "get" "del")
 ACTION=$1
@@ -32,9 +49,6 @@ if [[ "$ACTION" == "del" ]]; then
   fi
 fi
 
-CL_S3_BUCKET="genesis.casperlabs.io"
-CL_S3_LOCATION="drone"
-
 echo "CL_VAULT_TOKEN: '${CL_VAULT_TOKEN}'"
 echo "CL_VAULT_HOST: '${CL_VAULT_HOST}'"
 # get aws credentials files
@@ -46,17 +60,20 @@ export AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY=$(echo "$CREDENTIALS" | jq -r .data.cicd_agent_to_s3.aws_secret_key)
 export AWS_SECRET_ACCESS_KEY
 
+CL_S3_BUCKET="genesis.casperlabs.io"
+CL_S3_LOCATION="drone/$GIT_HASH"
+
 case "$ACTION" in
-  "put")
-    echo "sync ${LOCAL} s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER}"
-    s3cmd sync "${LOCAL}" "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER}"
-    ;;
-  "get")
-    echo "sync s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER} ${LOCAL}"
-    s3cmd sync "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER}" "${LOCAL}"
-    ;;
-  "del")
-    echo "del --recursive s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER}"
-    s3cmd del --recursive "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER}"
-    ;;
+"put")
+  echo "sync ${LOCAL} s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION}"
+  s3cmd sync "${LOCAL}" "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION}"
+  ;;
+"get")
+  echo "sync s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION} ${LOCAL}"
+  s3cmd sync "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION}" "${LOCAL}"
+  ;;
+"del")
+  echo "del --recursive s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}"
+  s3cmd del --recursive "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}"
+  ;;
 esac

--- a/ci/upgrade_package_s3_storage.sh
+++ b/ci/upgrade_package_s3_storage.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# This script allows uploading, downloading and purging of files to genesis.casperlabs.io s3 for storing
+# possible upgrade package releases to promote to a network or use for testing.
+
+# Using DRONE_BUILD_NUMBER as s3 bucket location
+
+valid_commands=("put" "get" "del")
+ACTION=$1
+if [[ " ${valid_commands[*]} " != *" $ACTION "* ]]; then
+  echo "Invalid command passed: $ACTION"
+  echo "Possible commands are:"
+  echo " put <local source with ending />"
+  echo " get <local target>"
+  echo " del "
+  exit 1
+fi
+
+if [[ "$ACTION" == "del" ]]; then
+  LOCAL=$2
+
+  if [ -z "$LOCAL" ]; then
+    echo "Source not provided"
+    exit 1
+  fi
+
+  if [ -z "$LOCAL" ]; then
+    echo "Target not provided"
+    exit 1
+  fi
+fi
+
+CL_S3_BUCKET="genesis.casperlabs.io"
+CL_S3_LOCATION="drone"
+
+echo "CL_VAULT_TOKEN: '${CL_VAULT_TOKEN}'"
+echo "CL_VAULT_HOST: '${CL_VAULT_HOST}'"
+# get aws credentials files
+CL_VAULT_URL="${CL_VAULT_HOST}/v1/sre/cicd/s3/aws_credentials"
+CREDENTIALS=$(curl -s -q -H "X-Vault-Token: $CL_VAULT_TOKEN" -X GET "$CL_VAULT_URL")
+# get just the body required by s3cmd, strip off vault payload
+AWS_ACCESS_KEY_ID=$(echo "$CREDENTIALS" | jq -r .data.cicd_agent_to_s3.aws_access_key)
+export AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY=$(echo "$CREDENTIALS" | jq -r .data.cicd_agent_to_s3.aws_secret_key)
+export AWS_SECRET_ACCESS_KEY
+
+case "$ACTION" in
+  "put")
+    echo "sync ${LOCAL} s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER}"
+    s3cmd sync "${LOCAL}" "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER}"
+    ;;
+  "get")
+    echo "sync s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER} ${LOCAL}"
+    s3cmd sync "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER}" "${LOCAL}"
+    ;;
+  "del")
+    echo "del --recursive s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER}"
+    s3cmd del --recursive "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${DRONE_BUILD_NUMBER}"
+    ;;
+esac


### PR DESCRIPTION
This builds `bin.tar.gz` and `config.tar.gz`.

`config.tar.gz` includes `chainspec.toml`, `accounts.csv`, and `config-example.toml` from `/resources/production`.

`bin.tar.gz` includes `casper-node` built for Ubuntu 18.04 and `README.md` with repo link and github commit hash used to build, to allow other platforms to build casper-node from same code.

Upload script will place these artifacts at http://genesis.casperlabs.io/drone/[git-hash]/[protocol_version].  Where protocol_version is from `resources/production/chainspec.toml` with underscores replacing periods.  

These can be used in upgrade tests and one can be selected for network upgrade and moved into the correct location in the `genesis.casperlabs.io` S3 bucket.   