### PR TITLE
NDRS-878: Add networking metrics for `network` component

### DIFF
--- a/node/src/components/network/error.rs
+++ b/node/src/components/network/error.rs
@@ -39,4 +39,8 @@ pub enum Error {
     /// Message too large.
     #[error("message of {actual_size} bytes exceeds limit of {max_size} bytes")]
     MessageTooLarge { max_size: u32, actual_size: u64 },
+
+    /// Instantiating metrics failed.
+    #[error(transparent)]
+    MetricsError(#[from] prometheus::Error),
 }

--- a/node/src/components/network/tests.rs
+++ b/node/src/components/network/tests.rs
@@ -69,14 +69,20 @@ impl Reactor for TestReactor {
 
     fn new(
         config: Self::Config,
-        _registry: &Registry,
+        registry: &Registry,
         event_queue: EventQueueHandle<Self::Event>,
         rng: &mut NodeRng,
     ) -> anyhow::Result<(Self, Effects<Self::Event>)> {
         let chainspec = Chainspec::random(rng);
         let network_identity = NetworkIdentity::new();
-        let (network_component, effects) =
-            NetworkComponent::new(event_queue, config, network_identity, &chainspec, false)?;
+        let (network_component, effects) = NetworkComponent::new(
+            event_queue,
+            config,
+            registry,
+            network_identity,
+            &chainspec,
+            false,
+        )?;
 
         Ok((
             TestReactor { network_component },

--- a/node/src/components/network/tests_bulk_gossip.rs
+++ b/node/src/components/network/tests_bulk_gossip.rs
@@ -35,7 +35,7 @@ reactor!(LoadTestingReactor {
 
   components: {
       net = has_effects Network::<LoadTestingReactorEvent, DummyPayload>(
-        event_queue, cfg.network_config, NetworkIdentity::new(), &cfg.chainspec, false
+        event_queue, cfg.network_config, registry, NetworkIdentity::new(), &cfg.chainspec, false
       );
       collector = infallible Collector::<DummyPayload>();
   }

--- a/node/src/components/networking_metrics.rs
+++ b/node/src/components/networking_metrics.rs
@@ -10,7 +10,7 @@ pub(crate) struct NetworkingMetrics {
     pub(crate) open_connections: IntGauge,
     /// Number of messages still waiting to be sent out (broadcast and direct).
     pub(crate) queued_messages: IntGauge,
-    /// Number of peers.
+    /// Number of connected peers.
     pub(crate) peers: IntGauge,
 
     /// Registry instance.

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -212,8 +212,6 @@ where
         let secret_key = small_network_identity.secret_key;
         let certificate = small_network_identity.tls_certificate;
 
-        let net_metrics = NetworkingMetrics::new(&registry)?;
-
         // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without starting the
         // server.
         if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
@@ -235,10 +233,12 @@ where
                 shutdown_receiver: watch::channel(()).1,
                 server_join_handle: None,
                 is_stopped: Arc::new(AtomicBool::new(true)),
-                net_metrics,
+                net_metrics: NetworkingMetrics::new(&Registry::default())?,
             };
             return Ok((model, Effects::new()));
         }
+
+        let net_metrics = NetworkingMetrics::new(&registry)?;
 
         // We can now create a listener.
         let bind_address = utils::resolve_address(&cfg.bind_address).map_err(Error::ResolveAddr)?;

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -118,8 +118,9 @@ pub enum Error {
     /// Server has stopped.
     #[error("failed to create outgoing connection as server has stopped")]
     ServerStopped,
-    #[error(transparent)]
+
     /// Instantiating metrics failed.
+    #[error(transparent)]
     MetricsError(
         #[serde(skip_serializing)]
         #[from]

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -409,6 +409,7 @@ impl reactor::Reactor for Reactor {
         let (network, network_effects) = Network::new(
             event_queue,
             network_config,
+            registry,
             network_identity,
             chainspec_loader.chainspec(),
             false,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -404,6 +404,7 @@ impl reactor::Reactor for Reactor {
         let (network, network_effects) = Network::new(
             event_queue,
             network_config,
+            registry,
             network_identity,
             chainspec_loader.chainspec(),
             true,


### PR DESCRIPTION
Adds the regular networking metrics to the networking component, except for `open_connections`.

Some things are left as `TODO`, as the work has already been done in another branch that is pending a merge in the future.