### PR TITLE
NDRS-895: provide hard reset chainspec option

### DIFF
--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -40,7 +40,7 @@ use casper_types::{bytesrepr, ProtocolVersion};
 #[cfg(test)]
 use crate::utils::RESOURCES_PATH;
 use crate::{
-    components::Component,
+    components::{consensus::EraId, Component},
     crypto::hash::Digest,
     effect::{
         announcements::ChainspecLoaderAnnouncement,
@@ -295,6 +295,15 @@ impl ChainspecLoader {
 
     pub(crate) fn highest_block_hash(&self) -> Option<BlockHash> {
         self.highest_block_hash
+    }
+
+    /// Returns the era ID of where we should reset back to.  This means stored blocks in that and
+    /// subsequent eras are ignored (conceptually deleted from storage).
+    pub(crate) fn hard_reset_to_start_of_era(&self) -> Option<EraId> {
+        self.chainspec
+            .protocol_config
+            .hard_reset
+            .then(|| self.chainspec.protocol_config.activation_point.era_id)
     }
 
     fn handle_initialize<REv>(

--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -70,7 +70,10 @@ reactor!(Reactor {
             effect_builder
         );
         network = infallible InMemoryNetwork::<Message>(event_queue, rng);
-        storage = Storage(&WithDir::new(cfg.temp_dir.path(), cfg.storage_config));
+        storage = Storage(
+            &WithDir::new(cfg.temp_dir.path(), cfg.storage_config),
+            chainspec_loader.hard_reset_to_start_of_era(),
+        );
         deploy_acceptor = infallible DeployAcceptor(cfg.deploy_acceptor_config, &*chainspec_loader.chainspec());
         deploy_fetcher = Fetcher::<Deploy>("deploy", cfg.fetcher_config, registry);
     }

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -147,7 +147,7 @@ impl reactor::Reactor for Reactor {
 
         let (storage_config, storage_tempdir) = storage::Config::default_for_tests();
         let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
-        let storage = Storage::new(&storage_withdir).unwrap();
+        let storage = Storage::new(&storage_withdir, None).unwrap();
 
         let contract_runtime_config = contract_runtime::Config::default();
         let contract_runtime =

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -10,6 +10,7 @@ use casper_types::ExecutionResult;
 
 use super::{Config, Storage};
 use crate::{
+    components::consensus::EraId,
     effect::{
         requests::{StateStoreRequest, StorageRequest},
         Multiple,
@@ -19,6 +20,19 @@ use crate::{
     utils::WithDir,
 };
 
+fn new_config(harness: &ComponentHarness<()>) -> Config {
+    const MIB: usize = 1024 * 1024;
+
+    // Restrict all stores to 50 mibibytes, to catch issues before filling up the entire disk.
+    Config {
+        path: harness.tmp.path().join("storage"),
+        max_block_store_size: 50 * MIB,
+        max_deploy_store_size: 50 * MIB,
+        max_deploy_metadata_store_size: 50 * MIB,
+        max_state_store_size: 50 * MIB,
+    }
+}
+
 /// Storage component test fixture.
 ///
 /// Creates a storage component in a temporary directory.
@@ -26,22 +40,23 @@ use crate::{
 /// # Panics
 ///
 /// Panics if setting up the storage fixture fails.
-fn storage_fixture(harness: &mut ComponentHarness<()>) -> Storage {
-    const MIB: usize = 1024 * 1024;
+fn storage_fixture(harness: &ComponentHarness<()>) -> Storage {
+    let cfg = new_config(harness);
+    Storage::new(&WithDir::new(harness.tmp.path(), cfg), None)
+        .expect("could not create storage component fixture")
+}
 
-    // Restrict all stores to 50 mibibytes, to catch issues before filling up the entire disk.
-    let cfg = Config {
-        path: harness.tmp.path().join("storage"),
-        max_block_store_size: 50 * MIB,
-        max_deploy_store_size: 50 * MIB,
-        max_deploy_metadata_store_size: 50 * MIB,
-        max_state_store_size: 50 * MIB,
-    };
-
-    Storage::new(&WithDir::new(harness.tmp.path(), cfg)).expect(
-        "could not create storage component
-    fixture",
-    )
+/// Storage component test fixture.
+///
+/// Creates a storage component in a temporary directory, but with a hard reset to a specified era.
+///
+/// # Panics
+///
+/// Panics if setting up the storage fixture fails.
+fn storage_fixture_with_hard_reset(harness: &ComponentHarness<()>, reset_era_id: EraId) -> Storage {
+    let cfg = new_config(harness);
+    Storage::new(&WithDir::new(harness.tmp.path(), cfg), Some(reset_era_id))
+        .expect("could not create storage component fixture")
 }
 
 /// Creates a random block with a specific block height.
@@ -208,7 +223,7 @@ fn save_state<T>(
 #[test]
 fn get_block_of_non_existing_block_returns_none() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     let block_hash = BlockHash::random(&mut harness.rng);
     let response = get_block(&mut harness, &mut storage, block_hash);
@@ -220,7 +235,7 @@ fn get_block_of_non_existing_block_returns_none() {
 #[test]
 fn can_put_and_get_block() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     // Create a random block, store and load it.
     let block = Box::new(Block::random(&mut harness.rng));
@@ -253,7 +268,7 @@ fn can_put_and_get_block() {
 #[test]
 fn can_retrieve_block_by_height() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     // Create a random block, load and store it.
     let block_33 = random_block_at_height(&mut harness.rng, 33);
@@ -329,7 +344,7 @@ fn can_retrieve_block_by_height() {
 #[should_panic(expected = "duplicate entries")]
 fn different_block_at_height_is_fatal() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     // Create two different blocks at the same height.
     let block_44_a = random_block_at_height(&mut harness.rng, 44);
@@ -348,7 +363,7 @@ fn different_block_at_height_is_fatal() {
 #[test]
 fn get_vec_of_non_existing_deploy_returns_nones() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     let deploy_id = DeployHash::random(&mut harness.rng);
     let response = get_deploys(&mut harness, &mut storage, smallvec![deploy_id]);
@@ -362,7 +377,7 @@ fn get_vec_of_non_existing_deploy_returns_nones() {
 #[test]
 fn can_retrieve_store_and_load_deploys() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     // Create a random deploy, store and load it.
     let deploy = Box::new(Deploy::random(&mut harness.rng));
@@ -410,7 +425,7 @@ fn can_retrieve_store_and_load_deploys() {
 #[test]
 fn storing_and_loading_a_lot_of_deploys_does_not_exhaust_handles() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     let total = 1000;
     let batch_size = 25;
@@ -436,7 +451,7 @@ fn storing_and_loading_a_lot_of_deploys_does_not_exhaust_handles() {
 #[test]
 fn store_execution_results_for_two_blocks() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     let deploy = Deploy::random(&mut harness.rng);
 
@@ -488,7 +503,7 @@ fn store_execution_results_for_two_blocks() {
 #[test]
 fn store_random_execution_results() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     // We store results for two different blocks. Each block will have five deploys executed in it,
     // with two of these deploys being shared by both blocks, while the remaining three are unique
@@ -594,7 +609,7 @@ fn store_random_execution_results() {
 #[should_panic(expected = "duplicate execution result")]
 fn store_execution_results_twice_for_same_block_deploy_pair() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     let block_hash = BlockHash::random(&mut harness.rng);
     let deploy_hash = DeployHash::random(&mut harness.rng);
@@ -614,7 +629,7 @@ fn store_execution_results_twice_for_same_block_deploy_pair() {
 #[test]
 fn store_identical_execution_results() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     let block_hash = BlockHash::random(&mut harness.rng);
     let deploy_hash = DeployHash::random(&mut harness.rng);
@@ -641,7 +656,7 @@ fn store_and_load_state_data() {
     let key2 = b"exkey-2".to_vec();
 
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     // Initially, both keys should return nothing.
     let load1 = load_state::<StateData>(&mut harness, &mut storage, key1.clone().into());
@@ -682,7 +697,7 @@ fn persist_state_data() {
     let key = b"sample-key-1".to_vec();
 
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     let load = load_state::<StateData>(&mut harness, &mut storage, key.clone().into());
     assert!(load.is_none());
@@ -702,7 +717,7 @@ fn persist_state_data() {
         .on_disk(on_disk)
         .rng(rng)
         .build();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     let load = load_state::<StateData>(&mut harness, &mut storage, key.into());
     assert_eq!(load, Some(data));
@@ -711,7 +726,7 @@ fn persist_state_data() {
 #[test]
 fn test_legacy_interface() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     let deploy = Box::new(Deploy::random(&mut harness.rng));
     let was_new = put_deploy(&mut harness, &mut storage, deploy.clone());
@@ -730,7 +745,7 @@ fn test_legacy_interface() {
 #[test]
 fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
     let mut harness = ComponentHarness::default();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     // Create some sample data.
     let deploy = Deploy::random(&mut harness.rng);
@@ -755,7 +770,7 @@ fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
         .on_disk(on_disk)
         .rng(rng)
         .build();
-    let mut storage = storage_fixture(&mut harness);
+    let mut storage = storage_fixture(&harness);
 
     let actual_block = get_block(&mut harness, &mut storage, *block.hash())
         .expect("missing block we stored earlier");
@@ -775,4 +790,59 @@ fn persist_blocks_deploys_and_deploy_metadata_across_instantiations() {
         get_block_at_height(&mut harness, &mut storage, 42).expect("block index was not restored"),
         *block
     );
+}
+
+#[test]
+fn should_hard_reset() {
+    let blocks_count = 8_usize;
+    let blocks_per_era = 3;
+    let mut harness = ComponentHarness::default();
+    let mut storage = storage_fixture(&harness);
+
+    // Create and store 8 blocks, 0-2 in era 0, 3-5 in era 1, and 6,7 in era 2.
+    let blocks: Vec<Block> = (0..blocks_count)
+        .map(|index| {
+            let is_switch = index % blocks_per_era == blocks_per_era - 1;
+            Block::random_with_specifics(
+                &mut harness.rng,
+                EraId(index as u64 / 3),
+                index as u64,
+                is_switch,
+            )
+        })
+        .collect();
+
+    for block in &blocks {
+        assert!(put_block(
+            &mut harness,
+            &mut storage,
+            Box::new(block.clone())
+        ));
+    }
+    // Check the highest block is #7.
+    assert_eq!(
+        Some(blocks[blocks_count - 1].clone()),
+        get_highest_block(&mut harness, &mut storage)
+    );
+
+    // Initialize a new storage with a hard reset to era 2, effectively hiding blocks 6 and 7.
+    let mut storage = storage_fixture_with_hard_reset(&harness, EraId(2));
+    // Check the highest block is #5.
+    assert_eq!(
+        Some(blocks[blocks_count - blocks_per_era].clone()),
+        get_highest_block(&mut harness, &mut storage)
+    );
+
+    // Initialize a new storage with a hard reset to era 1, effectively hiding blocks 3-7.
+    let mut storage = storage_fixture_with_hard_reset(&harness, EraId(1));
+    // Check the highest block is #2.
+    assert_eq!(
+        Some(blocks[blocks_count - (2 * blocks_per_era)].clone()),
+        get_highest_block(&mut harness, &mut storage)
+    );
+
+    // Initialize a new storage with a hard reset to era 0, effectively hiding all blocks.
+    let mut storage = storage_fixture_with_hard_reset(&harness, EraId(0));
+    // Check the highest block is `None`.
+    assert!(get_highest_block(&mut harness, &mut storage).is_none());
 }

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -156,8 +156,10 @@ impl Reactor {
         chainspec_loader: ChainspecLoader,
         chainspec_effects: Effects<chainspec_loader::Event>,
     ) -> Result<(Self, Effects<Event>), Error> {
+        let hard_reset_to_start_of_era = chainspec_loader.hard_reset_to_start_of_era();
+
         let storage_config = config.map_ref(|cfg| cfg.storage.clone());
-        let storage = Storage::new(&storage_config)?;
+        let storage = Storage::new(&storage_config, hard_reset_to_start_of_era)?;
 
         let contract_runtime =
             ContractRuntime::new(storage_config, &config.value().contract_runtime, registry)?;

--- a/node/src/reactor/initializer2.rs
+++ b/node/src/reactor/initializer2.rs
@@ -10,7 +10,10 @@ reactor!(Initializer {
 
   components: {
     chainspec_loader = has_effects ChainspecLoader(cfg.dir(), effect_builder);
-    storage = Storage(&cfg.map_ref(|cfg| cfg.storage.clone()));
+    storage = Storage(
+        &cfg.map_ref(|cfg| cfg.storage.clone()),
+        chainspec_loader.hard_reset_to_start_of_era()
+    );
     contract_runtime = ContractRuntime(cfg.map_ref(|cfg| cfg.storage.clone()),
 &cfg.value().contract_runtime, registry);   }
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -429,6 +429,21 @@ impl FinalizedBlock {
     /// Generates a random instance using a `TestRng`.
     #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
+        let era = rng.gen_range(0, 5);
+        let height = era * 10 + rng.gen_range(0, 10);
+        let is_switch = rng.gen_bool(0.1);
+
+        FinalizedBlock::random_with_specifics(rng, EraId(era), height, is_switch)
+    }
+
+    /// Generates a random instance using a `TestRng`, but using the specified era ID and height.
+    #[cfg(test)]
+    pub fn random_with_specifics(
+        rng: &mut TestRng,
+        era_id: EraId,
+        height: u64,
+        is_switch: bool,
+    ) -> Self {
         let deploy_count = rng.gen_range(0, 11);
         let deploy_hashes = iter::repeat_with(|| DeployHash::new(Digest::random(rng)))
             .take(deploy_count)
@@ -438,7 +453,7 @@ impl FinalizedBlock {
 
         // TODO - make Timestamp deterministic.
         let timestamp = Timestamp::now();
-        let era_report = if rng.gen_bool(0.1) {
+        let era_report = if is_switch {
             let equivocators_count = rng.gen_range(0, 5);
             let rewards_count = rng.gen_range(0, 5);
             let inactive_count = rng.gen_range(0, 5);
@@ -462,7 +477,6 @@ impl FinalizedBlock {
         } else {
             None
         };
-        let era = rng.gen_range(0, 5);
         let secret_key: SecretKey = SecretKey::ed25519(rng.gen());
         let public_key = PublicKey::from(&secret_key);
 
@@ -470,8 +484,8 @@ impl FinalizedBlock {
             proto_block,
             timestamp,
             era_report,
-            EraId(era),
-            era * 10 + rng.gen_range(0, 10),
+            era_id,
+            height,
             public_key,
         )
     }
@@ -1132,9 +1146,24 @@ impl Block {
     /// Generates a random instance using a `TestRng`.
     #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
+        let era = rng.gen_range(0, 5);
+        let height = era * 10 + rng.gen_range(0, 10);
+        let is_switch = rng.gen_bool(0.1);
+
+        Block::random_with_specifics(rng, EraId(era), height, is_switch)
+    }
+
+    /// Generates a random instance using a `TestRng`, but using the specified era ID and height.
+    #[cfg(test)]
+    pub fn random_with_specifics(
+        rng: &mut TestRng,
+        era_id: EraId,
+        height: u64,
+        is_switch: bool,
+    ) -> Self {
         let parent_hash = BlockHash::new(Digest::random(rng));
         let state_root_hash = Digest::random(rng);
-        let finalized_block = FinalizedBlock::random(rng);
+        let finalized_block = FinalizedBlock::random_with_specifics(rng, era_id, height, is_switch);
         let parent_seed = Digest::random(rng);
         let protocol_version = ProtocolVersion::V1_0_0;
         let next_era_validator_weights = match finalized_block.era_report {

--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -81,6 +81,9 @@ impl FromBytes for GlobalStateUpdate {
 pub struct ProtocolConfig {
     #[data_size(skip)]
     pub(crate) version: Version,
+    /// Whether we need to clear latest blocks back to the switch block just before the activation
+    /// point or not.
+    pub(crate) hard_reset: bool,
     /// This protocol config applies starting at the era specified in the activation point.
     pub(crate) activation_point: ActivationPoint,
     /// Any arbitrary updates we might want to make to the global state at the start of the era
@@ -103,6 +106,7 @@ impl ProtocolConfig {
 
         ProtocolConfig {
             version: protocol_version,
+            hard_reset: rng.gen(),
             activation_point,
             global_state_update: None,
         }
@@ -113,6 +117,7 @@ impl ToBytes for ProtocolConfig {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         buffer.extend(self.version.to_string().to_bytes()?);
+        buffer.extend(self.hard_reset.to_bytes()?);
         buffer.extend(self.activation_point.era_id.to_bytes()?);
         buffer.extend(self.global_state_update.to_bytes()?);
         Ok(buffer)
@@ -120,6 +125,7 @@ impl ToBytes for ProtocolConfig {
 
     fn serialized_length(&self) -> usize {
         self.version.to_string().serialized_length()
+            + self.hard_reset.serialized_length()
             + self.activation_point.era_id.serialized_length()
             + self.global_state_update.serialized_length()
     }
@@ -130,6 +136,7 @@ impl FromBytes for ProtocolConfig {
         let (protocol_version_string, remainder) = String::from_bytes(bytes)?;
         let protocol_version =
             Version::parse(&protocol_version_string).map_err(|_| bytesrepr::Error::Formatting)?;
+        let (hard_reset, remainder) = bool::from_bytes(remainder)?;
         let (era_id, remainder) = EraId::from_bytes(remainder)?;
         let activation_point = ActivationPoint { era_id };
         let (global_state_update, remainder) = Option::<GlobalStateUpdate>::from_bytes(remainder)?;
@@ -137,6 +144,7 @@ impl FromBytes for ProtocolConfig {
             version: protocol_version,
             activation_point,
             global_state_update,
+            hard_reset,
         };
         Ok((protocol_config, remainder))
     }

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -1,6 +1,8 @@
 [protocol]
 # Protocol version.
 version = '1.0.0'
+# Whether we need to clear latest blocks back to the switch block just before the activation point or not.
+hard_reset = false
 
 [protocol.activation_point]
 # This protocol version becomes active at the start of this era.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,8 @@
 [protocol]
 # Protocol version.
 version = '1.0.0'
+# Whether we need to clear latest blocks back to the switch block just before the activation point or not.
+hard_reset = false
 
 [protocol.activation_point]
 # This protocol version becomes active at the start of this era.

--- a/resources/production/validation.md5
+++ b/resources/production/validation.md5
@@ -1,2 +1,2 @@
 1ce492ebe9a768f86df7016469862d0c  accounts.csv
-43471b0d6858833e8f6f625b515e1664  chainspec.toml
+18d28fc8abccfa080e0735ef3c88b557  chainspec.toml

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -1,5 +1,6 @@
 [protocol]
 version = '0.9.0'
+hard_reset = false
 
 [protocol.activation_point]
 era_id = 0

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -1,5 +1,6 @@
 [protocol]
 version = '1.0.0'
+hard_reset = false
 
 [protocol.activation_point]
 era_id = 1


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-895

This PR adds functionality which allows an upgrade chainspec to specify that the node should ignore all blocks created during and after a given era ID.

This will hopefully never be needed, but until our upgrades can handle starting mid-era, we can use this as a fallback mechanism.