### PR TITLE
HWY-257: Clear the protocol state of unbonded eras.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -126,7 +126,6 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
         &mut self,
         sender: I,
         msg: Vec<u8>,
-        evidence_only: bool,
         rng: &mut NodeRng,
     ) -> Vec<ProtocolOutcome<I, C>>;
 
@@ -176,6 +175,9 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
 
     /// Turns this instance into a passive observer, that does not create any new vertices.
     fn deactivate_validator(&mut self);
+
+    /// Clears this instance and keeps only the information necessary to validate evidence.
+    fn set_evidence_only(&mut self);
 
     /// Returns whether the validator `vid` is known to be faulty.
     fn has_evidence(&self, vid: &C::ValidatorId) -> bool;

--- a/node/src/components/consensus/highway_core/evidence.rs
+++ b/node/src/components/consensus/highway_core/evidence.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 use super::validators::ValidatorIndex;
 use crate::components::consensus::{
     highway_core::{
-        endorsement::SignedEndorsement, highway::SignedWireUnit, state::State,
+        endorsement::SignedEndorsement, highway::SignedWireUnit, state::Params,
         validators::Validators,
     },
     traits::Context,
@@ -86,7 +86,7 @@ impl<C: Context> Evidence<C> {
         &self,
         validators: &Validators<C::ValidatorId>,
         instance_id: &C::InstanceId,
-        state: &State<C>,
+        params: &Params,
     ) -> Result<(), EvidenceError> {
         match self {
             Evidence::Equivocation(unit1, unit2) => {
@@ -99,7 +99,7 @@ impl<C: Context> Evidence<C> {
                 unit2,
                 swimlane2,
             } => {
-                if swimlane2.len() as u64 > state.params().endorsement_evidence_limit() {
+                if swimlane2.len() as u64 > params.endorsement_evidence_limit() {
                     return Err(EvidenceError::EndorsementTooManyUnits);
                 }
                 let v_id = validators

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -453,6 +453,12 @@ impl<C: Context> Highway<C> {
         }
     }
 
+    /// Drops all state other than evidence.
+    pub(crate) fn retain_evidence_only(&mut self) {
+        self.deactivate_validator();
+        self.state.retain_evidence_only();
+    }
+
     fn on_new_unit(
         &mut self,
         uhash: &C::Hash,
@@ -536,7 +542,7 @@ impl<C: Context> Highway<C> {
                 Ok(self.state.pre_validate_unit(unit)?)
             }
             Vertex::Evidence(evidence) => {
-                Ok(evidence.validate(&self.validators, &self.instance_id, &self.state)?)
+                Ok(evidence.validate(&self.validators, &self.instance_id, self.state.params())?)
             }
             Vertex::Endorsements(endorsements) => {
                 let unit = *endorsements.unit();

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -890,6 +890,22 @@ impl<C: Context> State<C> {
         result
     }
 
+    /// Drops all state other than evidence.
+    pub(crate) fn retain_evidence_only(&mut self) {
+        self.units.clear();
+        self.blocks.clear();
+        self.panorama = self
+            .panorama
+            .iter()
+            .map(|obs| match obs {
+                Observation::Faulty => Observation::Faulty,
+                Observation::None | Observation::Correct(_) => Observation::None,
+            })
+            .collect();
+        self.endorsements.clear();
+        self.incomplete_endorsements.clear();
+    }
+
     /// Validates whether a unit with the given panorama and `endorsed` set satsifies the
     /// Limited Naïveté Criterion (LNC).
     /// Returns index of the first equivocator that was cited naively in violation of the LNC, or

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -894,14 +894,11 @@ impl<C: Context> State<C> {
     pub(crate) fn retain_evidence_only(&mut self) {
         self.units.clear();
         self.blocks.clear();
-        self.panorama = self
-            .panorama
-            .iter()
-            .map(|obs| match obs {
-                Observation::Faulty => Observation::Faulty,
-                Observation::None | Observation::Correct(_) => Observation::None,
-            })
-            .collect();
+        for obs in self.panorama.iter_mut() {
+            if obs.is_correct() {
+                *obs = Observation::None;
+            }
+        }
         self.endorsements.clear();
         self.incomplete_endorsements.clear();
     }

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -157,6 +157,11 @@ impl<T> ValidatorMap<T> {
         self.0.iter()
     }
 
+    /// Returns an iterator over mutable references to all values.
+    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.0.iter_mut()
+    }
+
     /// Returns an iterator over all values, by validator index.
     pub(crate) fn enumerate(&self) -> impl Iterator<Item = (ValidatorIndex, &T)> {
         self.iter()

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -71,6 +71,7 @@ where
     /// A tracker for whether we are keeping up with the current round exponent or not.
     round_success_meter: RoundSuccessMeter<C>,
     synchronizer: Synchronizer<I, C>,
+    evidence_only: bool,
 }
 
 impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
@@ -186,6 +187,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             highway: Highway::new(instance_id, validators, params),
             round_success_meter,
             synchronizer: Synchronizer::new(config.pending_vertex_timeout),
+            evidence_only: false,
         });
         (hw_proto, outcomes)
     }
@@ -345,6 +347,10 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         rng: &mut NodeRng,
         now: Timestamp,
     ) -> ProtocolOutcomes<I, C> {
+        if self.evidence_only && !vv.inner().is_evidence() {
+            error!(vertex = ?vv.inner(), "unexpected vertex in evidence-only mode");
+            return vec![];
+        }
         // Check whether we should change the round exponent.
         // It's important to do it before the vertex is added to the state - this way if the last
         // round has finished, we now have all the vertices from that round in the state, and no
@@ -427,7 +433,6 @@ where
         &mut self,
         sender: I,
         msg: Vec<u8>,
-        evidence_only: bool,
         _rng: &mut NodeRng,
     ) -> ProtocolOutcomes<I, C> {
         match bincode::deserialize(msg.as_slice()) {
@@ -437,12 +442,12 @@ where
                 err.into(),
             )],
             Ok(HighwayMessage::NewVertex(v))
-                if self.highway.has_vertex(&v) || (evidence_only && !v.is_evidence()) =>
+                if self.highway.has_vertex(&v) || (self.evidence_only && !v.is_evidence()) =>
             {
                 trace!(
                     has_vertex = self.highway.has_vertex(&v),
                     is_evidence = v.is_evidence(),
-                    %evidence_only,
+                    evidence_only = %self.evidence_only,
                     "received an irrelevant vertex"
                 );
                 vec![]
@@ -694,6 +699,15 @@ where
 
     fn deactivate_validator(&mut self) {
         self.highway.deactivate_validator()
+    }
+
+    fn set_evidence_only(&mut self) {
+        // TODO: We could also drop the finality detector and round success meter here. Maybe make
+        // HighwayProtocol an enum with an EvidenceOnly variant?
+        self.pending_values.clear();
+        self.synchronizer.retain_evidence_only();
+        self.highway.retain_evidence_only();
+        self.evidence_only = true;
     }
 
     fn has_evidence(&self, vid: &C::ValidatorId) -> bool {

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -72,6 +72,11 @@ impl<I: NodeIdT, C: Context> PendingVertices<I, C> {
         Some(PendingVertex::new(sender, pvv, timestamp))
     }
 
+    /// Drops all pending vertices other than evidence.
+    pub(crate) fn retain_evidence_only(&mut self) {
+        self.0.retain(|pvv, _| pvv.inner().is_evidence());
+    }
+
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -308,6 +313,13 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
             senders.extend(new_senders);
         }
         senders
+    }
+
+    /// Drops all pending vertices other than evidence.
+    pub(crate) fn retain_evidence_only(&mut self) {
+        self.vertex_deps.clear();
+        self.vertices_to_be_added_later.clear();
+        self.vertices_to_be_added.retain_evidence_only();
     }
 
     /// Schedules vertices to be added to the protocol state.

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -103,7 +103,7 @@ fn test_highway_protocol_handle_message_parse_error() {
     let msg = vec![];
     let mut rng = TestRng::new();
     let mut effects: Vec<ProtocolOutcome<NodeId, ClContext>> =
-        highway_protocol.handle_message(sender.to_owned(), msg.to_owned(), false, &mut rng);
+        highway_protocol.handle_message(sender.to_owned(), msg.to_owned(), &mut rng);
 
     assert_eq!(effects.len(), 1);
 
@@ -149,8 +149,7 @@ fn send_a_wire_unit_with_too_small_a_round_exp() {
     let mut highway_protocol = new_test_highway_protocol(validators, vec![]);
     let sender = NodeId(123);
     let msg = bincode::serialize(&highway_message).unwrap();
-    let mut outcomes =
-        highway_protocol.handle_message(sender.to_owned(), msg.to_owned(), false, &mut rng);
+    let mut outcomes = highway_protocol.handle_message(sender.to_owned(), msg.to_owned(), &mut rng);
     assert_eq!(outcomes.len(), 1);
 
     let maybe_protocol_outcome = outcomes.pop();
@@ -207,7 +206,7 @@ fn send_a_valid_wire_unit() {
     let sender = NodeId(123);
     let msg = bincode::serialize(&highway_message).unwrap();
 
-    let mut outcomes = highway_protocol.handle_message(sender, msg, false, &mut rng);
+    let mut outcomes = highway_protocol.handle_message(sender, msg, &mut rng);
     while let Some(outcome) = outcomes.pop() {
         match outcome {
             ProtocolOutcome::CreatedGossipMessage(_) | ProtocolOutcome::FinalizedBlock(_) => (),
@@ -259,7 +258,7 @@ fn detect_doppelganger() {
     // "Send" a message created by ALICE to an instance of Highway where she's an active validator.
     // An incoming unit, created by the same validator, should be properly detected as a
     // doppelganger.
-    let mut outcomes = highway_protocol.handle_message(sender, msg, false, &mut rng);
+    let mut outcomes = highway_protocol.handle_message(sender, msg, &mut rng);
     while let Some(outcome) = outcomes.pop() {
         match outcome {
             ProtocolOutcome::DoppelgangerDetected => return,


### PR DESCRIPTION
All bonded eras are kept in memory because we still need to handle messages for them and detect equivocations.
However, since each era can refer to evidence from previous eras for cross-era slashing, even eras older than that are kept in memory, so that that evidence can be validated. This PR clears the protocol state of all unbonded eras and retains only evidence, to free up the memory. The dropped information is not needed anymore, since evidence cannot have any dependencies.
This should reduce consensus memory usage by almost 50%.

https://casperlabs.atlassian.net/browse/HWY-257