### PR TITLE
EE-1179: deactivate bids instead of removing them

### DIFF
--- a/execution_engine_testing/tests/src/test/regression/ee_1119.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1119.rs
@@ -242,7 +242,9 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
     );
 
     let bids: Bids = builder.get_value(auction, BIDS_KEY);
-    assert!(!bids.contains_key(&VALIDATOR_1)); // still bid upon
+    let validator_1_bid = bids.get(&VALIDATOR_1).unwrap();
+    assert!(validator_1_bid.inactive());
+    assert!(validator_1_bid.staked_amount().is_zero());
 
     let total_supply_after_slashing: U512 =
         builder.get_value(builder.get_mint_contract_hash(), TOTAL_SUPPLY_KEY);

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -281,8 +281,10 @@ fn should_run_ee_1120_slash_delegators() {
     // Compare bids after slashing validator 2
     let bids_after: Bids = builder.get_value(auction, BIDS_KEY);
     assert_ne!(bids_before, bids_after);
-    assert_eq!(bids_after.len(), 1);
-    assert!(!bids_after.contains_key(&VALIDATOR_2));
+    assert_eq!(bids_after.len(), 2);
+    let validator_2_bid = bids_after.get(&VALIDATOR_2).unwrap();
+    assert!(validator_2_bid.inactive());
+    assert!(validator_2_bid.staked_amount().is_zero());
 
     assert!(bids_after.contains_key(&VALIDATOR_1));
     assert_eq!(bids_after[&VALIDATOR_1].delegators().len(), 2);
@@ -334,7 +336,11 @@ fn should_run_ee_1120_slash_delegators() {
     builder.exec(slash_request_2).expect_success().commit();
 
     let bids_after: Bids = builder.get_value(auction, BIDS_KEY);
-    assert!(bids_after.is_empty());
+    assert_eq!(bids_after.len(), 2);
+    let validator_1_bid = bids_after.get(&VALIDATOR_1).unwrap();
+    assert!(validator_1_bid.inactive());
+    assert!(validator_1_bid.staked_amount().is_zero());
+
     let unbond_purses_after: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
     assert!(unbond_purses_after.is_empty());
 }

--- a/execution_engine_testing/tests/src/test/step.rs
+++ b/execution_engine_testing/tests/src/test/step.rs
@@ -110,11 +110,9 @@ fn should_step() {
     builder.step(step_request);
 
     let bids_after_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
-    assert!(
-        !bids_after_slashing.contains_key(&ACCOUNT_1_PK),
-        "should not have entry in bids table after slashing {:?}",
-        bids_after_slashing
-    );
+    let account_1_bid = bids_after_slashing.get(&ACCOUNT_1_PK).unwrap();
+    assert!(account_1_bid.inactive());
+    assert!(account_1_bid.staked_amount().is_zero());
 
     let bids_after_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
     assert_ne!(

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -1477,10 +1477,10 @@ fn should_undelegate_delegators_when_validator_unbonds() {
         .expect_success();
 
     let bids_after: Bids = builder.get_value(auction, auction::BIDS_KEY);
-    assert!(
-        bids_after.get(&VALIDATOR_1).is_none(),
-        "does not have validator 1 bid and delegator bids are removed as well"
-    );
+    let validator_1_bid = bids_after.get(&VALIDATOR_1).unwrap();
+    assert!(validator_1_bid.inactive());
+    assert!(validator_1_bid.staked_amount().is_zero());
+
     let unbonding_purses_after: UnbondingPurses =
         builder.get_value(auction, auction::UNBONDING_PURSES_KEY);
     assert_ne!(unbonding_purses_after, unbonding_purses_before);
@@ -1691,10 +1691,10 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         .expect_success();
 
     let bids_after: Bids = builder.get_value(auction, auction::BIDS_KEY);
-    assert!(
-        bids_after.get(&VALIDATOR_1).is_none(),
-        "does not have validator 1 bid and delegator bids are removed as well"
-    );
+    let validator_1_bid = bids_after.get(&VALIDATOR_1).unwrap();
+    assert!(validator_1_bid.inactive());
+    assert!(validator_1_bid.staked_amount().is_zero());
+
     let unbonding_purses_before: UnbondingPurses =
         builder.get_value(auction, auction::UNBONDING_PURSES_KEY);
 

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -322,10 +322,9 @@ fn should_distribute_delegation_rate_zero() {
             *VALIDATOR_1,
             validator_1_balance + U512::from(VALIDATOR_1_STAKE),
         );
-        assert!(
-            get_validator_bid(&mut builder, *VALIDATOR_1).is_none(),
-            "validator 1 should have zero stake after withdrawing full amount"
-        );
+        let validator_1_bid = get_validator_bid(&mut builder, *VALIDATOR_1).unwrap();
+        assert!(validator_1_bid.inactive());
+        assert!(validator_1_bid.staked_amount().is_zero());
         U512::zero()
     };
     assert_eq!(validator_1_balance, U512::zero());
@@ -613,10 +612,11 @@ fn should_withdraw_bids_after_distribute() {
             *VALIDATOR_1,
             withdraw_bid_amount,
         );
-        assert!(
-            get_validator_bid(&mut builder, *VALIDATOR_1).is_none(),
-            "validator 1 should have zero stake after withdrawing full amount"
-        );
+
+        let bid = get_validator_bid(&mut builder, *VALIDATOR_1).unwrap();
+        assert!(bid.inactive());
+        assert!(bid.staked_amount().is_zero());
+
         withdraw_bid_amount
     };
     assert!(!validator_1_balance.is_zero());

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -186,7 +186,9 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
     );
 
     let bids: Bids = builder.get_value(auction, BIDS_KEY);
-    assert!(bids.is_empty());
+    let default_account_bid = bids.get(&DEFAULT_ACCOUNT_PUBLIC_KEY).unwrap();
+    assert!(default_account_bid.inactive());
+    assert!(default_account_bid.staked_amount().is_zero());
 
     let account_balance_after_slashing = builder.get_purse_balance(unbonding_purse);
     assert_eq!(account_balance_after_slashing, account_balance_before);

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -75,6 +75,11 @@ impl Bid {
         &self.staked_amount
     }
 
+    /// Gets the staked amount of the provided bid
+    pub fn staked_amount_mut(&mut self) -> &mut U512 {
+        &mut self.staked_amount
+    }
+
     /// Gets the delegation rate of the provided bid
     pub fn delegation_rate(&self) -> &DelegationRate {
         &self.delegation_rate


### PR DESCRIPTION
This PR updates the auction module to disable fully-unstaked and slashed bids instead of removing them from the bids map. 

This precedes upcoming changes to how bids are persisted in the auction module.

~**NOTE**: This PR depends on #984.~ (MERGED) 

~**Actual diff here**: https://github.com/henrytill/casper-node/compare/EE-1178...henrytill:EE-1179~

