### PR TITLE
NO-TICKET: add public key and round length to status endpoint

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -34,8 +34,9 @@ use crate::{
     effect::{
         announcements::ConsensusAnnouncement,
         requests::{
-            self, BlockExecutorRequest, BlockProposerRequest, BlockValidationRequest,
-            ChainspecLoaderRequest, ContractRuntimeRequest, NetworkRequest, StorageRequest,
+            BlockExecutorRequest, BlockProposerRequest, BlockValidationRequest,
+            ChainspecLoaderRequest, ConsensusRequest, ContractRuntimeRequest, NetworkRequest,
+            StorageRequest,
         },
         EffectBuilder, Effects,
     },
@@ -91,7 +92,7 @@ pub enum Event<I> {
         block_context: BlockContext,
     },
     #[from]
-    ConsensusRequest(requests::ConsensusRequest),
+    ConsensusRequest(ConsensusRequest),
     /// The proto-block has been validated.
     ResolveValidity {
         era_id: EraId,
@@ -292,10 +293,9 @@ where
                 proto_block,
                 block_context,
             } => handling_es.handle_new_proto_block(era_id, proto_block, block_context),
-            Event::ConsensusRequest(requests::ConsensusRequest::HandleLinearBlock(
-                block,
-                responder,
-            )) => handling_es.handle_linear_chain_block(*block, responder),
+            Event::ConsensusRequest(ConsensusRequest::HandleLinearBlock(block, responder)) => {
+                handling_es.handle_linear_chain_block(*block, responder)
+            }
             Event::ResolveValidity {
                 era_id,
                 sender,
@@ -340,11 +340,12 @@ where
             Event::GotUpgradeActivationPoint(activation_point) => {
                 handling_es.got_upgrade_activation_point(activation_point)
             }
-            Event::ConsensusRequest(requests::ConsensusRequest::IsBondedValidator(
-                era_id,
-                pk,
-                responder,
-            )) => handling_es.is_bonded_validator(era_id, pk, responder),
+            Event::ConsensusRequest(ConsensusRequest::IsBondedValidator(era_id, pk, responder)) => {
+                handling_es.is_bonded_validator(era_id, pk, responder)
+            }
+            Event::ConsensusRequest(ConsensusRequest::Status(responder)) => {
+                handling_es.status(responder)
+            }
         }
     }
 }

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -205,5 +205,6 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
     /// TODO: Remove this once the Joiner no longer has a consensus component.
     fn recreate_timers(&self) -> Vec<ProtocolOutcome<I, C>>;
 
+    // TODO: Make this lees Highway-specific.
     fn next_round_length(&self) -> Option<TimeDiff>;
 }

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     components::consensus::{traits::Context, ActionId, TimerId},
-    types::Timestamp,
+    types::{TimeDiff, Timestamp},
     NodeRng,
 };
 
@@ -204,4 +204,6 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
     /// Returns the protocol outcomes for all the required timers.
     /// TODO: Remove this once the Joiner no longer has a consensus component.
     fn recreate_timers(&self) -> Vec<ProtocolOutcome<I, C>>;
+
+    fn next_round_length(&self) -> Option<TimeDiff>;
 }

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -607,6 +607,10 @@ impl<C: Context> ActiveValidator<C> {
             Vertex::Evidence(_) => false,
         }
     }
+
+    pub(crate) fn next_round_length(&self) -> TimeDiff {
+        state::round_len(self.next_round_exp)
+    }
 }
 
 #[cfg(test)]

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -22,7 +22,7 @@ use crate::{
         },
         traits::Context,
     },
-    types::Timestamp,
+    types::{TimeDiff, Timestamp},
     NodeRng,
 };
 
@@ -646,6 +646,12 @@ impl<C: Context> Highway<C> {
     /// Returns the instance ID of this Highway instance.
     pub(crate) fn instance_id(&self) -> &C::InstanceId {
         &self.instance_id
+    }
+
+    pub(crate) fn next_round_length(&self) -> Option<TimeDiff> {
+        self.active_validator
+            .as_ref()
+            .map(|av| av.next_round_length())
     }
 }
 

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -357,22 +357,19 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     /// Returns the median round exponent of all the validators that haven't been observed to be
     /// malicious, as seen by the current panorama.
     /// Returns `None` if there are no correct validators in the panorama.
-    pub(crate) fn median_round_exp(&self) -> Option<u8> {
+    fn median_round_exp(&self) -> Option<u8> {
         self.highway.state().median_round_exp()
     }
 
     /// Returns an instance of `RoundSuccessMeter` for the new era: resetting the counters where
     /// appropriate.
-    pub(crate) fn next_era_round_succ_meter(
-        &self,
-        era_start_timestamp: Timestamp,
-    ) -> RoundSuccessMeter<C> {
+    fn next_era_round_succ_meter(&self, era_start_timestamp: Timestamp) -> RoundSuccessMeter<C> {
         self.round_success_meter.next_era(era_start_timestamp)
     }
 
     /// Returns an iterator over all the values that are expected to become finalized, but are not
     /// finalized yet.
-    pub(crate) fn non_finalized_values(
+    fn non_finalized_values(
         &self,
         mut fork_choice: Option<C::Hash>,
     ) -> impl Iterator<Item = &C::ConsensusValue> {
@@ -782,5 +779,9 @@ where
         );
 
         outcomes
+    }
+
+    fn next_round_length(&self) -> Option<TimeDiff> {
+        self.highway.next_round_length()
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -84,6 +84,7 @@ use casper_execution_engine::{
         execute_request::ExecuteRequest,
         execution_result::ExecutionResults,
         genesis::GenesisResult,
+        put_trie::InsertedTrieKeyAndMissingDescendants,
         step::{StepRequest, StepResult},
         upgrade::{UpgradeConfig, UpgradeResult},
         BalanceRequest, BalanceResult, QueryRequest, QueryResult, MAX_PAYMENT,
@@ -113,7 +114,7 @@ use crate::{
     types::{
         Block, BlockByHeight, BlockHash, BlockHeader, BlockLike, BlockSignatures, Chainspec,
         ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
-        FinalizedBlock, Item, ProtoBlock, Timestamp,
+        FinalizedBlock, Item, ProtoBlock, TimeDiff, Timestamp,
     },
     utils::Source,
 };
@@ -122,7 +123,6 @@ use announcements::{
     DeployAcceptorAnnouncement, GossiperAnnouncement, LinearChainAnnouncement, NetworkAnnouncement,
     RpcServerAnnouncement,
 };
-use casper_execution_engine::core::engine_state::put_trie::InsertedTrieKeyAndMissingDescendants;
 use requests::{
     BlockExecutorRequest, BlockProposerRequest, BlockValidationRequest, ChainspecLoaderRequest,
     ConsensusRequest, ContractRuntimeRequest, FetcherRequest, MetricsRequest, NetworkInfoRequest,
@@ -1463,6 +1463,15 @@ impl<REv> EffectBuilder<REv> {
             QueueKind::Regular,
         )
         .await
+    }
+
+    /// Get our public key from consensus, and if we're a validator, the next round length.
+    pub(crate) async fn consensus_status(self) -> (PublicKey, Option<TimeDiff>)
+    where
+        REv: From<ConsensusRequest>,
+    {
+        self.make_request(ConsensusRequest::Status, QueueKind::Regular)
+            .await
     }
 
     /// Check if validator is bonded in the future era (`era_id`).

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -24,12 +24,16 @@ use casper_execution_engine::{
         execute_request::ExecuteRequest,
         execution_result::ExecutionResults,
         genesis::GenesisResult,
+        put_trie::InsertedTrieKeyAndMissingDescendants,
         query::{QueryRequest, QueryResult},
         step::{StepRequest, StepResult},
         upgrade::{UpgradeConfig, UpgradeResult},
     },
-    shared::{additive_map::AdditiveMap, transform::Transform},
-    storage::{global_state::CommitResult, protocol_data::ProtocolData},
+    shared::{
+        additive_map::AdditiveMap, newtypes::Blake2bHash, stored_value::StoredValue,
+        transform::Transform,
+    },
+    storage::{global_state::CommitResult, protocol_data::ProtocolData, trie::Trie},
 };
 use casper_types::{
     system::auction::{EraValidators, ValidatorWeights},
@@ -49,14 +53,9 @@ use crate::{
     types::{
         Block as LinearBlock, Block, BlockHash, BlockHeader, BlockSignatures, Chainspec,
         ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
-        FinalizedBlock, Item, NodeId, ProtoBlock, StatusFeed, Timestamp,
+        FinalizedBlock, Item, NodeId, ProtoBlock, StatusFeed, TimeDiff, Timestamp,
     },
     utils::DisplayIter,
-};
-use casper_execution_engine::{
-    core::engine_state::put_trie::InsertedTrieKeyAndMissingDescendants,
-    shared::{newtypes::Blake2bHash, stored_value::StoredValue},
-    storage::trie::Trie,
 };
 
 const _STORAGE_REQUEST_SIZE: usize = mem::size_of::<StorageRequest>();
@@ -960,6 +959,8 @@ pub enum ConsensusRequest {
     HandleLinearBlock(Box<Block>, Responder<Option<FinalitySignature>>),
     /// Check whether validator identifying with the public key is bonded.
     IsBondedValidator(EraId, PublicKey, Responder<bool>),
+    /// Request for our public key, and if we're a validator, the next round length.
+    Status(Responder<(PublicKey, Option<TimeDiff>)>),
 }
 
 /// ChainspecLoader component requests.


### PR DESCRIPTION
This PR enhances the status endpoints by providing the public signing key of the node and the next round length if the node is a validator.  Example output:

```json
{
  "api_version": "1.0.0",
  "chainspec_name": "casper-net-1",
  "starting_state_root_hash": "fd7b..0314",
  "peers": [
    {
      "node_id": "NodeId::Tls(470b..d032)",
      "address": "127.0.0.1:34554"
    },
    {
      "node_id": "NodeId::Tls(606d..b959)",
      "address": "127.0.0.1:34555"
    },
    {
      "node_id": "NodeId::Tls(a0ef..4e84)",
      "address": "127.0.0.1:34557"
    },
    {
      "node_id": "NodeId::Tls(e85b..0726)",
      "address": "127.0.0.1:34556"
    }
  ],
  "last_added_block_info": {
    "hash": "4453a99848956ad0b81883c78e6434a58997e0532314b4125746a0ee7e7accb6",
    "timestamp": "2021-02-19T00:28:12.672Z",
    "era_id": 3,
    "height": 39,
    "state_root_hash": "ba922bb17997a4481f3f3850560c7e209b3fee889d2b66926650480c8cfaa29f",
    "creator": "015ac2b49f86688057fc2426bf16067bfe428fbb33d1007f1c1583e7f59233cedd"
  },
  "our_public_signing_key": "011925e95db3df8da31ee8dc406471cc29cd413a6ee0dc08aef3eb5732a7b63f07",
  "round_length": "4s 96ms",
  "next_upgrade": null,
  "build_version": "0.9.0-7f5425bf"
}
```