### PR TITLE
NDRS-898: Add `ProtocolVersion` to the block header.

### DIFF
--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -23,7 +23,7 @@ use casper_execution_engine::{
     },
     storage::global_state::CommitResult,
 };
-use casper_types::{ExecutionResult, ProtocolVersion, PublicKey, U512};
+use casper_types::{ExecutionResult, ProtocolVersion, PublicKey, SemVer, U512};
 
 use crate::{
     components::{
@@ -424,6 +424,7 @@ impl BlockExecutor {
             state_root_hash,
             finalized_block,
             next_era_validator_weights,
+            ProtocolVersion::new(SemVer::new(1, 0, 0)), // TODO: Fix
         );
         let summary = ExecutedBlockSummary {
             hash: *block.hash(),

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -31,7 +31,7 @@ use thiserror::Error;
 use casper_types::auction::BLOCK_REWARD;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    PublicKey, SecretKey, Signature, U512,
+    ProtocolVersion, PublicKey, SecretKey, Signature, U512,
 };
 
 use super::{Item, Tag, Timestamp};
@@ -113,6 +113,7 @@ static BLOCK: Lazy<Block> = Lazy::new(|| {
     let state_root_hash = Digest::from([8u8; Digest::LENGTH]);
     let finalized_block = FinalizedBlock::doc_example().clone();
     let parent_seed = Digest::from([9u8; Digest::LENGTH]);
+    let protocol_version = ProtocolVersion::V1_0_0;
 
     let secret_key = SecretKey::doc_example();
     let public_key = PublicKey::from(secret_key);
@@ -137,6 +138,7 @@ static BLOCK: Lazy<Block> = Lazy::new(|| {
         state_root_hash,
         finalized_block,
         next_era_validator_weights,
+        protocol_version,
     )
 });
 static JSON_BLOCK: Lazy<JsonBlock> = Lazy::new(|| {
@@ -673,6 +675,7 @@ pub struct BlockHeader {
     timestamp: Timestamp,
     era_id: EraId,
     height: u64,
+    protocol_version: ProtocolVersion,
 }
 
 impl BlockHeader {
@@ -791,6 +794,7 @@ impl ToBytes for BlockHeader {
         buffer.extend(self.timestamp.to_bytes()?);
         buffer.extend(self.era_id.to_bytes()?);
         buffer.extend(self.height.to_bytes()?);
+        buffer.extend(self.protocol_version.to_bytes()?);
         Ok(buffer)
     }
 
@@ -804,6 +808,7 @@ impl ToBytes for BlockHeader {
             + self.timestamp.serialized_length()
             + self.era_id.serialized_length()
             + self.height.serialized_length()
+            + self.protocol_version.serialized_length()
     }
 }
 
@@ -818,6 +823,7 @@ impl FromBytes for BlockHeader {
         let (timestamp, remainder) = Timestamp::from_bytes(remainder)?;
         let (era_id, remainder) = EraId::from_bytes(remainder)?;
         let (height, remainder) = u64::from_bytes(remainder)?;
+        let (protocol_version, remainder) = ProtocolVersion::from_bytes(remainder)?;
         let block_header = BlockHeader {
             parent_hash,
             state_root_hash,
@@ -828,6 +834,7 @@ impl FromBytes for BlockHeader {
             timestamp,
             era_id,
             height,
+            protocol_version,
         };
         Ok((block_header, remainder))
     }
@@ -1012,6 +1019,7 @@ impl Block {
         state_root_hash: Digest,
         finalized_block: FinalizedBlock,
         next_era_validator_weights: Option<BTreeMap<PublicKey, U512>>,
+        protocol_version: ProtocolVersion,
     ) -> Self {
         let body = BlockBody::new(
             finalized_block.proposer,
@@ -1047,6 +1055,7 @@ impl Block {
             timestamp: finalized_block.timestamp,
             era_id,
             height,
+            protocol_version,
         };
 
         Self::new_from_header_and_body(header, body)
@@ -1127,6 +1136,7 @@ impl Block {
         let state_root_hash = Digest::random(rng);
         let finalized_block = FinalizedBlock::random(rng);
         let parent_seed = Digest::random(rng);
+        let protocol_version = ProtocolVersion::V1_0_0;
         let next_era_validator_weights = match finalized_block.era_report {
             Some(_) => Some(BTreeMap::<PublicKey, U512>::default()),
             None => None,
@@ -1138,6 +1148,7 @@ impl Block {
             state_root_hash,
             finalized_block,
             next_era_validator_weights,
+            protocol_version,
         )
     }
 }
@@ -1372,6 +1383,7 @@ pub(crate) mod json_compatibility {
         timestamp: Timestamp,
         era_id: EraId,
         height: u64,
+        protocol_version: ProtocolVersion,
     }
 
     impl From<BlockHeader> for JsonBlockHeader {
@@ -1386,6 +1398,7 @@ pub(crate) mod json_compatibility {
                 timestamp: block_header.timestamp,
                 era_id: block_header.era_id,
                 height: block_header.height,
+                protocol_version: block_header.protocol_version,
             }
         }
     }
@@ -1402,6 +1415,7 @@ pub(crate) mod json_compatibility {
                 timestamp: block_header.timestamp,
                 era_id: block_header.era_id,
                 height: block_header.height,
+                protocol_version: block_header.protocol_version,
             }
         }
     }

--- a/types/src/protocol_version.rs
+++ b/types/src/protocol_version.rs
@@ -1,6 +1,8 @@
 use alloc::vec::Vec;
 use core::fmt;
 
+use datasize::DataSize;
+use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -10,7 +12,18 @@ use crate::{
 
 /// A newtype wrapping a [`SemVer`] which represents a Casper Platform protocol version.
 #[derive(
-    Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+    Copy,
+    Clone,
+    DataSize,
+    Debug,
+    Default,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
 )]
 pub struct ProtocolVersion(SemVer);
 
@@ -146,6 +159,19 @@ impl FromBytes for ProtocolVersion {
 impl fmt::Display for ProtocolVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl JsonSchema for ProtocolVersion {
+    fn schema_name() -> String {
+        String::from("ProtocolVersion")
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        let schema = gen.subschema_for::<String>();
+        let mut schema_object = schema.into_object();
+        schema_object.metadata().description = Some("Protocol version of the network".to_string());
+        schema_object.into()
     }
 }
 

--- a/types/src/protocol_version.rs
+++ b/types/src/protocol_version.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use core::fmt;
 
 use datasize::DataSize;
+#[cfg(feature = "std")]
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{Deserialize, Serialize};
 
@@ -162,6 +163,7 @@ impl fmt::Display for ProtocolVersion {
     }
 }
 
+#[cfg(feature = "std")]
 impl JsonSchema for ProtocolVersion {
     fn schema_name() -> String {
         String::from("ProtocolVersion")

--- a/types/src/protocol_version.rs
+++ b/types/src/protocol_version.rs
@@ -1,6 +1,5 @@
-use alloc::vec::Vec;
-use core::fmt;
-use std::{convert::TryFrom, string::String};
+use alloc::{format, string::String, vec::Vec};
+use core::{convert::TryFrom, fmt};
 
 use datasize::DataSize;
 

--- a/types/src/semver.rs
+++ b/types/src/semver.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use core::{convert::TryFrom, fmt, num::ParseIntError};
 
+use datasize::DataSize;
 use failure::Fail;
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +12,18 @@ pub const SEM_VER_SERIALIZED_LENGTH: usize = 3 * U32_SERIALIZED_LENGTH;
 
 /// A struct for semantic versioning.
 #[derive(
-    Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+    Copy,
+    Clone,
+    DataSize,
+    Debug,
+    Default,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
 )]
 pub struct SemVer {
     /// Major version.


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-898

NOTE: we still populate the header with the hardcoded version `1.0.0`. Once #918 is merged, I will create a follow-up PR that uses `BlockExecutor`'s protocol version when creating new blocks.