### PR TITLE
NDRS-857/sample memory metrics in consensus

### DIFF
--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -41,7 +41,7 @@ use crate::{
         traits::Context,
     },
     types::{TimeDiff, Timestamp},
-    utils::weighted_median,
+    utils::{ds, weighted_median},
 };
 use block::Block;
 use tallies::Tallies;
@@ -155,9 +155,11 @@ where
     /// All units imported so far, by hash.
     /// This is a downward closed set: A unit must only be added here once all of its dependencies
     /// have been added as well, and it has been fully validated.
+    #[data_size(with = ds::hashmap_sample)]
     units: HashMap<C::Hash, Unit<C>>,
     /// All blocks, by hash. All block hashes are also unit hashes, but units that did not
     /// introduce a new block don't have their own entry here.
+    #[data_size(with = ds::hashmap_sample)]
     blocks: HashMap<C::Hash, Block<C>>,
     /// List of faulty validators and their type of fault.
     /// Every validator that has an equivocation in `units` must have an entry here, but there can
@@ -168,10 +170,12 @@ where
     panorama: Panorama<C>,
     /// All currently endorsed units, by hash: units that have enough endorsements to be cited even
     /// if they naively cite an equivocator.
+    #[data_size(with = ds::hashmap_sample)]
     endorsements: HashMap<C::Hash, ValidatorMap<Option<C::Signature>>>,
     /// Units that don't yet have 1/2 of stake endorsing them.
     /// Signatures are stored in a map so that a single validator sending lots of signatures for
     /// different units doesn't cause us to allocate a lot of memory.
+    #[data_size(with = ds::hashmap_sample)]
     incomplete_endorsements: HashMap<C::Hash, BTreeMap<ValidatorIndex, C::Signature>>,
     /// Timestamp of the last ping or unit we received from each validator.
     pings: ValidatorMap<Timestamp>,

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -12,6 +12,7 @@ use derive_more::{AsRef, From};
 use serde::{Deserialize, Serialize};
 
 use super::Weight;
+use crate::utils::ds;
 
 /// The index of a validator, in a list of all validators, ordered by ID.
 #[derive(
@@ -138,8 +139,21 @@ impl<VID: Ord + Hash + fmt::Debug> fmt::Display for Validators<VID> {
     }
 }
 
-#[derive(Clone, DataSize, Debug, Eq, PartialEq, Serialize, Deserialize, AsRef, From, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRef, From, Hash)]
 pub(crate) struct ValidatorMap<T>(Vec<T>);
+
+impl<T> DataSize for ValidatorMap<T>
+where
+    T: DataSize,
+{
+    const IS_DYNAMIC: bool = Vec::<T>::IS_DYNAMIC;
+
+    const STATIC_HEAP_SIZE: usize = Vec::<T>::STATIC_HEAP_SIZE;
+
+    fn estimate_heap_size(&self) -> usize {
+        ds::vec_sample(&self.0)
+    }
+}
 
 impl<T> ValidatorMap<T> {
     /// Returns the value for the given validator. Panics if the index is out of range.

--- a/node/src/utils/ds.rs
+++ b/node/src/utils/ds.rs
@@ -1,18 +1,96 @@
 //! Datasize helper functions.
 
-use std::mem::size_of;
+use std::{
+    collections::{HashMap, HashSet},
+    mem::size_of,
+};
+
+use datasize::DataSize;
+use rand::{
+    rngs::StdRng,
+    seq::{IteratorRandom, SliceRandom},
+    SeedableRng,
+};
+
+/// Number of items to sample when sampling a large collection.
+const SAMPLE_SIZE: usize = 100;
 
 /// Estimate memory usage of a hashmap of keys and values each with no heap allocations.
-pub fn hash_map_fixed_size<K, V>(hashmap: &std::collections::HashMap<K, V>) -> usize {
+pub fn hash_map_fixed_size<K, V>(hashmap: &HashMap<K, V>) -> usize {
     hashmap.capacity() * (size_of::<V>() + size_of::<K>() + size_of::<usize>())
 }
 
 /// Estimate memory usage of a hashset of items with no heap allocations.
-pub fn hash_set_fixed_size<T>(hashset: &std::collections::HashSet<T>) -> usize {
+pub fn hash_set_fixed_size<T>(hashset: &HashSet<T>) -> usize {
     hashset.capacity() * (size_of::<T>() + size_of::<usize>())
 }
 
 /// Estimate memory usage of a vec of items with no heap allocations.
 pub fn vec_fixed_size<T>(vec: &Vec<T>) -> usize {
     vec.capacity() * size_of::<T>()
+}
+
+/// Creates an RNG for sampling based on the length of a collection.
+fn sampling_rng(len: usize) -> StdRng {
+    // We use a fixed seed RNG here and hope the size will provide enough entropy to avoid gross
+    // misestimations. This has the added benefit that repeated measurements will consider the
+    // same nodes, reducing jitter and making this a pure function.
+
+    // Initialize a buffer suitable for the seed, which might be larger then our length bytes.
+    let mut seed = <StdRng as SeedableRng>::Seed::default();
+    let len_be = len.to_be_bytes();
+
+    // Mix in entropy from length.
+    for (b1, b2) in seed.iter_mut().zip(len_be.iter()) {
+        *b1 ^= *b2;
+    }
+
+    StdRng::from_seed(seed)
+}
+
+/// Given a length and a total of `sampled` bytes from sampling `SAMPLE_SIZE` items, return an
+/// estimate for the total heap memory consumption of the collection.
+fn scale_sample(len: usize, sampled: usize) -> usize {
+    let scaling_factor = len as f64 / SAMPLE_SIZE as f64;
+    (sampled as f64 * scaling_factor).round() as usize
+}
+
+/// Extrapolate memory usage of a Vec by from a random subset of `SAMPLE_SIZE` items.
+pub fn vec_sample<T>(vec: &Vec<T>) -> usize
+where
+    T: DataSize,
+{
+    if vec.len() < SAMPLE_SIZE {
+        vec.estimate_heap_size()
+    } else {
+        let mut rng = sampling_rng(vec.len());
+        let sampled = vec
+            .as_slice()
+            .choose_multiple(&mut rng, SAMPLE_SIZE)
+            .map(DataSize::estimate_heap_size)
+            .sum();
+        scale_sample(vec.len(), sampled)
+    }
+}
+
+/// Extrapolate memory usage of a HashMap by from a random subset of `SAMPLE_SIZE` items.
+pub fn hashmap_sample<K, V>(map: &HashMap<K, V>) -> usize
+where
+    K: DataSize,
+    V: DataSize,
+{
+    if map.len() < SAMPLE_SIZE {
+        map.estimate_heap_size()
+    } else {
+        let mut rng = sampling_rng(map.len());
+
+        let sampled = map
+            .values()
+            .choose_multiple(&mut rng, SAMPLE_SIZE)
+            .into_iter()
+            .map(DataSize::estimate_heap_size)
+            .sum();
+
+        scale_sample(map.len(), sampled)
+    }
 }

--- a/node/src/utils/ds.rs
+++ b/node/src/utils/ds.rs
@@ -55,6 +55,7 @@ fn scale_sample(len: usize, sampled: usize) -> usize {
 }
 
 /// Extrapolate memory usage of a Vec by from a random subset of `SAMPLE_SIZE` items.
+#[allow(clippy::ptr_arg)]
 pub fn vec_sample<T>(vec: &Vec<T>) -> usize
 where
     T: DataSize,

--- a/node/src/utils/ds.rs
+++ b/node/src/utils/ds.rs
@@ -36,7 +36,7 @@ fn sampling_rng(len: usize) -> StdRng {
     // misestimations. This has the added benefit that repeated measurements will consider the
     // same nodes, reducing jitter and making this a pure function.
 
-    // Initialize a buffer suitable for the seed, which might be larger then our length bytes.
+    // Initialize a buffer suitable for the seed, which might be larger than our length bytes.
     let mut seed = <StdRng as SeedableRng>::Seed::default();
     let len_be = len.to_be_bytes();
 
@@ -54,7 +54,7 @@ fn scale_sample(len: usize, sampled: usize) -> usize {
     sampled * len / SAMPLE_SIZE
 }
 
-/// Extrapolate memory usage of a Vec by from a random subset of `SAMPLE_SIZE` items.
+/// Extrapolate memory usage of a `Vec` by from a random subset of `SAMPLE_SIZE` items.
 #[allow(clippy::ptr_arg)]
 pub fn vec_sample<T>(vec: &Vec<T>) -> usize
 where
@@ -73,7 +73,7 @@ where
     }
 }
 
-/// Extrapolate memory usage of a HashMap by from a random subset of `SAMPLE_SIZE` items.
+/// Extrapolate memory usage of a `HashMap` by from a random subset of `SAMPLE_SIZE` items.
 pub fn hashmap_sample<K, V>(map: &HashMap<K, V>) -> usize
 where
     K: DataSize,

--- a/node/src/utils/ds.rs
+++ b/node/src/utils/ds.rs
@@ -94,7 +94,6 @@ where
             .choose_multiple(&mut rng, SAMPLE_SIZE)
             .into_iter()
             .map(|(k, v)| k.estimate_heap_size() + v.estimate_heap_size())
-            .map(|v| v)
             .sum();
 
         base_size + scale_sample(map.len(), sampled)
@@ -102,6 +101,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::assertions_on_constants)] // used by sanity checks around `SAMPLE_SIZE`
 mod tests {
     use std::collections::HashMap;
 

--- a/node/src/utils/ds.rs
+++ b/node/src/utils/ds.rs
@@ -13,7 +13,7 @@ use rand::{
 };
 
 /// Number of items to sample when sampling a large collection.
-const SAMPLE_SIZE: usize = 100;
+const SAMPLE_SIZE: usize = 50;
 
 /// Estimate memory usage of a hashmap of keys and values each with no heap allocations.
 pub fn hash_map_fixed_size<K, V>(hashmap: &HashMap<K, V>) -> usize {
@@ -51,8 +51,7 @@ fn sampling_rng(len: usize) -> StdRng {
 /// Given a length and a total of `sampled` bytes from sampling `SAMPLE_SIZE` items, return an
 /// estimate for the total heap memory consumption of the collection.
 fn scale_sample(len: usize, sampled: usize) -> usize {
-    let scaling_factor = len as f64 / SAMPLE_SIZE as f64;
-    (sampled as f64 * scaling_factor).round() as usize
+    sampled * len / SAMPLE_SIZE
 }
 
 /// Extrapolate memory usage of a Vec by from a random subset of `SAMPLE_SIZE` items.


### PR DESCRIPTION
Reduces heap measuring of large collections by sampling only a subset of their contents.