### PR TITLE
EE-1171: Automatically undelegate delegators when a validator fully unbonds

### DIFF
--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -1537,6 +1537,10 @@ fn should_undelegate_delegators_when_validator_unbonds() {
     );
 
     // Process unbonding requests to verify delegators recevied their stakes
+    let validator_1 = builder
+        .get_account(*VALIDATOR_1_ADDR)
+        .expect("should have validator 1 account");
+    let validator_1_balance_before = builder.get_purse_balance(validator_1.main_purse());
 
     let delegator_1 = builder
         .get_account(*DELEGATOR_1_ADDR)
@@ -1553,9 +1557,14 @@ fn should_undelegate_delegators_when_validator_unbonds() {
         timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
     }
 
+    let validator_1_balance_after = builder.get_purse_balance(validator_1.main_purse());
     let delegator_1_balance_after = builder.get_purse_balance(delegator_1.main_purse());
     let delegator_2_balance_after = builder.get_purse_balance(delegator_2.main_purse());
 
+    assert_eq!(
+        validator_1_balance_before + U512::from(VALIDATOR_1_STAKE),
+        validator_1_balance_after
+    );
     assert_eq!(
         delegator_1_balance_before + U512::from(DELEGATOR_1_STAKE),
         delegator_1_balance_after
@@ -1722,6 +1731,10 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
     );
 
     // Process unbonding requests to verify delegators recevied their stakes
+    let validator_1 = builder
+        .get_account(*VALIDATOR_1_ADDR)
+        .expect("should have validator 1 account");
+    let validator_1_balance_before = builder.get_purse_balance(validator_1.main_purse());
 
     let delegator_1 = builder
         .get_account(*DELEGATOR_1_ADDR)
@@ -1738,9 +1751,14 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
     }
 
+    let validator_1_balance_after = builder.get_purse_balance(validator_1.main_purse());
     let delegator_1_balance_after = builder.get_purse_balance(delegator_1.main_purse());
     let delegator_2_balance_after = builder.get_purse_balance(delegator_2.main_purse());
 
+    assert_eq!(
+        validator_1_balance_before + U512::from(VALIDATOR_1_STAKE),
+        validator_1_balance_after
+    );
     assert_eq!(
         delegator_1_balance_before + U512::from(DELEGATOR_1_STAKE),
         delegator_1_balance_after

--- a/types/src/auction.rs
+++ b/types/src/auction.rs
@@ -145,6 +145,17 @@ pub trait Auction:
         )?;
 
         if new_amount.is_zero() {
+            // Automatically unbond delegators
+            for (delegator_public_key, delegator) in bid.delegators() {
+                detail::create_unbonding_purse(
+                    self,
+                    public_key,
+                    *delegator_public_key,
+                    *delegator.bonding_purse(),
+                    *delegator.staked_amount(),
+                )?;
+            }
+
             // NOTE: Assumed safe as we're checking for existence above
             bids.remove(&public_key).unwrap();
         }

--- a/types/src/auction/detail.rs
+++ b/types/src/auction/detail.rs
@@ -205,7 +205,7 @@ pub(crate) fn create_unbonding_purse<P: Auction + ?Sized>(
     unbonder_public_key: PublicKey,
     bonding_purse: URef,
     amount: U512,
-) -> Result<U512> {
+) -> Result<()> {
     if provider.get_balance(bonding_purse)?.unwrap_or_default() < amount {
         return Err(Error::UnbondTooLarge);
     }
@@ -225,10 +225,7 @@ pub(crate) fn create_unbonding_purse<P: Auction + ?Sized>(
         .push(new_unbonding_purse);
     set_unbonding_purses(provider, unbonding_purses)?;
 
-    // Remaining motes in the validator's bid purse
-    let remaining_bond = provider.get_balance(bonding_purse)?.unwrap_or_default();
-
-    Ok(remaining_bond)
+    Ok(())
 }
 
 /// Reinvests delegator reward by increasing its stake.


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1171

This PR introduces an automatic undelegation of delegator funds when a validator fully unbonds their stakes.