### PR TITLE
NO-TICKET: Wait a bit shorter after an upgrade.

### DIFF
--- a/utils/nctl/sh/scenarios/sync_upgrade_test.sh
+++ b/utils/nctl/sh/scenarios/sync_upgrade_test.sh
@@ -79,7 +79,7 @@ function do_upgrade_network() {
 function do_await_network_upgrade() {
     log_step "wait for the network to upgrade"
     local WAIT_TIME_SEC=0
-    local WAIT_UNTIL=$((ACTIVATE_ERA + 2))
+    local WAIT_UNTIL=$((ACTIVATE_ERA + 1))
     while [ "$(get_chain_era)" != "$WAIT_UNTIL" ]; do
     if [ "$WAIT_TIME_SEC" = "$SYNC_TIMEOUT_SEC" ]; then
         log "ERROR: Failed to upgrade the network in ${SYNC_TIMEOUT_SEC} seconds"


### PR DESCRIPTION
Instead of waiting 2 eras we can wait 1.