### PR TITLE
NDRS-887: Enable test_joiner again.

### DIFF
--- a/node/src/testing/multi_stage_test_reactor/test_chain.rs
+++ b/node/src/testing/multi_stage_test_reactor/test_chain.rs
@@ -316,8 +316,6 @@ async fn get_switch_block_hash(
     *switch_block_hash
 }
 
-// TODO remove ignore once joiner test is consistent again.
-#[ignore]
 #[tokio::test]
 async fn test_joiner() {
     testing::init_logging();


### PR DESCRIPTION
The test used to be flaky, but it just passed 60 times in a row for me, so the problem seems to be fixed.

https://casperlabs.atlassian.net/browse/NDRS-887