### PR TITLE
NDRS-927: support flexible handshake for delta and upgraded delta nodes

### DIFF
--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -2,16 +2,25 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
+use crate::crypto::hash::Digest;
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Message<P> {
-    Handshake { network_name: String },
+    Handshake {
+        genesis_config_hash: Digest,
+        #[serde(default)]
+        network_name: String,
+    },
     Payload(P),
 }
 
 impl<P: Display> Display for Message<P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Message::Handshake { network_name } => write!(f, "handshake: {}", network_name),
+            Message::Handshake {
+                genesis_config_hash,
+                network_name,
+            } => write!(f, "handshake: {} -- {}", genesis_config_hash, network_name),
             Message::Payload(payload) => write!(f, "payload: {}", payload),
         }
     }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -24,6 +24,7 @@ use crate::{
         small_network::SmallNetworkIdentity,
         Component,
     },
+    crypto::hash::Digest,
     effect::{
         announcements::{GossiperAnnouncement, NetworkAnnouncement},
         requests::{NetworkRequest, StorageRequest},
@@ -126,7 +127,8 @@ impl Reactor for TestReactor {
             cfg,
             registry,
             small_network_identity,
-            "test_network".to_string(),
+            Digest::default(),
+            "test-network".to_string(),
             false,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -408,12 +408,14 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             false,
         )?;
+        let genesis_config_hash = chainspec_loader.chainspec().hash();
         let network_name = chainspec_loader.chainspec().network_config.name.clone();
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network.clone(),
             registry,
             small_network_identity,
+            genesis_config_hash,
             network_name,
             false,
         )?;

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -406,12 +406,14 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             true,
         )?;
+        let genesis_config_hash = chainspec_loader.chainspec().hash();
         let network_name = chainspec_loader.chainspec().network_config.name.clone();
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network,
             registry,
             small_network_identity,
+            genesis_config_hash,
             network_name,
             true,
         )?;


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-927

This PR re-introduces the relaxation of the network handshake message.  However to ensure it is compatible with 0.7.6 nodes currently running (which require the handshake to provide the chainspec hash), the handshake message has been updated to hold the chainspec hash and the network name.

The change is required in order to support future potential upgrades to the delta network.  For example, a new user would need to run this version of the node to initially join an upgraded delta network, and so the node must be able to communicate with nodes at a newer protocol version.  This would not be possible if we used the chainspec hash to handshake as the protocol version difference would be reflected in the hash, and the nodes would refuse to remain connected.

Nodes will now provide both pieces of data.  Old 0.7.6 nodes will be able to parse this message, silently ignoring the new `network_name` field.  New nodes will deserialize old nodes' handshakes such that the `network_name` is defaulted to an empty string.

On receipt of a handshake message, the nodes now favour checking the `network_name` and fall back to checking the `genesis_config_hash` only if the `network_name` is empty (indicating the handshake was sent from an old 0.7.6 node).

I tested via nctl that a network running this code connects correctly, and also that a single node running this code can remain connected to a network running the 0.7.6 nodes.