### PR TITLE
NDRS-889: Add `Fetcher` metrics.

### DIFF
--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -3,7 +3,7 @@ mod event;
 mod metrics;
 mod tests;
 
-use std::{collections::HashMap, convert::Infallible, fmt::Debug, time::Duration};
+use std::{collections::HashMap, fmt::Debug, time::Duration};
 
 use datasize::DataSize;
 use prometheus::Registry;
@@ -311,7 +311,7 @@ where
     REv: ReactorEventT<T>,
 {
     type Event = Event<T>;
-    type ConstructionError = Infallible;
+    type ConstructionError = prometheus::Error;
 
     fn handle_event(
         &mut self,

--- a/node/src/components/fetcher/metrics.rs
+++ b/node/src/components/fetcher/metrics.rs
@@ -1,0 +1,57 @@
+use prometheus::{IntCounter, Registry};
+
+#[derive(Debug)]
+pub struct FetcherMetrics {
+    /// Number of fetch requests that found an item in the storage.
+    pub(super) found_in_storage: IntCounter,
+    /// Number of fetch requests that fetcher an item from peer.
+    pub(super) found_on_peer: IntCounter,
+    /// Number of fetch requests that timed out.
+    pub(super) timeouts: IntCounter,
+    /// Reference to the registry for unregistering.
+    registry: Registry,
+}
+
+impl FetcherMetrics {
+    pub fn new(name: &str, registry: &Registry) -> Result<Self, prometheus::Error> {
+        let found_in_storage = IntCounter::new(
+            format!("{}_found_in_storage", name),
+            format!(
+                "number of fetch requests that found {} in the storage.",
+                name
+            ),
+        )?;
+        let found_on_peer = IntCounter::new(
+            format!("{}_found_on_peer", name),
+            format!("number of fetch requests that fetched {} from peer.", name),
+        )?;
+        let timeouts = IntCounter::new(
+            format!("{}_timeouts", name),
+            format!("number of {} fetch requests that timed out", name),
+        )?;
+        registry.register(Box::new(found_in_storage.clone()))?;
+        registry.register(Box::new(found_on_peer.clone()))?;
+        registry.register(Box::new(timeouts.clone()))?;
+
+        Ok(FetcherMetrics {
+            found_in_storage,
+            found_on_peer,
+            timeouts,
+            registry: registry.clone(),
+        })
+    }
+}
+
+impl Drop for FetcherMetrics {
+    fn drop(&mut self) {
+        self.registry
+            .unregister(Box::new(self.found_in_storage.clone()))
+            .expect("did not expect deregistering found_in_storage to fail");
+        self.registry
+            .unregister(Box::new(self.found_on_peer.clone()))
+            .expect("did not expect deregistering found_on_peer to fail");
+        self.registry
+            .unregister(Box::new(self.timeouts.clone()))
+            .expect("did not expect deregistering timeouts to fail");
+    }
+}

--- a/node/src/components/fetcher/metrics.rs
+++ b/node/src/components/fetcher/metrics.rs
@@ -1,10 +1,11 @@
 use prometheus::{IntCounter, Registry};
+use tracing::warn;
 
 #[derive(Debug)]
 pub struct FetcherMetrics {
     /// Number of fetch requests that found an item in the storage.
     pub(super) found_in_storage: IntCounter,
-    /// Number of fetch requests that fetcher an item from peer.
+    /// Number of fetch requests that fetched an item from peer.
     pub(super) found_on_peer: IntCounter,
     /// Number of fetch requests that timed out.
     pub(super) timeouts: IntCounter,
@@ -46,12 +47,16 @@ impl Drop for FetcherMetrics {
     fn drop(&mut self) {
         self.registry
             .unregister(Box::new(self.found_in_storage.clone()))
-            .expect("did not expect deregistering found_in_storage to fail");
+            .unwrap_or_else(
+                |err| warn!(%err, "did not expect deregistering found_in_storage to fail"),
+            );
         self.registry
             .unregister(Box::new(self.found_on_peer.clone()))
-            .expect("did not expect deregistering found_on_peer to fail");
+            .unwrap_or_else(
+                |err| warn!(%err, "did not expect deregistering found_on_peer to fail"),
+            );
         self.registry
             .unregister(Box::new(self.timeouts.clone()))
-            .expect("did not expect deregistering timeouts to fail");
+            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering timeouts to fail"));
     }
 }

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -72,7 +72,7 @@ reactor!(Reactor {
         network = infallible InMemoryNetwork::<Message>(event_queue, rng);
         storage = Storage(&WithDir::new(cfg.temp_dir.path(), cfg.storage_config));
         deploy_acceptor = infallible DeployAcceptor(cfg.deploy_acceptor_config);
-        deploy_fetcher = infallible Fetcher::<Deploy>(cfg.fetcher_config);
+        deploy_fetcher = Fetcher::<Deploy>("deploy", cfg.fetcher_config, registry);
     }
 
     events: {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -423,7 +423,7 @@ impl reactor::Reactor for Reactor {
             false,
         )?;
 
-        let linear_chain_fetcher = Fetcher::new(config.fetcher);
+        let linear_chain_fetcher = Fetcher::new("linear_chain", config.fetcher, &registry)?;
 
         let mut effects = reactor::wrap_effects(Event::Network, network_effects);
         effects.extend(reactor::wrap_effects(
@@ -468,9 +468,9 @@ impl reactor::Reactor for Reactor {
             block_validator_effects,
         ));
 
-        let deploy_fetcher = Fetcher::new(config.fetcher);
+        let deploy_fetcher = Fetcher::new("deploy", config.fetcher, &registry)?;
 
-        let block_by_height_fetcher = Fetcher::new(config.fetcher);
+        let block_by_height_fetcher = Fetcher::new("block_by_height", config.fetcher, &registry)?;
 
         let deploy_acceptor = DeployAcceptor::new(config.deploy_acceptor);
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -425,7 +425,7 @@ impl reactor::Reactor for Reactor {
         let rest_server = RestServer::new(config.rest_server.clone(), effect_builder)?;
 
         let deploy_acceptor = DeployAcceptor::new(config.deploy_acceptor);
-        let deploy_fetcher = Fetcher::new(config.fetcher);
+        let deploy_fetcher = Fetcher::new("deploy", config.fetcher, &registry)?;
         let deploy_gossiper = Gossiper::new_for_partial_items(
             "deploy_gossiper",
             config.gossip,


### PR DESCRIPTION
Adds three metrics do the fetcher:
* found_in_storage
* found_on_peer
* timeouts

Metrics are prefixed with the "type" of the fetcher:
* linear_chain
* deploy
* block_by_height.