### PR TITLE
NDRS-913: Push whole block to the event stream.

### DIFF
--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -91,12 +91,9 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {
-            Event::BlockAdded {
+            Event::BlockAdded { block_hash, block } => self.broadcast(SseData::BlockAdded {
                 block_hash,
-                block_header,
-            } => self.broadcast(SseData::BlockAdded {
-                block_hash,
-                block_header: Box::new(*block_header),
+                block: Box::new(*block),
             }),
             Event::DeployProcessed {
                 deploy_hash,

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -4,14 +4,14 @@ use casper_types::{ExecutionResult, PublicKey};
 
 use crate::{
     components::consensus::EraId,
-    types::{BlockHash, BlockHeader, DeployHash, DeployHeader, FinalitySignature, Timestamp},
+    types::{Block, BlockHash, DeployHash, DeployHeader, FinalitySignature, Timestamp},
 };
 
 #[derive(Debug)]
 pub enum Event {
     BlockAdded {
         block_hash: BlockHash,
-        block_header: Box<BlockHeader>,
+        block: Box<Block>,
     },
     DeployProcessed {
         deploy_hash: DeployHash,

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -19,7 +19,7 @@ use casper_types::{ExecutionResult, PublicKey};
 
 use crate::{
     components::consensus::EraId,
-    types::{BlockHash, BlockHeader, DeployHash, FinalitySignature, TimeDiff, Timestamp},
+    types::{Block, BlockHash, DeployHash, FinalitySignature, TimeDiff, Timestamp},
 };
 
 /// The URL path.
@@ -38,7 +38,7 @@ pub enum SseData {
     /// The given block has been added to the linear chain and stored locally.
     BlockAdded {
         block_hash: BlockHash,
-        block_header: Box<BlockHeader>,
+        block: Box<Block>,
     },
     /// The given deploy has been executed, committed and forms part of the given block.
     DeployProcessed {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -441,7 +441,7 @@ where
                 );
                 effects.extend(
                     effect_builder
-                        .announce_block_added(block_hash, block.take_header())
+                        .announce_block_added(block_hash, block)
                         .ignore(),
                 );
                 effects

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1150,16 +1150,13 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// The linear chain has stored a newly-created block.
-    pub(crate) async fn announce_block_added(self, block_hash: BlockHash, block_header: BlockHeader)
+    pub(crate) async fn announce_block_added(self, block_hash: BlockHash, block: Box<Block>)
     where
         REv: From<LinearChainAnnouncement>,
     {
         self.0
             .schedule(
-                LinearChainAnnouncement::BlockAdded {
-                    block_hash,
-                    block_header: Box::new(block_header),
-                },
+                LinearChainAnnouncement::BlockAdded { block_hash, block },
                 QueueKind::Regular,
             )
             .await

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -19,8 +19,8 @@ use crate::{
     },
     effect::Responder,
     types::{
-        Block, BlockHash, BlockHeader, Deploy, DeployHash, DeployHeader, FinalitySignature,
-        FinalizedBlock, Item, Timestamp,
+        Block, BlockHash, Deploy, DeployHash, DeployHeader, FinalitySignature, FinalizedBlock,
+        Item, Timestamp,
     },
     utils::Source,
 };
@@ -218,8 +218,8 @@ pub enum LinearChainAnnouncement {
     BlockAdded {
         /// Block hash.
         block_hash: BlockHash,
-        /// Block header.
-        block_header: Box<BlockHeader>,
+        /// Block.
+        block: Box<Block>,
     },
     /// New finality signature received.
     NewFinalitySignature(Box<FinalitySignature>),

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -842,16 +842,13 @@ impl reactor::Reactor for Reactor {
 
             Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded {
                 block_hash,
-                block_header,
+                block,
             }) => reactor::wrap_effects(
                 Event::EventStreamServer,
                 self.event_stream_server.handle_event(
                     effect_builder,
                     rng,
-                    event_stream_server::Event::BlockAdded {
-                        block_hash,
-                        block_header,
-                    },
+                    event_stream_server::Event::BlockAdded { block_hash, block },
                 ),
             ),
             Event::LinearChainAnnouncement(LinearChainAnnouncement::NewFinalitySignature(fs)) => {

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -915,12 +915,12 @@ impl reactor::Reactor for Reactor {
             }
             Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded {
                 block_hash,
-                block_header,
+                block,
             }) => {
                 let reactor_event =
                     Event::EventStreamServer(event_stream_server::Event::BlockAdded {
                         block_hash,
-                        block_header,
+                        block,
                     });
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-913

https://github.com/CasperLabs/casper-node/pull/892 moved `deploy_hashes`, `transfer_hashes` and `proposer` from the `BlockHeader` structure to the new `BlockBody`. Up until now, we've been pushing only `BlockHeader` to the event stream, which means that since #892 got merged those three were missing from the event stream events. This PR changes what gets pushed to the event stream – we're now pushing the whole `Block`.

The main differences are in the structure of the event. Instead of `block_header` field containing `BlockHeader` structure, there's now a `block` field with `Block` struct. Structure of the `Block` can be found [here](https://github.com/CasperLabs/casper-node/blob/master/node/src/types/block.rs#L1023).