### PR TITLE
NDRS-840: preparation to support upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,9 +565,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -917,7 +917,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -1859,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
  "humantime",
@@ -2741,9 +2741,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "libp2p"
@@ -3179,18 +3179,18 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2382d8ed3918ea4ba70d98d5b74e47a168e0331965f3f17cdbc748bdebc5a3"
+checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
 dependencies = [
  "hashbrown",
 ]
 
 [[package]]
 name = "lru_time_cache"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a559ce34615abd3145e6ca99df0e33ac069dc5298d1bfecfcc1ca821803f0cb2"
+checksum = "7ce7a913007f8d825242cd5017962f09bc3f19f91a382498c1e6756c842e3908"
 
 [[package]]
 name = "mach"
@@ -3382,7 +3382,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "digest 0.9.0",
- "sha-1 0.9.3",
+ "sha-1 0.9.4",
  "sha2 0.9.3",
  "sha3",
  "unsigned-varint",
@@ -3462,12 +3462,12 @@ dependencies = [
 
 [[package]]
 name = "nb-connect"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "socket2",
 ]
 
 [[package]]
@@ -3742,7 +3742,7 @@ checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api 0.4.2",
- "parking_lot_core 0.8.2",
+ "parking_lot_core 0.8.3",
 ]
 
 [[package]]
@@ -3761,14 +3761,14 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.1.57",
+ "redox_syscall 0.2.5",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -3794,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c220d01f863d13d96ca82359d1e81e64a7c6bf0637bcde7b2349630addf0c6"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
 dependencies = [
  "base64 0.13.0",
  "once_cell",
@@ -4237,9 +4237,9 @@ checksum = "70731852eec72c56d11226c8a5f96ad5058a3dab73647ca5f7ee351e464f2571"
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca36dea94d187597e104a5c8e4b07576a8a45aa5db48a65e12940d3eb7461f55"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
 dependencies = [
  "bitflags 1.2.1",
  "memchr",
@@ -4315,9 +4315,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -4344,7 +4344,7 @@ checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
 
@@ -4365,7 +4365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -4379,9 +4379,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
 ]
@@ -4401,7 +4401,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -4464,9 +4464,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags 1.2.1",
 ]
@@ -4644,6 +4644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -4935,9 +4944,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b312c3731e3fe78a185e6b9b911a7aa715b8e31cce117975219aab2acf285d"
+checksum = "dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -5057,7 +5066,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ring",
- "rustc_version",
+ "rustc_version 0.2.3",
  "sha2 0.9.3",
  "subtle 2.4.0",
  "x25519-dalek",
@@ -5253,7 +5262,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.4",
+ "redox_syscall 0.2.5",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -5625,11 +5634,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-futures"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project 1.0.5",
  "tracing",
 ]
 
@@ -5826,7 +5835,7 @@ dependencies = [
  "input_buffer",
  "log 0.4.14",
  "rand 0.7.3",
- "sha-1 0.9.3",
+ "sha-1 0.9.4",
  "url",
  "utf-8",
 ]
@@ -5892,9 +5901,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
@@ -6014,19 +6023,20 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce50d8996df1f85af15f2cd8d33daae6e479575123ef4314a51a70a230739cb"
+checksum = "e7141e445af09c8919f1d5f8a20dae0b20c3b57a45dee0d5823c6ed5d237f15a"
 dependencies = [
  "bitflags 1.2.1",
  "chrono",
+ "rustc_version 0.3.3",
 ]
 
 [[package]]
 name = "version-sync"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b77d2a6f56988f7bb54102fe73ab963df4e7374b58298a7efa1361f681e0e2"
+checksum = "7cb94ca10ca0cf44f5d926ac977f0cac2d13e9789aa4bbe9d9388de445e61028"
 dependencies = [
  "proc-macro2",
  "pulldown-cmark",
@@ -6378,9 +6388,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
+checksum = "1cc7bd8c983209ed5d527f44b01c41b7dc146fd960c61cf9e1d25399841dc271"
 dependencies = [
  "futures",
  "log 0.4.14",

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use casper_types::{
     account::AccountHash,
     auction::{
-        Bid, Bids, DelegationRate, EraId, SeigniorageRecipient, SeigniorageRecipients,
+        Bid, Bids, DelegationRate, SeigniorageRecipient, SeigniorageRecipients,
         SeigniorageRecipientsSnapshot, UnbondingPurses, ValidatorWeights, ARG_DELEGATION_RATE,
         ARG_DELEGATOR, ARG_ERA_END_TIMESTAMP_MILLIS, ARG_PUBLIC_KEY, ARG_REWARD_FACTORS,
         ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY, AUCTION_DELAY_KEY, BIDS_KEY,
@@ -311,7 +311,7 @@ pub struct ExecConfig {
     auction_delay: u64,
     locked_funds_period_millis: u64,
     round_seigniorage_rate: Ratio<u64>,
-    unbonding_delay: EraId,
+    unbonding_delay: u64,
     genesis_timestamp_millis: u64,
 }
 
@@ -325,7 +325,7 @@ impl ExecConfig {
         auction_delay: u64,
         locked_funds_period_millis: u64,
         round_seigniorage_rate: Ratio<u64>,
-        unbonding_delay: EraId,
+        unbonding_delay: u64,
         genesis_timestamp_millis: u64,
     ) -> ExecConfig {
         ExecConfig {
@@ -379,7 +379,7 @@ impl ExecConfig {
         self.round_seigniorage_rate
     }
 
-    pub fn unbonding_delay(&self) -> EraId {
+    pub fn unbonding_delay(&self) -> u64 {
         self.unbonding_delay
     }
 

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -321,7 +321,7 @@ where
             tracking_copy.borrow_mut().write(auction_delay_key, value);
         }
 
-        if let Some(new_locked_funds_period) = upgrade_config.new_locked_funds_period() {
+        if let Some(new_locked_funds_period) = upgrade_config.new_locked_funds_period_millis() {
             let auction_contract = tracking_copy
                 .borrow_mut()
                 .get_contract(correlation_id, new_protocol_data.auction())?;

--- a/execution_engine/src/core/engine_state/upgrade.rs
+++ b/execution_engine/src/core/engine_state/upgrade.rs
@@ -85,9 +85,9 @@ pub struct UpgradeConfig {
     activation_point: Option<ActivationPoint>,
     new_validator_slots: Option<u32>,
     new_auction_delay: Option<u64>,
-    new_locked_funds_period: Option<EraId>,
+    new_locked_funds_period_millis: Option<u64>,
     new_round_seigniorage_rate: Option<Ratio<u64>>,
-    new_unbonding_delay: Option<EraId>,
+    new_unbonding_delay: Option<u64>,
     global_state_update: BTreeMap<Key, StoredValue>,
 }
 
@@ -102,9 +102,9 @@ impl UpgradeConfig {
         activation_point: Option<ActivationPoint>,
         new_validator_slots: Option<u32>,
         new_auction_delay: Option<u64>,
-        new_locked_funds_period: Option<EraId>,
+        new_locked_funds_period_millis: Option<EraId>,
         new_round_seigniorage_rate: Option<Ratio<u64>>,
-        new_unbonding_delay: Option<EraId>,
+        new_unbonding_delay: Option<u64>,
         global_state_update: BTreeMap<Key, StoredValue>,
     ) -> Self {
         UpgradeConfig {
@@ -116,7 +116,7 @@ impl UpgradeConfig {
             activation_point,
             new_validator_slots,
             new_auction_delay,
-            new_locked_funds_period,
+            new_locked_funds_period_millis,
             new_round_seigniorage_rate,
             new_unbonding_delay,
             global_state_update,
@@ -155,15 +155,15 @@ impl UpgradeConfig {
         self.new_auction_delay
     }
 
-    pub fn new_locked_funds_period(&self) -> Option<EraId> {
-        self.new_locked_funds_period
+    pub fn new_locked_funds_period_millis(&self) -> Option<u64> {
+        self.new_locked_funds_period_millis
     }
 
     pub fn new_round_seigniorage_rate(&self) -> Option<Ratio<u64>> {
         self.new_round_seigniorage_rate
     }
 
-    pub fn new_unbonding_delay(&self) -> Option<EraId> {
+    pub fn new_unbonding_delay(&self) -> Option<u64> {
         self.new_unbonding_delay
     }
 

--- a/execution_engine/src/core/engine_state/upgrade.rs
+++ b/execution_engine/src/core/engine_state/upgrade.rs
@@ -4,7 +4,6 @@ use num_rational::Ratio;
 use thiserror::Error;
 
 use casper_types::{
-    auction::EraId,
     bytesrepr,
     system_contract_type::{AUCTION, MINT, PROOF_OF_STAKE, STANDARD_PAYMENT},
     ContractHash, Key, ProtocolVersion,
@@ -102,7 +101,7 @@ impl UpgradeConfig {
         activation_point: Option<ActivationPoint>,
         new_validator_slots: Option<u32>,
         new_auction_delay: Option<u64>,
-        new_locked_funds_period_millis: Option<EraId>,
+        new_locked_funds_period_millis: Option<u64>,
         new_round_seigniorage_rate: Option<Ratio<u64>>,
         new_unbonding_delay: Option<u64>,
         global_state_update: BTreeMap<Key, StoredValue>,

--- a/execution_engine_testing/test_support/src/internal/mod.rs
+++ b/execution_engine_testing/test_support/src/internal/mod.rs
@@ -20,9 +20,7 @@ use casper_execution_engine::{
         motes::Motes, newtypes::Blake2bHash, system_config::SystemConfig, wasm_config::WasmConfig,
     },
 };
-use casper_types::{
-    account::AccountHash, auction::EraId, ProtocolVersion, PublicKey, SecretKey, U512,
-};
+use casper_types::{account::AccountHash, ProtocolVersion, PublicKey, SecretKey, U512};
 
 use super::DEFAULT_ACCOUNT_INITIAL_BALANCE;
 
@@ -40,7 +38,7 @@ pub const DEFAULT_AUCTION_DELAY: u64 = 3;
 /// Default lock-in period of 90 days
 pub const DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS: u64 = 90 * 24 * 60 * 60 * 1000;
 /// Default number of eras that need to pass to be able to withdraw unbonded funds.
-pub const DEFAULT_UNBONDING_DELAY: EraId = 14;
+pub const DEFAULT_UNBONDING_DELAY: u64 = 14;
 
 /// Default round seigniorage rate represented as a fractional number.
 ///

--- a/execution_engine_testing/test_support/src/internal/upgrade_request_builder.rs
+++ b/execution_engine_testing/test_support/src/internal/upgrade_request_builder.rs
@@ -9,7 +9,7 @@ use casper_execution_engine::{
         wasm_config::WasmConfig,
     },
 };
-use casper_types::{auction::EraId, Key, ProtocolVersion};
+use casper_types::{Key, ProtocolVersion};
 
 #[derive(Default)]
 pub struct UpgradeRequestBuilder {
@@ -21,9 +21,9 @@ pub struct UpgradeRequestBuilder {
     activation_point: Option<ActivationPoint>,
     new_validator_slots: Option<u32>,
     new_auction_delay: Option<u64>,
-    new_locked_funds_period: Option<EraId>,
+    new_locked_funds_period_millis: Option<u64>,
     new_round_seigniorage_rate: Option<Ratio<u64>>,
-    new_unbonding_delay: Option<EraId>,
+    new_unbonding_delay: Option<u64>,
     global_state_update: BTreeMap<Key, StoredValue>,
 }
 
@@ -61,8 +61,11 @@ impl UpgradeRequestBuilder {
         self
     }
 
-    pub fn with_new_locked_funds_period(mut self, new_locked_funds_period: EraId) -> Self {
-        self.new_locked_funds_period = Some(new_locked_funds_period);
+    pub fn with_new_locked_funds_period_millis(
+        mut self,
+        new_locked_funds_period_millis: u64,
+    ) -> Self {
+        self.new_locked_funds_period_millis = Some(new_locked_funds_period_millis);
         self
     }
 
@@ -71,7 +74,7 @@ impl UpgradeRequestBuilder {
         self
     }
 
-    pub fn with_new_unbonding_delay(mut self, unbonding_delay: EraId) -> Self {
+    pub fn with_new_unbonding_delay(mut self, unbonding_delay: u64) -> Self {
         self.new_unbonding_delay = Some(unbonding_delay);
         self
     }
@@ -104,7 +107,7 @@ impl UpgradeRequestBuilder {
             self.activation_point,
             self.new_validator_slots,
             self.new_auction_delay,
-            self.new_locked_funds_period,
+            self.new_locked_funds_period_millis,
             self.new_round_seigniorage_rate,
             self.new_unbonding_delay,
             self.global_state_update,

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -19,8 +19,8 @@ use casper_execution_engine::{
 use casper_types::{
     account::AccountHash,
     auction::{
-        Bids, DelegationRate, EraId, UnbondingPurses, ARG_VALIDATOR_PUBLIC_KEYS, BIDS_KEY,
-        INITIAL_ERA_ID, METHOD_SLASH, UNBONDING_PURSES_KEY,
+        Bids, DelegationRate, UnbondingPurses, ARG_VALIDATOR_PUBLIC_KEYS, BIDS_KEY, INITIAL_ERA_ID,
+        METHOD_SLASH, UNBONDING_PURSES_KEY,
     },
     runtime_args,
     system_contract_errors::auction,
@@ -500,7 +500,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
     let mut builder = InMemoryWasmTestBuilder::default();
     builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
 
-    let new_unbonding_delay: EraId = DEFAULT_UNBONDING_DELAY + 5;
+    let new_unbonding_delay = DEFAULT_UNBONDING_DELAY + 5;
 
     let old_protocol_version = *DEFAULT_PROTOCOL_VERSION;
     let sem_ver = old_protocol_version.value();

--- a/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/upgrade.rs
@@ -24,7 +24,7 @@ use casper_execution_engine::{
 };
 use casper_types::{
     auction::{
-        EraId, AUCTION_DELAY_KEY, LOCKED_FUNDS_PERIOD_KEY, UNBONDING_DELAY_KEY, VALIDATOR_SLOTS_KEY,
+        AUCTION_DELAY_KEY, LOCKED_FUNDS_PERIOD_KEY, UNBONDING_DELAY_KEY, VALIDATOR_SLOTS_KEY,
     },
     mint::ROUND_SEIGNIORAGE_RATE_KEY,
     CLValue, ProtocolVersion, U512,
@@ -411,7 +411,7 @@ fn should_upgrade_only_locked_funds_period() {
         .expect("auction should exist")
         .named_keys()[LOCKED_FUNDS_PERIOD_KEY];
 
-    let before_locked_funds_period: EraId = builder
+    let before_locked_funds_period_millis: u64 = builder
         .query(None, locked_funds_period_key, &[])
         .expect("should have locked funds period")
         .as_cl_value()
@@ -420,14 +420,14 @@ fn should_upgrade_only_locked_funds_period() {
         .into_t()
         .expect("should be u64");
 
-    let new_locked_funds_period = before_locked_funds_period + 1;
+    let new_locked_funds_period_millis = before_locked_funds_period_millis + 1;
 
     let mut upgrade_request = {
         UpgradeRequestBuilder::new()
             .with_current_protocol_version(PROTOCOL_VERSION)
             .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
-            .with_new_locked_funds_period(new_locked_funds_period)
+            .with_new_locked_funds_period_millis(new_locked_funds_period_millis)
             .build()
     };
 
@@ -435,7 +435,7 @@ fn should_upgrade_only_locked_funds_period() {
         .upgrade_with_upgrade_request(&mut upgrade_request)
         .expect_upgrade_success();
 
-    let after_locked_funds_period: EraId = builder
+    let after_locked_funds_period_millis: u64 = builder
         .query(None, locked_funds_period_key, &[])
         .expect("should have locked funds period")
         .as_cl_value()
@@ -445,7 +445,7 @@ fn should_upgrade_only_locked_funds_period() {
         .expect("should be u64");
 
     assert_eq!(
-        new_locked_funds_period, after_locked_funds_period,
+        new_locked_funds_period_millis, after_locked_funds_period_millis,
         "Should have upgraded locked funds period"
     )
 }
@@ -528,7 +528,7 @@ fn should_upgrade_only_unbonding_delay() {
         .expect("auction should exist")
         .named_keys()[UNBONDING_DELAY_KEY];
 
-    let before_unbonding_delay: EraId = builder
+    let before_unbonding_delay: u64 = builder
         .query(None, unbonding_delay_key, &[])
         .expect("should have locked funds period")
         .as_cl_value()
@@ -537,7 +537,7 @@ fn should_upgrade_only_unbonding_delay() {
         .into_t()
         .expect("should be u64");
 
-    let new_unbonding_delay: EraId = DEFAULT_UNBONDING_DELAY + 5;
+    let new_unbonding_delay = DEFAULT_UNBONDING_DELAY + 5;
 
     let mut upgrade_request = {
         UpgradeRequestBuilder::new()
@@ -552,7 +552,7 @@ fn should_upgrade_only_unbonding_delay() {
         .upgrade_with_upgrade_request(&mut upgrade_request)
         .expect_upgrade_success();
 
-    let after_unbonding_delay: EraId = builder
+    let after_unbonding_delay: u64 = builder
         .query(None, unbonding_delay_key, &[])
         .expect("should have locked funds period")
         .as_cl_value()
@@ -586,7 +586,7 @@ fn should_apply_global_state_upgrade() {
         .expect("auction should exist")
         .named_keys()[UNBONDING_DELAY_KEY];
 
-    let before_unbonding_delay: EraId = builder
+    let before_unbonding_delay: u64 = builder
         .query(None, unbonding_delay_key, &[])
         .expect("should have locked funds period")
         .as_cl_value()
@@ -595,7 +595,7 @@ fn should_apply_global_state_upgrade() {
         .into_t()
         .expect("should be u64");
 
-    let new_unbonding_delay: EraId = DEFAULT_UNBONDING_DELAY + 5;
+    let new_unbonding_delay = DEFAULT_UNBONDING_DELAY + 5;
 
     let mut update_map = BTreeMap::new();
     update_map.insert(
@@ -616,7 +616,7 @@ fn should_apply_global_state_upgrade() {
         .upgrade_with_upgrade_request(&mut upgrade_request)
         .expect_upgrade_success();
 
-    let after_unbonding_delay: EraId = builder
+    let after_unbonding_delay: u64 = builder
         .query(None, unbonding_delay_key, &[])
         .expect("should have locked funds period")
         .as_cl_value()

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -30,16 +30,10 @@ pub(crate) mod networking_metrics;
 pub(crate) mod small_network;
 pub(crate) mod storage;
 
-use once_cell::sync::Lazy;
-use semver::Version;
-
 use crate::{
     effect::{EffectBuilder, Effects},
     NodeRng,
 };
-
-// TODO - confirm if we want to use the protocol version for this.
-pub(crate) static CLIENT_API_VERSION: Lazy<Version> = Lazy::new(|| Version::new(1, 0, 0));
 
 /// Core Component.
 ///

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -82,7 +82,7 @@ type BlockHeight = u64;
 /// The Block executor component.
 #[derive(DataSize, Debug, Default)]
 pub(crate) struct BlockExecutor {
-    genesis_state_root_hash: Digest,
+    genesis_state_root_hash: Option<Digest>,
     /// A mapping from proto block to executed block's ID and post-state hash, to allow
     /// identification of a parent block's details once a finalized block has been executed.
     ///
@@ -98,7 +98,7 @@ pub(crate) struct BlockExecutor {
 }
 
 impl BlockExecutor {
-    pub(crate) fn new(genesis_state_root_hash: Digest, registry: Registry) -> Self {
+    pub(crate) fn new(genesis_state_root_hash: Option<Digest>, registry: Registry) -> Self {
         let metrics = BlockExecutorMetrics::new(registry).unwrap();
         BlockExecutor {
             genesis_state_root_hash,
@@ -436,7 +436,7 @@ impl BlockExecutor {
 
     fn pre_state_hash(&mut self, finalized_block: &FinalizedBlock) -> Option<Digest> {
         if finalized_block.is_genesis_child() {
-            Some(self.genesis_state_root_hash)
+            self.genesis_state_root_hash
         } else {
             // Try to get the parent's post-state-hash from the `parent_map`.
             // We're subtracting 1 from the height as we want to get _parent's_ post-state hash.

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -11,6 +11,7 @@ use std::{
 use datasize::DataSize;
 use itertools::Itertools;
 use prometheus::Registry;
+use semver::Version;
 use smallvec::SmallVec;
 use tracing::{debug, error, trace};
 
@@ -83,6 +84,8 @@ type BlockHeight = u64;
 #[derive(DataSize, Debug, Default)]
 pub(crate) struct BlockExecutor {
     genesis_state_root_hash: Option<Digest>,
+    #[data_size(skip)]
+    protocol_version: ProtocolVersion,
     /// A mapping from proto block to executed block's ID and post-state hash, to allow
     /// identification of a parent block's details once a finalized block has been executed.
     ///
@@ -98,10 +101,19 @@ pub(crate) struct BlockExecutor {
 }
 
 impl BlockExecutor {
-    pub(crate) fn new(genesis_state_root_hash: Option<Digest>, registry: Registry) -> Self {
+    pub(crate) fn new(
+        genesis_state_root_hash: Option<Digest>,
+        protocol_version: Version,
+        registry: Registry,
+    ) -> Self {
         let metrics = BlockExecutorMetrics::new(registry).unwrap();
         BlockExecutor {
             genesis_state_root_hash,
+            protocol_version: ProtocolVersion::from_parts(
+                protocol_version.major as u32,
+                protocol_version.minor as u32,
+                protocol_version.patch as u32,
+            ),
             parent_map: HashMap::new(),
             exec_queue: HashMap::new(),
             metrics,
@@ -243,7 +255,7 @@ impl BlockExecutor {
                 let era_end_timestamp_millis = state.finalized_block.timestamp().millis();
                 let request = StepRequest {
                     pre_state_hash: state.state_root_hash.into(),
-                    protocol_version: ProtocolVersion::V1_0_0,
+                    protocol_version: self.protocol_version,
                     reward_items,
                     slash_items,
                     evict_items,
@@ -264,7 +276,7 @@ impl BlockExecutor {
             state.state_root_hash.into(),
             state.finalized_block.timestamp().millis(),
             vec![Ok(deploy_item)],
-            ProtocolVersion::V1_0_0,
+            self.protocol_version,
             state.finalized_block.proposer(),
         );
 

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -18,7 +18,6 @@ use std::{
 
 use datasize::DataSize;
 use prometheus::{self, Registry};
-use semver::Version;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{
@@ -27,7 +26,7 @@ use crate::{
         requests::{BlockProposerRequest, ProtoBlockRequest, StateStoreRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects,
     },
-    types::{chainspec::DeployConfig, DeployHash, DeployHeader, ProtoBlock, Timestamp},
+    types::{chainspec::DeployConfig, Chainspec, DeployHash, DeployHeader, ProtoBlock, Timestamp},
     NodeRng,
 };
 use casper_execution_engine::shared::gas::Gas;
@@ -72,7 +71,14 @@ type RequestQueue = HashMap<BlockHeight, Vec<ProtoBlockRequest>>;
 #[allow(clippy::large_enum_variant)]
 enum BlockProposerState {
     /// Block proposer is initializing, waiting for a state snapshot.
-    Initializing { pending: Vec<Event> },
+    Initializing {
+        /// Events cached pending transition to `Ready` state when they can be handled.
+        pending: Vec<Event>,
+        /// The key under which this component's state is cached in storage.
+        state_key: Vec<u8>,
+        /// The deploy config from the current chainspec.
+        deploy_config: DeployConfig,
+    },
     /// Normal operation.
     Ready(BlockProposerReady),
 }
@@ -83,32 +89,20 @@ impl BlockProposer {
         registry: Registry,
         effect_builder: EffectBuilder<REv>,
         next_finalized_block: BlockHeight,
+        chainspec: &Chainspec,
     ) -> Result<(Self, Effects<Event>), prometheus::Error>
     where
         REv: From<Event> + From<StorageRequest> + From<StateStoreRequest> + Send + 'static,
     {
-        // Note: Version is currently not honored by the storage component, so we just hardcode
-        // 1.0.0.
+        // load the state from storage or use a fresh instance if loading fails.
+        let state_key = deploy_sets::create_storage_key(chainspec);
         let effects = async move {
-            let chainspec = effect_builder
-                .get_chainspec(Version::new(1, 0, 0))
+            effect_builder
+                .load_state(state_key.into())
                 .await
-                // Note: Currently the storage component will always return a chainspec, however the
-                // interface has not kept up with this yet.
-                .expect("chainspec should be infallible");
-
-            // With the chainspec, we can now load the state from storage or use a fresh instance if
-            // loading fails.
-            let key = deploy_sets::create_storage_key(&chainspec);
-            let sets = effect_builder
-                .load_state(key.into())
-                .await
-                .unwrap_or_default();
-
-            (chainspec, sets)
+                .unwrap_or_default()
         }
-        .event(move |(chainspec, sets)| Event::Loaded {
-            chainspec,
+        .event(move |sets| Event::Loaded {
             sets,
             next_finalized_block,
         });
@@ -116,6 +110,8 @@ impl BlockProposer {
         let block_proposer = BlockProposer {
             state: BlockProposerState::Initializing {
                 pending: Vec::new(),
+                state_key: deploy_sets::create_storage_key(chainspec),
+                deploy_config: chainspec.deploy_config,
             },
             metrics: BlockProposerMetrics::new(registry)?,
         };
@@ -144,9 +140,12 @@ where
         // enough to handle it here directly.
         match (&mut self.state, event) {
             (
-                BlockProposerState::Initializing { ref mut pending },
+                BlockProposerState::Initializing {
+                    ref mut pending,
+                    state_key,
+                    deploy_config,
+                },
                 Event::Loaded {
-                    chainspec,
                     sets,
                     next_finalized_block,
                 },
@@ -155,10 +154,10 @@ where
                     sets: sets
                         .unwrap_or_default()
                         .with_next_finalized(next_finalized_block),
-                    deploy_config: chainspec.deploy_config,
-                    state_key: deploy_sets::create_storage_key(&chainspec),
-                    request_queue: Default::default(),
                     unhandled_finalized: Default::default(),
+                    deploy_config: *deploy_config,
+                    state_key: state_key.clone(),
+                    request_queue: Default::default(),
                 };
 
                 // Replay postponed events onto new state.
@@ -175,7 +174,12 @@ where
                         .event(|_| Event::Prune),
                 );
             }
-            (BlockProposerState::Initializing { ref mut pending }, event) => {
+            (
+                BlockProposerState::Initializing {
+                    ref mut pending, ..
+                },
+                event,
+            ) => {
                 // Any incoming events are just buffered until initialization is complete.
                 pending.push(event);
             }
@@ -203,7 +207,7 @@ struct BlockProposerReady {
     /// seen but were reported as reported to `finalized_deploys()`. They are used to
     /// filter deploys for proposal, similar to `self.sets.finalized_deploys`.
     unhandled_finalized: HashSet<DeployHash>,
-    // We don't need the whole Chainspec here, just the deploy config.
+    /// We don't need the whole Chainspec here, just the deploy config.
     deploy_config: DeployConfig,
     /// Key for storing the block proposer state.
     state_key: Vec<u8>,

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -96,9 +96,10 @@ impl BlockProposer {
     {
         // load the state from storage or use a fresh instance if loading fails.
         let state_key = deploy_sets::create_storage_key(chainspec);
+        let cloned_state_key = state_key.clone();
         let effects = async move {
             effect_builder
-                .load_state(state_key.into())
+                .load_state(cloned_state_key.into())
                 .await
                 .unwrap_or_default()
         }
@@ -110,7 +111,7 @@ impl BlockProposer {
         let block_proposer = BlockProposer {
             state: BlockProposerState::Initializing {
                 pending: Vec::new(),
-                state_key: deploy_sets::create_storage_key(chainspec),
+                state_key,
                 deploy_config: chainspec.deploy_config,
             },
             metrics: BlockProposerMetrics::new(registry)?,

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::{self, Formatter},
-    sync::Arc,
-};
+use std::fmt::{self, Formatter};
 
 use datasize::DataSize;
 use derive_more::From;
@@ -11,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::{BlockHeight, BlockProposerDeploySets};
 use crate::{
     effect::requests::BlockProposerRequest,
-    types::{Chainspec, DeployHash, DeployHeader, ProtoBlock},
+    types::{DeployHash, DeployHeader, ProtoBlock},
 };
 use casper_execution_engine::shared::motes::Motes;
 
@@ -84,8 +81,6 @@ pub enum Event {
     Request(BlockProposerRequest),
     /// The chainspec and previous sets have been successfully loaded from storage.
     Loaded {
-        /// Loaded chainspec.
-        chainspec: Arc<Chainspec>,
         /// Loaded previously stored block proposer sets.
         sets: Option<BlockProposerDeploySets>,
         /// The height of the next expected finalized block.
@@ -112,7 +107,6 @@ impl Display for Event {
             Event::Loaded {
                 sets: Some(sets),
                 next_finalized_block,
-                ..
             } => write!(
                 f,
                 "loaded block-proposer deploy sets: {}; expected next finalized block: {}",
@@ -121,7 +115,6 @@ impl Display for Event {
             Event::Loaded {
                 sets: None,
                 next_finalized_block,
-                ..
             } => write!(
                 f,
                 "loaded block-proposer deploy sets, none found in storage; \

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -65,7 +65,7 @@ impl From<&Chainspec> for ProtocolConfig {
             era_duration: chainspec.core_config.era_duration,
             minimum_era_height: chainspec.core_config.minimum_era_height,
             auction_delay: chainspec.core_config.auction_delay,
-            unbonding_delay: chainspec.core_config.unbonding_delay.into(),
+            unbonding_delay: chainspec.core_config.unbonding_delay,
             protocol_version: chainspec.protocol_config.version.clone(),
             name: chainspec.network_config.name.clone(),
             timestamp: chainspec.network_config.timestamp,

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -541,7 +541,7 @@ where
             trace!(era = era_id.0, "executed block in old era");
             return effects;
         }
-        if block.header().switch_block() {
+        if block.header().is_switch_block() {
             // if the block is a switch block, we have to get the validators for the new era and
             // create it, before we can say we handled the block
             let new_era_id = era_id.successor();

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -133,7 +133,8 @@ where
         effect_builder: EffectBuilder<REv>,
         validators: BTreeMap<PublicKey, U512>,
         protocol_config: ProtocolConfig,
-        genesis_state_root_hash: Digest,
+        state_root_hash: Digest,
+        next_upgrade_activation_point: Option<ActivationPoint>,
         registry: &Registry,
         new_consensus: Box<ConsensusConstructor<I>>,
         mut rng: &mut NodeRng,
@@ -162,7 +163,7 @@ where
             metrics,
             finished_joining: false,
             unit_hashes_folder,
-            next_upgrade_activation_point: None,
+            next_upgrade_activation_point,
             stop_for_upgrade: false,
             next_executed_height: 0,
         };
@@ -175,7 +176,7 @@ where
             0,      // hardcoded seed for era 0
             genesis_start_time,
             0, // the first block has height 0
-            genesis_state_root_hash,
+            state_root_hash,
         );
         let effects = era_supervisor
             .handling_wrapper(effect_builder, &mut rng)

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -576,7 +576,7 @@ impl ContractRuntime {
     }
 
     /// Commits a genesis using a chainspec
-    fn commit_genesis(&self, chainspec: Box<Chainspec>) -> Result<GenesisResult, Error> {
+    fn commit_genesis(&self, chainspec: Arc<Chainspec>) -> Result<GenesisResult, Error> {
         let correlation_id = CorrelationId::new();
         let genesis_config_hash = chainspec.hash();
         let protocol_version = ProtocolVersion::from_parts(
@@ -585,7 +585,7 @@ impl ContractRuntime {
             chainspec.protocol_config.version.patch as u32,
         );
         // Transforms a chainspec into a valid genesis config for execution engine.
-        let ee_config = (*chainspec).into();
+        let ee_config = chainspec.as_ref().into();
         self.engine_state.commit_genesis(
             correlation_id,
             genesis_config_hash.into(),

--- a/node/src/components/deploy_acceptor/event.rs
+++ b/node/src/components/deploy_acceptor/event.rs
@@ -1,9 +1,8 @@
 use std::fmt::{self, Display, Formatter};
 
-use semver::Version;
 use serde::Serialize;
 
-use super::{DeployAcceptorChainspec, Source};
+use super::Source;
 use crate::{
     components::deploy_acceptor::Error,
     effect::{announcements::RpcServerAnnouncement, Responder},
@@ -19,14 +18,6 @@ pub enum Event {
         deploy: Box<Deploy>,
         source: Source<NodeId>,
         responder: Option<Responder<Result<(), Error>>>,
-    },
-    /// The result of getting the chainspec from the storage component.
-    GetChainspecResult {
-        deploy: Box<Deploy>,
-        source: Source<NodeId>,
-        chainspec_version: Version,
-        maybe_chainspec: Box<Option<DeployAcceptorChainspec>>,
-        maybe_responder: Option<Responder<Result<(), Error>>>,
     },
     /// The result of the `DeployAcceptor` putting a `Deploy` to the storage component.
     PutToStorageResult {
@@ -61,21 +52,6 @@ impl Display for Event {
         match self {
             Event::Accept { deploy, source, .. } => {
                 write!(formatter, "accept {} from {}", deploy.id(), source)
-            }
-            Event::GetChainspecResult {
-                chainspec_version,
-                maybe_chainspec,
-                ..
-            } => {
-                if maybe_chainspec.is_some() {
-                    write!(formatter, "got chainspec at {}", chainspec_version)
-                } else {
-                    write!(
-                        formatter,
-                        "failed to get chainspec at {}",
-                        chainspec_version
-                    )
-                }
             }
             Event::PutToStorageResult { deploy, is_new, .. } => {
                 if *is_new {

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -28,6 +28,7 @@ mod sse_server;
 use std::{convert::Infallible, fmt::Debug};
 
 use datasize::DataSize;
+use semver::Version;
 use tokio::sync::mpsc::{self, UnboundedSender};
 
 use super::Component;
@@ -56,16 +57,15 @@ pub(crate) struct EventStreamServer {
 }
 
 impl EventStreamServer {
-    pub(crate) fn new<REv>(
-        config: Config,
-        _effect_builder: EffectBuilder<REv>,
-    ) -> Result<Self, ListeningError>
-    where
-        REv: ReactorEventT,
-    {
+    pub(crate) fn new(config: Config, api_version: Version) -> Result<Self, ListeningError> {
         let (sse_data_sender, sse_data_receiver) = mpsc::unbounded_channel();
         let builder = utils::start_listening(&config.address)?;
-        tokio::spawn(http_server::run(config, builder, sse_data_receiver));
+        tokio::spawn(http_server::run(
+            config,
+            api_version,
+            builder,
+            sse_data_receiver,
+        ));
 
         Ok(EventStreamServer { sse_data_sender })
     }

--- a/node/src/components/event_stream_server/http_server.rs
+++ b/node/src/components/event_stream_server/http_server.rs
@@ -70,7 +70,9 @@ pub(super) async fn run(
                     if let Some(subscriber) = maybe_new_subscriber {
                         // First send the client the `ApiVersion` event.  We don't care if this
                         // errors - the client may have disconnected already.
-                        let _ = subscriber.initial_events_sender.send(ServerSentEvent::initial_event(api_version.clone()));
+                        let _ = subscriber
+                            .initial_events_sender
+                            .send(ServerSentEvent::initial_event(api_version.clone()));
                         // If the client supplied a "start_from" index, provide the buffered events.
                         // If they requested more than is buffered, just provide the whole buffer.
                         if let Some(start_index) = subscriber.start_from {

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -2,7 +2,6 @@
 
 use datasize::DataSize;
 use futures::{Stream, StreamExt};
-use once_cell::sync::Lazy;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{
@@ -19,18 +18,12 @@ use warp::{
 use casper_types::{ExecutionResult, PublicKey};
 
 use crate::{
-    components::{consensus::EraId, CLIENT_API_VERSION},
+    components::consensus::EraId,
     types::{BlockHash, BlockHeader, DeployHash, FinalitySignature, TimeDiff, Timestamp},
 };
 
 /// The URL path.
 pub const SSE_API_PATH: &str = "events";
-
-/// The first event sent to every subscribing client.
-pub(super) static SSE_INITIAL_EVENT: Lazy<ServerSentEvent> = Lazy::new(|| ServerSentEvent {
-    id: None,
-    data: SseData::ApiVersion(CLIENT_API_VERSION.clone()),
-});
 
 /// The "id" field of the events sent on the event stream to clients.
 type Id = u32;
@@ -74,6 +67,16 @@ pub(super) struct ServerSentEvent {
     /// The ID should only be `None` where the `data` is `SseData::ApiVersion`.
     pub(super) id: Option<Id>,
     pub(super) data: SseData,
+}
+
+impl ServerSentEvent {
+    /// The first event sent to every subscribing client.
+    pub(super) fn initial_event(client_api_version: Version) -> Self {
+        ServerSentEvent {
+            id: None,
+            data: SseData::ApiVersion(client_api_version),
+        }
+    }
 }
 
 /// The messages sent via the tokio broadcast channel to the handler of each client's SSE stream.

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -85,6 +85,7 @@ reactor!(Reactor {
         LinearChainRequest<NodeId> -> !;
         NetworkRequest<NodeId, Message> -> network;
         StorageRequest -> storage;
+        StateStoreRequest -> storage;
         FetcherRequest<NodeId, Deploy> -> deploy_fetcher;
 
         // The only contract runtime request will be the commit of genesis, which we discard.

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -71,7 +71,7 @@ reactor!(Reactor {
         );
         network = infallible InMemoryNetwork::<Message>(event_queue, rng);
         storage = Storage(&WithDir::new(cfg.temp_dir.path(), cfg.storage_config));
-        deploy_acceptor = infallible DeployAcceptor(cfg.deploy_acceptor_config, Arc::clone(chainspec_loader.chainspec()));
+        deploy_acceptor = infallible DeployAcceptor(cfg.deploy_acceptor_config, &*chainspec_loader.chainspec());
         deploy_fetcher = infallible Fetcher::<Deploy>(cfg.fetcher_config);
     }
 

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -71,7 +71,7 @@ reactor!(Reactor {
         );
         network = infallible InMemoryNetwork::<Message>(event_queue, rng);
         storage = Storage(&WithDir::new(cfg.temp_dir.path(), cfg.storage_config));
-        deploy_acceptor = infallible DeployAcceptor(cfg.deploy_acceptor_config);
+        deploy_acceptor = infallible DeployAcceptor(cfg.deploy_acceptor_config, Arc::clone(chainspec_loader.chainspec()));
         deploy_fetcher = infallible Fetcher::<Deploy>(cfg.fetcher_config);
     }
 

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -154,7 +154,10 @@ impl reactor::Reactor for Reactor {
         let contract_runtime =
             ContractRuntime::new(storage_withdir, &contract_runtime_config, &registry).unwrap();
 
-        let deploy_acceptor = DeployAcceptor::new(deploy_acceptor::Config::new(false));
+        let deploy_acceptor = DeployAcceptor::new(
+            deploy_acceptor::Config::new(false),
+            Arc::new(Chainspec::from_resources("local")),
+        );
         let deploy_gossiper = Gossiper::new_for_partial_items(
             "deploy_gossiper",
             config,

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -3,7 +3,6 @@ use std::{
     collections::{BTreeSet, HashMap},
     fmt::{self, Debug, Display, Formatter},
     iter,
-    sync::Arc,
 };
 
 use derive_more::From;
@@ -156,7 +155,7 @@ impl reactor::Reactor for Reactor {
 
         let deploy_acceptor = DeployAcceptor::new(
             deploy_acceptor::Config::new(false),
-            Arc::new(Chainspec::from_resources("local")),
+            &Chainspec::from_resources("local"),
         );
         let deploy_gossiper = Gossiper::new_for_partial_items(
             "deploy_gossiper",

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -186,12 +186,6 @@ impl reactor::Reactor for Reactor {
         event: Event,
     ) -> Effects<Self::Event> {
         match event {
-            Event::Storage(storage::Event::StorageRequest(StorageRequest::GetChainspec {
-                responder,
-                ..
-            })) => responder
-                .respond(Some(Arc::new(Chainspec::from_resources("local"))))
-                .ignore(),
             Event::Storage(event) => reactor::wrap_effects(
                 Event::Storage,
                 self.storage.handle_event(effect_builder, rng, event),

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -328,6 +328,10 @@ impl reactor::Reactor for Reactor {
             ),
         }
     }
+
+    fn maybe_exit(&self) -> Option<crate::reactor::ReactorExit> {
+        unimplemented!()
+    }
 }
 
 impl NetworkedReactor for Reactor {

--- a/node/src/components/linear_chain_fast_sync.rs
+++ b/node/src/components/linear_chain_fast_sync.rs
@@ -22,7 +22,9 @@ use super::{
 };
 use crate::{
     effect::{EffectBuilder, EffectExt, EffectOptionExt, Effects},
-    types::{Block, BlockByHeight, BlockHash, BlockHeader, Chainspec, FinalizedBlock},
+    types::{
+        ActivationPoint, Block, BlockByHeight, BlockHash, BlockHeader, Chainspec, FinalizedBlock,
+    },
     NodeRng,
 };
 use event::BlockByHeightResult;
@@ -48,6 +50,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainFastSync<I> {
         _storage: &Storage,
         init_hash: Option<BlockHash>,
         genesis_validator_weights: BTreeMap<PublicKey, U512>,
+        _next_upgrade_activation_point: Option<ActivationPoint>,
     ) -> Result<Self, Err>
     where
         Err: From<prometheus::Error> + From<storage::Error>,

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -199,7 +199,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         let height = block.height();
         let hash = block.hash();
         trace!(%hash, %height, "downloaded linear chain block.");
-        if block.header().switch_block() && self.should_upgrade(block.header().era_id()) {
+        if block.header().is_switch_block() && self.should_upgrade(block.header().era_id()) {
             info!(era = block.header().era_id().0, "shutting down for upgrade");
             return effect_builder
                 .immediately()

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -118,6 +118,10 @@ impl Reactor for TestReactor {
             }
         }
     }
+
+    fn maybe_exit(&self) -> Option<crate::reactor::ReactorExit> {
+        unimplemented!()
+    }
 }
 
 impl NetworkedReactor for TestReactor {

--- a/node/src/components/network/tests_bulk_gossip.rs
+++ b/node/src/components/network/tests_bulk_gossip.rs
@@ -3,6 +3,7 @@ use std::{
     convert::TryFrom,
     env, fmt,
     fmt::{Debug, Display, Formatter},
+    sync::Arc,
     time::Duration,
 };
 
@@ -66,7 +67,7 @@ impl NetworkedReactor for LoadTestingReactor {
 #[derive(Debug)]
 pub struct TestReactorConfig {
     /// The fixed chainspec used in testing.
-    chainspec: Chainspec,
+    chainspec: Arc<Chainspec>,
     /// Network configuration used in testing.
     network_config: NetworkComponentConfig,
 }
@@ -153,11 +154,11 @@ async fn send_large_message_across_network() {
     let first_node_port = testing::unused_port_on_localhost() + 1;
 
     let mut net = TestingNetwork::<LoadTestingReactor>::new();
-    let chainspec = Chainspec::random(&mut rng);
+    let chainspec = Arc::new(Chainspec::random(&mut rng));
 
     // Create the root node.
     let cfg = TestReactorConfig {
-        chainspec: chainspec.clone(),
+        chainspec: Arc::clone(&chainspec),
         network_config: NetworkComponentConfig::default_local_net_first_node(first_node_port),
     };
 
@@ -166,7 +167,7 @@ async fn send_large_message_across_network() {
     // Create `node_count-1` additional node instances.
     for _ in 1..node_count {
         let cfg = TestReactorConfig {
-            chainspec: chainspec.clone(),
+            chainspec: Arc::clone(&chainspec),
             network_config: NetworkComponentConfig::default_local_net(first_node_port),
         };
 

--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -27,6 +27,7 @@ use std::{convert::Infallible, fmt::Debug};
 
 use datasize::DataSize;
 use futures::{future::BoxFuture, join, FutureExt};
+use semver::Version;
 use tokio::{sync::oneshot, task::JoinHandle};
 use tracing::{debug, error, warn};
 
@@ -82,6 +83,7 @@ impl RestServer {
     pub(crate) fn new<REv>(
         config: Config,
         effect_builder: EffectBuilder<REv>,
+        api_version: Version,
     ) -> Result<Self, ListeningError>
     where
         REv: ReactorEventT,
@@ -92,6 +94,7 @@ impl RestServer {
         let server_join_handle = tokio::spawn(http_server::run(
             builder,
             effect_builder,
+            api_version,
             shutdown_receiver,
             config.qps_limit,
         ));

--- a/node/src/components/rest_server/http_server.rs
+++ b/node/src/components/rest_server/http_server.rs
@@ -2,6 +2,7 @@ use std::{convert::Infallible, time::Duration};
 
 use futures::{future, TryFutureExt};
 use hyper::server::{conn::AddrIncoming, Builder};
+use semver::Version;
 use tokio::sync::oneshot;
 use tower::builder::ServiceBuilder;
 use tracing::{info, warn};
@@ -16,11 +17,12 @@ use crate::effect::EffectBuilder;
 pub(super) async fn run<REv: ReactorEventT>(
     builder: Builder<AddrIncoming>,
     effect_builder: EffectBuilder<REv>,
+    api_version: Version,
     shutdown_receiver: oneshot::Receiver<()>,
     qps_limit: u64,
 ) {
     // REST filters.
-    let rest_status = filters::create_status_filter(effect_builder);
+    let rest_status = filters::create_status_filter(effect_builder, api_version);
     let rest_metrics = filters::create_metrics_filter(effect_builder);
 
     let service = warp_json_rpc::service(rest_status.or(rest_metrics));

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -23,6 +23,7 @@ use std::{convert::Infallible, fmt::Debug};
 
 use datasize::DataSize;
 use futures::join;
+use semver::Version;
 
 use casper_execution_engine::{
     core::engine_state::{
@@ -91,12 +92,18 @@ impl RpcServer {
     pub(crate) fn new<REv>(
         config: Config,
         effect_builder: EffectBuilder<REv>,
+        api_version: Version,
     ) -> Result<Self, ListeningError>
     where
         REv: ReactorEventT,
     {
         let builder = utils::start_listening(&config.address)?;
-        tokio::spawn(http_server::run(builder, effect_builder, config.qps_limit));
+        tokio::spawn(http_server::run(
+            builder,
+            effect_builder,
+            api_version,
+            config.qps_limit,
+        ));
 
         Ok(RpcServer {})
     }

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -6,6 +6,7 @@ use hyper::{
     server::{conn::AddrIncoming, Builder},
     Body,
 };
+use semver::Version;
 use serde::Serialize;
 use tokio::sync::oneshot;
 use tower::builder::ServiceBuilder;
@@ -46,21 +47,28 @@ fn new_error_response(error: warp_json_rpc::Error) -> Response<Body> {
 pub(super) async fn run<REv: ReactorEventT>(
     builder: Builder<AddrIncoming>,
     effect_builder: EffectBuilder<REv>,
+    api_version: Version,
     qps_limit: u64,
 ) {
     // RPC filters.
-    let rpc_put_deploy = rpcs::account::PutDeploy::create_filter(effect_builder);
-    let rpc_get_block = rpcs::chain::GetBlock::create_filter(effect_builder);
-    let rpc_get_block_transfers = rpcs::chain::GetBlockTransfers::create_filter(effect_builder);
-    let rpc_get_state_root_hash = rpcs::chain::GetStateRootHash::create_filter(effect_builder);
-    let rpc_get_item = rpcs::state::GetItem::create_filter(effect_builder);
-    let rpc_get_balance = rpcs::state::GetBalance::create_filter(effect_builder);
-    let rpc_get_deploy = rpcs::info::GetDeploy::create_filter(effect_builder);
-    let rpc_get_peers = rpcs::info::GetPeers::create_filter(effect_builder);
-    let rpc_get_status = rpcs::info::GetStatus::create_filter(effect_builder);
-    let rpc_get_era_info = rpcs::chain::GetEraInfoBySwitchBlock::create_filter(effect_builder);
-    let rpc_get_auction_info = rpcs::state::GetAuctionInfo::create_filter(effect_builder);
-    let rpc_get_rpcs = rpcs::docs::ListRpcs::create_filter(effect_builder);
+    let rpc_put_deploy =
+        rpcs::account::PutDeploy::create_filter(effect_builder, api_version.clone());
+    let rpc_get_block = rpcs::chain::GetBlock::create_filter(effect_builder, api_version.clone());
+    let rpc_get_block_transfers =
+        rpcs::chain::GetBlockTransfers::create_filter(effect_builder, api_version.clone());
+    let rpc_get_state_root_hash =
+        rpcs::chain::GetStateRootHash::create_filter(effect_builder, api_version.clone());
+    let rpc_get_item = rpcs::state::GetItem::create_filter(effect_builder, api_version.clone());
+    let rpc_get_balance =
+        rpcs::state::GetBalance::create_filter(effect_builder, api_version.clone());
+    let rpc_get_deploy = rpcs::info::GetDeploy::create_filter(effect_builder, api_version.clone());
+    let rpc_get_peers = rpcs::info::GetPeers::create_filter(effect_builder, api_version.clone());
+    let rpc_get_status = rpcs::info::GetStatus::create_filter(effect_builder, api_version.clone());
+    let rpc_get_era_info =
+        rpcs::chain::GetEraInfoBySwitchBlock::create_filter(effect_builder, api_version.clone());
+    let rpc_get_auction_info =
+        rpcs::state::GetAuctionInfo::create_filter(effect_builder, api_version.clone());
+    let rpc_get_rpcs = rpcs::docs::ListRpcs::create_filter(effect_builder, api_version);
 
     // Catch requests where the method is not one we handle.
     let unknown_method = warp::path(RPC_API_PATH)

--- a/node/src/components/rpc_server/rpcs/account.rs
+++ b/node/src/components/rpc_server/rpcs/account.rs
@@ -15,9 +15,12 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 use warp_json_rpc::Builder;
 
-use super::{docs::DocExample, Error, ReactorEventT, RpcRequest, RpcWithParams, RpcWithParamsExt};
+use super::{
+    docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
+    Error, ReactorEventT, RpcRequest, RpcWithParams, RpcWithParamsExt,
+};
 use crate::{
-    components::{rpc_server::rpcs::ErrorCode, CLIENT_API_VERSION},
+    components::rpc_server::rpcs::ErrorCode,
     effect::EffectBuilder,
     reactor::QueueKind,
     types::{Deploy, DeployHash},
@@ -27,7 +30,7 @@ static PUT_DEPLOY_PARAMS: Lazy<PutDeployParams> = Lazy::new(|| PutDeployParams {
     deploy: Deploy::doc_example().clone(),
 });
 static PUT_DEPLOY_RESULT: Lazy<PutDeployResult> = Lazy::new(|| PutDeployResult {
-    api_version: CLIENT_API_VERSION.clone(),
+    api_version: DOCS_EXAMPLE_PROTOCOL_VERSION.clone(),
     deploy_hash: *Deploy::doc_example().id(),
 });
 
@@ -76,6 +79,7 @@ impl RpcWithParamsExt for PutDeploy {
         effect_builder: EffectBuilder<REv>,
         response_builder: Builder,
         params: Self::RequestParams,
+        api_version: Version,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
             let deploy_hash = *params.deploy.id();
@@ -97,7 +101,7 @@ impl RpcWithParamsExt for PutDeploy {
                     "deploy was stored"
                     );
                     let result = Self::ResponseResult {
-                        api_version: CLIENT_API_VERSION.clone(),
+                        api_version,
                         deploy_hash,
                     };
                     Ok(response_builder.success(result)?)

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info};
+use tracing::info;
 use warp_json_rpc::Builder;
 
 use casper_execution_engine::{
@@ -22,10 +22,10 @@ use casper_execution_engine::{
 use casper_types::{bytesrepr::ToBytes, CLValue, Key, ProtocolVersion, URef, U512};
 
 use super::{
-    docs::DocExample, Error, ErrorCode, ReactorEventT, RpcRequest, RpcWithParams, RpcWithParamsExt,
+    docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
+    Error, ErrorCode, ReactorEventT, RpcRequest, RpcWithParams, RpcWithParamsExt,
 };
 use crate::{
-    components::CLIENT_API_VERSION,
     crypto::hash::Digest,
     effect::EffectBuilder,
     reactor::QueueKind,
@@ -45,7 +45,7 @@ static GET_ITEM_PARAMS: Lazy<GetItemParams> = Lazy::new(|| GetItemParams {
     path: vec!["inner".to_string()],
 });
 static GET_ITEM_RESULT: Lazy<GetItemResult> = Lazy::new(|| GetItemResult {
-    api_version: CLIENT_API_VERSION.clone(),
+    api_version: DOCS_EXAMPLE_PROTOCOL_VERSION.clone(),
     stored_value: StoredValue::CLValue(CLValue::from_t(1u64).unwrap()),
     merkle_proof: MERKLE_PROOF.clone(),
 });
@@ -55,12 +55,12 @@ static GET_BALANCE_PARAMS: Lazy<GetBalanceParams> = Lazy::new(|| GetBalanceParam
         .to_string(),
 });
 static GET_BALANCE_RESULT: Lazy<GetBalanceResult> = Lazy::new(|| GetBalanceResult {
-    api_version: CLIENT_API_VERSION.clone(),
+    api_version: DOCS_EXAMPLE_PROTOCOL_VERSION.clone(),
     balance_value: U512::from(123_456),
     merkle_proof: MERKLE_PROOF.clone(),
 });
 static GET_AUCTION_INFO_RESULT: Lazy<GetAuctionInfoResult> = Lazy::new(|| GetAuctionInfoResult {
-    api_version: CLIENT_API_VERSION.clone(),
+    api_version: DOCS_EXAMPLE_PROTOCOL_VERSION.clone(),
     auction_state: AuctionState::doc_example().clone(),
 });
 
@@ -116,6 +116,7 @@ impl RpcWithParamsExt for GetItem {
         effect_builder: EffectBuilder<REv>,
         response_builder: Builder,
         params: Self::RequestParams,
+        api_version: Version,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
             // Try to parse a `casper_types::Key` from the params.
@@ -155,7 +156,7 @@ impl RpcWithParamsExt for GetItem {
             };
 
             let result = Self::ResponseResult {
-                api_version: CLIENT_API_VERSION.clone(),
+                api_version,
                 stored_value,
                 merkle_proof: hex::encode(proof_bytes),
             };
@@ -215,6 +216,7 @@ impl RpcWithParamsExt for GetBalance {
         effect_builder: EffectBuilder<REv>,
         response_builder: Builder,
         params: Self::RequestParams,
+        api_version: Version,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
             // Try to parse the purse's URef from the params.
@@ -279,7 +281,7 @@ impl RpcWithParamsExt for GetBalance {
 
             // Return the result.
             let result = Self::ResponseResult {
-                api_version: CLIENT_API_VERSION.clone(),
+                api_version,
                 balance_value,
                 merkle_proof,
             };
@@ -318,6 +320,7 @@ impl RpcWithoutParamsExt for GetAuctionInfo {
     fn handle_request<REv: ReactorEventT>(
         effect_builder: EffectBuilder<REv>,
         response_builder: Builder,
+        api_version: Version,
     ) -> BoxFuture<'static, Result<Response<Body>, Error>> {
         async move {
             let block: Block = {
@@ -345,7 +348,11 @@ impl RpcWithoutParamsExt for GetAuctionInfo {
                 }
             };
 
-            let protocol_version = ProtocolVersion::V1_0_0;
+            let protocol_version = ProtocolVersion::from_parts(
+                api_version.major as u32,
+                api_version.minor as u32,
+                api_version.patch as u32,
+            );
             let protocol_version_result = effect_builder
                 .make_request(
                     |responder| RpcRequest::QueryProtocolData {
@@ -408,8 +415,12 @@ impl RpcWithoutParamsExt for GetAuctionInfo {
 
             let auction_state =
                 AuctionState::new(state_root_hash, block_height, era_validators, bids);
-            debug!("responding to client with: {:?}", auction_state);
-            Ok(response_builder.success(auction_state)?)
+
+            let result = Self::ResponseResult {
+                api_version,
+                auction_state,
+            };
+            Ok(response_builder.success(result)?)
         }
         .boxed()
     }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -1188,8 +1188,8 @@ where
 ///
 /// Reads from a channel and sends all messages, until the stream is closed or an error occurs.
 ///
-/// Initially sends a handshake including the `genesis_config_hash` as a final handshake step.  If
-/// the recipient's `genesis_config_hash` doesn't match, the connection will be closed.
+/// Initially sends a handshake including the `chainspec_hash` as a final handshake step.  If the
+/// recipient's `chainspec_hash` doesn't match, the connection will be closed.
 async fn message_sender<P>(
     mut queue: UnboundedReceiver<Message<P>>,
     mut sink: SplitSink<FramedTransport<P>, Message<P>>,

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -185,6 +185,10 @@ impl Reactor for TestReactor {
             }
         }
     }
+
+    fn maybe_exit(&self) -> Option<crate::reactor::ReactorExit> {
+        unimplemented!()
+    }
 }
 
 impl NetworkedReactor for TestReactor {

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -47,7 +47,6 @@ use std::{
     fmt::{self, Display, Formatter},
     fs, io,
     path::PathBuf,
-    sync::Arc,
 };
 
 use datasize::DataSize;
@@ -72,7 +71,7 @@ use crate::{
     },
     fatal,
     types::{
-        Block, BlockBody, BlockHash, BlockHeader, BlockSignatures, Chainspec, Deploy, DeployHash,
+        Block, BlockBody, BlockHash, BlockHeader, BlockSignatures, Deploy, DeployHash,
         DeployMetadata,
     },
     utils::WithDir,
@@ -200,8 +199,6 @@ pub struct Storage {
     block_height_index: BTreeMap<u64, BlockHash>,
     /// A map of era ID to switch block ID.
     switch_block_era_id_index: BTreeMap<EraId, BlockHash>,
-    /// Chainspec cache.
-    chainspec_cache: Option<Arc<Chainspec>>,
 }
 
 impl<REv> Component<REv> for Storage {
@@ -310,7 +307,6 @@ impl Storage {
             state_store_db,
             block_height_index,
             switch_block_era_id_index,
-            chainspec_cache: None,
         })
     }
 
@@ -643,18 +639,6 @@ impl Storage {
                     .respond(Some((highest_block, signatures)))
                     .ignore()
             }
-            StorageRequest::PutChainspec {
-                chainspec,
-                responder,
-            } => {
-                self.chainspec_cache = Some(chainspec);
-
-                responder.respond(()).ignore()
-            }
-            StorageRequest::GetChainspec {
-                version: _version,
-                responder,
-            } => responder.respond(self.chainspec_cache.clone()).ignore(),
             StorageRequest::PutBlockSignatures {
                 signatures,
                 responder,

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -819,7 +819,7 @@ fn insert_to_block_header_indices(
         }
     }
 
-    if block_header.switch_block() {
+    if block_header.is_switch_block() {
         match switch_block_era_id_index.entry(block_header.era_id()) {
             Entry::Vacant(entry) => {
                 let _ = entry.insert(block_hash);

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1,9 +1,8 @@
 //! Unit tests for the storage component.
 
-use std::{borrow::Cow, collections::HashMap, sync::Arc};
+use std::{borrow::Cow, collections::HashMap};
 
 use rand::{prelude::SliceRandom, Rng};
-use semver::Version;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use smallvec::smallvec;
 
@@ -16,7 +15,7 @@ use crate::{
         Multiple,
     },
     testing::{ComponentHarness, TestRng},
-    types::{Block, BlockHash, Chainspec, Deploy, DeployHash, DeployMetadata},
+    types::{Block, BlockHash, Deploy, DeployHash, DeployMetadata},
     utils::WithDir,
 };
 
@@ -77,19 +76,6 @@ fn get_block(
             responder,
         }
         .into()
-    });
-    assert!(harness.is_idle());
-    response
-}
-
-/// Loads the chainspec from a storage component.
-fn get_chainspec(
-    harness: &mut ComponentHarness<()>,
-    storage: &mut Storage,
-    version: Version,
-) -> Option<Arc<Chainspec>> {
-    let response = harness.send_request(storage, move |responder| {
-        StorageRequest::GetChainspec { version, responder }.into()
     });
     assert!(harness.is_idle());
     response
@@ -163,22 +149,6 @@ fn put_block(harness: &mut ComponentHarness<()>, storage: &mut Storage, block: B
     });
     assert!(harness.is_idle());
     response
-}
-
-/// Stores the chainspec in a storage component.
-fn put_chainspec(
-    harness: &mut ComponentHarness<()>,
-    storage: &mut Storage,
-    chainspec: Arc<Chainspec>,
-) {
-    harness.send_request(storage, move |responder| {
-        StorageRequest::PutChainspec {
-            chainspec,
-            responder,
-        }
-        .into()
-    });
-    assert!(harness.is_idle());
 }
 
 /// Stores a deploy in a storage component.
@@ -656,26 +626,6 @@ fn store_identical_execution_results() {
 
     // We should be fine storing the exact same result twice.
     put_execution_results(&mut harness, &mut storage, block_hash, exec_result);
-}
-
-#[test]
-fn store_and_load_chainspec() {
-    let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
-
-    let version = Version::new(1, 2, 3);
-
-    // Initially expect a `None` value for the chainspec.
-    let response = get_chainspec(&mut harness, &mut storage, version.clone());
-    assert!(response.is_none());
-
-    // Store a random chainspec.
-    let chainspec = Arc::new(Chainspec::random(&mut harness.rng));
-    put_chainspec(&mut harness, &mut storage, Arc::clone(&chainspec));
-
-    // Compare returned chainspec.
-    let response = get_chainspec(&mut harness, &mut storage, version);
-    assert_eq!(response, Some(chainspec));
 }
 
 /// Example state used in storage.

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -166,10 +166,14 @@ fn put_block(harness: &mut ComponentHarness<()>, storage: &mut Storage, block: B
 }
 
 /// Stores the chainspec in a storage component.
-fn put_chainspec(harness: &mut ComponentHarness<()>, storage: &mut Storage, chainspec: Chainspec) {
+fn put_chainspec(
+    harness: &mut ComponentHarness<()>,
+    storage: &mut Storage,
+    chainspec: Arc<Chainspec>,
+) {
     harness.send_request(storage, move |responder| {
         StorageRequest::PutChainspec {
-            chainspec: Arc::new(chainspec),
+            chainspec,
             responder,
         }
         .into()
@@ -666,12 +670,12 @@ fn store_and_load_chainspec() {
     assert!(response.is_none());
 
     // Store a random chainspec.
-    let chainspec = Chainspec::random(&mut harness.rng);
-    put_chainspec(&mut harness, &mut storage, chainspec.clone());
+    let chainspec = Arc::new(Chainspec::random(&mut harness.rng));
+    put_chainspec(&mut harness, &mut storage, Arc::clone(&chainspec));
 
     // Compare returned chainspec.
     let response = get_chainspec(&mut harness, &mut storage, version);
-    assert_eq!(response, Some(Arc::new(chainspec)));
+    assert_eq!(response, Some(chainspec));
 }
 
 /// Example state used in storage.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -100,7 +100,7 @@ use casper_types::{
 
 use crate::{
     components::{
-        chainspec_loader::{ChainspecInfo, NextUpgrade},
+        chainspec_loader::NextUpgrade,
         consensus::{BlockContext, EraId},
         contract_runtime::EraValidatorsRequest,
         deploy_acceptor,
@@ -112,8 +112,8 @@ use crate::{
     reactor::{EventQueueHandle, QueueKind},
     types::{
         Block, BlockByHeight, BlockHash, BlockHeader, BlockLike, BlockSignatures, Chainspec,
-        Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature, FinalizedBlock, Item,
-        ProtoBlock, Timestamp,
+        ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
+        FinalizedBlock, Item, ProtoBlock, Timestamp,
     },
     utils::Source,
 };
@@ -1180,14 +1180,14 @@ impl<REv> EffectBuilder<REv> {
     /// Runs the genesis process on the contract runtime.
     pub(crate) async fn commit_genesis(
         self,
-        chainspec: Chainspec,
+        chainspec: Arc<Chainspec>,
     ) -> Result<GenesisResult, engine_state::Error>
     where
         REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::CommitGenesis {
-                chainspec: Box::new(chainspec),
+                chainspec,
                 responder,
             },
             QueueKind::Regular,
@@ -1196,13 +1196,13 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Puts the given chainspec into the chainspec store.
-    pub(crate) async fn put_chainspec(self, chainspec: Chainspec)
+    pub(crate) async fn put_chainspec(self, chainspec: Arc<Chainspec>)
     where
         REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::PutChainspec {
-                chainspec: Arc::new(chainspec),
+                chainspec,
                 responder,
             },
             QueueKind::Regular,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -73,7 +73,6 @@ use std::{
 
 use datasize::DataSize;
 use futures::{channel::oneshot, future::BoxFuture, FutureExt};
-use semver::Version;
 use serde::{de::DeserializeOwned, Serialize};
 use smallvec::{smallvec, SmallVec};
 use tracing::{error, warn};
@@ -1209,33 +1208,6 @@ impl<REv> EffectBuilder<REv> {
                 upgrade_config,
                 responder,
             },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    /// Puts the given chainspec into the chainspec store.
-    pub(crate) async fn put_chainspec(self, chainspec: Arc<Chainspec>)
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::PutChainspec {
-                chainspec,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    /// Gets the requested chainspec from the chainspec store.
-    pub(crate) async fn get_chainspec(self, version: Version) -> Option<Arc<Chainspec>>
-    where
-        REv: From<StorageRequest>,
-    {
-        self.make_request(
-            |responder| StorageRequest::GetChainspec { version, responder },
             QueueKind::Regular,
         )
         .await

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -86,6 +86,7 @@ use casper_execution_engine::{
         execution_result::ExecutionResults,
         genesis::GenesisResult,
         step::{StepRequest, StepResult},
+        upgrade::{UpgradeConfig, UpgradeResult},
         BalanceRequest, BalanceResult, QueryRequest, QueryResult, MAX_PAYMENT,
     },
     shared::{
@@ -1188,6 +1189,24 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| ContractRuntimeRequest::CommitGenesis {
                 chainspec,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Runs the upgrade process on the contract runtime.
+    pub(crate) async fn upgrade_contract_runtime(
+        self,
+        upgrade_config: Box<UpgradeConfig>,
+    ) -> Result<UpgradeResult, engine_state::Error>
+    where
+        REv: From<ContractRuntimeRequest>,
+    {
+        self.make_request(
+            |responder| ContractRuntimeRequest::Upgrade {
+                upgrade_config,
                 responder,
             },
             QueueKind::Regular,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -38,7 +38,6 @@ use casper_types::{
 use super::{Multiple, Responder};
 use crate::{
     components::{
-        chainspec_loader::ChainspecInfo,
         consensus::EraId,
         contract_runtime::{EraValidatorsRequest, ValidatorWeightsByEraIdRequest},
         deploy_acceptor::Error,
@@ -47,9 +46,9 @@ use crate::{
     crypto::hash::Digest,
     rpcs::chain::BlockIdentifier,
     types::{
-        Block as LinearBlock, Block, BlockHash, BlockHeader, BlockSignatures, Chainspec, Deploy,
-        DeployHash, DeployHeader, DeployMetadata, FinalitySignature, FinalizedBlock, Item,
-        ProtoBlock, StatusFeed, Timestamp,
+        Block as LinearBlock, Block, BlockHash, BlockHeader, BlockSignatures, Chainspec,
+        ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
+        FinalizedBlock, Item, ProtoBlock, StatusFeed, Timestamp,
     },
     utils::DisplayIter,
 };
@@ -686,7 +685,7 @@ pub enum ContractRuntimeRequest {
     /// Commit genesis chainspec.
     CommitGenesis {
         /// The chainspec.
-        chainspec: Box<Chainspec>,
+        chainspec: Arc<Chainspec>,
         /// Responder to call with the result.
         responder: Responder<Result<GenesisResult, engine_state::Error>>,
     },
@@ -946,7 +945,7 @@ pub enum LinearChainRequest<I> {
     /// Request for a linear chain block at height.
     BlockAtHeight(BlockHeight, I),
     /// Local request for a linear chain block at height.
-    /// TODO: Unify `BlockAtHeight` and `BlockAtHeightLocal`.
+    // TODO: Unify `BlockAtHeight` and `BlockAtHeightLocal`.
     BlockAtHeightLocal(BlockHeight, Responder<Option<Block>>),
 }
 

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -12,7 +12,6 @@ use std::{
 
 use datasize::DataSize;
 use hex_fmt::HexFmt;
-use semver::Version;
 use serde::Serialize;
 
 use casper_execution_engine::{
@@ -316,20 +315,6 @@ pub enum StorageRequest {
         /// The responder to call the results with.
         responder: Responder<Option<(Block, BlockSignatures)>>,
     },
-    /// Store given chainspec.
-    PutChainspec {
-        /// Chainspec.
-        chainspec: Arc<Chainspec>,
-        /// Responder to call with the result.
-        responder: Responder<()>,
-    },
-    /// Retrieve chainspec with given version.
-    GetChainspec {
-        /// Version.
-        version: Version,
-        /// Responder to call with the result.
-        responder: Responder<Option<Arc<Chainspec>>>,
-    },
     /// Get finality signatures for a Block hash.
     GetBlockSignatures {
         /// The hash for the request
@@ -399,16 +384,6 @@ impl Display for StorageRequest {
             }
             StorageRequest::GetHighestBlockWithMetadata { .. } => {
                 write!(formatter, "get highest block with metadata")
-            }
-            StorageRequest::PutChainspec { chainspec, .. } => {
-                write!(
-                    formatter,
-                    "put chainspec {}",
-                    chainspec.protocol_config.version
-                )
-            }
-            StorageRequest::GetChainspec { version, .. } => {
-                write!(formatter, "get chainspec {}", version)
             }
             StorageRequest::GetBlockSignatures { block_hash, .. } => {
                 write!(

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -31,6 +31,8 @@ pub mod joiner;
 mod queue_kind;
 pub mod validator;
 
+#[cfg(test)]
+use std::sync::Arc;
 use std::{
     collections::HashMap,
     env,
@@ -646,7 +648,7 @@ where
 impl Runner<InitializerReactor> {
     pub(crate) async fn new_with_chainspec(
         cfg: <InitializerReactor as Reactor>::Config,
-        chainspec: Chainspec,
+        chainspec: Arc<Chainspec>,
     ) -> Result<Self, <InitializerReactor as Reactor>::Error> {
         let registry = Registry::new();
         let scheduler = utils::leak(Scheduler::new(QueueKind::weights()));

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -56,7 +56,7 @@ use tracing_futures::Instrument;
 
 use crate::{
     effect::{Effect, EffectBuilder, Effects},
-    types::Timestamp,
+    types::{ExitCode, Timestamp},
     utils::{self, WeightedRoundRobin},
     NodeRng,
 };
@@ -98,6 +98,16 @@ static DISPATCH_EVENT_THRESHOLD: Lazy<Duration> = Lazy::new(|| {
         })
         .unwrap_or_else(|_| DEFAULT_DISPATCH_EVENT_THRESHOLD)
 });
+
+/// The value returned by a reactor on completion of the `run()` loop.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, DataSize)]
+pub enum ReactorExit {
+    /// The process should continue running, moving to the next reactor.
+    ProcessShouldContinue,
+    /// The process should exit with the given exit code to allow the launcher to react
+    /// accordingly.
+    ProcessShouldExit(ExitCode),
+}
 
 /// Event scheduler
 ///
@@ -189,18 +199,9 @@ pub trait Reactor: Sized {
         rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Self::Event>), Self::Error>;
 
-    /// Indicates that the reactor has completed all its work and should no longer dispatch events.
-    #[inline]
-    fn is_stopped(&mut self) -> bool {
-        false
-    }
-
-    /// Indicates that the reactor shut down due to the restart.
-    /// Should no longer dispatch events.
-    #[inline]
-    fn needs_upgrade(&mut self) -> bool {
-        false
-    }
+    /// If `Some`, indicates that the reactor has completed all its work and should no longer
+    /// dispatch events.  The running process may stop or may keep running with a new reactor.
+    fn maybe_exit(&self) -> Option<ReactorExit>;
 
     /// Instructs the reactor to update performance metrics, if any.
     fn update_metrics(&mut self, _event_queue_handle: EventQueueHandle<Self::Event>) {}
@@ -352,12 +353,6 @@ impl Drop for RunnerMetrics {
             .expect("did not expect deregistering total_ram_bytes to fail");
     }
 }
-
-/// Exit status of a runner instance.
-pub type RunnerExitStatus = Result<(), u8>;
-
-/// Exit code indicating that node should shut down for a scheduled upgrade.
-pub const UPGRADE_EXIT_CODE: u8 = 0;
 
 impl<R> Runner<R>
 where
@@ -613,16 +608,15 @@ where
         }
     }
 
-    /// Runs the reactor until `is_stopped()` returns true.
+    /// Runs the reactor until `maybe_exit()` returns Some.
     #[inline]
-    pub async fn run(&mut self, rng: &mut NodeRng) -> RunnerExitStatus {
-        while !self.reactor.is_stopped() {
-            if self.reactor.needs_upgrade() {
-                return RunnerExitStatus::Err(UPGRADE_EXIT_CODE);
+    pub async fn run(&mut self, rng: &mut NodeRng) -> ReactorExit {
+        loop {
+            if let Some(reactor_exit) = self.reactor.maybe_exit() {
+                return reactor_exit;
             }
             self.crank(rng).await;
         }
-        RunnerExitStatus::Ok(())
     }
 
     /// Returns a reference to the reactor.

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -28,11 +28,11 @@ use crate::{
     },
     effect::{
         announcements::ChainspecLoaderAnnouncement,
-        requests::{ContractRuntimeRequest, NetworkRequest, StorageRequest},
+        requests::{ContractRuntimeRequest, NetworkRequest, StateStoreRequest, StorageRequest},
         EffectBuilder, Effects,
     },
     protocol::Message,
-    reactor::{self, validator, EventQueueHandle},
+    reactor::{self, validator, EventQueueHandle, ReactorExit},
     types::{chainspec, NodeId},
     utils::WithDir,
     NodeRng,
@@ -53,6 +53,10 @@ pub enum Event {
     /// Contract runtime event.
     #[from]
     ContractRuntime(contract_runtime::Event),
+
+    /// Request for state storage.
+    #[from]
+    StateStoreRequest(StateStoreRequest),
 }
 
 impl From<StorageRequest> for Event {
@@ -85,6 +89,9 @@ impl Display for Event {
             Event::Chainspec(event) => write!(formatter, "chainspec: {}", event),
             Event::Storage(event) => write!(formatter, "storage: {}", event),
             Event::ContractRuntime(event) => write!(formatter, "contract runtime: {}", event),
+            Event::StateStoreRequest(request) => {
+                write!(formatter, "state store request: {}", request)
+            }
         }
     }
 }
@@ -130,11 +137,6 @@ pub struct Reactor {
 }
 
 impl Reactor {
-    /// Returns whether the initialization process completed successfully or not.
-    pub fn stopped_successfully(&self) -> bool {
-        self.chainspec_loader.stopped_successfully()
-    }
-
     #[cfg(test)]
     pub(crate) fn new_with_chainspec(
         config: <Self as reactor::Reactor>::Config,
@@ -226,11 +228,14 @@ impl reactor::Reactor for Reactor {
                 self.contract_runtime
                     .handle_event(effect_builder, rng, event),
             ),
+            Event::StateStoreRequest(request) => {
+                self.dispatch_event(effect_builder, rng, Event::Storage(request.into()))
+            }
         }
     }
 
-    fn is_stopped(&mut self) -> bool {
-        self.chainspec_loader.is_stopped()
+    fn maybe_exit(&self) -> Option<ReactorExit> {
+        self.chainspec_loader.reactor_exit()
     }
 }
 

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -3,6 +3,8 @@
 #[cfg(test)]
 use std::env;
 use std::fmt::{self, Display, Formatter};
+#[cfg(test)]
+use std::sync::Arc;
 
 use datasize::DataSize;
 use derive_more::From;
@@ -138,7 +140,7 @@ impl Reactor {
         config: <Self as reactor::Reactor>::Config,
         registry: &Registry,
         event_queue: EventQueueHandle<Event>,
-        chainspec: Chainspec,
+        chainspec: Arc<Chainspec>,
     ) -> Result<(Self, Effects<Event>), Error> {
         let effect_builder = EffectBuilder::new(event_queue);
         let (chainspec_loader, chainspec_effects) =

--- a/node/src/reactor/initializer2.rs
+++ b/node/src/reactor/initializer2.rs
@@ -18,6 +18,7 @@ reactor!(Initializer {
 
   requests: {
     StorageRequest -> storage;
+    StateStoreRequest -> storage;
     ContractRuntimeRequest -> contract_runtime;
 
     // No network traffic during initialization, just discard.
@@ -31,11 +32,4 @@ reactor!(Initializer {
 });
 
 // TODO: Metrics
-// TODO: is_stopped
-
-impl Initializer {
-    /// Returns whether the initialization process completed successfully or not.
-    pub fn stopped_successfully(&self) -> bool {
-        self.chainspec_loader.stopped_successfully()
-    }
-}
+// TODO: maybe_exit

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -468,11 +468,7 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec().protocol_config.version.clone(),
         )?;
 
-        let (block_validator, block_validator_effects) = BlockValidator::new(effect_builder);
-        effects.extend(reactor::wrap_effects(
-            Event::BlockValidator,
-            block_validator_effects,
-        ));
+        let block_validator = BlockValidator::new(Arc::clone(&chainspec_loader.chainspec()));
 
         let deploy_fetcher = Fetcher::new(config.fetcher);
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -436,7 +436,10 @@ impl reactor::Reactor for Reactor {
 
         let effect_builder = EffectBuilder::new(event_queue);
 
-        let init_hash = config.node.trusted_hash;
+        let init_hash = config
+            .node
+            .trusted_hash
+            .or_else(|| chainspec_loader.highest_block_hash());
 
         match init_hash {
             None => {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -476,10 +476,8 @@ impl reactor::Reactor for Reactor {
 
         let block_by_height_fetcher = Fetcher::new(config.fetcher);
 
-        let deploy_acceptor = DeployAcceptor::new(
-            config.deploy_acceptor,
-            Arc::clone(chainspec_loader.chainspec()),
-        );
+        let deploy_acceptor =
+            DeployAcceptor::new(config.deploy_acceptor, &*chainspec_loader.chainspec());
 
         let genesis_state_root_hash = chainspec_loader.genesis_state_root_hash();
         let block_executor = BlockExecutor::new(
@@ -513,16 +511,13 @@ impl reactor::Reactor for Reactor {
         // Used to decide whether era should be activated.
         let timestamp = Timestamp::now();
 
-        let state_root_hash = chainspec_loader
-            .state_root_hash()
-            .expect("should have chainspec state root hash");
         let (consensus, init_consensus_effects) = EraSupervisor::new(
             timestamp,
             WithDir::new(root, config.consensus.clone()),
             effect_builder,
             validator_weights,
             chainspec_loader.chainspec().as_ref().into(),
-            state_root_hash,
+            chainspec_loader.starting_state_root_hash(),
             maybe_next_activation_point,
             registry,
             Box::new(HighwayProtocol::new_boxed),

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -457,16 +457,15 @@ impl reactor::Reactor for Reactor {
             Some(hash) => info!("Synchronizing linear chain from: {:?}", hash),
         }
 
+        let protocol_version = &chainspec_loader.chainspec().protocol_config.version;
         let rest_server = RestServer::new(
             config.rest_server.clone(),
             effect_builder,
-            chainspec_loader.chainspec().protocol_config.version.clone(),
+            protocol_version.clone(),
         )?;
 
-        let event_stream_server = EventStreamServer::new(
-            config.event_stream_server.clone(),
-            chainspec_loader.chainspec().protocol_config.version.clone(),
-        )?;
+        let event_stream_server =
+            EventStreamServer::new(config.event_stream_server.clone(), protocol_version.clone())?;
 
         let block_validator = BlockValidator::new(Arc::clone(&chainspec_loader.chainspec()));
 
@@ -480,7 +479,11 @@ impl reactor::Reactor for Reactor {
         );
 
         let genesis_state_root_hash = chainspec_loader.genesis_state_root_hash();
-        let block_executor = BlockExecutor::new(genesis_state_root_hash, registry.clone());
+        let block_executor = BlockExecutor::new(
+            genesis_state_root_hash,
+            protocol_version.clone(),
+            registry.clone(),
+        );
 
         let linear_chain = linear_chain::LinearChain::new(&registry)?;
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -59,8 +59,8 @@ use crate::{
         EffectBuilder, EffectExt, Effects,
     },
     protocol::Message,
-    reactor::{self, event_queue_metrics::EventQueueMetrics, EventQueueHandle},
-    types::{Block, Deploy, NodeId, ProtoBlock, Tag, TimeDiff, Timestamp},
+    reactor::{self, event_queue_metrics::EventQueueMetrics, EventQueueHandle, ReactorExit},
+    types::{Block, Deploy, ExitCode, NodeId, ProtoBlock, Tag, TimeDiff, Timestamp},
     utils::Source,
     NodeRng,
 };
@@ -952,12 +952,10 @@ impl reactor::Reactor for Reactor {
             .record_event_queue_counts(&event_queue_handle)
     }
 
-    fn is_stopped(&mut self) -> bool {
-        self.consensus.stop_for_upgrade()
-    }
-
-    fn needs_upgrade(&mut self) -> bool {
-        self.consensus.stop_for_upgrade()
+    fn maybe_exit(&self) -> Option<ReactorExit> {
+        self.consensus
+            .stop_for_upgrade()
+            .then(|| ReactorExit::ProcessShouldExit(ExitCode::Success))
     }
 }
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -457,13 +457,9 @@ impl reactor::Reactor for Reactor {
         let genesis_state_root_hash = chainspec_loader.genesis_state_root_hash();
         let block_executor = BlockExecutor::new(genesis_state_root_hash, registry.clone())
             .with_parent_map(latest_block);
-        let (proto_block_validator, block_validator_effects) = BlockValidator::new(effect_builder);
+        let proto_block_validator = BlockValidator::new(Arc::clone(&chainspec_loader.chainspec()));
         let linear_chain = LinearChain::new(registry)?;
 
-        effects.extend(reactor::wrap_effects(
-            Event::ProtoBlockValidator,
-            block_validator_effects,
-        ));
         effects.extend(reactor::wrap_effects(Event::Network, network_effects));
         effects.extend(reactor::wrap_effects(
             Event::SmallNetwork,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -422,15 +422,16 @@ impl reactor::Reactor for Reactor {
         let address_gossiper =
             Gossiper::new_for_complete_items("address_gossiper", config.gossip, registry)?;
 
+        let protocol_version = &chainspec_loader.chainspec().protocol_config.version;
         let rpc_server = RpcServer::new(
             config.rpc_server.clone(),
             effect_builder,
-            chainspec_loader.chainspec().protocol_config.version.clone(),
+            protocol_version.clone(),
         )?;
         let rest_server = RestServer::new(
             config.rest_server.clone(),
             effect_builder,
-            chainspec_loader.chainspec().protocol_config.version.clone(),
+            protocol_version.clone(),
         )?;
 
         let deploy_acceptor = DeployAcceptor::new(
@@ -455,8 +456,12 @@ impl reactor::Reactor for Reactor {
         )?;
         let mut effects = reactor::wrap_effects(Event::BlockProposer, block_proposer_effects);
         let genesis_state_root_hash = chainspec_loader.genesis_state_root_hash();
-        let block_executor = BlockExecutor::new(genesis_state_root_hash, registry.clone())
-            .with_parent_map(latest_block);
+        let block_executor = BlockExecutor::new(
+            genesis_state_root_hash,
+            protocol_version.clone(),
+            registry.clone(),
+        )
+        .with_parent_map(latest_block);
         let proto_block_validator = BlockValidator::new(Arc::clone(&chainspec_loader.chainspec()));
         let linear_chain = LinearChain::new(registry)?;
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -434,10 +434,8 @@ impl reactor::Reactor for Reactor {
             protocol_version.clone(),
         )?;
 
-        let deploy_acceptor = DeployAcceptor::new(
-            config.deploy_acceptor,
-            Arc::clone(chainspec_loader.chainspec()),
-        );
+        let deploy_acceptor =
+            DeployAcceptor::new(config.deploy_acceptor, &*chainspec_loader.chainspec());
         let deploy_fetcher = Fetcher::new(config.fetcher);
         let deploy_gossiper = Gossiper::new_for_partial_items(
             "deploy_gossiper",

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -451,6 +451,7 @@ impl reactor::Reactor for Reactor {
                 .as_ref()
                 .map(|block| block.height() + 1)
                 .unwrap_or(0),
+            chainspec_loader.chainspec().as_ref(),
         )?;
         let mut effects = reactor::wrap_effects(Event::BlockProposer, block_proposer_effects);
         let genesis_state_root_hash = chainspec_loader.genesis_state_root_hash();

--- a/node/src/testing/condition_check_reactor.rs
+++ b/node/src/testing/condition_check_reactor.rs
@@ -6,7 +6,7 @@ use prometheus::Registry;
 use super::network::NetworkedReactor;
 use crate::{
     effect::{EffectBuilder, Effects},
-    reactor::{EventQueueHandle, Finalize, Reactor},
+    reactor::{EventQueueHandle, Finalize, Reactor, ReactorExit},
     NodeRng,
 };
 
@@ -86,6 +86,10 @@ impl<R: Reactor> Reactor for ConditionCheckReactor<R> {
             self.condition_checker = None;
         }
         self.reactor.dispatch_event(effect_builder, rng, event)
+    }
+
+    fn maybe_exit(&self) -> Option<ReactorExit> {
+        self.reactor.maybe_exit()
     }
 }
 

--- a/node/src/testing/multi_stage_test_reactor.rs
+++ b/node/src/testing/multi_stage_test_reactor.rs
@@ -4,6 +4,7 @@ use std::{
     fmt::{self, Display, Formatter},
     mem,
     path::PathBuf,
+    sync::Arc,
 };
 
 use derive_more::From;
@@ -156,7 +157,7 @@ where
 
 pub(crate) struct InitializerReactorConfigWithChainspec {
     config: <InitializerReactor as Reactor>::Config,
-    chainspec: Chainspec,
+    chainspec: Arc<Chainspec>,
 }
 
 impl Reactor for MultiStageTestReactor {

--- a/node/src/testing/multi_stage_test_reactor.rs
+++ b/node/src/testing/multi_stage_test_reactor.rs
@@ -236,14 +236,12 @@ impl Reactor for MultiStageTestReactor {
                     initializer_reactor.dispatch_event(effect_builder, rng, initializer_event),
                 );
 
-                if initializer_reactor.maybe_exit().is_some() {
-                    if initializer_reactor.maybe_exit().unwrap()
-                        != ReactorExit::ProcessShouldContinue
-                    {
-                        panic!("failed to transition from initializer to joiner");
+                match initializer_reactor.maybe_exit() {
+                    Some(ReactorExit::ProcessShouldContinue) => {
+                        should_transition = true;
                     }
-
-                    should_transition = true;
+                    Some(_) => panic!("failed to transition from initializer to joiner"),
+                    None => (),
                 }
 
                 effects
@@ -263,12 +261,12 @@ impl Reactor for MultiStageTestReactor {
                     joiner_reactor.dispatch_event(effect_builder, rng, joiner_event),
                 );
 
-                if joiner_reactor.maybe_exit().is_some() {
-                    if joiner_reactor.maybe_exit().unwrap() != ReactorExit::ProcessShouldContinue {
-                        panic!("failed to transition from joiner to validator");
+                match joiner_reactor.maybe_exit() {
+                    Some(ReactorExit::ProcessShouldContinue) => {
+                        should_transition = true;
                     }
-
-                    should_transition = true;
+                    Some(_) => panic!("failed to transition from initializer to joiner"),
+                    None => (),
                 }
 
                 effects

--- a/node/src/testing/multi_stage_test_reactor/test_chain.rs
+++ b/node/src/testing/multi_stage_test_reactor/test_chain.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use log::info;
 use num_rational::Ratio;
@@ -41,7 +41,7 @@ impl Eq for SecretKeyWithStake {}
 struct TestChain {
     // Keys that validator instances will use, can include duplicates
     storages: Vec<TempDir>,
-    chainspec: Chainspec,
+    chainspec: Arc<Chainspec>,
     first_node_port: u16,
     network: Network<MultiStageTestReactor>,
 }
@@ -119,7 +119,7 @@ impl TestChain {
         let network: Network<MultiStageTestReactor> = Network::new();
 
         let mut test_chain = TestChain {
-            chainspec,
+            chainspec: Arc::new(chainspec),
             storages: Vec::new(),
             first_node_port,
             network,
@@ -175,7 +175,7 @@ impl TestChain {
         // Bundle our config with a chainspec for creating a multi-stage reactor
         let config = InitializerReactorConfigWithChainspec {
             config: WithDir::new(&*CONFIG_DIR, validator_config),
-            chainspec: self.chainspec.clone(),
+            chainspec: Arc::clone(&self.chainspec),
         };
 
         // Add the node (a multi-stage reactor) with the specified config to the network

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -30,7 +30,7 @@ pub use item::{Item, Tag};
 pub use node_config::NodeConfig;
 pub(crate) use node_id::NodeId;
 pub use peers_map::PeersMap;
-pub use status_feed::{GetStatusResult, StatusFeed};
+pub use status_feed::{ChainspecInfo, GetStatusResult, StatusFeed};
 pub use timestamp::{TimeDiff, Timestamp};
 
 /// An object-safe RNG trait that requires a cryptographically strong random number generator.

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -3,6 +3,7 @@
 mod block;
 pub mod chainspec;
 mod deploy;
+mod exit_code;
 mod item;
 pub mod json_compatibility;
 mod node_config;
@@ -26,6 +27,7 @@ pub use deploy::{
     Approval, Deploy, DeployHash, DeployHeader, DeployMetadata, DeployValidationFailure,
     Error as DeployError,
 };
+pub use exit_code::ExitCode;
 pub use item::{Item, Tag};
 pub use node_config::NodeConfig;
 pub(crate) use node_id::NodeId;

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -715,7 +715,7 @@ impl BlockHeader {
     }
 
     /// Returns `true` if this block is the last one in the current era.
-    pub fn switch_block(&self) -> bool {
+    pub fn is_switch_block(&self) -> bool {
         self.era_end.is_some()
     }
 

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -12,10 +12,8 @@ mod protocol_config;
 use std::{fmt::Debug, path::Path};
 
 use datasize::DataSize;
-use once_cell::sync::Lazy;
 #[cfg(test)]
 use rand::Rng;
-use semver::Version;
 use serde::Serialize;
 use tracing::{error, warn};
 
@@ -40,8 +38,6 @@ use crate::{
 
 /// The name of the chainspec file on disk.
 pub const CHAINSPEC_NAME: &str = "chainspec.toml";
-/// The protocol version at genesis.
-static GENESIS_VERSION: Lazy<Version> = Lazy::new(|| Version::new(1, 0, 0));
 
 /// A collection of configuration settings describing the state of the system at genesis and after
 /// upgrades to basic system functionality occurring after genesis.
@@ -89,9 +85,9 @@ impl Chainspec {
         hash::hash(&serialized_chainspec)
     }
 
-    /// Returns true if this chainspec has version <= genesis version (v1.0.0)
+    /// Returns true if this chainspec has an activation_point specifying era ID 0.
     pub(crate) fn is_genesis(&self) -> bool {
-        self.protocol_config.version <= *GENESIS_VERSION
+        self.protocol_config.activation_point.era_id.0 == 0
     }
 }
 
@@ -183,7 +179,7 @@ impl From<&Chainspec> for ExecConfig {
             chainspec.core_config.auction_delay,
             chainspec.core_config.locked_funds_period.millis(),
             chainspec.core_config.round_seigniorage_rate,
-            chainspec.core_config.unbonding_delay.into(),
+            chainspec.core_config.unbonding_delay,
             chainspec.network_config.timestamp.millis(),
         )
     }

--- a/node/src/types/chainspec/core_config.rs
+++ b/node/src/types/chainspec/core_config.rs
@@ -8,7 +8,7 @@ use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 
 #[cfg(test)]
 use crate::testing::TestRng;
-use crate::{components::consensus::EraId, types::TimeDiff};
+use crate::types::TimeDiff;
 
 #[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
@@ -23,8 +23,8 @@ pub struct CoreConfig {
     pub(crate) auction_delay: u64,
     /// The period after genesis during which a genesis validator's bid is locked.
     pub(crate) locked_funds_period: TimeDiff,
-    /// The delay for paying out the the unbonding amount.
-    pub(crate) unbonding_delay: EraId,
+    /// The delay in number of eras for paying out the the unbonding amount.
+    pub(crate) unbonding_delay: u64,
     /// Round seigniorage rate represented as a fractional number.
     #[data_size(skip)]
     pub(crate) round_seigniorage_rate: Ratio<u64>,
@@ -39,7 +39,7 @@ impl CoreConfig {
         let validator_slots = rng.gen();
         let auction_delay = rng.gen::<u32>() as u64;
         let locked_funds_period = TimeDiff::from(rng.gen_range(600_000, 604_800_000));
-        let unbonding_delay = EraId(rng.gen_range(1, 1_000_000_000));
+        let unbonding_delay = rng.gen_range(1, 1_000_000_000);
         let round_seigniorage_rate = Ratio::new(
             rng.gen_range(1, 1_000_000_000),
             rng.gen_range(1, 1_000_000_000),
@@ -88,7 +88,7 @@ impl FromBytes for CoreConfig {
         let (validator_slots, remainder) = u32::from_bytes(remainder)?;
         let (auction_delay, remainder) = u64::from_bytes(remainder)?;
         let (locked_funds_period, remainder) = TimeDiff::from_bytes(remainder)?;
-        let (unbonding_delay, remainder) = EraId::from_bytes(remainder)?;
+        let (unbonding_delay, remainder) = u64::from_bytes(remainder)?;
         let (round_seigniorage_rate, remainder) = Ratio::<u64>::from_bytes(remainder)?;
         let config = CoreConfig {
             era_duration,

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -608,8 +608,8 @@ impl Deploy {
     /// Note: if everything else checks out, calls the computationally expensive `is_valid` method.
     pub fn is_acceptable(
         &mut self,
-        chain_name: String,
-        config: DeployConfig,
+        chain_name: &str,
+        config: &DeployConfig,
     ) -> Result<(), DeployValidationFailure> {
         let header = self.header();
         if header.chain_name() != chain_name {
@@ -620,7 +620,7 @@ impl Deploy {
                 "invalid chain identifier"
             );
             return Err(DeployValidationFailure::InvalidChainName {
-                expected: chain_name,
+                expected: chain_name.to_string(),
                 got: header.chain_name().to_string(),
             });
         }
@@ -1018,7 +1018,7 @@ mod tests {
     #[test]
     fn is_acceptable() {
         let mut rng = crate::new_rng();
-        let chain_name = "net-1".to_string();
+        let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
 
         let mut deploy = create_deploy(
@@ -1028,14 +1028,14 @@ mod tests {
             &chain_name,
         );
         deploy
-            .is_acceptable(chain_name, deploy_config)
+            .is_acceptable(chain_name, &deploy_config)
             .expect("should be acceptable");
     }
 
     #[test]
     fn not_acceptable_due_to_invalid_chain_name() {
         let mut rng = crate::new_rng();
-        let expected_chain_name = "net-1".to_string();
+        let expected_chain_name = "net-1";
         let wrong_chain_name = "net-2".to_string();
         let deploy_config = DeployConfig::default();
 
@@ -1047,12 +1047,12 @@ mod tests {
         );
 
         let expected_error = DeployValidationFailure::InvalidChainName {
-            expected: expected_chain_name.clone(),
+            expected: expected_chain_name.to_string(),
             got: wrong_chain_name,
         };
 
         assert_eq!(
-            deploy.is_acceptable(expected_chain_name, deploy_config),
+            deploy.is_acceptable(expected_chain_name, &deploy_config),
             Err(expected_error)
         );
         assert!(
@@ -1064,7 +1064,7 @@ mod tests {
     #[test]
     fn not_acceptable_due_to_excessive_dependencies() {
         let mut rng = crate::new_rng();
-        let chain_name = "net-1".to_string();
+        let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
 
         let dependency_count = usize::from(deploy_config.max_dependencies + 1);
@@ -1082,7 +1082,7 @@ mod tests {
         };
 
         assert_eq!(
-            deploy.is_acceptable(chain_name, deploy_config),
+            deploy.is_acceptable(chain_name, &deploy_config),
             Err(expected_error)
         );
         assert!(
@@ -1094,7 +1094,7 @@ mod tests {
     #[test]
     fn not_acceptable_due_to_excessive_ttl() {
         let mut rng = crate::new_rng();
-        let chain_name = "net-1".to_string();
+        let chain_name = "net-1";
         let deploy_config = DeployConfig::default();
 
         let ttl = deploy_config.max_ttl + TimeDiff::from(Duration::from_secs(1));
@@ -1112,7 +1112,7 @@ mod tests {
         };
 
         assert_eq!(
-            deploy.is_acceptable(chain_name, deploy_config),
+            deploy.is_acceptable(chain_name, &deploy_config),
             Err(expected_error)
         );
         assert!(

--- a/node/src/types/exit_code.rs
+++ b/node/src/types/exit_code.rs
@@ -1,0 +1,19 @@
+use datasize::DataSize;
+
+/// Exit codes which should be used by the casper-node binary, and provided by the initializer
+/// reactor to the binary.
+///
+/// Note that a panic will result in the Rust process producing an exit code of 101.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, DataSize)]
+#[repr(u8)]
+pub enum ExitCode {
+    /// The process should exit with success.  The launcher should proceed to run the next
+    /// installed version of `casper-node`.
+    Success = 0,
+    /// The process should exit with `101`, equivalent to panicking.  The launcher should not
+    /// restart the node.
+    Abort = 101,
+    /// The process should exit with `102`.  The launcher should proceed to run the previous
+    /// installed version of `casper-node`.
+    DowngradeVersion = 102,
+}

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -16,13 +16,23 @@ use casper_types::PublicKey;
 
 use crate::{
     components::{
-        chainspec_loader::{ChainspecInfo, NextUpgrade},
+        chainspec_loader::NextUpgrade,
         consensus::EraId,
-        rpc_server::rpcs::docs::DocExample,
+        rpc_server::rpcs::docs::{DocExample, DOCS_EXAMPLE_PROTOCOL_VERSION},
     },
     crypto::hash::Digest,
-    types::{Block, BlockHash, NodeId, PeersMap, Timestamp},
+    types::{ActivationPoint, Block, BlockHash, NodeId, PeersMap, Timestamp},
 };
+
+static CHAINSPEC_INFO: Lazy<ChainspecInfo> = Lazy::new(|| {
+    let next_upgrade =
+        NextUpgrade::new(ActivationPoint { era_id: EraId(42) }, Version::new(2, 0, 1));
+    ChainspecInfo {
+        name: String::from("casper-example"),
+        state_root_hash: Some(Digest::from([2u8; Digest::LENGTH])),
+        next_upgrade: Some(next_upgrade),
+    }
+});
 
 static GET_STATUS_RESULT: Lazy<GetStatusResult> = Lazy::new(|| {
     let node_id = NodeId::doc_example();
@@ -35,8 +45,38 @@ static GET_STATUS_RESULT: Lazy<GetStatusResult> = Lazy::new(|| {
         chainspec_info: ChainspecInfo::doc_example().clone(),
         version: crate::VERSION_STRING.as_str(),
     };
-    GetStatusResult::from(status_feed)
+    GetStatusResult::new(status_feed, DOCS_EXAMPLE_PROTOCOL_VERSION.clone())
 });
+
+/// Summary information from the chainspec.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChainspecInfo {
+    /// Name of the network.
+    name: String,
+    /// If `Some` then genesis or upgrade process returned a valid post state hash.
+    state_root_hash: Option<Digest>,
+    next_upgrade: Option<NextUpgrade>,
+}
+
+impl DocExample for ChainspecInfo {
+    fn doc_example() -> &'static Self {
+        &*CHAINSPEC_INFO
+    }
+}
+
+impl ChainspecInfo {
+    pub(crate) fn new(
+        chainspec_network_name: String,
+        state_root_hash: Option<Digest>,
+        next_upgrade: Option<NextUpgrade>,
+    ) -> Self {
+        ChainspecInfo {
+            name: chainspec_network_name,
+            state_root_hash,
+            next_upgrade,
+        }
+    }
+}
 
 /// Data feed for client "info_get_status" endpoint.
 #[derive(Debug, Serialize)]
@@ -101,8 +141,8 @@ pub struct GetStatusResult {
     pub api_version: Version,
     /// The chainspec name.
     pub chainspec_name: String,
-    /// The genesis root hash.
-    pub genesis_root_hash: String,
+    /// The chainspec state root hash.
+    pub chainspec_state_root_hash: String,
     /// The node ID and network address of each connected peer.
     pub peers: PeersMap,
     /// The minimal info of the last block from the linear chain.
@@ -114,39 +154,31 @@ pub struct GetStatusResult {
 }
 
 impl GetStatusResult {
-    /// Set api version.
-    pub fn set_api_version(&mut self, version: Version) {
-        self.api_version = version;
+    pub(crate) fn new(status_feed: StatusFeed<NodeId>, api_version: Version) -> Self {
+        let chainspec_name = status_feed.chainspec_info.name;
+        let chainspec_state_root_hash = status_feed
+            .chainspec_info
+            .state_root_hash
+            .unwrap_or_default()
+            .to_string();
+        let peers = PeersMap::from(status_feed.peers);
+        let last_added_block_info = status_feed.last_added_block.map(Into::into);
+        let next_upgrade = status_feed.chainspec_info.next_upgrade;
+        let build_version = crate::VERSION_STRING.clone();
+        GetStatusResult {
+            api_version,
+            chainspec_name,
+            chainspec_state_root_hash,
+            peers,
+            last_added_block_info,
+            next_upgrade,
+            build_version,
+        }
     }
 }
 
 impl DocExample for GetStatusResult {
     fn doc_example() -> &'static Self {
         &*GET_STATUS_RESULT
-    }
-}
-
-impl From<StatusFeed<NodeId>> for GetStatusResult {
-    fn from(status_feed: StatusFeed<NodeId>) -> Self {
-        let chainspec_name = status_feed.chainspec_info.name();
-        let genesis_root_hash = status_feed
-            .chainspec_info
-            .root_hash()
-            .unwrap_or_default()
-            .to_string();
-        let api_version = Version::from((0, 0, 0));
-        let peers = PeersMap::from(status_feed.peers);
-        let last_added_block_info = status_feed.last_added_block.map(Into::into);
-        let next_upgrade = status_feed.chainspec_info.next_upgrade();
-        let build_version = crate::VERSION_STRING.clone();
-        GetStatusResult {
-            api_version,
-            chainspec_name,
-            genesis_root_hash,
-            peers,
-            last_added_block_info,
-            next_upgrade,
-            build_version,
-        }
     }
 }

--- a/node_macros/src/gen.rs
+++ b/node_macros/src/gen.rs
@@ -385,6 +385,8 @@ pub(crate) fn generate_reactor_impl(def: &ReactorDefinition) -> TokenStream {
 
                 Ok((reactor, all_effects))
             }
+
+            fn maybe_exit(&self) -> Option<crate::reactor::ReactorExit> { None }
         }
     )
 }

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -21,6 +21,7 @@ color = false
 # Abbreviate module names in text output.  Has no effect if format = 'json'.
 abbreviate_modules = false
 
+
 # ===================================
 # Configuration options for consensus
 # ===================================
@@ -77,9 +78,9 @@ gossip_interval = 120_000
 systemd_support = false
 
 
-# =============================================
+# ==================================================
 # Configuration options for the JSON-RPC HTTP server
-# =============================================
+# ==================================================
 [rpc_server]
 
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
@@ -94,9 +95,10 @@ address = '0.0.0.0:7777'
 # Request will be delayed to the next 1 second bucket once limited.
 qps_limit = 5
 
-# =============================================
+
+# ==============================================
 # Configuration options for the REST HTTP server
-# =============================================
+# ==============================================
 [rest_server]
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
@@ -111,9 +113,10 @@ address = '0.0.0.0:8888'
 # Request will be delayed to the next 1 second bucket once limited.
 qps_limit = 10
 
-# =============================================
+
+# ==========================================================
 # Configuration options for the SSE HTTP event stream server
-# =============================================
+# ==========================================================
 [event_stream_server]
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
@@ -133,6 +136,7 @@ broadcast_channel_size = 100
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
 qps_limit = 100
+
 
 # ===============================================
 # Configuration options for the storage component
@@ -175,6 +179,7 @@ max_deploy_metadata_store_size = 322_122_547_200
 # 10_737_418_240 == 10 GiB.
 max_state_store_size = 10_737_418_240
 
+
 # ===================================
 # Configuration options for gossiping
 # ===================================
@@ -207,15 +212,16 @@ gossip_request_timeout_secs = 30
 get_remainder_timeout_secs = 5
 
 
-# ===================================
+# =================================
 # Configuration options for fetcher
-# ===================================
+# =================================
 [fetcher]
 
 # The timeout duration in seconds for a single fetcher request, i.e. for a single fetcher message
 # sent from this node to another node, it will be considered timed out if the expected response from that peer is
 # not received within this specified duration.
 get_from_peer_timeout = 3
+
 
 # ===================================================
 # Configuration options for deploy acceptor component
@@ -224,6 +230,7 @@ get_from_peer_timeout = 3
 
 # If true, the deploy acceptor will verify the account associated with a received deploy prior to accepting it.
 verify_accounts = true
+
 
 # ========================================================
 # Configuration options for the contract runtime component

--- a/types/src/auction/detail.rs
+++ b/types/src/auction/detail.rs
@@ -137,7 +137,7 @@ where
     Ok(auction_delay)
 }
 
-fn get_unbonding_delay<P>(provider: &mut P) -> Result<EraId>
+fn get_unbonding_delay<P>(provider: &mut P) -> Result<u64>
 where
     P: StorageProvider + RuntimeProvider + ?Sized,
 {


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-840

This PR paves the way for node upgrades.  It contains the following high-level changes:

* The chainspec is now loaded on startup and a single version passed to all components requiring it.  It is no longer held in storage.
* The chainspec loader retrieves the highest block from storage and makes a decision on how to proceed based on the block's era ID, whether it's a switch block, the chainspec's protocol version, and the next upgrade's activation point.  The choice may result in the node exiting with a code 0 (an indication to the launcher to run the next installed version), a code 102 (the launcher should run the previous installed version), or a code 101 (the launcher and node should both exit).  Alternatively, the chainspec loader can indicate that the process should continue to run using the next reactor.
* The chainspec loader now calls the contract runtime methods `commit_genesis()` or `upgrade()` or neither as appropriate (it currently always calls `commit_genesis()`).
* The JSON-RPC server and event-stream server now use the current protocol version as the API version provided in responses/events to clients.
* If the trusted hash is not provided in the config, the hash of the highest block will be used instead.

Some details worth noting:
* The `unbonding_delay` throughout was defined as an `EraId` which was inappropriate, as it represents a count of eras rather than a specific one.  This largely went unnoticed as `EraId` as defined in `casper_types::auction::types` is just an alias.  These aliases would be much more useful if they were newtypes.  In the meantime, this PR replaces usages of `EraId` with `u64` for `unbonding_delay`.
* The JSON-RPC response to `state_get_auction_info` now follows the same format as other response data, and includes the API version along with the auction info, rather than just the bare auction info (@zie1ony, @momipsl please take note)

This code cannot be tested against current delta nodes as the format of blocks has changed since then, and handling that requires updates to the linear chain sync.  Testing it by trying to upgrade against itself with only a change to the chainspec version and activation point shows that we need to resolve the issue whereby a restarted network panics with `cannot start era with total weight 0`.