### PR TITLE
NO-TICK: set lfb hash back to original

### DIFF
--- a/utils/nctl/sh/scenarios/sync_test.sh
+++ b/utils/nctl/sh/scenarios/sync_test.sh
@@ -95,7 +95,8 @@ function do_await_deploy_inclusion() {
 }
 
 function do_read_lfb_hash() {
-    LFB_HASH=$(get_chain_latest_block_hash)
+    local NODE_ID=${1}
+    LFB_HASH=$(render_last_finalized_block_hash "$NODE_ID" | cut -f2 -d= | cut -f2 -d ' ')
     echo "$LFB_HASH"
 }
 


### PR DESCRIPTION
Previous change caused the synchronization function to always be true. Reverting back to how it originally was.