### PR TITLE
NO TICKET memory stat gathering from sys-info for consumed mem

### DIFF
--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -553,7 +553,7 @@ where
 
         // mem_info gives us kB
         let total = mem_info.total * 1024;
-        let consumed = total - (mem_info.avail * 1024);
+        let consumed = total - (mem_info.free * 1024);
 
         // whereas jemalloc_ctl gives us the numbers in bytes
         match jemalloc_epoch::mib() {

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -333,6 +333,7 @@ impl RunnerMetrics {
         registry.register(Box::new(events.clone()))?;
         registry.register(Box::new(event_dispatch_duration.clone()))?;
         registry.register(Box::new(allocated_ram_bytes.clone()))?;
+        registry.register(Box::new(consumed_ram_bytes.clone()))?;
         registry.register(Box::new(total_ram_bytes.clone()))?;
 
         Ok(RunnerMetrics {
@@ -359,7 +360,7 @@ impl Drop for RunnerMetrics {
             .expect("did not expect deregistering allocated_ram_bytes to fail");
         self.registry
             .unregister(Box::new(self.consumed_ram_bytes.clone()))
-            .expect("did not expect deregistering allocated_ram_bytes to fail");
+            .expect("did not expect deregistering consumed_ram_bytes to fail");
         self.registry
             .unregister(Box::new(self.total_ram_bytes.clone()))
             .expect("did not expect deregistering total_ram_bytes to fail");


### PR DESCRIPTION
Adds a metric `consumed_ram_bytes` for total ram consumed as reported by sys-info. This is useful to compare and contrast what value we get from internal memory metrics.