### PR TITLE
NO-TICK: Bump to 0.9.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -187,21 +187,21 @@ steps:
   commands:
     - "./ci/build_update_package.sh"
 
-- name: put-upgrade_package-s3
-  image: casperlabs/s3cmd-build:latest
-  commands:
-    - "./ci/upgrade_package_s3_storage.sh put $(pwd)/target/upgrade_package/"
-  environment:
-    CL_VAULT_TOKEN:
-      from_secret: vault_token
-    CL_VAULT_HOST:
-      from_secret: vault_host
-  when:
-    branch:
-      - master
-      - "release-*"
-    event:
-      - push
+#- name: put-upgrade_package-s3
+#  image: casperlabs/s3cmd-build:latest
+#  commands:
+#    - "./ci/upgrade_package_s3_storage.sh put $(pwd)/target/upgrade_package/"
+#  environment:
+#    CL_VAULT_TOKEN:
+#      from_secret: vault_token
+#    CL_VAULT_HOST:
+#      from_secret: vault_host
+#  when:
+#    branch:
+#      - master
+#      - "release-*"
+#    event:
+#      - push
 
 depends_on:
   - pre-checks
@@ -302,21 +302,21 @@ steps:
       - push
 
 # Build failed so remove the update_package candidate
-- name: del-upgrade_package-s3
-  image: casperlabs/s3cmd-build:latest
-  commands:
-    - ./ci/upgrade_package_s3_storage.sh del
-  environment:
-    CL_VAULT_TOKEN:
-      from_secret: vault_token
-    CL_VAULT_HOST:
-      from_secret: vault_host
-  when:
-    branch:
-      - master
-      - "release-*"
-    event:
-      - push
+#- name: del-upgrade_package-s3
+#  image: casperlabs/s3cmd-build:latest
+#  commands:
+#    - ./ci/upgrade_package_s3_storage.sh del
+#  environment:
+#    CL_VAULT_TOKEN:
+#      from_secret: vault_token
+#    CL_VAULT_HOST:
+#      from_secret: vault_host
+#  when:
+#    branch:
+#      - master
+#      - "release-*"
+#    event:
+#      - push
 
 - name: notify
   image: plugins/slack

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cargo-casper"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "casper-client"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "casper-contract"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "casper-types",
  "hex_fmt",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-test-support"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "casper-contract",
  "casper-execution-engine",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node-macros"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "Inflector",
  "indexmap",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "base16",
  "base64 0.13.0",
@@ -2240,7 +2240,7 @@ checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -5336,11 +5336,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -6151,9 +6152,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/ci/upgrade_package_s3_storage.sh
+++ b/ci/upgrade_package_s3_storage.sh
@@ -63,12 +63,12 @@ CL_S3_LOCATION="drone/$GIT_HASH"
 
 case "$ACTION" in
 "put")
-  echo "sync ${LOCAL} s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION}"
-  s3cmd sync "${LOCAL}" "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION}"
+  echo "sync ${LOCAL} s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION}/"
+  s3cmd sync "${LOCAL}" "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION}/"
   ;;
 "get")
-  echo "sync s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION} ${LOCAL}"
-  s3cmd sync "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION}" "${LOCAL}"
+  echo "sync s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION}/ ${LOCAL}"
+  s3cmd sync "s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}/${PROTOCOL_VERSION}/" "${LOCAL}"
   ;;
 "del")
   echo "del --recursive s3://${CL_S3_BUCKET}/${CL_S3_LOCATION}"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-client"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "A client for interacting with the Casper network"
@@ -22,9 +22,9 @@ doc = false
 
 [dependencies]
 base64 = "0.13.0"
-casper-execution-engine = { version = "0.7.0", path = "../execution_engine" }
-casper-node = { version = "0.7.0", path = "../node" }
-casper-types = { version = "0.7.0", path = "../types", features = ["std"] }
+casper-execution-engine = { version = "0.9.0", path = "../execution_engine" }
+casper-node = { version = "0.9.0", path = "../node" }
+casper-types = { version = "0.9.0", path = "../types", features = ["std"] }
 clap = "2.33.1"
 futures = "0.3.5"
 hex = { version = "0.4.2", features = ["serde"] }

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "0.7.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.9.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."
@@ -15,7 +15,7 @@ anyhow = "1.0.33"
 base16 = "0.2.1"
 bincode = "1.3.1"
 blake2 = "0.9.0"
-casper-types = { version = "0.7.0", path = "../types", features = ["std", "gens"] }
+casper-types = { version = "0.9.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 csv = "1.1.3"
 datasize = "0.2.4"

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/0.9.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine_testing/cargo_casper/Cargo.toml
+++ b/execution_engine_testing/cargo_casper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-casper"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Command line tool for creating a Wasm smart contract and tests for use on the Casper network."

--- a/execution_engine_testing/cargo_casper/src/common.rs
+++ b/execution_engine_testing/cargo_casper/src/common.rs
@@ -12,9 +12,9 @@ use once_cell::sync::Lazy;
 use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
 
 pub static CL_CONTRACT: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-contract", "0.7.0", "smart_contracts/contract"));
+    Lazy::new(|| Dependency::new("casper-contract", "0.9.0", "smart_contracts/contract"));
 pub static CL_TYPES: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-types", "0.7.0", "types"));
+    Lazy::new(|| Dependency::new("casper-types", "0.9.0", "types"));
 
 pub fn print_error_and_exit(msg: &str) -> ! {
     e_red!("error");

--- a/execution_engine_testing/cargo_casper/src/tests_package.rs
+++ b/execution_engine_testing/cargo_casper/src/tests_package.rs
@@ -115,7 +115,7 @@ static INTEGRATION_TESTS_RS: Lazy<PathBuf> = Lazy::new(|| {
 static ENGINE_TEST_SUPPORT: Lazy<Dependency> = Lazy::new(|| {
     Dependency::new(
         "casper-engine-test-support",
-        "0.7.0",
+        "0.9.0",
         "execution_engine_testing/test_support",
     )
 });

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-test-support"
-version = "0.7.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.9.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the Casper network."
@@ -11,9 +11,9 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-contract = { version = "0.7.0", path = "../../smart_contracts/contract", features = ["std"] }
-casper-execution-engine = { version = "0.7.0", path = "../../execution_engine", features = ["gens"] }
-casper-types = { version = "0.7.0", path = "../../types", features = ["std"] }
+casper-contract = { version = "0.9.0", path = "../../smart_contracts/contract", features = ["std"] }
+casper-execution-engine = { version = "0.9.0", path = "../../execution_engine", features = ["gens"] }
+casper-types = { version = "0.9.0", path = "../../types", features = ["std"] }
 lmdb = "0.8.0"
 log = "0.4.8"
 num-rational = "0.3.0"

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -56,7 +56,7 @@
 //! assert_eq!(expected_value, returned_value);
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/0.9.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "0.7.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.9.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -19,9 +19,9 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1.3.1"
 blake2 = { version = "0.9.0", default-features = false }
-casper-execution-engine = { version = "0.7.0", path = "../execution_engine" }
-casper-node-macros = { version = "0.7.0", path = "../node_macros" }
-casper-types = { version = "0.7.0", path = "../types", features = ["std", "gens"] }
+casper-execution-engine = { version = "0.9.0", path = "../execution_engine" }
+casper-node-macros = { version = "0.9.0", path = "../node_macros" }
+casper-types = { version = "0.9.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 csv = "1.1.3"
 datasize = { version = "0.2.6", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types", "tokio-types"] }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/casper-node/0.9.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node_macros/Cargo.toml
+++ b/node_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node-macros"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Marc Brinkmann <marc@casperlabs.io>"]
 edition = "2018"
 description = "A macro to create reactor implementations for the casper-node."

--- a/node_macros/src/lib.rs
+++ b/node_macros/src/lib.rs
@@ -1,6 +1,6 @@
 //! Generates reactors with routing from concise definitions. See `README.md` for details.
 
-#![doc(html_root_url = "https://docs.rs/casper-node-macros/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/casper-node-macros/0.9.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-contract"
-version = "0.7.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.9.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Library for developing Casper smart contracts."
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contra
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-types = { version = "0.7.0", path = "../../types" }
+casper-types = { version = "0.9.0", path = "../../types" }
 hex_fmt = "0.3.0"
 thiserror = "1.0.18"
 version-sync = { version = "0.9", optional = true }

--- a/smart_contracts/contract/src/lib.rs
+++ b/smart_contracts/contract/src/lib.rs
@@ -53,7 +53,7 @@
     not(feature = "std"),
     feature(alloc_error_handler, core_intrinsics, lang_items)
 )]
-#![doc(html_root_url = "https://docs.rs/casper-contract/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/casper-contract/0.9.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@casper/contract",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casper/contract",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "description": "Library for developing Casper smart contracts.",
   "main": "index.js",
   "ascMain": "assembly/index.ts",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-types"
-version = "0.7.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.9.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Types used to allow creation of Wasm contracts and tests for use on the Casper network."

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -10,7 +10,7 @@
     not(feature = "no-unstable-features"),
     feature(min_specialization, try_reserve)
 )]
-#![doc(html_root_url = "https://docs.rs/casper-types/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/casper-types/0.9.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
Bringing master up to 0.9.0 from 0.7.0 to not confuse with cherry-pick versions for release-0.8.0