### PR TITLE
NDRS-940: Do not return any effects after sync done.

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -266,6 +266,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                 );
                 if self.is_chain_end(&block) {
                     self.mark_done();
+                    return Effects::new()
                 }
                 match block.header().next_era_validator_weights() {
                     None => (),

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -266,7 +266,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                 );
                 if self.is_chain_end(&block) {
                     self.mark_done();
-                    return Effects::new()
+                    return Effects::new();
                 }
                 match block.header().next_era_validator_weights() {
                     None => (),


### PR DESCRIPTION
@fizyk20 found a bug in my code where it would replace the `self.state` with `curr_state` from before `mark_done()`.

We return `Effects::new()` (no effects) to stop the syncing process and let the reactor progress from joiner to validator.