### PR TITLE
NDRS-940: Stop sync after very recent block.

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -283,7 +283,8 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
 
     /// Returns whether `block` can be considered tip of the chain.
     fn is_chain_end(&self, block: &Block) -> bool {
-        let acceptable_drift_millis = 5000;
+        // 1 minute.
+        let acceptable_drift_millis = 60 * 1000;
         block.header().timestamp().elapsed().millis() <= acceptable_drift_millis
     }
 

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -47,9 +47,7 @@ use super::{
 };
 use crate::{
     effect::{EffectBuilder, EffectExt, EffectOptionExt, Effects},
-    types::{
-        ActivationPoint, Block, BlockByHeight, BlockHash, Chainspec, FinalizedBlock,
-    },
+    types::{ActivationPoint, Block, BlockByHeight, BlockHash, Chainspec, FinalizedBlock},
     NodeRng,
 };
 use event::BlockByHeightResult;


### PR DESCRIPTION
We used to mark syncing as done if none of the peers gave us any new block (successor of the latest block we downloaded). This proves to be problematic when we have many peers and they don't respond to us in time, before the next block is created. This way we end up being stuck in a syncing loop.

This PR considers newly downloaded block to be the tip of a chain if it was created less than 1 minute ago.