### PR TITLE
EE-1184: add StateReader::keys_with_prefix

### DIFF
--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -462,6 +462,14 @@ impl<R: StateReader<Key, StoredValue>> StateReader<Key, StoredValue> for &Tracki
     ) -> Result<Option<TrieMerkleProof<Key, StoredValue>>, Self::Error> {
         self.reader.read_with_proof(correlation_id, key)
     }
+
+    fn keys_with_prefix(
+        &self,
+        correlation_id: CorrelationId,
+        prefix: &[u8],
+    ) -> Result<Vec<Key>, Self::Error> {
+        self.reader.keys_with_prefix(correlation_id, prefix)
+    }
 }
 
 #[derive(Error, Debug, PartialEq, Eq)]

--- a/execution_engine/src/core/tracking_copy/tests.rs
+++ b/execution_engine/src/core/tracking_copy/tests.rs
@@ -71,6 +71,14 @@ impl StateReader<Key, StoredValue> for CountingDb {
     ) -> Result<Option<TrieMerkleProof<Key, StoredValue>>, Self::Error> {
         Ok(None)
     }
+
+    fn keys_with_prefix(
+        &self,
+        _correlation_id: CorrelationId,
+        _prefix: &[u8],
+    ) -> Result<Vec<Key>, Self::Error> {
+        Ok(Vec::new())
+    }
 }
 
 #[test]

--- a/execution_engine/src/storage/global_state/mod.rs
+++ b/execution_engine/src/storage/global_state/mod.rs
@@ -36,6 +36,13 @@ pub trait StateReader<K, V> {
         correlation_id: CorrelationId,
         key: &K,
     ) -> Result<Option<TrieMerkleProof<K, V>>, Self::Error>;
+
+    /// Returns the keys in the trie matching `prefix`.
+    fn keys_with_prefix(
+        &self,
+        correlation_id: CorrelationId,
+        prefix: &[u8],
+    ) -> Result<Vec<K>, Self::Error>;
 }
 
 #[derive(Debug)]

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -914,7 +914,6 @@ where
 /// Returns the iterator over the keys in the subtrie matching `prefix`.
 ///
 /// The root should be the apex of the trie.
-#[cfg(test)]
 pub fn keys_with_prefix<'a, 'b, K, V, T, S>(
     _correlation_id: CorrelationId,
     txn: &'b T,


### PR DESCRIPTION
This PR adds a `keys_with_prefix` method to `StateReader`.  

This is yet another move towards optimizing the way bids are stored in the auction.  It will be used to read all of the keys in the `Key::Bid` keyspace.