### PR TITLE
NCTL: meet minimum native transfer amount

### DIFF
--- a/utils/nctl/sh/scenarios/sync_test.sh
+++ b/utils/nctl/sh/scenarios/sync_test.sh
@@ -78,7 +78,7 @@ function do_send_wasm_deploys() {
 function do_send_transfers() {
     log_step "sending native transfers"
     # NOTE: Maybe make these arguments to the test?
-    local AMOUNT=1000
+    local AMOUNT=2500000000
     local TRANSFERS_COUNT=5
     local NODE_ID="random"
 


### PR DESCRIPTION
On master there is now a minimum transfer amount for "native" transfers, configured in the chainspec (deploy section, native_transfer_minimum_motes), and defaulted to 2_500_000_000 motes;