### PR TITLE
NDRS-915: add inactive field to JsonBids

### DIFF
--- a/node/src/types/json_compatibility/auction_state.rs
+++ b/node/src/types/json_compatibility/auction_state.rs
@@ -94,6 +94,8 @@ pub struct JsonBid {
     delegation_rate: DelegationRate,
     /// The delegators.
     delegators: Vec<JsonDelegator>,
+    /// Is this an inactive validator.
+    inactive: bool,
 }
 
 impl From<Bid> for JsonBid {
@@ -110,6 +112,7 @@ impl From<Bid> for JsonBid {
             staked_amount: *bid.staked_amount(),
             delegation_rate: *bid.delegation_rate(),
             delegators: json_delegators,
+            inactive: bid.inactive(),
         }
     }
 }


### PR DESCRIPTION
This PR adds the inactive field to the JsonBids structure.

https://casperlabs.atlassian.net/browse/NDRS-915