### PR TITLE
OP-1853: fix upload to genesis s3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -191,22 +191,25 @@ steps:
   commands:
     - "./ci/build_update_package.sh"
 
-#- name: put-upgrade_package-s3
-#  image: casperlabs/s3cmd-build:latest
-#  commands:
-#    - "./ci/upgrade_package_s3_storage.sh put $(pwd)/target/upgrade_package/"
-#  environment:
-#    CL_VAULT_TOKEN:
-#      from_secret: vault_token
-#    CL_VAULT_HOST:
-#      from_secret: vault_host
-#  when:
-#    branch:
-#      - master
-#      - dev
-#      - "release-*"
-#    event:
-#      - push
+- name: upload-to-s3-genesis
+  image: plugins/s3
+  settings:
+    bucket: 'genesis.casperlabs.io'
+    region: 'us-west-2'
+    access_key:
+      from_secret: drone_genesis_key_id
+    secret_key:
+      from_secret: drone_genesis_secret
+    source: "target/upgrade_build/**/*"
+    strip_prefix: 'target/upgrade_build/'
+    target: "/drone/$DRONE_COMMIT/"
+  when:
+    branch:
+      - master
+      - dev
+      - "release-*"
+    event:
+      - push
 
 depends_on:
   - pre-checks

--- a/ci/build_update_package.sh
+++ b/ci/build_update_package.sh
@@ -5,12 +5,13 @@
 set -e
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+GENESIS_FILES_DIR="$ROOT_DIR/resources/production"
 NODE_BUILD_TARGET="$ROOT_DIR/target/release/casper-node"
-UPGRADE_DIR="$ROOT_DIR/target/upgrade_build"
+PROTOCOL_VERSION=$(cat "$GENESIS_FILES_DIR/chainspec.toml" | python3 -c "import sys, toml; print(toml.load(sys.stdin)['protocol']['version'].replace('.','_'))")
+UPGRADE_DIR="$ROOT_DIR/target/upgrade_build/$PROTOCOL_VERSION"
 BIN_DIR="$UPGRADE_DIR/bin"
 CONFIG_DIR="$UPGRADE_DIR/config"
 NODE_BUILD_DIR="$ROOT_DIR/node"
-GENESIS_FILES_DIR="$ROOT_DIR/resources/production"
 
 echo "Building casper-node"
 cd "$NODE_BUILD_DIR"


### PR DESCRIPTION
Switches from `upgrade_package_s3_storage.sh` wrapper script to drone s3 plugin.

Reconfigures build wrapper to output into a protocol dir. Borrowed this logic from the `upgrade_package_s3_storage.sh` wrapper.