### PR TITLE
DEV-21: enforce minimum native transfer amount

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -83,7 +83,8 @@ use crate::{
     },
 };
 
-pub static MAX_PAYMENT: Lazy<U512> = Lazy::new(|| U512::from(2_500_000_000u64));
+pub const MAX_PAYMENT_AMOUNT: u64 = 2_500_000_000;
+pub static MAX_PAYMENT: Lazy<U512> = Lazy::new(|| U512::from(MAX_PAYMENT_AMOUNT));
 
 pub const SYSTEM_ACCOUNT_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 

--- a/node/src/types/chainspec/deploy_config.rs
+++ b/node/src/types/chainspec/deploy_config.rs
@@ -51,7 +51,8 @@ impl DeployConfig {
         let block_gas_limit = rng.gen_range(100_000_000_000, 1_000_000_000_000_000);
         let payment_args_max_length = rng.gen();
         let session_args_max_length = rng.gen();
-        let native_transfer_minimum_motes = rng.gen_range(0, 1_000_000_000_000_000);
+        let native_transfer_minimum_motes =
+            rng.gen_range(MAX_PAYMENT_AMOUNT, 1_000_000_000_000_000);
 
         DeployConfig {
             max_payment_cost,

--- a/node/src/types/chainspec/deploy_config.rs
+++ b/node/src/types/chainspec/deploy_config.rs
@@ -8,6 +8,8 @@ use num_traits::Zero;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+use casper_execution_engine::core::engine_state::MAX_PAYMENT_AMOUNT;
 use casper_execution_engine::shared::motes::Motes;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
@@ -31,6 +33,7 @@ pub struct DeployConfig {
     pub(crate) block_gas_limit: u64,
     pub(crate) payment_args_max_length: u32,
     pub(crate) session_args_max_length: u32,
+    pub(crate) native_transfer_minimum_motes: u64,
 }
 
 #[cfg(test)]
@@ -48,6 +51,7 @@ impl DeployConfig {
         let block_gas_limit = rng.gen_range(100_000_000_000, 1_000_000_000_000_000);
         let payment_args_max_length = rng.gen();
         let session_args_max_length = rng.gen();
+        let native_transfer_minimum_motes = rng.gen_range(0, 1_000_000_000_000_000);
 
         DeployConfig {
             max_payment_cost,
@@ -59,6 +63,7 @@ impl DeployConfig {
             block_gas_limit,
             payment_args_max_length,
             session_args_max_length,
+            native_transfer_minimum_motes,
         }
     }
 }
@@ -76,6 +81,7 @@ impl Default for DeployConfig {
             block_gas_limit: 10_000_000_000_000,
             payment_args_max_length: 1024,
             session_args_max_length: 1024,
+            native_transfer_minimum_motes: MAX_PAYMENT_AMOUNT,
         }
     }
 }
@@ -92,6 +98,7 @@ impl ToBytes for DeployConfig {
         buffer.extend(self.block_gas_limit.to_bytes()?);
         buffer.extend(self.payment_args_max_length.to_bytes()?);
         buffer.extend(self.session_args_max_length.to_bytes()?);
+        buffer.extend(self.native_transfer_minimum_motes.to_bytes()?);
         Ok(buffer)
     }
 
@@ -105,6 +112,7 @@ impl ToBytes for DeployConfig {
             + self.block_gas_limit.serialized_length()
             + self.payment_args_max_length.serialized_length()
             + self.session_args_max_length.serialized_length()
+            + self.native_transfer_minimum_motes.serialized_length()
     }
 }
 
@@ -120,6 +128,7 @@ impl FromBytes for DeployConfig {
         let (block_gas_limit, remainder) = u64::from_bytes(remainder)?;
         let (payment_args_max_length, remainder) = u32::from_bytes(remainder)?;
         let (session_args_max_length, remainder) = u32::from_bytes(remainder)?;
+        let (native_transfer_minimum_motes, remainder) = u64::from_bytes(remainder)?;
         let config = DeployConfig {
             max_payment_cost,
             max_ttl,
@@ -130,6 +139,7 @@ impl FromBytes for DeployConfig {
             block_gas_limit,
             payment_args_max_length,
             session_args_max_length,
+            native_transfer_minimum_motes,
         };
         Ok((config, remainder))
     }

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -905,11 +905,10 @@ mod tests {
     use std::{iter, time::Duration};
 
     use casper_execution_engine::core::engine_state::MAX_PAYMENT_AMOUNT;
-    use casper_types::bytesrepr::Bytes;
+    use casper_types::{bytesrepr::Bytes, CLValue};
 
     use super::*;
     use crate::crypto::AsymmetricKeyExt;
-    use casper_types::CLValue;
 
     #[test]
     fn json_roundtrip() {

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -171,7 +171,7 @@ pub enum DeployValidationFailure {
     InvalidTransferAmount,
 
     /// Insufficient transfer amount.
-    #[error("invalid transfer amount; minimum: {minimum} actual:{attempted}")]
+    #[error("insufficient transfer amount; minimum: {minimum} attempted: {attempted}")]
     InsufficientTransferAmount {
         /// The minimum transfer amount.
         minimum: U512,

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -77,6 +77,8 @@ block_gas_limit = 10_000_000_000_000
 payment_args_max_length = 1024
 # The limit of length of serialized session code arguments.
 session_args_max_length = 1024
+# The minimum amount in motes for a valid native transfer.
+native_transfer_minimum_motes = 2_500_000_000
 
 [wasm]
 # Amount of free memory (in 64kB pages) each contract can use for stack.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -77,6 +77,8 @@ block_gas_limit = 10_000_000_000_000
 payment_args_max_length = 1024
 # The limit of length of serialized session code arguments.
 session_args_max_length = 1024
+# The minimum amount in motes for a valid native transfer.
+native_transfer_minimum_motes = 2_500_000_000
 
 [wasm]
 # Amount of free memory (in 64kB pages) each contract can use for stack.

--- a/resources/production/validation.md5
+++ b/resources/production/validation.md5
@@ -1,2 +1,2 @@
 1ce492ebe9a768f86df7016469862d0c  accounts.csv
-c7d8ba911663b949947e6f213634e46e  chainspec.toml
+43471b0d6858833e8f6f625b515e1664  chainspec.toml

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -33,6 +33,7 @@ block_max_transfer_count = 1000
 block_gas_limit = 13
 payment_args_max_length = 1024
 session_args_max_length = 1024
+native_transfer_minimum_motes = 2_500_000_000
 
 [wasm]
 max_memory = 17

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -33,6 +33,7 @@ block_max_transfer_count = 1000
 block_gas_limit = 13
 payment_args_max_length = 1024
 session_args_max_length = 1024
+native_transfer_minimum_motes = 2_500_000_000
 
 [wasm]
 max_memory = 17


### PR DESCRIPTION
This PR adds a new deploy config chainspec parameter for a minimum transfer amount and logic to reject native transfer deploys with an amount less than the minimum. 

https://casperlabs.atlassian.net/browse/DEV-21

I defaulted the configured amount to the minimum balance required to exec deploys using an account; but the value can be tweaked if necessary.
