### PR TITLE
NDRS-880: Disable the test.

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -38,7 +38,7 @@ function start_run_teardown() {
 }
 
 start_run_teardown "sync_test.sh node=6 timeout=500"
-start_run_teardown "sync_upgrade_test.sh node=6 timeout=500"
+# start_run_teardown "sync_upgrade_test.sh node=6 timeout=500"
 start_run_teardown "itst01.sh"
 start_run_teardown "itst02.sh"
 


### PR DESCRIPTION
Disables the `sync_upgrade_test` integratoin test until the relevant PR in consensus is merged.