### PR TITLE
EE-1168: refactor Mint to remove use of named keys

### DIFF
--- a/client/lib/validation.rs
+++ b/client/lib/validation.rs
@@ -187,10 +187,7 @@ pub(crate) fn validate_get_balance_response(
         .as_object()
         .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
 
-    let (purse_proof, balance_proof): (
-        TrieMerkleProof<Key, StoredValue>,
-        TrieMerkleProof<Key, StoredValue>,
-    ) = {
+    let balance_proof: TrieMerkleProof<Key, StoredValue> = {
         let proof = object
             .get(GET_ITEM_RESULT_MERKLE_PROOF)
             .ok_or(ValidateResponseError::ValidateResponseFailedToParse)?;
@@ -215,7 +212,6 @@ pub(crate) fn validate_get_balance_response(
 
     core::validate_balance_proof(
         &state_root_hash.to_owned().into(),
-        &purse_proof,
         &balance_proof,
         *key,
         &balance,

--- a/execution_engine/src/core/engine_state/balance.rs
+++ b/execution_engine/src/core/engine_state/balance.rs
@@ -10,8 +10,7 @@ pub enum BalanceResult {
     RootNotFound,
     Success {
         motes: U512,
-        purse_proof: Box<TrieMerkleProof<Key, StoredValue>>,
-        balance_proof: Box<TrieMerkleProof<Key, StoredValue>>,
+        proof: Box<TrieMerkleProof<Key, StoredValue>>,
     },
 }
 
@@ -23,18 +22,9 @@ impl BalanceResult {
         }
     }
 
-    pub fn proofs(
-        self,
-    ) -> Option<(
-        TrieMerkleProof<Key, StoredValue>,
-        TrieMerkleProof<Key, StoredValue>,
-    )> {
+    pub fn proof(self) -> Option<TrieMerkleProof<Key, StoredValue>> {
         match self {
-            BalanceResult::Success {
-                purse_proof,
-                balance_proof,
-                ..
-            } => Some((*purse_proof, *balance_proof)),
+            BalanceResult::Success { proof, .. } => Some(*proof),
             _ => None,
         }
     }

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -505,18 +505,13 @@ where
             Some(tracking_copy) => tracking_copy,
             None => return Ok(BalanceResult::RootNotFound),
         };
-        let (purse_balance_key, purse_proof) =
-            tracking_copy.get_purse_balance_key_with_proof(correlation_id, purse_uref.into())?;
-        let (balance, balance_proof) =
+        let purse_balance_key =
+            tracking_copy.get_purse_balance_key(correlation_id, purse_uref.into())?;
+        let (balance, proof) =
             tracking_copy.get_purse_balance_with_proof(correlation_id, purse_balance_key)?;
-        let purse_proof = Box::new(purse_proof);
-        let balance_proof = Box::new(balance_proof);
+        let proof = Box::new(proof);
         let motes = balance.value();
-        Ok(BalanceResult::Success {
-            motes,
-            purse_proof,
-            balance_proof,
-        })
+        Ok(BalanceResult::Success { motes, proof })
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/execution_engine/src/core/engine_state/transfer.rs
+++ b/execution_engine/src/core/engine_state/transfer.rs
@@ -107,10 +107,16 @@ impl TransferRuntimeArgsBuilder {
         R: StateReader<Key, StoredValue>,
         R::Error: Into<ExecError>,
     {
-        // it is a URef but is it a purse URef?
-        tracking_copy
+        let key = match tracking_copy
             .borrow_mut()
             .get_purse_balance_key(correlation_id, uref.into())
+        {
+            Ok(key) => key,
+            Err(_) => return false,
+        };
+        tracking_copy
+            .borrow_mut()
+            .get_purse_balance(correlation_id, key)
             .is_ok()
     }
 

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -95,6 +95,7 @@ pub fn key_to_tuple(key: Key) -> Option<([u8; 32], AccessRights)> {
         Key::Transfer(_) => None,
         Key::DeployInfo(_) => None,
         Key::EraInfo(_) => None,
+        Key::Balance(_) => None,
     }
 }
 

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -2982,25 +2982,15 @@ where
     }
 
     fn get_balance(&mut self, purse: URef) -> Result<Option<U512>, Error> {
-        let balance_uref_key = match self.context.read_purse_uref(&purse)? {
-            Some(cl_value) => {
-                let key: Key = cl_value.into_t()?;
-                if key.as_uref().is_none() {
-                    return Err(Error::KeyIsNotAURef(key));
-                }
-                key
+        let maybe_value = self.context.read_gs_direct(&Key::Balance(purse.addr()))?;
+        match maybe_value {
+            Some(StoredValue::CLValue(value)) => {
+                let value = CLValue::into_t(value)?;
+                Ok(Some(value))
             }
-            None => return Ok(None),
-        };
-        let ret = match self.context.read_gs_direct(&balance_uref_key)? {
-            Some(StoredValue::CLValue(cl_value)) => {
-                let balance: U512 = cl_value.into_t()?;
-                Some(balance)
-            }
-            Some(_) => return Err(Error::UnexpectedStoredValueVariant),
-            None => None,
-        };
-        Ok(ret)
+            Some(_) => Err(Error::UnexpectedStoredValueVariant),
+            None => Ok(None),
+        }
     }
 
     fn get_balance_host_buffer(

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -248,6 +248,10 @@ where
                 // Users cannot remove era infos from global state
                 Ok(())
             }
+            Key::Balance(_) => {
+                self.named_keys.remove(name);
+                Ok(())
+            }
         }
     }
 
@@ -649,6 +653,7 @@ where
             Key::Transfer(_) => true,
             Key::DeployInfo(_) => true,
             Key::EraInfo(_) => true,
+            Key::Balance(_) => false,
         }
     }
 
@@ -660,6 +665,7 @@ where
             Key::Transfer(_) => false,
             Key::DeployInfo(_) => false,
             Key::EraInfo(_) => false,
+            Key::Balance(_) => false,
         }
     }
 
@@ -671,6 +677,7 @@ where
             Key::Transfer(_) => false,
             Key::DeployInfo(_) => false,
             Key::EraInfo(_) => false,
+            Key::Balance(_) => false,
         }
     }
 

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -776,7 +776,11 @@ where
         Ok(())
     }
 
-    fn metered_add_gs_unsafe(&mut self, key: Key, value: StoredValue) -> Result<(), Error> {
+    pub(crate) fn metered_add_gs_unsafe(
+        &mut self,
+        key: Key,
+        value: StoredValue,
+    ) -> Result<(), Error> {
         let value_bytes_count = value.serialized_length();
         self.charge_gas_storage(value_bytes_count)?;
 

--- a/execution_engine_testing/test_support/src/internal/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/internal/wasm_test_builder.rs
@@ -711,15 +711,7 @@ where
     }
 
     pub fn get_purse_balance(&self, purse: URef) -> U512 {
-        let purse_addr = purse.addr();
-        let balance_mapping_key = Key::Hash(purse_addr);
-
-        let base_key = self
-            .query(None, balance_mapping_key, &[])
-            .and_then(|v| CLValue::try_from(v).map_err(|error| format!("{:?}", error)))
-            .and_then(|cl_value| cl_value.into_t().map_err(|error| format!("{:?}", error)))
-            .expect("should find balance uref");
-
+        let base_key = Key::Balance(purse.addr());
         self.query(None, base_key, &[])
             .and_then(|v| CLValue::try_from(v).map_err(|error| format!("{:?}", error)))
             .and_then(|cl_value| cl_value.into_t().map_err(|error| format!("{:?}", error)))

--- a/execution_engine_testing/tests/src/test/contract_api/transfer_purse_to_purse.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/transfer_purse_to_purse.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use casper_types::{runtime_args, system::mint, ApiError, CLValue, Key, RuntimeArgs, U512};
+use casper_types::{runtime_args, system::mint, ApiError, CLValue, RuntimeArgs, U512};
 
 use casper_engine_test_support::{
     internal::{
@@ -74,32 +74,8 @@ fn should_run_purse_to_purse_transfer() {
 
     // Assert secondary purse value after successful transfer
     let purse_secondary_key = default_account.named_keys()["purse:secondary"];
-    let _purse_main_key = default_account.named_keys()["purse:main"];
-
-    // Lookup key used to find the actual purse uref
-    // TODO: This should be more consistent
-    let purse_secondary_lookup_key = purse_secondary_key
-        .as_uref()
-        .unwrap()
-        .remove_access_rights()
-        .to_formatted_string();
-
-    let mint_contract_hash = builder.get_mint_contract_hash();
-    let mint_contract = builder
-        .get_contract(mint_contract_hash)
-        .expect("should have mint contract");
-
-    // Find `purse:secondary`.
-    let purse_secondary_uref = mint_contract.named_keys()[&purse_secondary_lookup_key];
-    let purse_secondary_key: Key = purse_secondary_uref.normalize();
-    let purse_secondary_balance = CLValue::try_from(
-        builder
-            .query(None, purse_secondary_key, &[])
-            .expect("should have main purse balance"),
-    )
-    .expect("should be a CLValue")
-    .into_t::<U512>()
-    .expect("should be U512");
+    let purse_secondary_uref = purse_secondary_key.into_uref().unwrap();
+    let purse_secondary_balance = builder.get_purse_balance(purse_secondary_uref);
 
     // Final balance of the destination purse
     assert_eq!(purse_secondary_balance, U512::from(PURSE_TO_PURSE_AMOUNT));
@@ -167,32 +143,8 @@ fn should_run_purse_to_purse_transfer_with_error() {
 
     // Assert secondary purse value after successful transfer
     let purse_secondary_key = default_account.named_keys()["purse:secondary"];
-    let _purse_main_key = default_account.named_keys()["purse:main"];
-
-    // Lookup key used to find the actual purse uref
-    // TODO: This should be more consistent
-    let purse_secondary_lookup_key = purse_secondary_key
-        .as_uref()
-        .unwrap()
-        .remove_access_rights()
-        .to_formatted_string();
-
-    let mint_contract_uref = builder.get_mint_contract_hash();
-    let mint_contract = builder
-        .get_contract(mint_contract_uref)
-        .expect("should have mint contract");
-
-    // Find `purse:secondary` for a balance
-    let purse_secondary_uref = mint_contract.named_keys()[&purse_secondary_lookup_key];
-    let purse_secondary_key: Key = purse_secondary_uref.normalize();
-    let purse_secondary_balance = CLValue::try_from(
-        builder
-            .query(None, purse_secondary_key, &[])
-            .expect("should have main purse balance"),
-    )
-    .expect("should be a CLValue")
-    .into_t::<U512>()
-    .expect("should be U512");
+    let purse_secondary_uref = purse_secondary_key.into_uref().unwrap();
+    let purse_secondary_balance = builder.get_purse_balance(purse_secondary_uref);
 
     // Final balance of the destination purse equals to 0 as this purse is created
     // as new.

--- a/node/src/components/rpc_server/rpcs/state.rs
+++ b/node/src/components/rpc_server/rpcs/state.rs
@@ -245,12 +245,8 @@ impl RpcWithParamsExt for GetBalance {
                 )
                 .await;
 
-            let (balance_value, purse_proof, balance_proof) = match balance_result {
-                Ok(BalanceResult::Success {
-                    motes,
-                    purse_proof,
-                    balance_proof,
-                }) => (motes, purse_proof, balance_proof),
+            let (balance_value, balance_proof) = match balance_result {
+                Ok(BalanceResult::Success { motes, proof }) => (motes, proof),
                 Ok(balance_result) => {
                     let error_msg = format!("get-balance failed: {:?}", balance_result);
                     info!("{}", error_msg);
@@ -269,7 +265,7 @@ impl RpcWithParamsExt for GetBalance {
                 }
             };
 
-            let proof_bytes = match (*purse_proof, *balance_proof).to_bytes() {
+            let proof_bytes = match balance_proof.to_bytes() {
                 Ok(proof_bytes) => proof_bytes,
                 Err(error) => {
                     info!("failed to encode stored value: {}", error);

--- a/types/src/system/mint/storage_provider.rs
+++ b/types/src/system/mint/storage_provider.rs
@@ -1,19 +1,13 @@
 use crate::{
     bytesrepr::{FromBytes, ToBytes},
     system::mint::Error,
-    CLTyped, Key, URef,
+    CLTyped, URef, U512,
 };
 
 /// Provides functionality of a contract storage.
 pub trait StorageProvider {
     /// Create new [`URef`].
     fn new_uref<T: CLTyped + ToBytes>(&mut self, init: T) -> Result<URef, Error>;
-
-    /// Write data to a local key.
-    fn write_balance_entry(&mut self, purse_uref: URef, balance_uref: URef) -> Result<(), Error>;
-
-    /// Read data from a local key.
-    fn read_balance_entry(&mut self, purse_uref: &URef) -> Result<Option<Key>, Error>;
 
     /// Read data from [`URef`].
     fn read<T: CLTyped + FromBytes>(&mut self, uref: URef) -> Result<Option<T>, Error>;
@@ -23,4 +17,13 @@ pub trait StorageProvider {
 
     /// Add data to a [`URef`].
     fn add<T: CLTyped + ToBytes>(&mut self, uref: URef, value: T) -> Result<(), Error>;
+
+    /// Read balance.
+    fn read_balance(&mut self, uref: URef) -> Result<Option<U512>, Error>;
+
+    /// Write balance.
+    fn write_balance(&mut self, uref: URef, balance: U512) -> Result<(), Error>;
+
+    /// Add amount to an existing balance.
+    fn add_balance(&mut self, uref: URef, value: U512) -> Result<(), Error>;
 }


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1168

This PR
- introduces a `Key::Balance` variant, under which balance values are stored.  These values are only readable and writable by host-side code.
- removes the various URefs used for indirection in the mint code.
- simplifies the structure of balance proofs now that the indirection is gone.
