### PR TITLE
NDRS-880: Add `nctl-upgrade-protocol` command.

### DIFF
--- a/utils/nctl/activate
+++ b/utils/nctl/activate
@@ -53,6 +53,7 @@ alias nctl-start-after-n-blocks='source $NCTL/sh/node/start_after_n_blocks.sh'
 alias nctl-start-after-n-eras='source $NCTL/sh/node/start_after_n_eras.sh'
 alias nctl-status='source $NCTL/sh/node/status.sh'
 alias nctl-stop='source $NCTL/sh/node/stop.sh'
+alias nctl-upgrade='source $NCTL/sh/node/upgrade.sh'
 
 # Blocking commands.
 alias nctl-await-n-blocks='source $NCTL/sh/misc/await_n_blocks.sh'

--- a/utils/nctl/activate
+++ b/utils/nctl/activate
@@ -53,7 +53,7 @@ alias nctl-start-after-n-blocks='source $NCTL/sh/node/start_after_n_blocks.sh'
 alias nctl-start-after-n-eras='source $NCTL/sh/node/start_after_n_eras.sh'
 alias nctl-status='source $NCTL/sh/node/status.sh'
 alias nctl-stop='source $NCTL/sh/node/stop.sh'
-alias nctl-upgrade='source $NCTL/sh/node/upgrade.sh'
+alias nctl-upgrade-protocol='source $NCTL/sh/node/upgrade.sh'
 
 # Blocking commands.
 alias nctl-await-n-blocks='source $NCTL/sh/misc/await_n_blocks.sh'

--- a/utils/nctl/sh/node/upgrade.sh
+++ b/utils/nctl/sh/node/upgrade.sh
@@ -12,11 +12,11 @@ for ARGUMENT in "$@"; do
     KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
     VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
     case "$KEY" in
-    protocolversion) PROTOCOL_VERSION=${VALUE} ;;
-    activateera) ACTIVATE_ERA=${VALUE} ;;
-    loglevel) LOG_LEVEL=${VALUE} ;;
-    node) NODE_ID=${VALUE} ;;
-    *) ;;
+        version) PROTOCOL_VERSION=${VALUE} ;;
+        era) ACTIVATE_ERA=${VALUE} ;;
+        loglevel) LOG_LEVEL=${VALUE} ;;
+        node) NODE_ID=${VALUE} ;;
+        *) ;;
     esac
 done
 

--- a/utils/nctl/sh/node/upgrade.sh
+++ b/utils/nctl/sh/node/upgrade.sh
@@ -16,7 +16,7 @@ for ARGUMENT in "$@"; do
         era) ACTIVATE_ERA=${VALUE} ;;
         loglevel) LOG_LEVEL=${VALUE} ;;
         node) NODE_ID=${VALUE} ;;
-        *) ;;
+        *) echo "Unknown argument '${KEY}'. Use 'version', 'era' or 'loglevel'." && exit 1;;
     esac
 done
 

--- a/utils/nctl/sh/node/upgrade.sh
+++ b/utils/nctl/sh/node/upgrade.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+source "$NCTL"/sh/utils/main.sh
+source "$NCTL"/sh/node/svc_"$NCTL_DAEMON_TYPE".sh
+
+unset LOG_LEVEL
+unset NODE_ID
+unset PROTOCOL_VERSION
+unset ACTIVATE_ERA
+
+for ARGUMENT in "$@"; do
+    KEY=$(echo "$ARGUMENT" | cut -f1 -d=)
+    VALUE=$(echo "$ARGUMENT" | cut -f2 -d=)
+    case "$KEY" in
+    protocolversion) PROTOCOL_VERSION=${VALUE} ;;
+    activateera) ACTIVATE_ERA=${VALUE} ;;
+    loglevel) LOG_LEVEL=${VALUE} ;;
+    node) NODE_ID=${VALUE} ;;
+    *) ;;
+    esac
+done
+
+LOG_LEVEL=${LOG_LEVEL:-$RUST_LOG}
+LOG_LEVEL=${LOG_LEVEL:-debug}
+export RUST_LOG=$LOG_LEVEL
+NODE_ID=${NODE_ID:-"all"}
+
+function do_upgrade() {
+    local PROTOCOL_VERSION=${1}
+    local ACTIVATE_ERA=${2}
+    local NODE_COUNT=${3:-5}
+
+    local PATH_TO_NET
+    local PATH_TO_NODE
+
+    PATH_TO_NET=$(get_path_to_net)
+
+    # Set file.
+    PATH_TO_CHAINSPEC_FILE="$PATH_TO_NET"/chainspec/chainspec.toml
+    mkdir -p "$PATH_TO_NET"/chainspec/"$PROTOCOL_VERSION"
+    PATH_TO_UPGRADED_CHAINSPEC_FILE="$PATH_TO_NET"/chainspec/"$PROTOCOL_VERSION"/chainspec.toml
+    cp "$PATH_TO_CHAINSPEC_FILE" "$PATH_TO_UPGRADED_CHAINSPEC_FILE"
+
+    # Write contents.
+    local SCRIPT=(
+        "import toml;"
+        "cfg=toml.load('$PATH_TO_CHAINSPEC_FILE');"
+        "cfg['protocol']['version']='$PROTOCOL_VERSION'.replace('_', '.');"
+        "cfg['protocol']['activation_point']['era_id']=$ACTIVATE_ERA;"
+        "toml.dump(cfg, open('$PATH_TO_UPGRADED_CHAINSPEC_FILE', 'w'));"
+    )
+    python3 -c "${SCRIPT[*]}"
+
+    for NODE_ID in $(seq 1 $((NODE_COUNT * 2))); do
+        PATH_TO_NODE=$(get_path_to_node "$NODE_ID")
+        # Copy the casper-node binary
+        mkdir -p "$PATH_TO_NODE"/bin/"$PROTOCOL_VERSION"
+        cp "$NCTL_CASPER_HOME"/target/release/casper-node "$PATH_TO_NODE"/bin/"$PROTOCOL_VERSION"/
+        # Copy chainspec
+        mkdir -p "$PATH_TO_NODE"/config/"$PROTOCOL_VERSION"/
+        cp "$PATH_TO_UPGRADED_CHAINSPEC_FILE" "$PATH_TO_NODE"/config/"$PROTOCOL_VERSION"/
+        # Copy config file
+        cp "$PATH_TO_NODE"/config/1_0_0/config.toml "$PATH_TO_NODE"/config/"$PROTOCOL_VERSION"/
+    done
+}
+
+# ----------------------------------------------------------------
+# MAIN
+# ----------------------------------------------------------------
+
+# Upgrade node(s).
+log "upgrade node(s) begins ... please wait"
+do_upgrade "$PROTOCOL_VERSION" "$ACTIVATE_ERA"
+log "upgrade node(s) complete"
+
+# Display status.
+sleep 1.0
+source "$NCTL"/sh/node/status.sh node="$NODE_ID"


### PR DESCRIPTION
This PR adds a new nctl command `nctl-upgrade-protocol`. The command takes two arguments `version` and `era`. Version is expected to be in format `X_Y_Z`.

The command will create `version` directories in all `node-X` directories and copy required files (`casper-node` binary, chainspec and config files). Chainspec will only be updated with the new protocol version and `activation_point.era`. No other changes to the protocol are made.

### Notes

We recognize that this code is not exactly up to `nctl` standards but the command is proving very useful when testing the node upgrades so we want to give it to people early while committing to improving the code as soon as possible.