### PR TITLE
NO-TICKET: Speed up sync/join integration test.

### DIFF
--- a/utils/nctl/sh/scenarios/sync_test.sh
+++ b/utils/nctl/sh/scenarios/sync_test.sh
@@ -63,8 +63,8 @@ function do_await_genesis_era_to_complete() {
 
 function do_send_wasm_deploys() {
     # NOTE: Maybe make these arguments to the test?
-    local BATCH_COUNT=2
-    local BATCH_SIZE=10
+    local BATCH_COUNT=1
+    local BATCH_SIZE=1
     local TRANSFER_AMOUNT=10000
     log_step "sending Wasm deploys"
     # prepare wasm batch
@@ -79,7 +79,7 @@ function do_send_transfers() {
     log_step "sending native transfers"
     # NOTE: Maybe make these arguments to the test?
     local AMOUNT=1000
-    local TRANSFERS_COUNT=10
+    local TRANSFERS_COUNT=5
     local NODE_ID="random"
 
     # Enumerate set of users.
@@ -89,8 +89,8 @@ function do_send_transfers() {
 }
 
 function do_await_deploy_inclusion() {
-    # Should be enough to await for two eras.
-    log_step "awaiting two eras…"
+    # Should be enough to await for one era.
+    log_step "awaiting one era…"
     await_n_eras 1
 }
 


### PR DESCRIPTION
This PR decreases the batch sizes of Wasm deploys and native transfers used in the `sync_test.sh`.

The main goal of the `sync_test.sh` is correctness, not performance, so the number of deploys in the network does not matter as long as that number is positive and we have a different type of deploys (native vs Wasm) both before and after the trusted hash.