### PR TITLE
NDRS-879: Log active/inactive stake.

### DIFF
--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -437,10 +437,9 @@ impl<C: Context> Highway<C> {
     /// Returns an iterator over all validators against which we have direct evidence.
     pub(crate) fn validators_with_evidence(&self) -> impl Iterator<Item = &C::ValidatorId> {
         self.validators
-            .iter()
-            .enumerate()
-            .filter(move |(i, _)| self.state.has_evidence((*i as u32).into()))
-            .map(|(_, v)| v.id())
+            .enumerate_ids()
+            .filter(move |(idx, _)| self.state.has_evidence(*idx))
+            .map(|(_, v_id)| v_id)
     }
 
     pub(crate) fn state(&self) -> &State<C> {

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -320,6 +320,12 @@ impl<C: Context> State<C> {
             .cloned()
     }
 
+    /// Returns the timestamp of the last ping or unit received from the validator, or the start
+    /// timestamp if we haven't received anything yet.
+    pub(crate) fn last_seen(&self, idx: ValidatorIndex) -> Timestamp {
+        self.pings[idx]
+    }
+
     /// Marks the given validator as faulty, unless it is already banned or we have direct evidence.
     pub(crate) fn mark_faulty(&mut self, idx: ValidatorIndex) {
         self.panorama[idx] = Observation::Faulty;

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -94,11 +94,16 @@ impl<VID: Eq + Hash> Validators<VID> {
 
     /// Returns an iterator of all indices of banned validators.
     pub(crate) fn iter_banned_idx(&self) -> impl Iterator<Item = ValidatorIndex> + '_ {
-        self.validators
-            .iter()
+        self.iter()
             .enumerate()
             .filter(|(_, v)| v.banned)
             .map(|(idx, _)| ValidatorIndex::from(idx as u32))
+    }
+
+    pub(crate) fn enumerate_ids<'a>(&'a self) -> impl Iterator<Item = (ValidatorIndex, &'a VID)> {
+        let to_idx =
+            |(idx, v): (usize, &'a Validator<VID>)| (ValidatorIndex::from(idx as u32), v.id());
+        self.iter().enumerate().map(to_idx)
     }
 
     /// Returns the size of validator list.

--- a/node/src/components/consensus/protocols/highway/participation.rs
+++ b/node/src/components/consensus/protocols/highway/participation.rs
@@ -12,6 +12,7 @@ use crate::{
         traits::Context,
     },
     types::Timestamp,
+    utils::div_round,
 };
 
 /// A validator's participation status: whether they are faulty or inactive.
@@ -88,8 +89,8 @@ impl<C: Context> Participation<C> {
             .collect();
         Participation {
             instance_id: *highway.instance_id(),
-            inactive_stake_percent: ((inactive_w * 100 + total_w / 2) / total_w) as u8,
-            faulty_stake_percent: ((faulty_w * 100 + total_w / 2) / total_w) as u8,
+            inactive_stake_percent: div_round(inactive_w * 100, total_w) as u8,
+            faulty_stake_percent: div_round(faulty_w * 100, total_w) as u8,
             validators,
         }
     }

--- a/node/src/components/consensus/protocols/highway/participation.rs
+++ b/node/src/components/consensus/protocols/highway/participation.rs
@@ -1,0 +1,96 @@
+use std::cmp::Reverse;
+
+use itertools::Itertools;
+
+use crate::{
+    components::consensus::{
+        highway_core::{
+            highway::Highway,
+            state::{Fault, State},
+            validators::ValidatorIndex,
+        },
+        traits::Context,
+    },
+    types::Timestamp,
+};
+
+/// A validator's participation status: whether they are faulty or inactive.
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+enum Status {
+    LastSeenSecondsAgo(u64),
+    Inactive,
+    EquivocatedInOtherEra,
+    Equivocated,
+}
+
+impl Status {
+    /// Returns a `Status` for a validator unless they are honest and online.
+    fn for_index<C: Context>(
+        idx: ValidatorIndex,
+        state: &State<C>,
+        now: Timestamp,
+    ) -> Option<Status> {
+        if let Some(fault) = state.maybe_fault(idx) {
+            return Some(match fault {
+                Fault::Banned | Fault::Indirect => Status::EquivocatedInOtherEra,
+                Fault::Direct(_) => Status::Equivocated,
+            });
+        }
+        if state.panorama()[idx].is_none() {
+            return Some(Status::Inactive);
+        }
+        if state.last_seen(idx) + state.params().max_round_length() < now {
+            let seconds = (now - state.last_seen(idx)).millis() / 1000;
+            return Some(Status::LastSeenSecondsAgo(seconds));
+        }
+        None
+    }
+}
+
+/// A map of status (faulty, inactive) by validator ID.
+#[derive(Debug)]
+pub(crate) struct Participation<C>
+where
+    C: Context,
+{
+    instance_id: C::InstanceId,
+    faulty_stake_percent: u8,
+    inactive_stake_percent: u8,
+    /// The faulty and inactive validators, by ID and index.
+    validators: Vec<(ValidatorIndex, C::ValidatorId, Status)>,
+}
+
+impl<C: Context> Participation<C> {
+    /// Creates a new `Participation` map, showing validators seen as faulty or inactive by the
+    /// Highway instance.
+    pub(crate) fn new(highway: &Highway<C>) -> Self {
+        let now = Timestamp::now();
+        let state = highway.state();
+        let mut inactive_w = 0;
+        let mut faulty_w = 0;
+        let total_w = u128::from(state.total_weight().0);
+        let validators = highway
+            .validators()
+            .enumerate_ids()
+            .filter_map(|(idx, v_id)| {
+                let status = Status::for_index(idx, state, now)?;
+                match status {
+                    Status::Equivocated | Status::EquivocatedInOtherEra => {
+                        faulty_w += u128::from(state.weight(idx).0)
+                    }
+                    Status::Inactive | Status::LastSeenSecondsAgo(_) => {
+                        inactive_w += u128::from(state.weight(idx).0)
+                    }
+                }
+                Some((idx, v_id.clone(), status))
+            })
+            .sorted_by_key(|(idx, _, status)| (Reverse(*status), *idx))
+            .collect();
+        Participation {
+            instance_id: *highway.instance_id(),
+            inactive_stake_percent: ((inactive_w * 100 + total_w / 2) / total_w) as u8,
+            faulty_stake_percent: ((faulty_w * 100 + total_w / 2) / total_w) as u8,
+            validators,
+        }
+    }
+}

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -87,9 +87,9 @@ where
         0,
         start_timestamp,
     );
-    // We expect only the vertex purge timer outcome. If there are more, the tests might need to
-    // handle them.
-    assert_eq!(1, outcomes.len());
+    // We expect only the vertex purge timer and participation log timer outcomes.
+    // If there are more, the tests might need to handle them.
+    assert_eq!(2, outcomes.len());
     hw_proto
 }
 

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -11,6 +11,7 @@ use std::{
     fmt::{self, Display, Formatter},
     fs, io,
     net::{SocketAddr, ToSocketAddrs},
+    ops::{Add, Div},
     path::{Path, PathBuf},
 };
 
@@ -287,4 +288,12 @@ impl<I: Display> Display for Source<I> {
             Source::Client => write!(formatter, "client"),
         }
     }
+}
+
+/// Divides `numerator` by `denominator` and rounds to the closest integer.
+pub(crate) fn div_round<T>(numerator: T, denominator: T) -> T
+where
+    T: Add<Output = T> + Div<Output = T> + From<u8> + Copy,
+{
+    (numerator + denominator / T::from(2)) / denominator
 }


### PR DESCRIPTION
This adds a once-per-minute INFO-level log statement listing all faulty and inactive validators, and their total weight as a percentage. Example output:

`validator participation; participation=Participation { instance_id: 248c7d082e44ad352e10dcbdac6a442f2cb675d247d9732c276aefce1dddf5a6, faulty_stake_percent: 1, inactive_stake_percent: 0, validators: [(ValidatorIndex(1), PublicKey::Ed25519(2575b4c621544fa3dda5c06bd26eed6304ea10bc57aa4bef4af9d7483ae95115), Equivocated)] }; instance_id=248c..f5a6
`

https://casperlabs.atlassian.net/browse/NDRS-879