### PR TITLE
EE-1172: Delegators vesting schedule

### DIFF
--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -21,7 +21,7 @@ pub enum Error {
     #[error("Invalid protocol version: {0}")]
     InvalidProtocolVersion(ProtocolVersion),
     #[error("Genesis error.")]
-    Genesis(GenesisError),
+    Genesis(Box<GenesisError>),
     #[error("Wasm preprocessing error: {0}")]
     WasmPreprocessing(#[from] wasm_prep::PreprocessingError),
     #[error("Wasm serialization error: {0:?}")]
@@ -74,6 +74,12 @@ impl From<bytesrepr::Error> for Error {
 impl From<mint::Error> for Error {
     fn from(error: mint::Error) -> Self {
         Error::Mint(format!("{}", error))
+    }
+}
+
+impl From<GenesisError> for Error {
+    fn from(genesis_error: GenesisError) -> Self {
+        Self::Genesis(Box::new(genesis_error))
     }
 }
 

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -802,14 +802,15 @@ where
                             .expect("should have delegator variant");
                         if *validator_public_key == public_key {
                             let purse_uref = self.create_purse(
-                                staked_amount.value(),
+                                delegator_delegated_amount.value(),
                                 DeployHash::new(delegator_public_key.to_account_hash().value()),
                             )?;
 
-                            let delegator = Delegator::new(
+                            let delegator = Delegator::locked(
                                 delegator_delegated_amount.value(),
                                 purse_uref,
                                 *validator_public_key,
+                                release_timestamp_millis,
                             );
                             bid.delegators_mut()
                                 .insert(*delegator_public_key, delegator);

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -166,20 +166,16 @@ where
         );
 
         // Create mint
-        let mint_hash = genesis_installer.create_mint().map_err(Error::Genesis)?;
+        let mint_hash = genesis_installer.create_mint()?;
 
         // Create accounts
-        genesis_installer
-            .create_accounts()
-            .map_err(Error::Genesis)?;
+        genesis_installer.create_accounts()?;
 
         // Create proof of stake
-        let proof_of_stake_hash = genesis_installer
-            .create_proof_of_stake()
-            .map_err(Error::Genesis)?;
+        let proof_of_stake_hash = genesis_installer.create_proof_of_stake()?;
 
         // Create auction
-        let auction_hash = genesis_installer.create_auction().map_err(Error::Genesis)?;
+        let auction_hash = genesis_installer.create_auction()?;
 
         // Create standard payment
         let standard_payment_hash = genesis_installer.create_standard_payment();

--- a/execution_engine_testing/cargo_casper/src/tests_package.rs
+++ b/execution_engine_testing/cargo_casper/src/tests_package.rs
@@ -21,7 +21,6 @@ mod tests {
     use casper_types::{runtime_args, RuntimeArgs, U512, account::AccountHash, PublicKey, SecretKey};
 
     const MY_ACCOUNT: [u8; 32] = [7u8; 32];
-    const MY_ADDR: [u8; 32] = [8u8; 32];
     // define KEY constant to match that in the contract
     const KEY: &str = "special_value";
     const VALUE: &str = "hello world";
@@ -30,7 +29,7 @@ mod tests {
     #[test]
     fn should_store_hello_world() {
         let public_key: PublicKey = SecretKey::ed25519(MY_ACCOUNT).into();
-        let account_addr = AccountHash::new(MY_ADDR);
+        let account_addr = AccountHash::from(&public_key);
 
         let mut context = TestContextBuilder::new()
             .with_public_key(public_key, U512::from(500_000_000_000_000_000u64))

--- a/execution_engine_testing/cargo_casper/src/tests_package.rs
+++ b/execution_engine_testing/cargo_casper/src/tests_package.rs
@@ -33,7 +33,7 @@ mod tests {
         let account_addr = AccountHash::new(MY_ADDR);
 
         let mut context = TestContextBuilder::new()
-            .with_public_key(public_key, account_addr, U512::from(500_000_000_000_000_000u64))
+            .with_public_key(public_key, U512::from(500_000_000_000_000_000u64))
             .build();
 
         // The test framework checks for compiled Wasm files in '<current working dir>/wasm'.  Paths

--- a/execution_engine_testing/cargo_casper/tests/integration_tests.rs
+++ b/execution_engine_testing/cargo_casper/tests/integration_tests.rs
@@ -70,6 +70,7 @@ fn run_tool_and_resulting_tests() {
     fs::remove_dir_all(&temp_dir).unwrap();
 }
 
+#[ignore]
 #[test]
 fn should_run_casperlabs_node() {
     run_tool_and_resulting_tests();

--- a/execution_engine_testing/cargo_casper/tests/integration_tests.rs
+++ b/execution_engine_testing/cargo_casper/tests/integration_tests.rs
@@ -70,7 +70,6 @@ fn run_tool_and_resulting_tests() {
     fs::remove_dir_all(&temp_dir).unwrap();
 }
 
-#[ignore]
 #[test]
 fn should_run_casperlabs_node() {
     run_tool_and_resulting_tests();

--- a/execution_engine_testing/test_support/src/internal/mod.rs
+++ b/execution_engine_testing/test_support/src/internal/mod.rs
@@ -75,16 +75,14 @@ pub static DEFAULT_PROPOSER_ADDR: Lazy<AccountHash> =
     Lazy::new(|| AccountHash::from(&*DEFAULT_PROPOSER_PUBLIC_KEY));
 pub static DEFAULT_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
     let mut ret = Vec::new();
-    let genesis_account = GenesisAccount::new(
+    let genesis_account = GenesisAccount::account(
         *DEFAULT_ACCOUNT_PUBLIC_KEY,
-        *DEFAULT_ACCOUNT_ADDR,
         Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
         Motes::zero(),
     );
     ret.push(genesis_account);
-    let proposer_account = GenesisAccount::new(
+    let proposer_account = GenesisAccount::account(
         *DEFAULT_PROPOSER_PUBLIC_KEY,
-        *DEFAULT_PROPOSER_ADDR,
         Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
         Motes::zero(),
     );

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -33,7 +33,7 @@
 //! let account_addr = AccountHash::new(MY_ADDR);
 //!
 //! let mut context = TestContextBuilder::new()
-//!     .with_public_key(public_key, account_addr, U512::from(128_000_000_000_000u64))
+//!     .with_public_key(public_key, U512::from(128_000_000_000_000u64))
 //!     .build();
 //!
 //! // The test framework checks for compiled Wasm files in '<current working dir>/wasm'.  Paths

--- a/execution_engine_testing/test_support/src/test_context.rs
+++ b/execution_engine_testing/test_support/src/test_context.rs
@@ -168,18 +168,9 @@ impl TestContextBuilder {
     /// the Genesis block.
     ///
     /// Note: `initial_balance` represents the number of motes.
-    pub fn with_public_key(
-        mut self,
-        public_key: PublicKey,
-        account_hash: AccountHash,
-        initial_balance: U512,
-    ) -> Self {
-        let new_account = GenesisAccount::new(
-            public_key,
-            account_hash,
-            Motes::new(initial_balance),
-            Motes::zero(),
-        );
+    pub fn with_public_key(mut self, public_key: PublicKey, initial_balance: U512) -> Self {
+        let new_account =
+            GenesisAccount::account(public_key, Motes::new(initial_balance), Motes::zero());
         self.genesis_config
             .ee_config_mut()
             .push_account(new_account);

--- a/execution_engine_testing/tests/src/test/check_transfer_success.rs
+++ b/execution_engine_testing/tests/src/test/check_transfer_success.rs
@@ -25,7 +25,6 @@ fn test_check_transfer_success_with_source_only() {
     let mut test_context = TestContextBuilder::new()
         .with_public_key(
             *DEFAULT_ACCOUNT_PUBLIC_KEY,
-            *DEFAULT_ACCOUNT_ADDR,
             U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE),
         )
         .build();
@@ -61,7 +60,6 @@ fn test_check_transfer_success_with_source_only_errors() {
     let mut test_context = TestContextBuilder::new()
         .with_public_key(
             *DEFAULT_ACCOUNT_PUBLIC_KEY,
-            *DEFAULT_ACCOUNT_ADDR,
             U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE),
         )
         .build();
@@ -98,7 +96,6 @@ fn test_check_transfer_success_with_source_and_target() {
     let mut test_context = TestContextBuilder::new()
         .with_public_key(
             *DEFAULT_ACCOUNT_PUBLIC_KEY,
-            *DEFAULT_ACCOUNT_ADDR,
             U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE),
         )
         .build();
@@ -139,7 +136,6 @@ fn test_check_transfer_success_with_target_error() {
     let mut test_context = TestContextBuilder::new()
         .with_public_key(
             *DEFAULT_ACCOUNT_PUBLIC_KEY,
-            *DEFAULT_ACCOUNT_ADDR,
             U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE),
         )
         .build();

--- a/execution_engine_testing/tests/src/test/regression/eco_863.rs
+++ b/execution_engine_testing/tests/src/test/regression/eco_863.rs
@@ -1,4 +1,5 @@
 use assert_matches::assert_matches;
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -35,11 +36,10 @@ static ALICE_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ALICE));
 #[test]
 fn faucet_should_create_account() {
     let accounts = {
-        let faucet_account = GenesisAccount::new(
+        let faucet_account = GenesisAccount::account(
             *FAUCET,
-            *FAUCET_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(U512::zero()),
+            Motes::zero(),
         );
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         tmp.push(faucet_account);
@@ -127,17 +127,15 @@ fn faucet_should_create_account() {
 #[test]
 fn faucet_should_transfer_to_existing_account() {
     let accounts = {
-        let faucet_account = GenesisAccount::new(
+        let faucet_account = GenesisAccount::account(
             *FAUCET,
-            *FAUCET_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(U512::zero()),
+            Motes::zero(),
         );
-        let alice_account = GenesisAccount::new(
+        let alice_account = GenesisAccount::account(
             *ALICE,
-            *ALICE_ADDR,
             Motes::new(MINIMUM_ACCOUNT_CREATION_BALANCE.into()),
-            Motes::new(U512::zero()),
+            Motes::zero(),
         );
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         tmp.push(faucet_account);

--- a/execution_engine_testing/tests/src/test/regression/ee_1045.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1045.rs
@@ -25,25 +25,21 @@ const TRANSFER_AMOUNT: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE + 1000;
 
 static ACCOUNT_1_PK: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([200; SecretKey::ED25519_LENGTH]).into());
-static ACCOUNT_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_1_PK));
 const ACCOUNT_1_BALANCE: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 const ACCOUNT_1_BOND: u64 = 100_000;
 
 static ACCOUNT_2_PK: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([202; SecretKey::ED25519_LENGTH]).into());
-static ACCOUNT_2_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_2_PK));
 const ACCOUNT_2_BALANCE: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 const ACCOUNT_2_BOND: u64 = 200_000;
 
 static ACCOUNT_3_PK: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([204; SecretKey::ED25519_LENGTH]).into());
-static ACCOUNT_3_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_3_PK));
 const ACCOUNT_3_BALANCE: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 const ACCOUNT_3_BOND: u64 = 200_000;
 
 static ACCOUNT_4_PK: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([206; SecretKey::ED25519_LENGTH]).into());
-static ACCOUNT_4_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_4_PK));
 const ACCOUNT_4_BALANCE: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 const ACCOUNT_4_BOND: u64 = 200_000;
 
@@ -52,27 +48,23 @@ const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 #[ignore]
 #[test]
 fn should_run_ee_1045_squash_validators() {
-    let account_1 = GenesisAccount::new(
+    let account_1 = GenesisAccount::account(
         *ACCOUNT_1_PK,
-        *ACCOUNT_1_ADDR,
         Motes::new(ACCOUNT_1_BALANCE.into()),
         Motes::new(ACCOUNT_1_BOND.into()),
     );
-    let account_2 = GenesisAccount::new(
+    let account_2 = GenesisAccount::account(
         *ACCOUNT_2_PK,
-        *ACCOUNT_2_ADDR,
         Motes::new(ACCOUNT_2_BALANCE.into()),
         Motes::new(ACCOUNT_2_BOND.into()),
     );
-    let account_3 = GenesisAccount::new(
+    let account_3 = GenesisAccount::account(
         *ACCOUNT_3_PK,
-        *ACCOUNT_3_ADDR,
         Motes::new(ACCOUNT_3_BALANCE.into()),
         Motes::new(ACCOUNT_3_BOND.into()),
     );
-    let account_4 = GenesisAccount::new(
+    let account_4 = GenesisAccount::account(
         *ACCOUNT_4_PK,
-        *ACCOUNT_4_ADDR,
         Motes::new(ACCOUNT_4_BALANCE.into()),
         Motes::new(ACCOUNT_4_BOND.into()),
     );

--- a/execution_engine_testing/tests/src/test/regression/ee_1103.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1103.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -43,9 +44,6 @@ static DELEGATOR_3: Lazy<PublicKey> =
 // at the time of their introduction.
 
 static FAUCET_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*FAUCET));
-static VALIDATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_1));
-static VALIDATOR_2_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_2));
-static VALIDATOR_3_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_3));
 static FAUCET_BALANCE: Lazy<U512> = Lazy::new(|| U512::from(100_000_000_000_000_000u64));
 static VALIDATOR_1_BALANCE: Lazy<U512> = Lazy::new(|| U512::from(100_000_000_000_000_000u64));
 static VALIDATOR_2_BALANCE: Lazy<U512> = Lazy::new(|| U512::from(100_000_000_000_000_000u64));
@@ -67,27 +65,19 @@ static DELEGATOR_3_STAKE: Lazy<U512> = Lazy::new(|| U512::from(300_000_000_000_0
 #[test]
 fn validator_scores_should_reflect_delegates() {
     let accounts = {
-        let faucet = GenesisAccount::new(
-            *FAUCET,
-            *FAUCET_ADDR,
-            Motes::new(*FAUCET_BALANCE),
-            Motes::new(U512::zero()),
-        );
-        let validator_1 = GenesisAccount::new(
+        let faucet = GenesisAccount::account(*FAUCET, Motes::new(*FAUCET_BALANCE), Motes::zero());
+        let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
-            *VALIDATOR_1_ADDR,
             Motes::new(*VALIDATOR_1_BALANCE),
             Motes::new(*VALIDATOR_1_STAKE),
         );
-        let validator_2 = GenesisAccount::new(
+        let validator_2 = GenesisAccount::account(
             *VALIDATOR_2,
-            *VALIDATOR_2_ADDR,
             Motes::new(*VALIDATOR_2_BALANCE),
             Motes::new(*VALIDATOR_2_STAKE),
         );
-        let validator_3 = GenesisAccount::new(
+        let validator_3 = GenesisAccount::account(
             *VALIDATOR_3,
-            *VALIDATOR_3_ADDR,
             Motes::new(*VALIDATOR_3_BALANCE),
             Motes::new(*VALIDATOR_3_STAKE),
         );

--- a/execution_engine_testing/tests/src/test/regression/ee_1119.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1119.rs
@@ -47,9 +47,8 @@ const VESTING_WEEKS: u64 = 14;
 #[test]
 fn should_run_ee_1119_dont_slash_delegated_validators() {
     let accounts = {
-        let validator_1 = GenesisAccount::new(
+        let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
-            *VALIDATOR_1_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
             Motes::new(VALIDATOR_1_STAKE.into()),
         );

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -40,7 +40,6 @@ static DELEGATOR_1: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([5; SecretKey::ED25519_LENGTH]).into());
 
 static SYSTEM_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::new([0u8; ACCOUNT_HASH_LENGTH]));
-static VALIDATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_1));
 static VALIDATOR_2_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_2));
 static DELEGATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*DELEGATOR_1));
 
@@ -51,15 +50,13 @@ const VALIDATOR_2_STAKE: u64 = 350_000;
 #[test]
 fn should_run_ee_1120_slash_delegators() {
     let accounts = {
-        let validator_1 = GenesisAccount::new(
+        let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
-            *VALIDATOR_1_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
             Motes::new(VALIDATOR_1_STAKE.into()),
         );
-        let validator_2 = GenesisAccount::new(
+        let validator_2 = GenesisAccount::account(
             *VALIDATOR_2,
-            *VALIDATOR_2_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
             Motes::new(VALIDATOR_2_STAKE.into()),
         );

--- a/execution_engine_testing/tests/src/test/regression/ee_1129.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1129.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 use parity_wasm::builder;
 
@@ -41,9 +42,8 @@ static CALL_STORED_CONTRACT_OVERHEAD: Lazy<U512> = Lazy::new(|| U512::from(10_00
 #[test]
 fn should_run_ee_1129_underfunded_delegate_call() {
     let accounts = {
-        let validator_1 = GenesisAccount::new(
+        let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
-            *VALIDATOR_1_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
             Motes::new(VALIDATOR_1_STAKE.into()),
         );
@@ -104,11 +104,10 @@ fn should_run_ee_1129_underfunded_delegate_call() {
 #[test]
 fn should_run_ee_1129_underfunded_add_bid_call() {
     let accounts = {
-        let validator_1 = GenesisAccount::new(
+        let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
-            *VALIDATOR_1_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(U512::zero()),
+            Motes::zero(),
         );
 
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();

--- a/execution_engine_testing/tests/src/test/regression/ee_1152.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1152.rs
@@ -30,7 +30,6 @@ static VALIDATOR_1_SECRET_KEY: Lazy<SecretKey> =
 
 static VALIDATOR_1: Lazy<PublicKey> = Lazy::new(|| PublicKey::from(&*VALIDATOR_1_SECRET_KEY));
 static DELEGATOR_1: Lazy<PublicKey> = Lazy::new(|| PublicKey::from(&*DELEGATOR_1_SECRET_KEY));
-static VALIDATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_1));
 static DELEGATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*DELEGATOR_1));
 
 const VALIDATOR_STAKE: u64 = 1_000_000_000;
@@ -40,15 +39,13 @@ const DELEGATE_AMOUNT: u64 = 1_234_567;
 #[test]
 fn should_run_ee_1152_regression_test() {
     let accounts = {
-        let validator_1 = GenesisAccount::new(
+        let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
-            *VALIDATOR_1_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
             Motes::new(VALIDATOR_STAKE.into()),
         );
-        let validator_2 = GenesisAccount::new(
+        let validator_2 = GenesisAccount::account(
             *DELEGATOR_1,
-            *DELEGATOR_1_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
             Motes::new(VALIDATOR_STAKE.into()),
         );

--- a/execution_engine_testing/tests/src/test/regression/ee_597.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_597.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -6,7 +7,7 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
 use casper_types::{
-    account::AccountHash, system::auction, ApiError, PublicKey, RuntimeArgs, SecretKey, U512,
+    account::AccountHash, system::auction, ApiError, PublicKey, RuntimeArgs, SecretKey,
 };
 
 const CONTRACT_EE_597_REGRESSION: &str = "ee_597_regression.wasm";
@@ -21,11 +22,10 @@ const VALID_BALANCE: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 fn should_fail_when_bonding_amount_is_zero_ee_597_regression() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account = GenesisAccount::new(
+        let account = GenesisAccount::account(
             *VALID_PUBLIC_KEY,
-            *VALID_ADDR,
             Motes::new(VALID_BALANCE.into()),
-            Motes::new(U512::zero()),
+            Motes::zero(),
         );
         tmp.push(account);
         tmp

--- a/execution_engine_testing/tests/src/test/regression/ee_598.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_598.rs
@@ -33,12 +33,10 @@ static ACCOUNT_1_BOND: Lazy<U512> = Lazy::new(|| U512::from(25_000));
 #[test]
 fn should_fail_unbonding_more_than_it_was_staked_ee_598_regression() {
     let public_key: PublicKey = SecretKey::ed25519([42; SecretKey::ED25519_LENGTH]).into();
-    let account_hash = AccountHash::from(&public_key);
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account = GenesisAccount::new(
+        let account = GenesisAccount::account(
             public_key,
-            account_hash,
             Motes::new(GENESIS_VALIDATOR_STAKE.into()) * Motes::new(2.into()),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()),
         );

--- a/execution_engine_testing/tests/src/test/step.rs
+++ b/execution_engine_testing/tests/src/test/step.rs
@@ -11,7 +11,6 @@ use casper_execution_engine::{
     storage::global_state::in_memory::InMemoryGlobalState,
 };
 use casper_types::{
-    account::AccountHash,
     system::{
         auction::{
             Bids, SeigniorageRecipientsSnapshot, BIDS_KEY, BLOCK_REWARD,
@@ -24,13 +23,11 @@ use casper_types::{
 
 static ACCOUNT_1_PK: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([200; SecretKey::ED25519_LENGTH]).into());
-static ACCOUNT_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_1_PK));
 const ACCOUNT_1_BALANCE: u64 = 100_000_000;
 const ACCOUNT_1_BOND: u64 = 100_000_000;
 
 static ACCOUNT_2_PK: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([202; SecretKey::ED25519_LENGTH]).into());
-static ACCOUNT_2_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_2_PK));
 const ACCOUNT_2_BALANCE: u64 = 200_000_000;
 const ACCOUNT_2_BOND: u64 = 200_000_000;
 
@@ -52,15 +49,13 @@ fn initialize_builder() -> WasmTestBuilder<InMemoryGlobalState> {
 
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account_1 = GenesisAccount::new(
+        let account_1 = GenesisAccount::account(
             *ACCOUNT_1_PK,
-            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
-        let account_2 = GenesisAccount::new(
+        let account_2 = GenesisAccount::account(
             *ACCOUNT_2_PK,
-            *ACCOUNT_2_ADDR,
             Motes::new(ACCOUNT_2_BALANCE.into()),
             Motes::new(ACCOUNT_2_BOND.into()),
         );

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -118,9 +118,8 @@ const VALIDATOR_1_DELEGATION_RATE: DelegationRate = 0;
 fn should_run_add_bid() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account_1 = GenesisAccount::new(
+        let account_1 = GenesisAccount::account(
             *BID_ACCOUNT_1_PK,
-            *BID_ACCOUNT_1_ADDR,
             Motes::new(BID_ACCOUNT_1_BALANCE.into()),
             Motes::new(BID_ACCOUNT_1_BOND.into()),
         );
@@ -225,9 +224,8 @@ fn should_run_add_bid() {
 fn should_run_delegate_and_undelegate() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account_1 = GenesisAccount::new(
+        let account_1 = GenesisAccount::account(
             *BID_ACCOUNT_1_PK,
-            *BID_ACCOUNT_1_ADDR,
             Motes::new(BID_ACCOUNT_1_BALANCE.into()),
             Motes::new(BID_ACCOUNT_1_BOND.into()),
         );
@@ -388,21 +386,18 @@ fn should_calculate_era_validators() {
     assert_ne!(*ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR,);
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account_1 = GenesisAccount::new(
+        let account_1 = GenesisAccount::account(
             *ACCOUNT_1_PK,
-            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
-        let account_2 = GenesisAccount::new(
+        let account_2 = GenesisAccount::account(
             *ACCOUNT_2_PK,
-            *ACCOUNT_2_ADDR,
             Motes::new(ACCOUNT_2_BALANCE.into()),
             Motes::new(ACCOUNT_2_BOND.into()),
         );
-        let account_3 = GenesisAccount::new(
+        let account_3 = GenesisAccount::account(
             *BID_ACCOUNT_1_PK,
-            *BID_ACCOUNT_1_ADDR,
             Motes::new(BID_ACCOUNT_1_BALANCE.into()),
             Motes::new(BID_ACCOUNT_1_BOND.into()),
         );
@@ -544,15 +539,13 @@ fn should_calculate_era_validators() {
 fn should_get_first_seigniorage_recipients() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account_1 = GenesisAccount::new(
+        let account_1 = GenesisAccount::account(
             *ACCOUNT_1_PK,
-            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
-        let account_2 = GenesisAccount::new(
+        let account_2 = GenesisAccount::account(
             *ACCOUNT_2_PK,
-            *ACCOUNT_2_ADDR,
             Motes::new(ACCOUNT_2_BALANCE.into()),
             Motes::new(ACCOUNT_2_BOND.into()),
         );
@@ -745,9 +738,8 @@ fn should_release_founder_stake() {
 
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account_1 = GenesisAccount::new(
+        let account_1 = GenesisAccount::account(
             *ACCOUNT_1_PK,
-            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
@@ -875,9 +867,8 @@ fn should_release_founder_stake() {
 fn should_fail_to_get_era_validators() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account_1 = GenesisAccount::new(
+        let account_1 = GenesisAccount::account(
             *ACCOUNT_1_PK,
-            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
@@ -901,9 +892,8 @@ fn should_fail_to_get_era_validators() {
 #[ignore]
 #[test]
 fn should_use_era_validators_endpoint_for_first_era() {
-    let extra_accounts = vec![GenesisAccount::new(
+    let extra_accounts = vec![GenesisAccount::account(
         *ACCOUNT_1_PK,
-        *ACCOUNT_1_ADDR,
         Motes::new(ACCOUNT_1_BALANCE.into()),
         Motes::new(ACCOUNT_1_BOND.into()),
     )];
@@ -939,27 +929,23 @@ fn should_calculate_era_validators_multiple_new_bids() {
     assert_ne!(*ACCOUNT_2_ADDR, *DEFAULT_ACCOUNT_ADDR,);
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account_1 = GenesisAccount::new(
+        let account_1 = GenesisAccount::account(
             *ACCOUNT_1_PK,
-            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
-        let account_2 = GenesisAccount::new(
+        let account_2 = GenesisAccount::account(
             *ACCOUNT_2_PK,
-            *ACCOUNT_2_ADDR,
             Motes::new(ACCOUNT_2_BALANCE.into()),
             Motes::new(ACCOUNT_2_BOND.into()),
         );
-        let account_3 = GenesisAccount::new(
+        let account_3 = GenesisAccount::account(
             *BID_ACCOUNT_1_PK,
-            *BID_ACCOUNT_1_ADDR,
             Motes::new(BID_ACCOUNT_1_BALANCE.into()),
             Motes::new(BID_ACCOUNT_1_BOND.into()),
         );
-        let account_4 = GenesisAccount::new(
+        let account_4 = GenesisAccount::account(
             *BID_ACCOUNT_2_PK,
-            *BID_ACCOUNT_2_ADDR,
             Motes::new(BID_ACCOUNT_2_BALANCE.into()),
             Motes::new(BID_ACCOUNT_2_BOND.into()),
         );
@@ -1800,27 +1786,23 @@ fn should_handle_evictions() {
 
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account_1 = GenesisAccount::new(
+        let account_1 = GenesisAccount::account(
             *ACCOUNT_1_PK,
-            *ACCOUNT_1_ADDR,
             Motes::new(ACCOUNT_1_BALANCE.into()),
             Motes::new(ACCOUNT_1_BOND.into()),
         );
-        let account_2 = GenesisAccount::new(
+        let account_2 = GenesisAccount::account(
             *ACCOUNT_2_PK,
-            *ACCOUNT_2_ADDR,
             Motes::new(ACCOUNT_2_BALANCE.into()),
             Motes::new(ACCOUNT_2_BOND.into()),
         );
-        let account_3 = GenesisAccount::new(
+        let account_3 = GenesisAccount::account(
             *BID_ACCOUNT_1_PK,
-            *BID_ACCOUNT_1_ADDR,
             Motes::new(BID_ACCOUNT_1_BALANCE.into()),
             Motes::new(300_000.into()),
         );
-        let account_4 = GenesisAccount::new(
+        let account_4 = GenesisAccount::account(
             *BID_ACCOUNT_2_PK,
-            *BID_ACCOUNT_2_ADDR,
             Motes::new(BID_ACCOUNT_2_BALANCE.into()),
             Motes::new(400_000.into()),
         );

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -2275,8 +2275,8 @@ fn should_release_vfta_holder_stake() {
         builder.exec(partial_unbond).commit().expect_success();
     };
 
-    let expect_unbond_failure = |builder: &mut InMemoryWasmTestBuilder, amount: u64| {
-        let full_unbond = ExecuteRequestBuilder::standard(
+    let expect_undelegate_failure = |builder: &mut InMemoryWasmTestBuilder, amount: u64| {
+        let full_undelegate = ExecuteRequestBuilder::standard(
             *DELEGATOR_1_ADDR,
             CONTRACT_UNDELEGATE,
             runtime_args! {
@@ -2287,7 +2287,7 @@ fn should_release_vfta_holder_stake() {
         )
         .build();
 
-        builder.exec(full_unbond).commit();
+        builder.exec(full_undelegate).commit();
 
         let error = {
             let response = builder
@@ -2354,7 +2354,7 @@ fn should_release_vfta_holder_stake() {
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
             ARG_TARGET => SYSTEM_ADDR,
-            ARG_AMOUNT => U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE / 10)
+            ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE)
         },
     )
     .build();
@@ -2382,7 +2382,7 @@ fn should_release_vfta_holder_stake() {
 
     {
         // Attempt unbond of one mote
-        expect_unbond_failure(&mut builder, u64::one());
+        expect_undelegate_failure(&mut builder, u64::one());
     }
 
     builder.run_auction(WEEK_TIMESTAMPS[0], Vec::new());
@@ -2408,7 +2408,7 @@ fn should_release_vfta_holder_stake() {
 
     {
         // Attempt full unbond
-        expect_unbond_failure(&mut builder, DELEGATOR_1_STAKE);
+        expect_undelegate_failure(&mut builder, DELEGATOR_1_STAKE);
 
         // Attempt unbond of released amount
         expect_undelegate_success(&mut builder, EXPECTED_WEEKLY_RELEASE);
@@ -2426,13 +2426,13 @@ fn should_release_vfta_holder_stake() {
         builder.run_auction(WEEK_TIMESTAMPS[i] - 1, Vec::new());
 
         // Attempt unbond of 1 mote
-        expect_unbond_failure(&mut builder, u64::one());
+        expect_undelegate_failure(&mut builder, u64::one());
 
         // Run auction forward by one millisecond
         builder.run_auction(WEEK_TIMESTAMPS[i], Vec::new());
 
         // Attempt unbond of more than weekly release
-        expect_unbond_failure(&mut builder, EXPECTED_WEEKLY_RELEASE + 1);
+        expect_undelegate_failure(&mut builder, EXPECTED_WEEKLY_RELEASE + 1);
 
         // Attempt unbond of released amount
         expect_undelegate_success(&mut builder, EXPECTED_WEEKLY_RELEASE);
@@ -2450,7 +2450,7 @@ fn should_release_vfta_holder_stake() {
         builder.run_auction(WEEK_TIMESTAMPS[13] - 1, Vec::new());
 
         // Attempt unbond of 1 mote
-        expect_unbond_failure(&mut builder, u64::one());
+        expect_undelegate_failure(&mut builder, u64::one());
 
         // Run auction forward by one millisecond
         builder.run_auction(WEEK_TIMESTAMPS[13], Vec::new());

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -2245,7 +2245,6 @@ fn should_not_undelegate_vfta_holder_stake() {
 #[ignore]
 #[test]
 fn should_release_vfta_holder_stake() {
-    // ACCOUNT_1_BOND / 14 = 7_142
     const EXPECTED_WEEKLY_RELEASE: u64 = DELEGATOR_1_STAKE / 14;
 
     const EXPECTED_REMAINDER: u64 = 12;

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -250,9 +250,8 @@ fn should_fail_unbonding_validator_with_locked_funds() {
 
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account = GenesisAccount::new(
+        let account = GenesisAccount::account(
             account_1_public_key,
-            account_1_hash,
             Motes::new(account_1_balance),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()),
         );

--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -35,9 +35,8 @@ static GENESIS_CUSTOM_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
     let account_1 = {
         let account_1_balance = Motes::new(ACCOUNT_1_BALANCE.into());
         let account_1_bonded_amount = Motes::new(ACCOUNT_1_BONDED_AMOUNT.into());
-        GenesisAccount::new(
+        GenesisAccount::account(
             *ACCOUNT_1_PUBLIC_KEY,
-            *ACCOUNT_1_ADDR,
             account_1_balance,
             account_1_bonded_amount,
         )
@@ -45,9 +44,8 @@ static GENESIS_CUSTOM_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
     let account_2 = {
         let account_2_balance = Motes::new(ACCOUNT_2_BALANCE.into());
         let account_2_bonded_amount = Motes::new(ACCOUNT_2_BONDED_AMOUNT.into());
-        GenesisAccount::new(
+        GenesisAccount::account(
             *ACCOUNT_2_PUBLIC_KEY,
-            *ACCOUNT_2_ADDR,
             account_2_balance,
             account_2_bonded_amount,
         )
@@ -157,15 +155,15 @@ fn should_track_total_token_supply_in_mint() {
     let total_supply = builder.total_supply(None);
 
     let expected_balance: U512 = accounts.iter().map(|item| item.balance().value()).sum();
-    let expected_bonded_amount: U512 = accounts
+    let expected_staked_amount: U512 = accounts
         .iter()
-        .map(|item| item.bonded_amount().value())
+        .map(|item| item.staked_amount().value())
         .sum();
 
     // check total supply against expected
     assert_eq!(
         total_supply,
-        expected_balance + expected_bonded_amount,
+        expected_balance + expected_staked_amount,
         "unexpected total supply"
     )
 }

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -295,9 +295,8 @@ fn upgraded_add_bid_and_withdraw_bid_have_expected_costs() {
 fn delegate_and_undelegate_have_expected_costs() {
     let mut builder = InMemoryWasmTestBuilder::default();
     let accounts = {
-        let validator_1 = GenesisAccount::new(
+        let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
-            *VALIDATOR_1_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
             Motes::new(VALIDATOR_1_STAKE.into()),
         );
@@ -420,9 +419,8 @@ fn upgraded_delegate_and_undelegate_have_expected_costs() {
 
     let mut builder = InMemoryWasmTestBuilder::default();
     let accounts = {
-        let validator_1 = GenesisAccount::new(
+        let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
-            *VALIDATOR_1_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
             Motes::new(VALIDATOR_1_STAKE.into()),
         );
@@ -539,9 +537,8 @@ fn mint_transfer_has_expected_costs() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     let accounts = {
-        let validator_1 = GenesisAccount::new(
+        let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
-            *VALIDATOR_1_ADDR,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
             Motes::new(VALIDATOR_1_STAKE.into()),
         );

--- a/node/src/types/chainspec/accounts_config.rs
+++ b/node/src/types/chainspec/accounts_config.rs
@@ -312,15 +312,24 @@ impl Loadable for AccountsConfig {
 impl From<AccountsConfig> for Vec<GenesisAccount> {
     fn from(accounts_config: AccountsConfig) -> Self {
         let mut genesis_accounts = Vec::with_capacity(accounts_config.accounts.len());
-        for account in accounts_config.accounts {
-            let genesis_account = GenesisAccount::new(
-                account.public_key,
-                account.public_key.to_account_hash(),
-                account.balance,
-                account.bonded_amount,
+        for account_config in accounts_config.accounts {
+            let genesis_account = GenesisAccount::account(
+                account_config.public_key,
+                account_config.balance,
+                account_config.bonded_amount,
             );
             genesis_accounts.push(genesis_account);
         }
+        for delegator_config in accounts_config.delegators {
+            let genesis_account = GenesisAccount::delegator(
+                delegator_config.validator_public_key,
+                delegator_config.delegator_public_key,
+                delegator_config.balance,
+                delegator_config.delegated_amount,
+            );
+            genesis_accounts.push(genesis_account);
+        }
+
         genesis_accounts
     }
 }

--- a/node/src/types/json_compatibility/auction_state.rs
+++ b/node/src/types/json_compatibility/auction_state.rs
@@ -30,7 +30,7 @@ static BIDS: Lazy<Bids> = Lazy::new(|| {
     let staked_amount = U512::from(10);
     let release_era: u64 = 42;
 
-    let delegator = Delegator::new(
+    let delegator = Delegator::unlocked(
         U512::from(10),
         bonding_purse,
         SecretKey::ed25519([43; SecretKey::ED25519_LENGTH]).into(),

--- a/node/src/types/json_compatibility/auction_state.rs
+++ b/node/src/types/json_compatibility/auction_state.rs
@@ -79,7 +79,9 @@ pub struct JsonEraValidators {
 #[serde(deny_unknown_fields)]
 pub struct JsonDelegator {
     public_key: PublicKey,
-    delegator: Delegator,
+    staked_amount: U512,
+    bonding_purse: URef,
+    delegatee: PublicKey,
 }
 
 /// An entry in a founding validator map representing a bid.
@@ -100,11 +102,13 @@ pub struct JsonBid {
 
 impl From<Bid> for JsonBid {
     fn from(bid: Bid) -> Self {
-        let mut json_delegators: Vec<JsonDelegator> = Vec::new();
+        let mut json_delegators: Vec<JsonDelegator> = Vec::with_capacity(bid.delegators().len());
         for (public_key, delegator) in bid.delegators().iter() {
             json_delegators.push(JsonDelegator {
                 public_key: *public_key,
-                delegator: *delegator,
+                staked_amount: *delegator.staked_amount(),
+                bonding_purse: *delegator.bonding_purse(),
+                delegatee: *delegator.delegatee(),
             });
         }
         JsonBid {

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -175,7 +175,21 @@ impl Bid {
         if timestamp_millis < vesting_schedule.initial_release_timestamp_millis() {
             return false;
         }
-        vesting_schedule.initialize(staked_amount)
+
+        if !vesting_schedule.initialize(staked_amount) {
+            return false;
+        }
+
+        for delegator in self.delegators_mut().values_mut() {
+            let staked_amount = *delegator.staked_amount();
+            if let Some(vesting_schedule) = delegator.vesting_schedule_mut() {
+                if !vesting_schedule.initialize(staked_amount) {
+                    return false;
+                }
+            }
+        }
+
+        true
     }
 
     /// Sets given bid's `inactive` field to `false`

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -118,7 +118,7 @@ impl Bid {
             .checked_sub(amount)
             .ok_or(Error::UnbondTooLarge)?;
 
-        let vesting_schedule = match self.vesting_schedule {
+        let vesting_schedule = match self.vesting_schedule.as_ref() {
             Some(vesting_sechdule) => vesting_sechdule,
             None => {
                 self.staked_amount = updated_staked_amount;

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -176,20 +176,24 @@ impl Bid {
             return false;
         }
 
-        if !vesting_schedule.initialize(staked_amount) {
-            return false;
+        let mut initialized = false;
+
+        if vesting_schedule.initialize(staked_amount) {
+            initialized = true;
         }
 
         for delegator in self.delegators_mut().values_mut() {
             let staked_amount = *delegator.staked_amount();
             if let Some(vesting_schedule) = delegator.vesting_schedule_mut() {
-                if !vesting_schedule.initialize(staked_amount) {
-                    return false;
+                if timestamp_millis >= vesting_schedule.initial_release_timestamp_millis()
+                    && vesting_schedule.initialize(staked_amount)
+                {
+                    initialized = true;
                 }
             }
         }
 
-        true
+        initialized
     }
 
     /// Sets given bid's `inactive` field to `false`
@@ -272,8 +276,8 @@ mod tests {
 
     use crate::{
         bytesrepr,
-        system::auction::{bid::VestingSchedule, Bid, DelegationRate},
-        AccessRights, URef, U512,
+        system::auction::{bid::VestingSchedule, Bid, DelegationRate, Delegator},
+        AccessRights, SecretKey, URef, U512,
     };
 
     #[test]
@@ -287,5 +291,98 @@ mod tests {
             inactive: true,
         };
         bytesrepr::test_serialization_roundtrip(&founding_validator);
+    }
+
+    #[test]
+    fn should_initialize_delegators_different_timestamps() {
+        const WEEK_MILLIS: u64 = 7 * 24 * 60 * 60 * 1000;
+
+        const TIMESTAMP_MILLIS: u64 = WEEK_MILLIS as u64;
+
+        let validator_pk = SecretKey::ed25519([42; 32]).into();
+
+        let delegator_1_pk = SecretKey::ed25519([43; 32]).into();
+        let delegator_2_pk = SecretKey::ed25519([44; 32]).into();
+
+        let validator_release_timestamp = TIMESTAMP_MILLIS;
+        let validator_bonding_purse = URef::new([42; 32], AccessRights::ADD);
+        let validator_staked_amount = U512::from(1000);
+
+        let delegator_1_release_timestamp = TIMESTAMP_MILLIS + 1;
+        let delegator_1_bonding_purse = URef::new([52; 32], AccessRights::ADD);
+        let delegator_1_staked_amount = U512::from(2000);
+
+        let delegator_2_release_timestamp = TIMESTAMP_MILLIS + 2;
+        let delegator_2_bonding_purse = URef::new([62; 32], AccessRights::ADD);
+        let delegator_2_staked_amount = U512::from(3000);
+
+        let delegator_1 = Delegator::locked(
+            delegator_1_staked_amount,
+            delegator_1_bonding_purse,
+            validator_pk,
+            delegator_1_release_timestamp,
+        );
+
+        let delegator_2 = Delegator::locked(
+            delegator_2_staked_amount,
+            delegator_2_bonding_purse,
+            validator_pk,
+            delegator_2_release_timestamp,
+        );
+
+        let mut bid = Bid::locked(
+            validator_bonding_purse,
+            validator_staked_amount,
+            validator_release_timestamp,
+        );
+
+        assert!(!bid.process(validator_release_timestamp - 1));
+
+        {
+            let delegators = bid.delegators_mut();
+
+            delegators.insert(delegator_1_pk, delegator_1);
+            delegators.insert(delegator_2_pk, delegator_2);
+        }
+
+        assert!(bid.process(delegator_1_release_timestamp));
+
+        let delegator_1_updated_1 = bid.delegators().get(&delegator_1_pk).cloned().unwrap();
+        assert!(delegator_1_updated_1
+            .vesting_schedule()
+            .unwrap()
+            .locked_amounts()
+            .is_some());
+
+        let delegator_2_updated_1 = bid.delegators().get(&delegator_2_pk).cloned().unwrap();
+        assert!(delegator_2_updated_1
+            .vesting_schedule()
+            .unwrap()
+            .locked_amounts()
+            .is_none());
+
+        assert!(bid.process(delegator_2_release_timestamp));
+
+        let delegator_1_updated_2 = bid.delegators().get(&delegator_1_pk).cloned().unwrap();
+        assert!(delegator_1_updated_2
+            .vesting_schedule()
+            .unwrap()
+            .locked_amounts()
+            .is_some());
+        // Delegator 1 is already initialized and did not change after 2nd Bid::process
+        assert_eq!(delegator_1_updated_1, delegator_1_updated_2);
+
+        let delegator_2_updated_2 = bid.delegators().get(&delegator_2_pk).cloned().unwrap();
+        assert!(delegator_2_updated_2
+            .vesting_schedule()
+            .unwrap()
+            .locked_amounts()
+            .is_some());
+
+        // Delegator 2 is different compared to first Bid::process
+        assert_ne!(delegator_2_updated_1, delegator_2_updated_2);
+
+        // Validator initialized, and all delegators initialized
+        assert!(!bid.process(delegator_2_release_timestamp + 1));
     }
 }

--- a/types/src/system/auction/delegator.rs
+++ b/types/src/system/auction/delegator.rs
@@ -6,9 +6,8 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    auction::bid::VestingSchedule,
     bytesrepr::{self, FromBytes, ToBytes},
-    system::auction::Error,
+    system::auction::{bid::VestingSchedule, Error},
     CLType, CLTyped, PublicKey, URef, U512,
 };
 
@@ -168,7 +167,7 @@ impl FromBytes for Delegator {
 
 #[cfg(test)]
 mod tests {
-    use crate::{auction::Delegator, bytesrepr, AccessRights, SecretKey, URef, U512};
+    use crate::{bytesrepr, system::auction::Delegator, AccessRights, SecretKey, URef, U512};
 
     #[test]
     fn serialization_roundtrip() {

--- a/types/src/system/auction/error.rs
+++ b/types/src/system/auction/error.rs
@@ -131,14 +131,13 @@ pub enum Error {
     /// Failed to transfer funds.
     #[fail(display = "Transfer error")]
     Transfer = 36,
-    /// Raised whenever a delegator's funds are still locked in but an attempt to undelegate was
-    /// made.
-    #[fail(display = "Delegator's funds are locked")]
-    DelegatorFundsLocked = 37,
-
     /// Delegation rate exceeds rate.
     #[fail(display = "Delegation rate too large")]
     DelegationRateTooLarge = 37,
+    /// Raised whenever a delegator's funds are still locked in but an attempt to undelegate was
+    /// made.
+    #[fail(display = "Delegator's funds are locked")]
+    DelegatorFundsLocked = 38,
 
     // NOTE: These variants below and related plumbing will be removed once support for WASM
     // system contracts will be dropped.
@@ -217,6 +216,7 @@ impl TryFrom<u8> for Error {
             }
             d if d == Error::Transfer as u8 => Ok(Error::Transfer),
             d if d == Error::DelegationRateTooLarge as u8 => Ok(Error::DelegationRateTooLarge),
+            d if d == Error::DelegatorFundsLocked as u8 => Ok(Error::DelegatorFundsLocked),
             d if d == Error::GasLimit as u8 => Ok(Error::GasLimit),
             _ => Err(TryFromU8ForError(())),
         }

--- a/types/src/system/auction/error.rs
+++ b/types/src/system/auction/error.rs
@@ -128,10 +128,13 @@ pub enum Error {
     /// Missing seigniorage recipients for given era.
     #[fail(display = "Missing seigniorage recipients for given era")]
     MissingSeigniorageRecipients = 35,
-
     /// Failed to transfer funds.
     #[fail(display = "Transfer error")]
     Transfer = 36,
+    /// Raised whenever a delegator's funds are still locked in but an attempt to undelegate was
+    /// made.
+    #[fail(display = "Delegator's funds are locked")]
+    DelegatorFundsLocked = 37,
 
     /// Delegation rate exceeds rate.
     #[fail(display = "Delegation rate too large")]

--- a/types/src/system/auction/mod.rs
+++ b/types/src/system/auction/mod.rs
@@ -364,7 +364,9 @@ pub trait Auction:
         // Process bids
         let mut bids_modified = false;
         for (validator_public_key, bid) in bids.iter_mut() {
-            bids_modified = bid.process(era_end_timestamp_millis);
+            if bid.process(era_end_timestamp_millis) {
+                bids_modified = true;
+            }
 
             if evicted_validators.contains(validator_public_key) {
                 bids_modified = bid.deactivate()

--- a/types/src/system/auction/mod.rs
+++ b/types/src/system/auction/mod.rs
@@ -279,7 +279,9 @@ pub trait Auction:
                     *delegator.bonding_purse(),
                     amount,
                 )?;
-                let updated_stake = delegator.decrease_stake(amount)?;
+
+                let era_end_timestamp_millis = detail::get_era_end_timestamp_millis(self)?;
+                let updated_stake = delegator.decrease_stake(amount, era_end_timestamp_millis)?;
                 if updated_stake == U512::zero() {
                     delegators.remove(&delegator_public_key);
                 };

--- a/types/src/system/auction/mod.rs
+++ b/types/src/system/auction/mod.rs
@@ -232,7 +232,7 @@ pub trait Auction:
                 let bonding_purse = self.create_purse()?;
                 self.transfer_purse_to_purse(source, bonding_purse, amount)
                     .map_err(|_| Error::TransferToDelegatorPurse)?;
-                let delegator = Delegator::new(amount, bonding_purse, validator_public_key);
+                let delegator = Delegator::unlocked(amount, bonding_purse, validator_public_key);
                 delegators.insert(delegator_public_key, delegator);
                 amount
             }

--- a/types/src/system/auction/seigniorage_recipient.rs
+++ b/types/src/system/auction/seigniorage_recipient.rs
@@ -121,15 +121,15 @@ mod tests {
             delegators: BTreeMap::from_iter(vec![
                 (
                     validator_key,
-                    Delegator::new(U512::max_value(), uref, delegator_1_key),
+                    Delegator::unlocked(U512::max_value(), uref, delegator_1_key),
                 ),
                 (
                     validator_key,
-                    Delegator::new(U512::max_value(), uref, delegator_2_key),
+                    Delegator::unlocked(U512::max_value(), uref, delegator_2_key),
                 ),
                 (
                     validator_key,
-                    Delegator::new(U512::zero(), uref, delegator_3_key),
+                    Delegator::unlocked(U512::zero(), uref, delegator_3_key),
                 ),
             ]),
         };


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1138
Ref: https://casperlabs.atlassian.net/browse/EE-1172

This PR adds vesting schedule to genesis delegators which has similar behavior to vesting schedule of genesis validators. This PR also modifies genesis process which will create entries for each defined delegator in `accounts.toml`.