### PR TITLE
NDRS-933: Make delegator entries optional.

### DIFF
--- a/node/src/types/chainspec/accounts_config.rs
+++ b/node/src/types/chainspec/accounts_config.rs
@@ -230,6 +230,7 @@ impl FromBytes for DelegatorConfig {
 #[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Clone)]
 pub struct AccountsConfig {
     accounts: Vec<AccountConfig>,
+    #[serde(default)]
     delegators: Vec<DelegatorConfig>,
 }
 


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-933

This PR makes `[[delegators]]` entries in `accounts.toml` optional.