### PR TITLE
NO-TICKET: fix issue in Key::from_formatted_str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "schemars",
  "serde",
+ "serde_bytes",
  "serde_json",
  "tempfile",
  "thiserror",

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -17,8 +17,8 @@ bincode = "1.3.1"
 blake2 = "0.9.0"
 casper-types = { version = "0.7.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
-datasize = "0.2.4"
 csv = "1.1.3"
+datasize = "0.2.4"
 hex = "0.4.2"
 hex-buffer-serde = "0.2.1"
 hex_fmt = "0.3.0"
@@ -40,6 +40,7 @@ rand = "0.7.3"
 rand_chacha = "0.2.2"
 schemars = { version = "0.8.0", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
+serde_bytes = "0.11.5"
 serde_json = "1"
 thiserror = "1.0.18"
 tracing = "0.1.18"

--- a/execution_engine/src/shared/stored_value.rs
+++ b/execution_engine/src/shared/stored_value.rs
@@ -1,13 +1,7 @@
-use std::{
-    convert::TryFrom,
-    fmt::{self, Debug, Formatter},
-};
+use std::{convert::TryFrom, fmt::Debug};
 
-use serde::{
-    de::{self, SeqAccess, Visitor},
-    ser::{Error, SerializeSeq},
-    Deserialize, Deserializer, Serialize, Serializer,
-};
+use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
+use serde_bytes::ByteBuf;
 
 use casper_types::{
     auction::EraInfo,
@@ -309,83 +303,21 @@ impl FromBytes for StoredValue {
 }
 
 impl Serialize for StoredValue {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // The JSON representation of a StoredValue is just its bytesrepr
         // While this makes it harder to inspect, it makes deterministic representation simple.
         let bytes = self
             .to_bytes()
-            .map_err(|err| S::Error::custom(format!("{:?}", err)))?;
-
-        let number_of_bytes = bytes.len();
-        let mut seq = serializer.serialize_seq(Some(number_of_bytes))?;
-
-        // First push the number of bytes the StoredValue takes
-        seq.serialize_element(&number_of_bytes)?;
-        for byte in bytes {
-            seq.serialize_element(&byte)?;
-        }
-        seq.end()
+            .map_err(|error| ser::Error::custom(format!("{:?}", error)))?;
+        ByteBuf::from(bytes).serialize(serializer)
     }
 }
 
 impl<'de> Deserialize<'de> for StoredValue {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct StoredValueDeserializer;
-
-        impl<'de> Visitor<'de> for StoredValueDeserializer {
-            type Value = StoredValue;
-
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-                formatter.write_str("Serialized representation of StoredValue in bytes.")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
-                let number_of_bytes: usize = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::custom("Did not have leading number of bytes"))?;
-                let mut bytes: Vec<u8> = Vec::with_capacity(number_of_bytes);
-                let mut count: usize = 0;
-                while let Some(byte) = seq.next_element()? {
-                    count += 1;
-                    if count > number_of_bytes {
-                        return Err(de::Error::custom(format!(
-                            "Serialization should have {} bytes but exceeds this",
-                            number_of_bytes
-                        )));
-                    }
-                    bytes.push(byte);
-                }
-                if count < number_of_bytes {
-                    return Err(de::Error::custom(format!(
-                        "Serialization should have {} bytes but only has {}",
-                        number_of_bytes, count
-                    )));
-                }
-                let (stored_value, additional_bytes) = StoredValue::from_bytes(&bytes)
-                    .map_err(|err| de::Error::custom(format!("{:?}", err)))?;
-                if !additional_bytes.is_empty() {
-                    return Err(de::Error::custom(format!(
-                        "Parsed stored value as well as unexpected additional bytes.\n\
-                         \n\
-                         Stored value: {:?}\n\
-                         \n\
-                         Unexpected additional bytes: {:?}",
-                        stored_value, additional_bytes
-                    )));
-                }
-                Ok(stored_value)
-            }
-        }
-        deserializer.deserialize_seq(StoredValueDeserializer)
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bytes = ByteBuf::deserialize(deserializer)?.into_vec();
+        Ok(bytesrepr::deserialize::<StoredValue>(bytes)
+            .map_err(|error| de::Error::custom(format!("{:?}", error)))?)
     }
 }
 

--- a/execution_engine/src/storage/trie/mod.rs
+++ b/execution_engine/src/storage/trie/mod.rs
@@ -118,7 +118,7 @@ impl Serialize for PointerBlock {
         // Store the non-None entries with their indices
         for (index, maybe_pointer_block) in self.0.iter().enumerate() {
             if let Some(pointer_block_value) = maybe_pointer_block {
-                map.serialize_entry(&index, pointer_block_value)?;
+                map.serialize_entry(&(index as u8), pointer_block_value)?;
             }
         }
         map.end()
@@ -146,10 +146,8 @@ impl<'de> Deserialize<'de> for PointerBlock {
                 let mut pointer_block = PointerBlock::new();
 
                 // Unpack the sparse representation
-                while let Some((index, pointer_block_value)) =
-                    access.next_entry::<usize, Pointer>()?
-                {
-                    let element = pointer_block.0.get_mut(index).ok_or_else(|| {
+                while let Some((index, pointer_block_value)) = access.next_entry::<u8, Pointer>()? {
+                    let element = pointer_block.0.get_mut(usize::from(index)).ok_or_else(|| {
                         de::Error::custom(format!("invalid index {} in pointer block value", index))
                     })?;
                     *element = Some(pointer_block_value);

--- a/execution_engine/src/storage/trie/tests.rs
+++ b/execution_engine/src/storage/trie/tests.rs
@@ -95,7 +95,6 @@ mod proptests {
         }
 
         #[test]
-        #[ignore]
         fn bincode_roundtrip_trie(trie in trie_arb()) {
            let bincode_bytes = bincode::serialize(&trie)?;
            let deserialized_trie = bincode::deserialize(&bincode_bytes)?;

--- a/execution_engine/src/storage/trie/tests.rs
+++ b/execution_engine/src/storage/trie/tests.rs
@@ -100,5 +100,12 @@ mod proptests {
            let deserialized_trie = bincode::deserialize(&bincode_bytes)?;
            assert_eq!(trie, deserialized_trie)
         }
+
+        #[test]
+        fn bincode_roundtrip_trie_pointer_block(pointer_block in trie_pointer_block_arb()) {
+             let bincode_bytes = bincode::serialize(&pointer_block)?;
+             let deserialized_pointer_block = bincode::deserialize(&bincode_bytes)?;
+             assert_eq!(pointer_block, deserialized_pointer_block)
+        }
     }
 }

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -7,6 +7,8 @@ use core::{
     array::TryFromSliceError,
     convert::TryFrom,
     fmt::{self, Debug, Display, Formatter},
+    num::ParseIntError,
+    str::FromStr,
 };
 
 use datasize::DataSize;
@@ -92,6 +94,7 @@ pub enum FromStrError {
     Hash(TryFromSliceError),
     AccountHash(account::FromStrError),
     URef(uref::FromStrError),
+    EraId(ParseIntError),
 }
 
 impl From<base16::DecodeError> for FromStrError {
@@ -124,6 +127,12 @@ impl From<uref::FromStrError> for FromStrError {
     }
 }
 
+impl From<ParseIntError> for FromStrError {
+    fn from(error: ParseIntError) -> Self {
+        FromStrError::EraId(error)
+    }
+}
+
 impl Display for FromStrError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
@@ -135,6 +144,7 @@ impl Display for FromStrError {
                 write!(f, "account hash from string error: {:?}", error)
             }
             FromStrError::URef(error) => write!(f, "uref from string error: {:?}", error),
+            FromStrError::EraId(error) => write!(f, "era id from string error: {}", error),
         }
     }
 }
@@ -202,8 +212,12 @@ impl Key {
             )))
         } else if let Ok(transfer_addr) = TransferAddr::from_formatted_str(input) {
             Ok(Key::Transfer(transfer_addr))
+        } else if let Ok(uref) = URef::from_formatted_str(input) {
+            Ok(Key::URef(uref))
+        } else if let Some(era_id_str) = input.strip_prefix(ERA_INFO_PREFIX) {
+            Ok(Key::EraInfo(u64::from_str(era_id_str)?))
         } else {
-            Ok(Key::URef(URef::from_formatted_str(input)?))
+            Err(FromStrError::InvalidPrefix)
         }
     }
 
@@ -594,6 +608,8 @@ mod tests {
             format!("{}", deploy_info_key),
             format!("Key::DeployInfo({})", expected_hash)
         );
+        let era_info_key = Key::EraInfo(42);
+        assert_eq!(format!("{}", era_info_key), "Key::EraInfo(42)".to_string());
     }
 
     #[test]
@@ -651,9 +667,12 @@ mod tests {
 
         let key_deploy_info = Key::DeployInfo(DeployHash::new([42; BLAKE2B_DIGEST_LENGTH]));
         assert!(key_deploy_info.serialized_length() <= Key::max_serialized_length());
+
+        let key_era_info = Key::EraInfo(42);
+        assert!(key_era_info.serialized_length() <= Key::max_serialized_length());
     }
 
-    fn round_trip(key: Key) {
+    fn to_string_round_trip(key: Key) {
         let string = key.to_formatted_string();
         let parsed_key = Key::from_formatted_str(&string).unwrap();
         assert_eq!(key, parsed_key);
@@ -661,14 +680,15 @@ mod tests {
 
     #[test]
     fn key_from_str() {
-        round_trip(Key::Account(AccountHash::new([42; BLAKE2B_DIGEST_LENGTH])));
-        round_trip(Key::Hash([42; KEY_HASH_LENGTH]));
-        round_trip(Key::URef(URef::new(
+        to_string_round_trip(Key::Account(AccountHash::new([42; BLAKE2B_DIGEST_LENGTH])));
+        to_string_round_trip(Key::Hash([42; KEY_HASH_LENGTH]));
+        to_string_round_trip(Key::URef(URef::new(
             [255; BLAKE2B_DIGEST_LENGTH],
             AccessRights::READ,
         )));
-        round_trip(Key::Transfer(TransferAddr::new([42; KEY_HASH_LENGTH])));
-        round_trip(Key::DeployInfo(DeployHash::new([42; KEY_HASH_LENGTH])));
+        to_string_round_trip(Key::Transfer(TransferAddr::new([42; KEY_HASH_LENGTH])));
+        to_string_round_trip(Key::DeployInfo(DeployHash::new([42; KEY_HASH_LENGTH])));
+        to_string_round_trip(Key::EraInfo(42));
 
         let invalid_prefix = "a-0000000000000000000000000000000000000000000000000000000000000000";
         assert!(Key::from_formatted_str(invalid_prefix).is_err());
@@ -720,5 +740,47 @@ mod tests {
             serde_json::to_string(&key_deploy_info).unwrap(),
             format!(r#"{{"DeployInfo":"deploy-{}"}}"#, hex_bytes)
         );
+
+        let key_era_info = Key::EraInfo(42);
+        assert_eq!(
+            serde_json::to_string(&key_era_info).unwrap(),
+            r#"{{"EraInfo":"era-42"}}"#.to_string()
+        );
+    }
+
+    #[test]
+    fn serialization_roundtrip_bincode() {
+        let round_trip = |key: &Key| {
+            let encoded = bincode::serialize(key).unwrap();
+            let decoded = bincode::deserialize(&encoded).unwrap();
+            assert_eq!(key, &decoded);
+        };
+
+        let array = [42; BLAKE2B_DIGEST_LENGTH];
+
+        round_trip(&Key::Account(AccountHash::new(array)));
+        round_trip(&Key::Hash(array));
+        round_trip(&Key::URef(URef::new(array, AccessRights::READ)));
+        round_trip(&Key::Transfer(TransferAddr::new(array)));
+        round_trip(&Key::DeployInfo(DeployHash::new(array)));
+        round_trip(&Key::EraInfo(42));
+    }
+
+    #[test]
+    fn serialization_roundtrip_json() {
+        let round_trip = |key: &Key| {
+            let encoded = serde_json::to_string_pretty(key).unwrap();
+            let decoded = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(key, &decoded);
+        };
+
+        let array = [42; BLAKE2B_DIGEST_LENGTH];
+
+        round_trip(&Key::Account(AccountHash::new(array)));
+        round_trip(&Key::Hash(array));
+        round_trip(&Key::URef(URef::new(array, AccessRights::READ)));
+        round_trip(&Key::Transfer(TransferAddr::new(array)));
+        round_trip(&Key::DeployInfo(DeployHash::new(array)));
+        round_trip(&Key::EraInfo(42));
     }
 }

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -744,7 +744,7 @@ mod tests {
         let key_era_info = Key::EraInfo(42);
         assert_eq!(
             serde_json::to_string(&key_era_info).unwrap(),
-            r#"{{"EraInfo":"era-42"}}"#.to_string()
+            r#"{"EraInfo":"era-42"}"#.to_string()
         );
     }
 


### PR DESCRIPTION
This PR fixes a bug whereby `Key::from_formatted_str()` doesn't handle parsing a `Key::EraInfo` variant.  It also adds check for that variant to existing tests and adds a couple of serialization round trip tests, one using `bincode` and the other using `serde_json`.