### PR TITLE
EE-1182: simplify AccountHash::from_public_key

### DIFF
--- a/execution_engine/src/core/runtime/auction_internal.rs
+++ b/execution_engine/src/core/runtime/auction_internal.rs
@@ -1,12 +1,11 @@
 use casper_types::{
-    account,
     account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
     system::auction::{
         AccountProvider, Auction, EraInfo, Error, MintProvider, RuntimeProvider, StorageProvider,
         SystemProvider,
     },
-    CLTyped, CLValue, Key, TransferredTo, URef, BLAKE2B_DIGEST_LENGTH, U512,
+    CLTyped, CLValue, Key, TransferredTo, URef, U512,
 };
 
 use super::Runtime;
@@ -103,10 +102,6 @@ where
 
     fn get_key(&self, name: &str) -> Option<Key> {
         self.context.named_keys_get(name).cloned()
-    }
-
-    fn blake2b<T: AsRef<[u8]>>(&self, data: T) -> [u8; BLAKE2B_DIGEST_LENGTH] {
-        account::blake2b(data)
     }
 }
 

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -242,10 +242,7 @@ impl AccountHash {
     }
 
     #[doc(hidden)]
-    pub fn from_public_key(
-        public_key: &PublicKey,
-        blake2b_hash_fn: impl Fn(Vec<u8>) -> [u8; BLAKE2B_DIGEST_LENGTH],
-    ) -> Self {
+    pub fn from_public_key(public_key: &PublicKey) -> Self {
         const SYSTEM_LOWERCASE: &str = "system";
         const ED25519_LOWERCASE: &str = "ed25519";
         const SECP256K1_LOWERCASE: &str = "secp256k1";
@@ -266,7 +263,7 @@ impl AccountHash {
             data
         };
         // Hash the preimage data using blake2b256 and return it.
-        let digest = blake2b_hash_fn(preimage);
+        let digest = blake2b(preimage);
         Self::new(digest)
     }
 }
@@ -342,7 +339,7 @@ impl TryFrom<&alloc::vec::Vec<u8>> for AccountHash {
 
 impl From<&PublicKey> for AccountHash {
     fn from(public_key: &PublicKey) -> Self {
-        AccountHash::from_public_key(public_key, blake2b)
+        AccountHash::from_public_key(public_key)
     }
 }
 

--- a/types/src/system/auction/detail.rs
+++ b/types/src/system/auction/detail.rs
@@ -170,9 +170,7 @@ pub(crate) fn process_unbond_requests<P: Auction + ?Sized>(provider: &mut P) -> 
             // was calculated on `unbond` attempt.
             if current_era_id >= unbonding_purse.era_of_creation() + unbonding_delay {
                 let account_hash =
-                    AccountHash::from_public_key(unbonding_purse.unbonder_public_key(), |x| {
-                        provider.blake2b(x)
-                    });
+                    AccountHash::from_public_key(unbonding_purse.unbonder_public_key());
 
                 // Move funds from bid purse to unbonding purse
                 provider

--- a/types/src/system/auction/mod.rs
+++ b/types/src/system/auction/mod.rs
@@ -97,7 +97,7 @@ pub trait Auction:
         delegation_rate: DelegationRate,
         amount: U512,
     ) -> Result<U512, Error> {
-        let account_hash = AccountHash::from_public_key(&public_key, |x| self.blake2b(x));
+        let account_hash = AccountHash::from_public_key(&public_key);
         if self.get_caller() != account_hash {
             return Err(Error::InvalidPublicKey);
         }
@@ -144,7 +144,7 @@ pub trait Auction:
     /// The function returns a the new amount of motes remaining in the bid. If the target bid
     /// does not exist, the function call returns an error.
     fn withdraw_bid(&mut self, public_key: PublicKey, amount: U512) -> Result<U512, Error> {
-        let account_hash = AccountHash::from_public_key(&public_key, |x| self.blake2b(x));
+        let account_hash = AccountHash::from_public_key(&public_key);
         if self.get_caller() != account_hash {
             return Err(Error::InvalidPublicKey);
         }
@@ -200,7 +200,7 @@ pub trait Auction:
         validator_public_key: PublicKey,
         amount: U512,
     ) -> Result<U512, Error> {
-        let account_hash = AccountHash::from_public_key(&delegator_public_key, |x| self.blake2b(x));
+        let account_hash = AccountHash::from_public_key(&delegator_public_key);
         if self.get_caller() != account_hash {
             return Err(Error::InvalidPublicKey);
         }
@@ -255,7 +255,7 @@ pub trait Auction:
         validator_public_key: PublicKey,
         amount: U512,
     ) -> Result<U512, Error> {
-        let account_hash = AccountHash::from_public_key(&delegator_public_key, |x| self.blake2b(x));
+        let account_hash = AccountHash::from_public_key(&delegator_public_key);
         if self.get_caller() != account_hash {
             return Err(Error::InvalidPublicKey);
         }
@@ -559,7 +559,7 @@ pub trait Auction:
     /// Activates a given validator's bid.  To be used when a validator has been marked as inactive
     /// by consensus (aka "evicted").
     fn activate_bid(&mut self, validator_public_key: PublicKey) -> Result<(), Error> {
-        let account_hash = AccountHash::from_public_key(&validator_public_key, |x| self.blake2b(x));
+        let account_hash = AccountHash::from_public_key(&validator_public_key);
         if self.get_caller() != account_hash {
             return Err(Error::InvalidPublicKey);
         }

--- a/types/src/system/auction/providers.rs
+++ b/types/src/system/auction/providers.rs
@@ -2,7 +2,7 @@ use crate::{
     account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
     system::auction::{EraId, EraInfo, Error},
-    CLTyped, Key, TransferredTo, URef, BLAKE2B_DIGEST_LENGTH, U512,
+    CLTyped, Key, TransferredTo, URef, U512,
 };
 
 /// Provider of runtime host functionality.
@@ -12,9 +12,6 @@ pub trait RuntimeProvider {
 
     /// Gets named key under a `name`.
     fn get_key(&self, name: &str) -> Option<Key>;
-
-    /// Returns a 32-byte BLAKE2b digest
-    fn blake2b<T: AsRef<[u8]>>(&self, data: T) -> [u8; BLAKE2B_DIGEST_LENGTH];
 }
 
 /// Provides functionality of a contract storage.


### PR DESCRIPTION
This PR removes the `blake2b_hash_fn` parameter from `Account::from_public_key` and hardcodes its former use site to `account::blake2b`.  This parameter was originally necessary to support system contracts, but now that we have removed system contract support, it is no longer necessary.

This precedes upcoming changes to how bids are persisted in the auction module.