### PR TITLE
Backport the change to make handshake depend on network name.

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -87,7 +87,6 @@ use crate::{
     components::{
         network::ENABLE_SMALL_NET_ENV_VAR, networking_metrics::NetworkingMetrics, Component,
     },
-    crypto::hash::Digest,
     effect::{
         announcements::NetworkAnnouncement,
         requests::{NetworkInfoRequest, NetworkRequest},
@@ -154,9 +153,9 @@ where
     pending: HashSet<SocketAddr>,
     /// The interval between each fresh round of gossiping the node's public listening address.
     gossip_interval: Duration,
-    /// The hash of the chainspec.  We only remain connected to peers with the same
+    /// Name of the network we participate in. We only remain connected to peers with the same
     /// `genesis_config_hash` as us.
-    genesis_config_hash: Digest,
+    network_name: String,
     /// Channel signaling a shutdown of the small network.
     // Note: This channel is closed when `SmallNetwork` is dropped, signalling the receivers that
     // they should cease operation.
@@ -191,7 +190,7 @@ where
         cfg: Config,
         registry: &Registry,
         small_network_identity: SmallNetworkIdentity,
-        genesis_config_hash: Digest,
+        network_name: String,
         notify: bool,
     ) -> Result<(SmallNetwork<REv, P>, Effects<Event<P>>)> {
         // Assert we have at least one known address in the config.
@@ -224,7 +223,7 @@ where
                 pending: HashSet::new(),
                 blocklist: HashSet::new(),
                 gossip_interval: cfg.gossip_interval,
-                genesis_config_hash,
+                network_name: network_name,
                 shutdown_sender: None,
                 shutdown_receiver: watch::channel(()).1,
                 server_join_handle: None,
@@ -285,7 +284,7 @@ where
             pending: HashSet::new(),
             blocklist: HashSet::new(),
             gossip_interval: cfg.gossip_interval,
-            genesis_config_hash,
+            network_name: network_name,
             shutdown_sender: Some(server_shutdown_sender),
             shutdown_receiver,
             server_join_handle: Some(server_join_handle),
@@ -435,7 +434,7 @@ where
                 // The sink is only used to send a single handshake message, then dropped.
                 let (mut sink, stream) = framed::<P>(transport).split();
                 let handshake = Message::Handshake {
-                    genesis_config_hash: self.genesis_config_hash,
+                    network_name: self.network_name.clone()
                 };
                 let mut effects = async move {
                     let _ = sink.send(handshake).await;
@@ -534,7 +533,7 @@ where
         let mut effects = self.check_connection_complete(effect_builder, peer_id.clone());
 
         let handshake = Message::Handshake {
-            genesis_config_hash: self.genesis_config_hash,
+            network_name: self.network_name.clone(),
         };
         let peer_id_cloned = peer_id.clone();
         effects.extend(
@@ -678,16 +677,14 @@ where
         REv: From<NetworkAnnouncement<NodeId, P>>,
     {
         match msg {
-            Message::Handshake {
-                genesis_config_hash,
-            } => {
-                if genesis_config_hash != self.genesis_config_hash {
+            Message::Handshake { network_name } => {
+                if network_name != self.network_name {
                     info!(
                         our_id=%self.our_id,
                         %peer_id,
-                        our_hash=?self.genesis_config_hash,
-                        their_hash=?genesis_config_hash,
-                        "dropping connection due to genesis config hash mismatch"
+                        our_network=?self.network_name,
+                        their_network=?network_name,
+                        "dropping connection due to network name mismatch"
                     );
                     return self.remove(effect_builder, &peer_id, false);
                 }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -223,7 +223,7 @@ where
                 pending: HashSet::new(),
                 blocklist: HashSet::new(),
                 gossip_interval: cfg.gossip_interval,
-                network_name: network_name,
+                network_name,
                 shutdown_sender: None,
                 shutdown_receiver: watch::channel(()).1,
                 server_join_handle: None,
@@ -284,7 +284,7 @@ where
             pending: HashSet::new(),
             blocklist: HashSet::new(),
             gossip_interval: cfg.gossip_interval,
-            network_name: network_name,
+            network_name,
             shutdown_sender: Some(server_shutdown_sender),
             shutdown_receiver,
             server_join_handle: Some(server_join_handle),
@@ -434,7 +434,7 @@ where
                 // The sink is only used to send a single handshake message, then dropped.
                 let (mut sink, stream) = framed::<P>(transport).split();
                 let handshake = Message::Handshake {
-                    network_name: self.network_name.clone()
+                    network_name: self.network_name.clone(),
                 };
                 let mut effects = async move {
                     let _ = sink.send(handshake).await;

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -2,20 +2,16 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-use crate::crypto::hash::Digest;
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Message<P> {
-    Handshake { genesis_config_hash: Digest },
+    Handshake { network_name: String },
     Payload(P),
 }
 
 impl<P: Display> Display for Message<P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Message::Handshake {
-                genesis_config_hash,
-            } => write!(f, "handshake: {}", genesis_config_hash),
+            Message::Handshake { network_name } => write!(f, "handshake: {}", network_name),
             Message::Payload(payload) => write!(f, "payload: {}", payload),
         }
     }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -119,7 +119,7 @@ impl Reactor for TestReactor {
             cfg,
             registry,
             small_network_identity,
-            Digest::default(),
+            "test_network".to_string(),
             false,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -24,7 +24,6 @@ use crate::{
         small_network::SmallNetworkIdentity,
         Component,
     },
-    crypto::hash::Digest,
     effect::{
         announcements::{GossiperAnnouncement, NetworkAnnouncement},
         requests::{NetworkRequest, StorageRequest},

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -407,13 +407,13 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             false,
         )?;
-        let genesis_config_hash = chainspec_loader.chainspec().hash();
+        let network_name = chainspec_loader.chainspec().network_config.name.clone();
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network.clone(),
             registry,
             small_network_identity,
-            genesis_config_hash,
+            network_name,
             false,
         )?;
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -386,13 +386,13 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             true,
         )?;
-        let genesis_config_hash = chainspec_loader.chainspec().hash();
+        let network_name = chainspec_loader.chainspec().network_config.name.clone();
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network,
             registry,
             small_network_identity,
-            genesis_config_hash,
+            network_name,
             true,
         )?;
 


### PR DESCRIPTION
Handshake cannot use the chainspec hash anymore since post-upgrade nodes
will be using different chainspec from the joining node (which hasn't
upgraded yet).