### PR TITLE
EE-1185: add TrackingCopy::get_keys

### DIFF
--- a/execution_engine/src/core/tracking_copy/meter.rs
+++ b/execution_engine/src/core/tracking_copy/meter.rs
@@ -1,9 +1,15 @@
+use std::collections::BTreeSet;
+
 /// Trait for measuring "size" of key-value pairs.
 pub trait Meter<K, V> {
     fn measure(&self, k: &K, v: &V) -> usize;
+
+    fn measure_keys(&self, keys: &BTreeSet<K>) -> usize;
 }
 
 pub mod heap_meter {
+    use std::collections::BTreeSet;
+
     use crate::core::tracking_copy::byte_size::ByteSize;
 
     pub struct HeapSize;
@@ -12,16 +18,30 @@ pub mod heap_meter {
         fn measure(&self, _: &K, v: &V) -> usize {
             std::mem::size_of::<V>() + v.byte_size()
         }
+
+        fn measure_keys(&self, keys: &BTreeSet<K>) -> usize {
+            let mut total: usize = 0;
+            for key in keys {
+                total += key.byte_size();
+            }
+            total
+        }
     }
 }
 
 #[cfg(test)]
 pub mod count_meter {
+    use std::collections::BTreeSet;
+
     pub struct Count;
 
     impl<K, V> super::Meter<K, V> for Count {
         fn measure(&self, _k: &K, _v: &V) -> usize {
             1
+        }
+
+        fn measure_keys(&self, _keys: &BTreeSet<K>) -> usize {
+            unimplemented!()
         }
     }
 }

--- a/execution_engine/src/core/tracking_copy/tests.rs
+++ b/execution_engine/src/core/tracking_copy/tests.rs
@@ -7,7 +7,7 @@ use casper_types::{
     account::{AccountHash, Weight, ACCOUNT_HASH_LENGTH},
     contracts::NamedKeys,
     gens::*,
-    AccessRights, CLValue, Contract, EntryPoints, Key, ProtocolVersion, URef, U512,
+    AccessRights, CLValue, Contract, EntryPoints, Key, KeyTag, ProtocolVersion, URef, U512,
 };
 
 use super::{
@@ -797,4 +797,206 @@ fn validate_query_proof_should_work() {
         ),
         Err(ValidationError::InvalidProofHash)
     );
+}
+
+#[test]
+fn get_keys_should_return_keys_in_the_account_keyspace() {
+    // account 1
+    let account_1_hash = AccountHash::new([1; 32]);
+    let fake_purse = URef::new([42; 32], AccessRights::READ_ADD_WRITE);
+    let account_1_value = StoredValue::Account(Account::create(
+        account_1_hash,
+        NamedKeys::default(),
+        fake_purse,
+    ));
+    let account_1_key = Key::Account(account_1_hash);
+
+    // account 2
+    let account_2_hash = AccountHash::new([2; 32]);
+    let fake_purse = URef::new([43; 32], AccessRights::READ_ADD_WRITE);
+    let account_2_value = StoredValue::Account(Account::create(
+        account_2_hash,
+        NamedKeys::default(),
+        fake_purse,
+    ));
+    let account_2_key = Key::Account(account_2_hash);
+
+    // random value
+    let cl_value = CLValue::from_t(U512::zero()).expect("should convert");
+    let uref_value = StoredValue::CLValue(cl_value);
+    let uref_key = Key::URef(URef::new([8; 32], AccessRights::READ_ADD_WRITE));
+
+    // persist them
+    let correlation_id = CorrelationId::new();
+    let (global_state, root_hash) = InMemoryGlobalState::from_pairs(
+        correlation_id,
+        &[
+            (account_1_key, account_1_value),
+            (account_2_key, account_2_value),
+            (uref_key, uref_value),
+        ],
+    )
+    .unwrap();
+
+    let view = global_state
+        .checkout(root_hash)
+        .expect("should checkout")
+        .expect("should have view");
+
+    let mut tracking_copy = TrackingCopy::new(view);
+
+    let key_set = tracking_copy
+        .get_keys(correlation_id, &KeyTag::Account)
+        .unwrap();
+
+    assert_eq!(key_set.len(), 2);
+    assert!(key_set.contains(&account_1_key));
+    assert!(key_set.contains(&account_2_key));
+    assert!(!key_set.contains(&uref_key));
+}
+
+#[test]
+fn get_keys_should_return_keys_in_the_uref_keyspace() {
+    // account
+    let account_hash = AccountHash::new([1; 32]);
+    let fake_purse = URef::new([42; 32], AccessRights::READ_ADD_WRITE);
+    let account_value = StoredValue::Account(Account::create(
+        account_hash,
+        NamedKeys::default(),
+        fake_purse,
+    ));
+    let account_key = Key::Account(account_hash);
+
+    // random value 1
+    let cl_value = CLValue::from_t(U512::zero()).expect("should convert");
+    let uref_1_value = StoredValue::CLValue(cl_value);
+    let uref_1_key = Key::URef(URef::new([8; 32], AccessRights::READ_ADD_WRITE));
+
+    // random value 2
+    let cl_value = CLValue::from_t(U512::one()).expect("should convert");
+    let uref_2_value = StoredValue::CLValue(cl_value);
+    let uref_2_key = Key::URef(URef::new([9; 32], AccessRights::READ_ADD_WRITE));
+
+    // persist them
+    let correlation_id = CorrelationId::new();
+    let (global_state, root_hash) = InMemoryGlobalState::from_pairs(
+        correlation_id,
+        &[
+            (account_key, account_value),
+            (uref_1_key, uref_1_value),
+            (uref_2_key, uref_2_value),
+        ],
+    )
+    .unwrap();
+
+    let view = global_state
+        .checkout(root_hash)
+        .expect("should checkout")
+        .expect("should have view");
+
+    let mut tracking_copy = TrackingCopy::new(view);
+
+    let key_set = tracking_copy
+        .get_keys(correlation_id, &KeyTag::URef)
+        .unwrap();
+
+    assert_eq!(key_set.len(), 2);
+    assert!(key_set.contains(&uref_1_key.normalize()));
+    assert!(key_set.contains(&uref_2_key.normalize()));
+    assert!(!key_set.contains(&account_key));
+
+    // random value 3
+    let cl_value = CLValue::from_t(U512::from(2)).expect("should convert");
+    let uref_3_value = StoredValue::CLValue(cl_value);
+    let uref_3_key = Key::URef(URef::new([10; 32], AccessRights::READ_ADD_WRITE));
+    tracking_copy.write(uref_3_key, uref_3_value);
+
+    let key_set = tracking_copy
+        .get_keys(correlation_id, &KeyTag::URef)
+        .unwrap();
+
+    assert_eq!(key_set.len(), 3);
+    assert!(key_set.contains(&uref_1_key.normalize()));
+    assert!(key_set.contains(&uref_2_key.normalize()));
+    assert!(key_set.contains(&uref_3_key.normalize()));
+    assert!(!key_set.contains(&account_key));
+}
+
+#[test]
+fn get_keys_should_handle_reads_from_empty_trie() {
+    let correlation_id = CorrelationId::new();
+    let (global_state, root_hash) = InMemoryGlobalState::from_pairs(correlation_id, &[]).unwrap();
+
+    let view = global_state
+        .checkout(root_hash)
+        .expect("should checkout")
+        .expect("should have view");
+
+    let mut tracking_copy = TrackingCopy::new(view);
+
+    let key_set = tracking_copy
+        .get_keys(correlation_id, &KeyTag::URef)
+        .unwrap();
+
+    assert_eq!(key_set.len(), 0);
+    assert!(key_set.is_empty());
+
+    // persist random value 1
+    let cl_value = CLValue::from_t(U512::zero()).expect("should convert");
+    let uref_1_value = StoredValue::CLValue(cl_value);
+    let uref_1_key = Key::URef(URef::new([8; 32], AccessRights::READ_ADD_WRITE));
+    tracking_copy.write(uref_1_key, uref_1_value);
+
+    let key_set = tracking_copy
+        .get_keys(correlation_id, &KeyTag::URef)
+        .unwrap();
+
+    assert_eq!(key_set.len(), 1);
+    assert!(key_set.contains(&uref_1_key.normalize()));
+
+    // persist random value 2
+    let cl_value = CLValue::from_t(U512::one()).expect("should convert");
+    let uref_2_value = StoredValue::CLValue(cl_value);
+    let uref_2_key = Key::URef(URef::new([9; 32], AccessRights::READ_ADD_WRITE));
+    tracking_copy.write(uref_2_key, uref_2_value);
+
+    let key_set = tracking_copy
+        .get_keys(correlation_id, &KeyTag::URef)
+        .unwrap();
+
+    assert_eq!(key_set.len(), 2);
+    assert!(key_set.contains(&uref_1_key.normalize()));
+    assert!(key_set.contains(&uref_2_key.normalize()));
+
+    // persist account
+    let account_hash = AccountHash::new([1; 32]);
+    let fake_purse = URef::new([42; 32], AccessRights::READ_ADD_WRITE);
+    let account_value = StoredValue::Account(Account::create(
+        account_hash,
+        NamedKeys::default(),
+        fake_purse,
+    ));
+    let account_key = Key::Account(account_hash);
+    tracking_copy.write(account_key, account_value);
+
+    assert_eq!(key_set.len(), 2);
+    assert!(key_set.contains(&uref_1_key.normalize()));
+    assert!(key_set.contains(&uref_2_key.normalize()));
+    assert!(!key_set.contains(&account_key));
+
+    // persist random value 3
+    let cl_value = CLValue::from_t(U512::from(2)).expect("should convert");
+    let uref_3_value = StoredValue::CLValue(cl_value);
+    let uref_3_key = Key::URef(URef::new([10; 32], AccessRights::READ_ADD_WRITE));
+    tracking_copy.write(uref_3_key, uref_3_value);
+
+    let key_set = tracking_copy
+        .get_keys(correlation_id, &KeyTag::URef)
+        .unwrap();
+
+    assert_eq!(key_set.len(), 3);
+    assert!(key_set.contains(&uref_1_key.normalize()));
+    assert!(key_set.contains(&uref_2_key.normalize()));
+    assert!(key_set.contains(&uref_3_key.normalize()));
+    assert!(!key_set.contains(&account_key));
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -70,7 +70,7 @@ pub use execution_result::{
 };
 pub use json_pretty_printer::json_pretty_print;
 #[doc(inline)]
-pub use key::{HashAddr, Key, BLAKE2B_DIGEST_LENGTH, KEY_HASH_LENGTH};
+pub use key::{HashAddr, Key, KeyTag, BLAKE2B_DIGEST_LENGTH, KEY_HASH_LENGTH};
 pub use named_key::NamedKey;
 pub use phase::{Phase, PHASE_SERIALIZED_LENGTH};
 pub use protocol_version::{ProtocolVersion, VersionCheckResult};


### PR DESCRIPTION
This PR adds `get_keys` method to TrackingCopy which reads through the cache to `StateReader::keys_with_prefix`.

The caching behavior is marginally different than how we handle key-value pairs: cached writes must be unioned with reads rather than replace them.