### PR TITLE
NDRS-897 fixup: fix conversion to EE format

### DIFF
--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -442,18 +442,11 @@ impl ChainspecLoader {
             .global_state_update
             .as_ref()
             .map(|state_update| {
-                // TODO - confirm we're using base64 encoding for this.
                 state_update
                     .0
                     .iter()
-                    .map(|(key, encoded_bytes)| {
-                        let decoded_bytes = base64::decode(encoded_bytes).unwrap_or_else(|error| {
-                            panic!(
-                                "failed to base64 decode global state value for upgrade: {}",
-                                error
-                            )
-                        });
-                        let stored_value: StoredValue = bytesrepr::deserialize(decoded_bytes)
+                    .map(|(key, stored_value_bytes)| {
+                        let stored_value: StoredValue = bytesrepr::deserialize(stored_value_bytes)
                             .unwrap_or_else(|error| {
                                 panic!(
                                 "failed to parse global state value as StoredValue for upgrade: {}",

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -35,7 +35,7 @@ use casper_execution_engine::{
     },
     shared::stored_value::StoredValue,
 };
-use casper_types::{bytesrepr, ProtocolVersion};
+use casper_types::{bytesrepr::FromBytes, ProtocolVersion};
 
 #[cfg(test)]
 use crate::utils::RESOURCES_PATH;
@@ -446,13 +446,14 @@ impl ChainspecLoader {
                     .0
                     .iter()
                     .map(|(key, stored_value_bytes)| {
-                        let stored_value: StoredValue = bytesrepr::deserialize(stored_value_bytes)
+                        let stored_value = StoredValue::from_bytes(stored_value_bytes)
                             .unwrap_or_else(|error| {
                                 panic!(
                                 "failed to parse global state value as StoredValue for upgrade: {}",
                                 error
                             )
-                            });
+                            })
+                            .0;
                         (*key, stored_value)
                     })
                     .collect()


### PR DESCRIPTION
The chainspec loader was doing an unnecessary base64 decoding when preparing an `UpgradeConfig` struct (it's already being done when parsing the chainspec) - this is removing it.