### PR TITLE
NDRS-862: Client Intergration Tests using Tempdir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,7 @@ dependencies = [
  "semver 0.11.0",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tower",
@@ -819,7 +820,7 @@ dependencies = [
  "quanta",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
  "rand_pcg",
  "regex",
  "reqwest",
@@ -4344,7 +4345,7 @@ checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
 
@@ -4365,7 +4366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -4379,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
 ]
@@ -4401,7 +4402,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -36,6 +36,7 @@ reqwest = { version = "0.10.6", features = ["json"] }
 semver = { version = "0.11.0", features = ["serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1.0.55"
+tempfile = "3"
 thiserror = "1.0.20"
 tokio = { version = "0.2.20", features = ["macros", "rt-threaded", "sync", "tcp", "time", "blocking"] }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -104,7 +104,7 @@ assert_matches = "1.3.0"
 fake_instant = "0.4.0"
 multihash = "0.11.4"
 pnet = "0.27.2"
-rand_core = "0.5.1"
+rand_core = "0.6.2"
 rand_pcg = "0.2.1"
 reqwest = "0.10.8"
 tokio = { version = "0.2.20", features = ["test-util"] }


### PR DESCRIPTION
REF: https://casperlabs.atlassian.net/browse/NDRS-862

CHANGELOG:

- Refactored client integration tests to use `tempdir` for test file
- Removed `remove_dir` in `keygen` integration tests as it was outmoded due to use of `tempdir`
- Changed `rand-core` in `Cargo.toml` to account for a RUSTSEC advisory