### PR TITLE
NO-TICKET: revert handshake change

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -230,7 +230,7 @@ where
                 pending: HashSet::new(),
                 blocklist: HashMap::new(),
                 gossip_interval: cfg.gossip_interval,
-                network_name,
+                network_name: network_name,
                 shutdown_sender: None,
                 shutdown_receiver: watch::channel(()).1,
                 server_join_handle: None,
@@ -292,7 +292,7 @@ where
             pending: HashSet::new(),
             blocklist: HashMap::new(),
             gossip_interval: cfg.gossip_interval,
-            network_name,
+            network_name: network_name,
             shutdown_sender: Some(server_shutdown_sender),
             shutdown_receiver,
             server_join_handle: Some(server_join_handle),
@@ -442,7 +442,7 @@ where
                 // The sink is only used to send a single handshake message, then dropped.
                 let (mut sink, stream) = framed::<P>(transport).split();
                 let handshake = Message::Handshake {
-                    network_name: self.network_name.clone(),
+                    network_name: self.network_name.clone()
                 };
                 let mut effects = async move {
                     let _ = sink.send(handshake).await;

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -88,6 +88,7 @@ use crate::{
     components::{
         network::ENABLE_SMALL_NET_ENV_VAR, networking_metrics::NetworkingMetrics, Component,
     },
+    crypto::hash::Digest,
     effect::{
         announcements::NetworkAnnouncement,
         requests::{NetworkInfoRequest, NetworkRequest},
@@ -156,9 +157,9 @@ where
     pending: HashSet<SocketAddr>,
     /// The interval between each fresh round of gossiping the node's public listening address.
     gossip_interval: Duration,
-    /// Name of the network we participate in. We only remain connected to peers with the same
+    /// The hash of the chainspec.  We only remain connected to peers with the same
     /// `genesis_config_hash` as us.
-    network_name: String,
+    genesis_config_hash: Digest,
     /// Channel signaling a shutdown of the small network.
     // Note: This channel is closed when `SmallNetwork` is dropped, signalling the receivers that
     // they should cease operation.
@@ -196,7 +197,7 @@ where
         cfg: Config,
         registry: &Registry,
         small_network_identity: SmallNetworkIdentity,
-        network_name: String,
+        genesis_config_hash: Digest,
         notify: bool,
     ) -> Result<(SmallNetwork<REv, P>, Effects<Event<P>>)> {
         // Assert we have at least one known address in the config.
@@ -230,7 +231,7 @@ where
                 pending: HashSet::new(),
                 blocklist: HashMap::new(),
                 gossip_interval: cfg.gossip_interval,
-                network_name: network_name,
+                genesis_config_hash,
                 shutdown_sender: None,
                 shutdown_receiver: watch::channel(()).1,
                 server_join_handle: None,
@@ -292,7 +293,7 @@ where
             pending: HashSet::new(),
             blocklist: HashMap::new(),
             gossip_interval: cfg.gossip_interval,
-            network_name: network_name,
+            genesis_config_hash,
             shutdown_sender: Some(server_shutdown_sender),
             shutdown_receiver,
             server_join_handle: Some(server_join_handle),
@@ -442,7 +443,7 @@ where
                 // The sink is only used to send a single handshake message, then dropped.
                 let (mut sink, stream) = framed::<P>(transport).split();
                 let handshake = Message::Handshake {
-                    network_name: self.network_name.clone()
+                    genesis_config_hash: self.genesis_config_hash,
                 };
                 let mut effects = async move {
                     let _ = sink.send(handshake).await;
@@ -541,7 +542,7 @@ where
         let mut effects = self.check_connection_complete(effect_builder, peer_id.clone());
 
         let handshake = Message::Handshake {
-            network_name: self.network_name.clone(),
+            genesis_config_hash: self.genesis_config_hash,
         };
         let peer_id_cloned = peer_id.clone();
         effects.extend(
@@ -687,14 +688,16 @@ where
         REv: From<NetworkAnnouncement<NodeId, P>>,
     {
         match msg {
-            Message::Handshake { network_name } => {
-                if network_name != self.network_name {
+            Message::Handshake {
+                genesis_config_hash,
+            } => {
+                if genesis_config_hash != self.genesis_config_hash {
                     info!(
                         our_id=%self.our_id,
                         %peer_id,
-                        our_network=?self.network_name,
-                        their_network=?network_name,
-                        "dropping connection due to network name mismatch"
+                        our_hash=?self.genesis_config_hash,
+                        their_hash=?genesis_config_hash,
+                        "dropping connection due to genesis config hash mismatch"
                     );
                     return self.remove(effect_builder, &peer_id, false);
                 }

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -2,16 +2,20 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
+use crate::crypto::hash::Digest;
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Message<P> {
-    Handshake { network_name: String },
+    Handshake { genesis_config_hash: Digest },
     Payload(P),
 }
 
 impl<P: Display> Display for Message<P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Message::Handshake { network_name } => write!(f, "handshake: {}", network_name),
+            Message::Handshake {
+                genesis_config_hash,
+            } => write!(f, "handshake: {}", genesis_config_hash),
             Message::Payload(payload) => write!(f, "payload: {}", payload),
         }
     }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -24,6 +24,7 @@ use crate::{
         small_network::SmallNetworkIdentity,
         Component,
     },
+    crypto::hash::Digest,
     effect::{
         announcements::{GossiperAnnouncement, NetworkAnnouncement},
         requests::{NetworkRequest, StorageRequest},

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -119,7 +119,7 @@ impl Reactor for TestReactor {
             cfg,
             registry,
             small_network_identity,
-            "test_network".to_string(),
+            Digest::default(),
             false,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -407,13 +407,13 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             false,
         )?;
-        let network_name = chainspec_loader.chainspec().network_config.name.clone();
+        let genesis_config_hash = chainspec_loader.chainspec().hash();
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network.clone(),
             registry,
             small_network_identity,
-            network_name,
+            genesis_config_hash,
             false,
         )?;
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -386,13 +386,13 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             true,
         )?;
-        let network_name = chainspec_loader.chainspec().network_config.name.clone();
+        let genesis_config_hash = chainspec_loader.chainspec().hash();
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network,
             registry,
             small_network_identity,
-            network_name,
+            genesis_config_hash,
             true,
         )?;
 


### PR DESCRIPTION
This PR reverts the recent relaxation of the network handshake process in order to allow v0.7.7 nodes to communicate with v0.7.6 nodes.