### PR TITLE
NDRS-939: Add a delay before shutdown due to too many equivocations.

### DIFF
--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -110,6 +110,9 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     WeAreFaulty,
     /// We've received a unit from a doppelganger.
     DoppelgangerDetected,
+    /// Too many faulty validators. The protocol's fault tolerance threshold has been exceeded and
+    /// consensus cannot continue.
+    FttExceeded,
     /// We want to disconnect from a sender of invalid data.
     Disconnect(I),
 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -742,6 +742,7 @@ where
                     "attempted to create a new era with a non-switch block header: {}",
                     block
                 )
+                .ignore()
             }
         };
         let newly_slashed = era_end.equivocators.clone();
@@ -1047,6 +1048,7 @@ where
                 inactive era = {}",
                 self.era_supervisor.current_era
             )
+            .ignore()
         } else {
             Default::default()
         }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1025,12 +1025,12 @@ where
                 .collect(),
             ProtocolOutcome::WeAreFaulty => Default::default(),
             ProtocolOutcome::DoppelgangerDetected => Default::default(),
-            // TODO: Replace the panic with the appropriate shutdown effect once that's possible.
-            ProtocolOutcome::FttExceeded => self
-                .effect_builder
-                .set_timeout(Duration::from_millis(FTT_EXCEEDED_SHUTDOWN_DELAY_MILLIS))
-                .then(|_| async move { panic!("shutting down: too many faulty validators") })
-                .ignore(),
+            ProtocolOutcome::FttExceeded => {
+                let eb = self.effect_builder;
+                eb.set_timeout(Duration::from_millis(FTT_EXCEEDED_SHUTDOWN_DELAY_MILLIS))
+                    .then(move |_| fatal!(eb, "too many faulty validators"))
+                    .ignore()
+            }
         }
     }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -22,6 +22,7 @@ use blake2::{
     VarBlake2b,
 };
 use datasize::DataSize;
+use futures::FutureExt;
 use itertools::Itertools;
 use prometheus::Registry;
 use rand::Rng;
@@ -54,6 +55,10 @@ use crate::{
 };
 
 pub use self::era::{Era, EraId};
+
+/// The delay in milliseconds before we shutdown after the number of faulty validators exceeded the
+/// fault tolerance threshold.
+const FTT_EXCEEDED_SHUTDOWN_DELAY_MILLIS: u64 = 60 * 1000;
 
 type ConsensusConstructor<I> = dyn Fn(
     Digest,                                       // the era's unique instance ID
@@ -1019,6 +1024,12 @@ where
                 .collect(),
             ProtocolOutcome::WeAreFaulty => Default::default(),
             ProtocolOutcome::DoppelgangerDetected => Default::default(),
+            // TODO: Replace the panic with the appropriate shutdown effect once that's possible.
+            ProtocolOutcome::FttExceeded => self
+                .effect_builder
+                .set_timeout(Duration::from_millis(FTT_EXCEEDED_SHUTDOWN_DELAY_MILLIS))
+                .then(|_| async move { panic!("shutting down: too many faulty validators") })
+                .ignore(),
         }
     }
 
@@ -1032,7 +1043,8 @@ where
         if should_emit_error {
             fatal!(
                 self.effect_builder,
-                "Consensus shutting down due to inability to participate in the network; inactive era = {}",
+                "Consensus shutting down due to inability to participate in the network; \
+                inactive era = {}",
                 self.era_supervisor.current_era
             )
         } else {

--- a/node/src/components/consensus/highway_core/finality_detector.rs
+++ b/node/src/components/consensus/highway_core/finality_detector.rs
@@ -22,7 +22,7 @@ use horizon::Horizon;
 
 /// An error returned if the configured fault tolerance has been exceeded.
 #[derive(Debug)]
-pub(crate) struct FttExceeded(Weight);
+pub(crate) struct FttExceeded(pub Weight);
 
 /// An incremental finality detector.
 ///

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -319,6 +319,7 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Network<REv, P> {
                         "Could not acquire `known_addresses_mut` mutex: {:?}",
                         err
                     )
+                    .ignore()
                 }
             };
             if let Some(state) = known_addresses.get_mut(address) {
@@ -916,7 +917,7 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Component<REv> for Network<REv, P> {
             Event::ExpiredListenAddress(address) => {
                 self.listening_addresses.retain(|addr| *addr != address);
                 if self.listening_addresses.is_empty() {
-                    return fatal!(effect_builder, "no remaining listening addresses");
+                    return fatal!(effect_builder, "no remaining listening addresses").ignore();
                 }
                 debug!(%address, "{}: listening address expired", self.our_id);
                 Effects::new()
@@ -925,7 +926,7 @@ impl<REv: ReactorEventT<P>, P: PayloadT> Component<REv> for Network<REv, P> {
                 // If the listener closed without an error, we're already shutting down the server.
                 // Otherwise, we need to kill the node as it cannot function without a listener.
                 match reason {
-                    Err(error) => fatal!(effect_builder, "listener closed: {}", error),
+                    Err(error) => fatal!(effect_builder, "listener closed: {}", error).ignore(),
                     Ok(()) => {
                         debug!("{}: listener closed", self.our_id);
                         Effects::new()

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -338,10 +338,13 @@ where
 
         // If there are no pending connections, we failed to resolve any.
         if model.pending.is_empty() && !cfg.known_addresses.is_empty() {
-            effects.extend(fatal!(
-                effect_builder,
-                "was given known addresses, but failed to resolve any of them"
-            ));
+            effects.extend(
+                fatal!(
+                    effect_builder,
+                    "was given known addresses, but failed to resolve any of them"
+                )
+                .ignore(),
+            );
         } else {
             // Start broadcasting our public listening address.
             effects.extend(model.gossip_our_address(effect_builder));
@@ -781,7 +784,8 @@ where
                     effect_builder,
                     "{}: failed to connect to any known node, now isolated",
                     self.our_id
-                );
+                )
+                .ignore();
             }
         }
         Effects::new()

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -227,7 +227,7 @@ impl<REv> Component<REv> for Storage {
         // anyway, it should not matter.
         match result {
             Ok(effects) => effects,
-            Err(err) => fatal!(effect_builder, "storage error: {}", err),
+            Err(err) => fatal!(effect_builder, "storage error: {}", err).ignore(),
         }
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1524,6 +1524,6 @@ impl<REv> EffectBuilder<REv> {
 #[macro_export]
 macro_rules! fatal {
     ($effect_builder:expr, $($arg:tt)*) => {
-        $effect_builder.fatal(file!(), line!(), format_args!($($arg)*).to_string()).ignore()
+        $effect_builder.fatal(file!(), line!(), format_args!($($arg)*).to_string())
     };
 }


### PR DESCRIPTION
If the total weight of equivocators exceeds the configured fault tolerance threshold, consensus cannot continue and the node shuts down. This PR adds a delay for the shutdown so we can still broadcast evidence of the equivocations.

https://casperlabs.atlassian.net/browse/NDRS-939