### PR TITLE
NO-TICKET/Improve libp2p network memory metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,9 +1430,9 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "datasize"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7deb58b702f32765451051876bc9057269d83c9a5125544da3cddc3c36ea69c"
+checksum = "4cfa50a16bc31c1e8d1682876a26aa205e6669ac65645ae484064cbbc5263abc"
 dependencies = [
  "datasize_derive",
  "fake_instant",
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "datasize_derive"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820933a47a76ad9e04cc8d8a767ff178efd2890ced2ffd809ff60906cbdbd160"
+checksum = "2ebcbe9ac751b6e1700a10201b44ae32fa36396b46849fdb4f7ec5fb86326de3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
  "casper-node-macros",
  "casper-types",
  "chrono",
+ "csv",
  "datasize",
  "derive_more",
  "derp",
@@ -1429,9 +1430,9 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "datasize"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29aa9e31c464bc82c5965d92a28ff5895df6e5e35b2831fe679ced73c63d908"
+checksum = "a7deb58b702f32765451051876bc9057269d83c9a5125544da3cddc3c36ea69c"
 dependencies = [
  "datasize_derive",
  "fake_instant",
@@ -1443,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "datasize_derive"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ae1242652da371636ee090f259c142d82bd6cbf00496fdf3093fda61683175"
+checksum = "820933a47a76ad9e04cc8d8a767ff178efd2890ced2ffd809ff60906cbdbd160"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,6 @@ dependencies = [
  "casper-node-macros",
  "casper-types",
  "chrono",
- "csv",
  "datasize",
  "derive_more",
  "derp",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ casper-node-macros = { version = "0.9.0", path = "../node_macros" }
 casper-types = { version = "0.9.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 csv = "1.1.3"
-datasize = { version = "0.2.8", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types", "tokio-types"] }
+datasize = { version = "0.2.9", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types", "tokio-types"] }
 derive_more = "0.99.7"
 derp = "0.0.14"
 directories = "3.0.1"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,7 +23,8 @@ casper-execution-engine = { version = "0.9.0", path = "../execution_engine" }
 casper-node-macros = { version = "0.9.0", path = "../node_macros" }
 casper-types = { version = "0.9.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
-datasize = { version = "0.2.6", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types", "tokio-types"] }
+csv = "1.1.3"
+datasize = { version = "0.2.8", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types", "tokio-types"] }
 derive_more = "0.99.7"
 derp = "0.0.14"
 directories = "3.0.1"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,7 +23,6 @@ casper-execution-engine = { version = "0.9.0", path = "../execution_engine" }
 casper-node-macros = { version = "0.9.0", path = "../node_macros" }
 casper-types = { version = "0.9.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
-csv = "1.1.3"
 datasize = { version = "0.2.9", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types", "tokio-types"] }
 derive_more = "0.99.7"
 derp = "0.0.14"

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -60,7 +60,7 @@ use crate::{
     fatal,
     reactor::{EventQueueHandle, Finalize, QueueKind},
     types::{Chainspec, NodeId},
-    utils::{counting_unbounded_channel, ds, CountingReceiver, CountingSender, DisplayIter},
+    utils::{self, ds, CountingReceiver, CountingSender, DisplayIter},
     NodeRng,
 };
 
@@ -184,8 +184,9 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
             return Err(Error::NoKnownAddress);
         }
 
-        let (one_way_message_sender, one_way_message_receiver) = counting_unbounded_channel();
-        let (gossip_message_sender, gossip_message_receiver) = counting_unbounded_channel();
+        let (one_way_message_sender, one_way_message_receiver) =
+            utils::counting_unbounded_channel();
+        let (gossip_message_sender, gossip_message_receiver) = utils::counting_unbounded_channel();
         let (server_shutdown_sender, server_shutdown_receiver) = watch::channel(());
 
         // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, start the server and exit.

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -233,7 +233,12 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
             .boxed();
 
         // Create a Swarm to manage peers and events.
-        let behavior = Behavior::new(&config, chainspec, network_identity.keypair.public());
+        let behavior = Behavior::new(
+            registry,
+            &config,
+            chainspec,
+            network_identity.keypair.public(),
+        );
         let mut swarm = SwarmBuilder::new(transport, behavior, our_peer_id)
             .executor(Box::new(|future| {
                 tokio::spawn(future);

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -147,6 +147,14 @@ pub struct Network<REv, P> {
     net_metrics: NetworkingMetrics,
 
     _phantom: PhantomData<(REv, P)>,
+
+    // TODO: Replace with proper metrics module.
+    #[data_size(skip)]
+    in_flight_read_futures: prometheus::Gauge,
+    #[data_size(skip)]
+    in_flight_write_futures: prometheus::Gauge,
+    #[data_size(skip)]
+    registry: Registry,
 }
 
 impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
@@ -186,6 +194,26 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
         let (gossip_message_sender, gossip_message_receiver) = mpsc::unbounded_channel();
         let (server_shutdown_sender, server_shutdown_receiver) = watch::channel(());
 
+        // Metrics, for now:
+        let in_flight_read_futures = prometheus::Gauge::new(
+            "owm_read_reaponse_futures",
+            "number of do-nothing futures in flight created by `Codec::read_response`",
+        )
+        .expect("could not create metric");
+        let in_flight_write_futures = prometheus::Gauge::new(
+            "owm_write_response_futures",
+            "number of do-nothing futures in flight created by `Codec::write_response`",
+        )
+        .expect("could not create metric");
+
+        // TODO: Handle errors properly in metrics.
+        registry
+            .register(Box::new(in_flight_read_futures.clone()))
+            .expect("register failed");
+        registry
+            .register(Box::new(in_flight_write_futures.clone()))
+            .expect("register failed");
+
         // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, start the server and exit.
         if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
             let network = Network {
@@ -204,6 +232,10 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
                 server_join_handle: None,
                 net_metrics: NetworkingMetrics::new(&Registry::default())?,
                 _phantom: PhantomData,
+
+                registry: registry.clone(),
+                in_flight_read_futures,
+                in_flight_write_futures,
             };
             return Ok((network, Effects::new()));
         }
@@ -234,8 +266,9 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
 
         // Create a Swarm to manage peers and events.
         let behavior = Behavior::new(
-            registry,
             &config,
+            in_flight_read_futures.clone(),
+            in_flight_write_futures.clone(),
             chainspec,
             network_identity.keypair.public(),
         );
@@ -294,6 +327,10 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
             server_join_handle,
             net_metrics,
             _phantom: PhantomData,
+
+            registry: registry.clone(),
+            in_flight_read_futures,
+            in_flight_write_futures,
         };
         Ok((network, Effects::new()))
     }
@@ -410,6 +447,19 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
     #[cfg(test)]
     pub(crate) fn seen_peers(&self) -> &HashSet<PeerId> {
         &self.seen_peers
+    }
+}
+
+impl<REv, P> Drop for Network<REv, P> {
+    fn drop(&mut self) {
+        self.registry
+            .unregister(Box::new(self.in_flight_read_futures.clone()))
+            .map_err(|err| warn!(%err, "failed to unregister `in_flight_read_futures`"))
+            .ok();
+        self.registry
+            .unregister(Box::new(self.in_flight_write_futures.clone()))
+            .map_err(|err| warn!(%err, "failed to unregister `in_flight_write_futures`"))
+            .ok();
     }
 }
 

--- a/node/src/components/network/behavior.rs
+++ b/node/src/components/network/behavior.rs
@@ -13,6 +13,7 @@ use libp2p::{
     swarm::{NetworkBehaviourAction, NetworkBehaviourEventProcess, PollParameters},
     Multiaddr, NetworkBehaviour, PeerId,
 };
+use prometheus::Registry;
 use tracing::{debug, trace, warn};
 
 use super::{
@@ -48,8 +49,13 @@ pub(super) struct Behavior {
 }
 
 impl Behavior {
-    pub(super) fn new(config: &Config, chainspec: &Chainspec, our_public_key: PublicKey) -> Self {
-        let one_way_message_behavior = one_way_messaging::new_behavior(config, chainspec);
+    pub(super) fn new(
+        registry: &Registry,
+        config: &Config,
+        chainspec: &Chainspec,
+        our_public_key: PublicKey,
+    ) -> Self {
+        let one_way_message_behavior = one_way_messaging::new_behavior(registry, config, chainspec);
 
         let gossip_behavior = gossip::new_behavior(config, chainspec, our_public_key.clone());
 

--- a/node/src/components/network/behavior.rs
+++ b/node/src/components/network/behavior.rs
@@ -19,7 +19,10 @@ use super::{
     gossip::{self, TOPIC},
     one_way_messaging, peer_discovery, Config, GossipMessage, OneWayCodec, OneWayOutgoingMessage,
 };
-use crate::types::{Chainspec, NodeId};
+use crate::{
+    components::networking_metrics::NetworkingMetrics,
+    types::{Chainspec, NodeId},
+};
 
 /// An enum defining the top-level events passed to the swarm's handler.  This will be received in
 /// the swarm's handler wrapped in a `SwarmEvent::Behaviour`.
@@ -50,17 +53,12 @@ pub(super) struct Behavior {
 impl Behavior {
     pub(super) fn new(
         config: &Config,
-        in_flight_read_futures: prometheus::Gauge,
-        in_flight_write_futures: prometheus::Gauge,
+        net_metrics: &NetworkingMetrics,
         chainspec: &Chainspec,
         our_public_key: PublicKey,
     ) -> Self {
-        let one_way_message_behavior = one_way_messaging::new_behavior(
-            config,
-            in_flight_read_futures,
-            in_flight_write_futures,
-            chainspec,
-        );
+        let one_way_message_behavior =
+            one_way_messaging::new_behavior(config, net_metrics, chainspec);
 
         let gossip_behavior = gossip::new_behavior(config, chainspec, our_public_key.clone());
 

--- a/node/src/components/network/behavior.rs
+++ b/node/src/components/network/behavior.rs
@@ -13,7 +13,6 @@ use libp2p::{
     swarm::{NetworkBehaviourAction, NetworkBehaviourEventProcess, PollParameters},
     Multiaddr, NetworkBehaviour, PeerId,
 };
-use prometheus::Registry;
 use tracing::{debug, trace, warn};
 
 use super::{
@@ -50,12 +49,18 @@ pub(super) struct Behavior {
 
 impl Behavior {
     pub(super) fn new(
-        registry: &Registry,
         config: &Config,
+        in_flight_read_futures: prometheus::Gauge,
+        in_flight_write_futures: prometheus::Gauge,
         chainspec: &Chainspec,
         our_public_key: PublicKey,
     ) -> Self {
-        let one_way_message_behavior = one_way_messaging::new_behavior(registry, config, chainspec);
+        let one_way_message_behavior = one_way_messaging::new_behavior(
+            config,
+            in_flight_read_futures,
+            in_flight_write_futures,
+            chainspec,
+        );
 
         let gossip_behavior = gossip::new_behavior(config, chainspec, our_public_key.clone());
 

--- a/node/src/components/network/gossip.rs
+++ b/node/src/components/network/gossip.rs
@@ -1,6 +1,7 @@
 //! This module is home to types/functions related to using libp2p's `GossipSub` behavior, used for
 //! gossiping data to subscribed peers.
 
+use datasize::DataSize;
 use libp2p::{
     core::{ProtocolName, PublicKey},
     gossipsub::{Gossipsub, GossipsubConfigBuilder, MessageAuthenticity, Topic, ValidationMode},
@@ -17,6 +18,7 @@ const PROTOCOL_NAME_INNER: &str = "validator/gossip";
 
 pub(super) static TOPIC: Lazy<Topic> = Lazy::new(|| Topic::new("all".into()));
 
+#[derive(DataSize, Debug)]
 pub(super) struct GossipMessage(pub Vec<u8>);
 
 impl GossipMessage {

--- a/node/src/components/network/one_way_messaging.rs
+++ b/node/src/components/network/one_way_messaging.rs
@@ -6,6 +6,7 @@
 
 use std::{fmt::Debug, future::Future, io, iter, pin::Pin};
 
+use datasize::DataSize;
 use futures::{AsyncReadExt, AsyncWriteExt, FutureExt};
 use futures_io::{AsyncRead, AsyncWrite};
 use libp2p::{
@@ -41,8 +42,10 @@ pub(super) fn new_behavior(
     )
 }
 
-#[derive(Debug)]
+#[derive(DataSize, Debug)]
 pub(super) struct Outgoing {
+    // Datasize note: `PeerId` can be skipped, as in our case it should be 100% stack allocated.
+    #[data_size(skip)]
     pub destination: PeerId,
     pub message: Vec<u8>,
 }

--- a/node/src/reactor/validator/memory_metrics.rs
+++ b/node/src/reactor/validator/memory_metrics.rs
@@ -1,6 +1,10 @@
+use std::env;
+
 use datasize::DataSize;
 use prometheus::{self, Histogram, HistogramOpts, IntGauge, Registry};
 use tracing::{debug, warn};
+
+use crate::components::network::ENABLE_LIBP2P_NET_ENV_VAR;
 
 use super::Reactor;
 
@@ -150,7 +154,11 @@ impl MemoryMetrics {
         let timer = self.mem_estimator_runtime_s.start_timer();
 
         let metrics = reactor.metrics.estimate_heap_size() as i64;
-        let net = reactor.small_network.estimate_heap_size() as i64;
+        let net = if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
+            reactor.network.estimate_heap_size() as i64
+        } else {
+            reactor.small_network.estimate_heap_size() as i64
+        };
         let address_gossiper = reactor.address_gossiper.estimate_heap_size() as i64;
         let storage = reactor.storage.estimate_heap_size() as i64;
         let contract_runtime = reactor.contract_runtime.estimate_heap_size() as i64;

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -1,6 +1,7 @@
 //! Various functions that are not limited to a particular module, but are too small to warrant
 //! being factored out into standalone crates.
 
+mod counting_channel;
 mod external;
 mod median;
 pub mod milliseconds;
@@ -23,6 +24,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::warn;
 
+pub(crate) use counting_channel::{counting_unbounded_channel, CountingReceiver, CountingSender};
 #[cfg(test)]
 pub use external::RESOURCES_PATH;
 pub use external::{External, LoadError, Loadable};

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -2,6 +2,7 @@
 //! being factored out into standalone crates.
 
 mod counting_channel;
+pub mod ds;
 mod external;
 mod median;
 pub mod milliseconds;

--- a/node/src/utils/counting_channel.rs
+++ b/node/src/utils/counting_channel.rs
@@ -1,0 +1,102 @@
+//! Support for counting channels.
+//!
+//! Regular tokio channels do not make the number of pending items available. Counting channels wrap
+//! regular tokio channels but keep a counter of the number of items up-to-date with every `send`
+//! and `recv`. The `len` method can be used to retrieve the number of items.
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use tokio::sync::mpsc::{error::SendError, unbounded_channel, UnboundedReceiver, UnboundedSender};
+
+/// Create an unbounded tokio channel, wrapped in counting sender/receiver.
+pub fn counting_unbounded_channel<T>() -> (CountingSender<T>, CountingReceiver<T>) {
+    let (tx, rx) = unbounded_channel();
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    (
+        CountingSender {
+            sender: tx,
+            counter: counter.clone(),
+        },
+        CountingReceiver {
+            receiver: rx,
+            counter,
+        },
+    )
+}
+
+/// Counting sender.
+#[derive(Debug)]
+pub struct CountingSender<T> {
+    sender: UnboundedSender<T>,
+    counter: Arc<AtomicUsize>,
+}
+
+impl<T> CountingSender<T> {
+    /// Sends a message down the channel, increasing the count on success.
+    #[inline]
+    pub fn send(&self, message: T) -> Result<usize, SendError<T>> {
+        self.sender
+            .send(message)
+            .map(|_| self.counter.fetch_add(1, Ordering::SeqCst))
+    }
+
+    /// Returns the count, i.e. message currently inside the channel.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.counter.load(Ordering::SeqCst)
+    }
+}
+
+pub struct CountingReceiver<T> {
+    receiver: UnboundedReceiver<T>,
+    counter: Arc<AtomicUsize>,
+}
+
+impl<T> CountingReceiver<T> {
+    /// Receives a message from the channel, decreasing the count on success.
+    #[inline]
+    pub async fn recv(&mut self) -> Option<T> {
+        self.receiver.recv().await.map(|value| {
+            self.counter.fetch_sub(1, Ordering::SeqCst);
+            value
+        })
+    }
+
+    /// Returns the count, i.e. message currently inside the channel.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.counter.load(Ordering::SeqCst)
+    }
+}
+
+#[tokio::test]
+async fn test_counting_channel() {
+    let (tx, mut rc) = counting_unbounded_channel::<u32>();
+
+    assert_eq!(tx.len(), 0);
+    assert_eq!(rc.len(), 0);
+
+    tx.send(99).unwrap();
+    tx.send(100).unwrap();
+    tx.send(101).unwrap();
+    tx.send(102).unwrap();
+    tx.send(103).unwrap();
+
+    assert_eq!(tx.len(), 5);
+    assert_eq!(rc.len(), 5);
+
+    rc.recv().await.unwrap();
+    rc.recv().await.unwrap();
+
+    assert_eq!(tx.len(), 3);
+    assert_eq!(rc.len(), 3);
+
+    tx.send(104).unwrap();
+
+    assert_eq!(tx.len(), 4);
+    assert_eq!(rc.len(), 4);
+}

--- a/node/src/utils/counting_channel.rs
+++ b/node/src/utils/counting_channel.rs
@@ -8,6 +8,8 @@
 //! for `T` and `send_datasized` is used instead of send. Internally it stores the size of each item
 //! instead of recalculating on `recv` to avoid underflows due to interior mutability.
 
+#![allow(dead_code)]
+
 use std::{
     mem::size_of,
     sync::{

--- a/node/src/utils/counting_channel.rs
+++ b/node/src/utils/counting_channel.rs
@@ -8,8 +8,6 @@
 //! for `T` and `send_datasized` is used instead of send. Internally it stores the size of each item
 //! instead of recalculating on `recv` to avoid underflows due to interior mutability.
 
-#![allow(dead_code)]
-
 use std::{
     mem,
     sync::{
@@ -51,6 +49,7 @@ pub struct CountingSender<T> {
 
 impl<T> CountingSender<T> {
     /// Internal sending function.
+    // This function allows implementing a non-counting `send` function if needed.
     #[inline]
     fn do_send(&self, size: usize, message: T) -> Result<usize, SendError<T>> {
         // We increase the counters before attempting to add values, to avoid a race that would
@@ -69,14 +68,9 @@ impl<T> CountingSender<T> {
             .map(|_| count)
     }
 
-    /// Sends a message down the channel, increasing the count on success.
-    #[inline]
-    pub fn send(&self, message: T) -> Result<usize, SendError<T>> {
-        self.do_send(0, message)
-    }
-
     /// Returns the count, i.e. messages currently inside the channel.
     #[inline]
+    #[allow(dead_code)] // TODO: Remove once this function is used.
     pub fn len(&self) -> usize {
         self.counter.load(Ordering::SeqCst)
     }
@@ -127,6 +121,7 @@ impl<T> CountingReceiver<T> {
 
     /// Returns the count, i.e. messages currently inside the channel.
     #[inline]
+    #[allow(dead_code)] // TODO: Remove once this function is used.
     pub fn len(&self) -> usize {
         self.counter.load(Ordering::SeqCst)
     }

--- a/node/src/utils/counting_channel.rs
+++ b/node/src/utils/counting_channel.rs
@@ -11,7 +11,7 @@
 #![allow(dead_code)]
 
 use std::{
-    mem::size_of,
+    mem,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -75,7 +75,7 @@ impl<T> CountingSender<T> {
         self.do_send(0, message)
     }
 
-    /// Returns the count, i.e. message currently inside the channel.
+    /// Returns the count, i.e. messages currently inside the channel.
     #[inline]
     pub fn len(&self) -> usize {
         self.counter.load(Ordering::SeqCst)
@@ -90,7 +90,7 @@ where
     #[inline]
     pub fn send_datasized(&self, message: T) -> Result<usize, SendError<T>> {
         self.do_send(
-            message.estimate_heap_size() + size_of::<(usize, T)>(),
+            message.estimate_heap_size() + mem::size_of::<(usize, T)>(),
             message,
         )
     }
@@ -125,7 +125,7 @@ impl<T> CountingReceiver<T> {
         })
     }
 
-    /// Returns the count, i.e. message currently inside the channel.
+    /// Returns the count, i.e. messages currently inside the channel.
     #[inline]
     pub fn len(&self) -> usize {
         self.counter.load(Ordering::SeqCst)

--- a/node/src/utils/ds.rs
+++ b/node/src/utils/ds.rs
@@ -1,0 +1,18 @@
+//! Datasize helper functions.
+
+use std::mem::size_of;
+
+/// Estimate memory usage of a hashmap of keys and values each with no heap allocations.
+pub fn hash_map_fixed_size<K, V>(hashmap: &std::collections::HashMap<K, V>) -> usize {
+    hashmap.capacity() * (size_of::<V>() + size_of::<K>() + size_of::<usize>())
+}
+
+/// Estimate memory usage of a hashset of items with no heap allocations.
+pub fn hash_set_fixed_size<T>(hashset: &std::collections::HashSet<T>) -> usize {
+    hashset.capacity() * (size_of::<T>() + size_of::<usize>())
+}
+
+/// Estimate memory usage of a vec of items with no heap allocations.
+pub fn vec_fixed_size<T>(vec: &Vec<T>) -> usize {
+    vec.capacity() * size_of::<T>()
+}

--- a/node/src/utils/ds.rs
+++ b/node/src/utils/ds.rs
@@ -1,18 +1,21 @@
 //! Datasize helper functions.
 
-use std::mem::size_of;
+use std::{
+    collections::{HashMap, HashSet},
+    mem,
+};
 
 /// Estimate memory usage of a hashmap of keys and values each with no heap allocations.
-pub fn hash_map_fixed_size<K, V>(hashmap: &std::collections::HashMap<K, V>) -> usize {
-    hashmap.capacity() * (size_of::<V>() + size_of::<K>() + size_of::<usize>())
+pub fn hash_map_fixed_size<K, V>(hashmap: &HashMap<K, V>) -> usize {
+    hashmap.capacity() * (mem::size_of::<V>() + mem::size_of::<K>() + mem::size_of::<usize>())
 }
 
 /// Estimate memory usage of a hashset of items with no heap allocations.
-pub fn hash_set_fixed_size<T>(hashset: &std::collections::HashSet<T>) -> usize {
-    hashset.capacity() * (size_of::<T>() + size_of::<usize>())
+pub fn hash_set_fixed_size<T>(hashset: &HashSet<T>) -> usize {
+    hashset.capacity() * (mem::size_of::<T>() + mem::size_of::<usize>())
 }
 
 /// Estimate memory usage of a vec of items with no heap allocations.
 pub fn vec_fixed_size<T>(vec: &Vec<T>) -> usize {
-    vec.capacity() * size_of::<T>()
+    vec.capacity() * mem::size_of::<T>()
 }

--- a/shell.nix
+++ b/shell.nix
@@ -39,7 +39,7 @@ in pkgs.stdenv.mkDerivation {
   buildInputs = with pkgs;
     [ cmake pkg-config openssl.dev zlib.dev rustup ]
     ++ lists.optionals ops [ kubectl python skopeo git nix ]
-    ++ lists.optionals dev [ black podman shadow coreutils run-nctl ];
+    ++ lists.optionals dev [ black docker coreutils run-nctl ];
 
   # Enable SSL support in pure shells
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/shell.nix
+++ b/shell.nix
@@ -39,7 +39,7 @@ in pkgs.stdenv.mkDerivation {
   buildInputs = with pkgs;
     [ cmake pkg-config openssl.dev zlib.dev rustup ]
     ++ lists.optionals ops [ kubectl python skopeo git nix ]
-    ++ lists.optionals dev [ black podman coreutils run-nctl ];
+    ++ lists.optionals dev [ black podman shadow coreutils run-nctl ];
 
   # Enable SSL support in pure shells
   SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/utils/nctl-metrics/gen_prometheus_config.py
+++ b/utils/nctl-metrics/gen_prometheus_config.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import sys
 
 import toml
 
@@ -17,13 +18,13 @@ for node_dir in os.listdir(nodes_dir):
     if not os.path.isdir(node_path) or not node_dir.startswith("node-"):
         continue
 
+    cfg_path = os.path.join(node_path, "config", "1_0_0", "config.toml")
     try:
-        cfg_path = open(os.path.join(node_path, "config", "node-config.toml"))
-        config = toml.load(cfg_path)
+        config = toml.load(open(cfg_path))
         addr = config["rest_server"]["address"].replace("0.0.0.0", "127.0.0.1")
         addrs.append(addr)
     except Exception as e:
-        sys.stderr.write("error loading {}".format(cfg_path))
+        sys.stderr.write("error loading {}\n".format(cfg_path))
         continue
 
 

--- a/utils/nctl-metrics/gen_prometheus_config.py
+++ b/utils/nctl-metrics/gen_prometheus_config.py
@@ -17,9 +17,14 @@ for node_dir in os.listdir(nodes_dir):
     if not os.path.isdir(node_path) or not node_dir.startswith("node-"):
         continue
 
-    config = toml.load(open(os.path.join(node_path, "config", "node-config.toml")))
-    addr = config["rest_server"]["address"].replace("0.0.0.0", "127.0.0.1")
-    addrs.append(addr)
+    try:
+        cfg_path = open(os.path.join(node_path, "config", "node-config.toml"))
+        config = toml.load(cfg_path)
+        addr = config["rest_server"]["address"].replace("0.0.0.0", "127.0.0.1")
+        addrs.append(addr)
+    except Exception as e:
+        sys.stderr.write("error loading {}".format(cfg_path))
+        continue
 
 
 # Slightly dirty, we're not dealing with an extra dependency to generate YAML just yet and just

--- a/utils/nctl-metrics/prometheus.sh
+++ b/utils/nctl-metrics/prometheus.sh
@@ -4,13 +4,15 @@
 
 cd $(dirname $0)
 
-PROMETHEUS_TAG=docker.io/prom/prometheus
+PROMETHEUS_TAG=prom/prometheus
 
 echo "Genarating config."
 ./gen_prometheus_config.py > prometheus.yml
 
 echo "Starting prometheus."
-exec podman run \
+exec docker run \
+  -i \
+  --rm \
   --net=host \
   -p 9090:9090 \
   -v $(pwd)/prometheus.yml:/etc/prometheus/prometheus.yml \


### PR DESCRIPTION
This PR rolls up a few things:

* Completes the memory metrics for the `networking` component, including adding a special counting channel that makes it possible to inspect queues.
* Adds debug-metrics to the libp2p component that track the number of futures created.
* Fixes a few bugs in metrics reporting (some still present) for memory in the validator.
* Improves/fixes the `nctl-utils` prometheus metrics setup.

Almost all changes are confined to `components::network`, thus should have little impact on production.