### PR TITLE
NDRS-942: Delegation rate for validators in accounts.toml

### DIFF
--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     InvalidAccountHashLength { expected: usize, actual: usize },
     #[error("Invalid protocol version: {0}")]
     InvalidProtocolVersion(ProtocolVersion),
-    #[error("Genesis error.")]
+    #[error("{0:?}")]
     Genesis(Box<GenesisError>),
     #[error("Wasm preprocessing error: {0}")]
     WasmPreprocessing(#[from] wasm_prep::PreprocessingError),

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -23,12 +23,13 @@ use casper_types::{
             SeigniorageRecipientsSnapshot, UnbondingPurses, ValidatorWeights, ARG_DELEGATION_RATE,
             ARG_DELEGATOR, ARG_ERA_END_TIMESTAMP_MILLIS, ARG_PUBLIC_KEY, ARG_REWARD_FACTORS,
             ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY, AUCTION_DELAY_KEY, BIDS_KEY,
-            ERA_END_TIMESTAMP_MILLIS_KEY, ERA_ID_KEY, INITIAL_ERA_END_TIMESTAMP_MILLIS,
-            INITIAL_ERA_ID, LOCKED_FUNDS_PERIOD_KEY, METHOD_ACTIVATE_BID, METHOD_ADD_BID,
-            METHOD_DELEGATE, METHOD_DISTRIBUTE, METHOD_GET_ERA_VALIDATORS, METHOD_READ_ERA_ID,
-            METHOD_READ_SEIGNIORAGE_RECIPIENTS, METHOD_RUN_AUCTION, METHOD_SLASH,
-            METHOD_UNDELEGATE, METHOD_WITHDRAW_BID, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
-            UNBONDING_DELAY_KEY, UNBONDING_PURSES_KEY, VALIDATOR_SLOTS_KEY,
+            DELEGATION_RATE_DENOMINATOR, ERA_END_TIMESTAMP_MILLIS_KEY, ERA_ID_KEY,
+            INITIAL_ERA_END_TIMESTAMP_MILLIS, INITIAL_ERA_ID, LOCKED_FUNDS_PERIOD_KEY,
+            METHOD_ACTIVATE_BID, METHOD_ADD_BID, METHOD_DELEGATE, METHOD_DISTRIBUTE,
+            METHOD_GET_ERA_VALIDATORS, METHOD_READ_ERA_ID, METHOD_READ_SEIGNIORAGE_RECIPIENTS,
+            METHOD_RUN_AUCTION, METHOD_SLASH, METHOD_UNDELEGATE, METHOD_WITHDRAW_BID,
+            SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_DELAY_KEY, UNBONDING_PURSES_KEY,
+            VALIDATOR_SLOTS_KEY,
         },
         mint::{
             self, ARG_AMOUNT, ARG_ID, ARG_PURSE, ARG_ROUND_SEIGNIORAGE_RATE, ARG_SOURCE,
@@ -124,8 +125,65 @@ impl GenesisResult {
 #[repr(u8)]
 enum GenesisAccountTag {
     System = 0,
-    Validator = 1,
+    Account = 1,
     Delegator = 2,
+}
+
+#[derive(DataSize, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenesisValidator {
+    bonded_amount: Motes,
+    delegation_rate: DelegationRate,
+}
+
+impl ToBytes for GenesisValidator {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.extend(self.bonded_amount.to_bytes()?);
+        buffer.extend(self.delegation_rate.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.bonded_amount.serialized_length() + self.delegation_rate.serialized_length()
+    }
+}
+
+impl FromBytes for GenesisValidator {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (bonded_amount, remainder) = FromBytes::from_bytes(bytes)?;
+        let (delegation_rate, remainder) = FromBytes::from_bytes(remainder)?;
+        let genesis_validator = GenesisValidator {
+            bonded_amount,
+            delegation_rate,
+        };
+        Ok((genesis_validator, remainder))
+    }
+}
+
+impl GenesisValidator {
+    pub fn new(bonded_amount: Motes, delegation_rate: DelegationRate) -> Self {
+        Self {
+            bonded_amount,
+            delegation_rate,
+        }
+    }
+
+    pub fn bonded_amount(&self) -> Motes {
+        self.bonded_amount
+    }
+
+    pub fn delegation_rate(&self) -> DelegationRate {
+        self.delegation_rate
+    }
+}
+
+impl Distribution<GenesisValidator> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> GenesisValidator {
+        let bonded_amount = Motes::new(rng.gen());
+        let delegation_rate = rng.gen();
+
+        GenesisValidator::new(bonded_amount, delegation_rate)
+    }
 }
 
 #[derive(DataSize, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -134,7 +192,7 @@ pub enum GenesisAccount {
     Account {
         public_key: PublicKey,
         balance: Motes,
-        bonded_amount: Motes,
+        validator: Option<GenesisValidator>,
     },
     Delegator {
         validator_public_key: PublicKey,
@@ -151,11 +209,15 @@ impl GenesisAccount {
     }
 
     /// Create a standard account variant.
-    pub fn account(public_key: PublicKey, balance: Motes, bonded_amount: Motes) -> Self {
+    pub fn account(
+        public_key: PublicKey,
+        balance: Motes,
+        validator: Option<GenesisValidator>,
+    ) -> Self {
         Self::Account {
             public_key,
             balance,
-            bonded_amount,
+            validator,
         }
     }
 
@@ -213,8 +275,14 @@ impl GenesisAccount {
     /// some amount of delegated stake.
     pub fn staked_amount(&self) -> Motes {
         match self {
-            GenesisAccount::System { .. } => Motes::zero(),
-            GenesisAccount::Account { bonded_amount, .. } => *bonded_amount,
+            GenesisAccount::System { .. }
+            | GenesisAccount::Account {
+                validator: None, ..
+            } => Motes::zero(),
+            GenesisAccount::Account {
+                validator: Some(genesis_validator),
+                ..
+            } => genesis_validator.bonded_amount(),
             GenesisAccount::Delegator {
                 delegated_amount, ..
             } => *delegated_amount,
@@ -229,8 +297,25 @@ impl GenesisAccount {
     /// Is this a validator account.
     pub fn is_validator(&self) -> bool {
         match self {
-            GenesisAccount::Account { bonded_amount, .. } => !bonded_amount.is_zero(),
-            GenesisAccount::System { .. } | GenesisAccount::Delegator { .. } => false,
+            GenesisAccount::Account {
+                validator: Some(_), ..
+            } => true,
+            GenesisAccount::System { .. }
+            | GenesisAccount::Account {
+                validator: None, ..
+            }
+            | GenesisAccount::Delegator { .. } => false,
+        }
+    }
+
+    /// Details about the genesis validator.
+    pub fn validator(&self) -> Option<&GenesisValidator> {
+        match self {
+            GenesisAccount::Account {
+                validator: Some(genesis_validator),
+                ..
+            } => Some(genesis_validator),
+            _ => None,
         }
     }
 
@@ -261,15 +346,10 @@ impl GenesisAccount {
 impl Distribution<GenesisAccount> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> GenesisAccount {
         let public_key = SecretKey::ed25519(rng.gen()).into();
+        let balance = Motes::new(rng.gen());
+        let validator = rng.gen();
 
-        let mut u512_array = [0u8; 64];
-        rng.fill_bytes(u512_array.as_mut());
-        let balance = Motes::new(U512::from(u512_array));
-
-        rng.fill_bytes(u512_array.as_mut());
-        let bonded_amount = Motes::new(U512::from(u512_array));
-
-        GenesisAccount::account(public_key, balance, bonded_amount)
+        GenesisAccount::account(public_key, balance, validator)
     }
 }
 
@@ -283,12 +363,12 @@ impl ToBytes for GenesisAccount {
             GenesisAccount::Account {
                 public_key,
                 balance,
-                bonded_amount,
+                validator,
             } => {
-                buffer.push(GenesisAccountTag::Validator as u8);
+                buffer.push(GenesisAccountTag::Account as u8);
                 buffer.extend(public_key.to_bytes()?);
                 buffer.extend(balance.value().to_bytes()?);
-                buffer.extend(bonded_amount.value().to_bytes()?);
+                buffer.extend(validator.to_bytes()?);
             }
             GenesisAccount::Delegator {
                 validator_public_key,
@@ -312,11 +392,11 @@ impl ToBytes for GenesisAccount {
             GenesisAccount::Account {
                 public_key,
                 balance,
-                bonded_amount,
+                validator,
             } => {
                 public_key.serialized_length()
                     + balance.value().serialized_length()
-                    + bonded_amount.value().serialized_length()
+                    + validator.serialized_length()
                     + TAG_LENGTH
             }
             GenesisAccount::Delegator {
@@ -343,26 +423,26 @@ impl FromBytes for GenesisAccount {
                 let genesis_account = GenesisAccount::system();
                 Ok((genesis_account, remainder))
             }
-            tag if tag == GenesisAccountTag::Validator as u8 => {
-                let (public_key, remainder) = PublicKey::from_bytes(remainder)?;
-                let (balance_value, remainder) = U512::from_bytes(remainder)?;
-                let (bonded_amount_value, remainder) = U512::from_bytes(remainder)?;
+            tag if tag == GenesisAccountTag::Account as u8 => {
+                let (public_key, remainder) = FromBytes::from_bytes(remainder)?;
+                let (balance, remainder) = FromBytes::from_bytes(remainder)?;
+                let (validator, remainder) = FromBytes::from_bytes(remainder)?;
                 let genesis_account = GenesisAccount::account(
                     public_key,
-                    Motes::new(balance_value),
-                    Motes::new(bonded_amount_value),
+                    balance,
+                    Some(GenesisValidator::new(validator, DelegationRate::zero())),
                 );
                 Ok((genesis_account, remainder))
             }
             tag if tag == GenesisAccountTag::Delegator as u8 => {
-                let (validator_public_key, remainder) = PublicKey::from_bytes(remainder)?;
-                let (delegator_public_key, remainder) = PublicKey::from_bytes(remainder)?;
-                let (balance_value, remainder) = U512::from_bytes(remainder)?;
-                let (delegated_amount_value, remainder) = U512::from_bytes(remainder)?;
+                let (validator_public_key, remainder) = FromBytes::from_bytes(remainder)?;
+                let (delegator_public_key, remainder) = FromBytes::from_bytes(remainder)?;
+                let (balance, remainder) = FromBytes::from_bytes(remainder)?;
+                let (delegated_amount_value, remainder) = FromBytes::from_bytes(remainder)?;
                 let genesis_account = GenesisAccount::delegator(
                     validator_public_key,
                     delegator_public_key,
-                    Motes::new(balance_value),
+                    balance,
                     Motes::new(delegated_amount_value),
                 );
                 Ok((genesis_account, remainder))
@@ -594,6 +674,13 @@ pub enum GenesisError {
         validator_public_key: PublicKey,
         delegator_public_key: PublicKey,
     },
+    InvalidDelegationRate {
+        public_key: PublicKey,
+        delegation_rate: DelegationRate,
+    },
+    InvalidBondAmount {
+        public_key: PublicKey,
+    }
 }
 
 pub(crate) struct GenesisInstaller<S>
@@ -796,13 +883,30 @@ where
         let validators = {
             let mut validators = Bids::new();
 
-            for genesis_validator in genesis_validators {
-                let public_key = genesis_validator.public_key();
-                let staked_amount = genesis_validator.staked_amount();
+            for genesis_account in genesis_validators {
+                let genesis_validator = match genesis_account.validator() {
+                    Some(genesis_validator) => genesis_validator,
+                    None => continue,
+                };
+
+                let public_key = genesis_account.public_key();
+
+                if genesis_validator.bonded_amount().is_zero() {
+                    return Err(GenesisError::InvalidBondAmount {
+                        public_key,
+                    });
+                }
+
+                if genesis_validator.delegation_rate() > DELEGATION_RATE_DENOMINATOR {
+                    return Err(GenesisError::InvalidDelegationRate {
+                        public_key,
+                        delegation_rate: genesis_validator.delegation_rate(),
+                    });
+                }
                 debug_assert_ne!(public_key, PublicKey::System);
 
                 let purse_uref = self.create_purse(
-                    staked_amount.value(),
+                    genesis_validator.bonded_amount().value(),
                     DeployHash::new(public_key.to_account_hash().value()),
                 )?;
                 let release_timestamp_millis =
@@ -811,7 +915,8 @@ where
                     let mut bid = Bid::locked(
                         public_key,
                         purse_uref,
-                        staked_amount.value(),
+                        genesis_validator.bonded_amount().value(),
+                        genesis_validator.delegation_rate(),
                         release_timestamp_millis,
                     );
 
@@ -1461,10 +1566,15 @@ mod tests {
         let mut rng = rand::thread_rng();
         let public_key = SecretKey::ed25519(rng.gen()).into();
 
-        let genesis_account =
-            GenesisAccount::account(public_key, Motes::new(U512::from(100)), Motes::zero());
+        let genesis_account_1 =
+            GenesisAccount::account(public_key, Motes::new(U512::from(100)), None);
 
-        bytesrepr::test_serialization_roundtrip(&genesis_account);
+        bytesrepr::test_serialization_roundtrip(&genesis_account_1);
+
+        let genesis_account_2 =
+            GenesisAccount::account(public_key, Motes::new(U512::from(100)), Some(rng.gen()));
+
+        bytesrepr::test_serialization_roundtrip(&genesis_account_2);
     }
 
     #[test]

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -680,7 +680,7 @@ pub enum GenesisError {
     },
     InvalidBondAmount {
         public_key: PublicKey,
-    }
+    },
 }
 
 pub(crate) struct GenesisInstaller<S>
@@ -892,9 +892,7 @@ where
                 let public_key = genesis_account.public_key();
 
                 if genesis_validator.bonded_amount().is_zero() {
-                    return Err(GenesisError::InvalidBondAmount {
-                        public_key,
-                    });
+                    return Err(GenesisError::InvalidBondAmount { public_key });
                 }
 
                 if genesis_validator.delegation_rate() > DELEGATION_RATE_DENOMINATOR {

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -446,11 +446,7 @@ impl FromBytes for GenesisAccount {
                 let (public_key, remainder) = FromBytes::from_bytes(remainder)?;
                 let (balance, remainder) = FromBytes::from_bytes(remainder)?;
                 let (validator, remainder) = FromBytes::from_bytes(remainder)?;
-                let genesis_account = GenesisAccount::account(
-                    public_key,
-                    balance,
-                    Some(GenesisValidator::new(validator, DelegationRate::zero())),
-                );
+                let genesis_account = GenesisAccount::account(public_key, balance, validator);
                 Ok((genesis_account, remainder))
             }
             tag if tag == GenesisAccountTag::Delegator as u8 => {

--- a/execution_engine_testing/test_support/src/internal/mod.rs
+++ b/execution_engine_testing/test_support/src/internal/mod.rs
@@ -8,7 +8,6 @@ pub mod utils;
 mod wasm_test_builder;
 
 use num_rational::Ratio;
-use num_traits::identities::Zero;
 use once_cell::sync::Lazy;
 
 use casper_execution_engine::{
@@ -78,13 +77,13 @@ pub static DEFAULT_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
     let genesis_account = GenesisAccount::account(
         *DEFAULT_ACCOUNT_PUBLIC_KEY,
         Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-        Motes::zero(),
+        None,
     );
     ret.push(genesis_account);
     let proposer_account = GenesisAccount::account(
         *DEFAULT_PROPOSER_PUBLIC_KEY,
         Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-        Motes::zero(),
+        None,
     );
     ret.push(proposer_account);
     ret

--- a/execution_engine_testing/test_support/src/test_context.rs
+++ b/execution_engine_testing/test_support/src/test_context.rs
@@ -1,5 +1,3 @@
-use num_traits::identities::Zero;
-
 use casper_execution_engine::{
     core::engine_state::{
         genesis::{GenesisAccount, GenesisConfig},
@@ -169,8 +167,7 @@ impl TestContextBuilder {
     ///
     /// Note: `initial_balance` represents the number of motes.
     pub fn with_public_key(mut self, public_key: PublicKey, initial_balance: U512) -> Self {
-        let new_account =
-            GenesisAccount::account(public_key, Motes::new(initial_balance), Motes::zero());
+        let new_account = GenesisAccount::account(public_key, Motes::new(initial_balance), None);
         self.genesis_config
             .ee_config_mut()
             .push_account(new_account);

--- a/execution_engine_testing/tests/src/test/regression/eco_863.rs
+++ b/execution_engine_testing/tests/src/test/regression/eco_863.rs
@@ -1,5 +1,4 @@
 use assert_matches::assert_matches;
-use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -39,7 +38,7 @@ fn faucet_should_create_account() {
         let faucet_account = GenesisAccount::account(
             *FAUCET,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::zero(),
+            None,
         );
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         tmp.push(faucet_account);
@@ -130,12 +129,12 @@ fn faucet_should_transfer_to_existing_account() {
         let faucet_account = GenesisAccount::account(
             *FAUCET,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::zero(),
+            None,
         );
         let alice_account = GenesisAccount::account(
             *ALICE,
             Motes::new(MINIMUM_ACCOUNT_CREATION_BALANCE.into()),
-            Motes::zero(),
+            None,
         );
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         tmp.push(faucet_account);

--- a/execution_engine_testing/tests/src/test/regression/ee_1045.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1045.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use std::collections::BTreeSet;
 
 use casper_engine_test_support::{
@@ -8,11 +9,14 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{core::engine_state::genesis::GenesisAccount, shared::motes::Motes};
+use casper_execution_engine::{
+    core::engine_state::genesis::{GenesisAccount, GenesisValidator},
+    shared::motes::Motes,
+};
 use casper_types::{
     account::AccountHash,
     runtime_args,
-    system::auction::{ARG_VALIDATOR_PUBLIC_KEYS, INITIAL_ERA_ID, METHOD_SLASH},
+    system::auction::{DelegationRate, ARG_VALIDATOR_PUBLIC_KEYS, INITIAL_ERA_ID, METHOD_SLASH},
     PublicKey, RuntimeArgs, SecretKey, U512,
 };
 use once_cell::sync::Lazy;
@@ -51,22 +55,34 @@ fn should_run_ee_1045_squash_validators() {
     let account_1 = GenesisAccount::account(
         *ACCOUNT_1_PK,
         Motes::new(ACCOUNT_1_BALANCE.into()),
-        Motes::new(ACCOUNT_1_BOND.into()),
+        Some(GenesisValidator::new(
+            Motes::new(ACCOUNT_1_BOND.into()),
+            DelegationRate::zero(),
+        )),
     );
     let account_2 = GenesisAccount::account(
         *ACCOUNT_2_PK,
         Motes::new(ACCOUNT_2_BALANCE.into()),
-        Motes::new(ACCOUNT_2_BOND.into()),
+        Some(GenesisValidator::new(
+            Motes::new(ACCOUNT_2_BOND.into()),
+            DelegationRate::zero(),
+        )),
     );
     let account_3 = GenesisAccount::account(
         *ACCOUNT_3_PK,
         Motes::new(ACCOUNT_3_BALANCE.into()),
-        Motes::new(ACCOUNT_3_BOND.into()),
+        Some(GenesisValidator::new(
+            Motes::new(ACCOUNT_3_BOND.into()),
+            DelegationRate::zero(),
+        )),
     );
     let account_4 = GenesisAccount::account(
         *ACCOUNT_4_PK,
         Motes::new(ACCOUNT_4_BALANCE.into()),
-        Motes::new(ACCOUNT_4_BOND.into()),
+        Some(GenesisValidator::new(
+            Motes::new(ACCOUNT_4_BOND.into()),
+            DelegationRate::zero(),
+        )),
     );
 
     let round_1_validator_squash = vec![*ACCOUNT_2_PK, *ACCOUNT_4_PK];

--- a/execution_engine_testing/tests/src/test/regression/ee_1103.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1103.rs
@@ -9,11 +9,14 @@ use casper_engine_test_support::{
     },
     MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
+use casper_execution_engine::{
+    core::engine_state::{genesis::GenesisValidator, GenesisAccount},
+    shared::motes::Motes,
+};
 use casper_types::{
     account::AccountHash,
     runtime_args,
-    system::auction::{ARG_DELEGATOR, ARG_VALIDATOR},
+    system::auction::{DelegationRate, ARG_DELEGATOR, ARG_VALIDATOR},
     PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
@@ -65,21 +68,30 @@ static DELEGATOR_3_STAKE: Lazy<U512> = Lazy::new(|| U512::from(300_000_000_000_0
 #[test]
 fn validator_scores_should_reflect_delegates() {
     let accounts = {
-        let faucet = GenesisAccount::account(*FAUCET, Motes::new(*FAUCET_BALANCE), Motes::zero());
+        let faucet = GenesisAccount::account(*FAUCET, Motes::new(*FAUCET_BALANCE), None);
         let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
             Motes::new(*VALIDATOR_1_BALANCE),
-            Motes::new(*VALIDATOR_1_STAKE),
+            Some(GenesisValidator::new(
+                Motes::new(*VALIDATOR_1_STAKE),
+                DelegationRate::zero(),
+            )),
         );
         let validator_2 = GenesisAccount::account(
             *VALIDATOR_2,
             Motes::new(*VALIDATOR_2_BALANCE),
-            Motes::new(*VALIDATOR_2_STAKE),
+            Some(GenesisValidator::new(
+                Motes::new(*VALIDATOR_2_STAKE),
+                DelegationRate::zero(),
+            )),
         );
         let validator_3 = GenesisAccount::account(
             *VALIDATOR_3,
             Motes::new(*VALIDATOR_3_BALANCE),
-            Motes::new(*VALIDATOR_3_STAKE),
+            Some(GenesisValidator::new(
+                Motes::new(*VALIDATOR_3_STAKE),
+                DelegationRate::zero(),
+            )),
         );
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         tmp.push(faucet);

--- a/execution_engine_testing/tests/src/test/regression/ee_1119.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1119.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -8,14 +9,17 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{core::engine_state::genesis::GenesisAccount, shared::motes::Motes};
+use casper_execution_engine::{
+    core::engine_state::genesis::{GenesisAccount, GenesisValidator},
+    shared::motes::Motes,
+};
 use casper_types::{
     account::AccountHash,
     runtime_args,
     system::{
         auction::{
-            Bids, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEYS,
-            BIDS_KEY, METHOD_SLASH, UNBONDING_PURSES_KEY,
+            Bids, DelegationRate, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR,
+            ARG_VALIDATOR_PUBLIC_KEYS, BIDS_KEY, METHOD_SLASH, UNBONDING_PURSES_KEY,
         },
         mint::TOTAL_SUPPLY_KEY,
     },
@@ -50,7 +54,10 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(VALIDATOR_1_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(VALIDATOR_1_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
 
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -1,18 +1,22 @@
 use std::{collections::BTreeSet, iter::FromIterator};
 
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
     internal::{utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS},
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::{core::engine_state::genesis::GenesisAccount, shared::motes::Motes};
+use casper_execution_engine::{
+    core::engine_state::genesis::{GenesisAccount, GenesisValidator},
+    shared::motes::Motes,
+};
 use casper_types::{
     account::{AccountHash, ACCOUNT_HASH_LENGTH},
     runtime_args,
     system::auction::{
-        Bids, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEYS, BIDS_KEY,
-        METHOD_SLASH, UNBONDING_PURSES_KEY,
+        Bids, DelegationRate, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR,
+        ARG_VALIDATOR_PUBLIC_KEYS, BIDS_KEY, METHOD_SLASH, UNBONDING_PURSES_KEY,
     },
     PublicKey, RuntimeArgs, SecretKey, U512,
 };
@@ -53,12 +57,18 @@ fn should_run_ee_1120_slash_delegators() {
         let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(VALIDATOR_1_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(VALIDATOR_1_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
         let validator_2 = GenesisAccount::account(
             *VALIDATOR_2,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(VALIDATOR_2_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(VALIDATOR_2_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
 
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();

--- a/execution_engine_testing/tests/src/test/regression/ee_1129.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1129.rs
@@ -11,7 +11,10 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::{
-        engine_state::{genesis::GenesisAccount, Error},
+        engine_state::{
+            genesis::{GenesisAccount, GenesisValidator},
+            Error,
+        },
         execution,
     },
     shared::{motes::Motes, wasm::do_nothing_bytes, wasm_prep::PreprocessingError},
@@ -45,7 +48,10 @@ fn should_run_ee_1129_underfunded_delegate_call() {
         let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(VALIDATOR_1_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(VALIDATOR_1_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
 
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
@@ -107,7 +113,7 @@ fn should_run_ee_1129_underfunded_add_bid_call() {
         let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::zero(),
+            None,
         );
 
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();

--- a/execution_engine_testing/tests/src/test/regression/ee_1152.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1152.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -10,12 +11,14 @@ use casper_engine_test_support::{
     MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
 use casper_execution_engine::{
-    core::engine_state::{GenesisAccount, RewardItem, SYSTEM_ACCOUNT_ADDR},
+    core::engine_state::{
+        genesis::GenesisValidator, GenesisAccount, RewardItem, SYSTEM_ACCOUNT_ADDR,
+    },
     shared::motes::Motes,
 };
 use casper_types::{
     runtime_args,
-    system::auction::{self, BLOCK_REWARD, INITIAL_ERA_ID},
+    system::auction::{self, DelegationRate, BLOCK_REWARD, INITIAL_ERA_ID},
     ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
@@ -42,12 +45,18 @@ fn should_run_ee_1152_regression_test() {
         let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(VALIDATOR_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(VALIDATOR_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
         let validator_2 = GenesisAccount::account(
             *DELEGATOR_1,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(VALIDATOR_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(VALIDATOR_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
 
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();

--- a/execution_engine_testing/tests/src/test/regression/ee_597.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_597.rs
@@ -1,4 +1,3 @@
-use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -22,11 +21,8 @@ const VALID_BALANCE: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 fn should_fail_when_bonding_amount_is_zero_ee_597_regression() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
-        let account = GenesisAccount::account(
-            *VALID_PUBLIC_KEY,
-            Motes::new(VALID_BALANCE.into()),
-            Motes::zero(),
-        );
+        let account =
+            GenesisAccount::account(*VALID_PUBLIC_KEY, Motes::new(VALID_BALANCE.into()), None);
         tmp.push(account);
         tmp
     };

--- a/execution_engine_testing/tests/src/test/regression/ee_598.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_598.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -6,10 +7,15 @@ use casper_engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use casper_execution_engine::{core::engine_state::genesis::GenesisAccount, shared::motes::Motes};
+use casper_execution_engine::{
+    core::engine_state::genesis::{GenesisAccount, GenesisValidator},
+    shared::motes::Motes,
+};
 use casper_types::{
-    account::AccountHash, runtime_args, system::auction, ApiError, PublicKey, RuntimeArgs,
-    SecretKey, U512,
+    account::AccountHash,
+    runtime_args,
+    system::auction::{self, DelegationRate},
+    ApiError, PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
 const ARG_AMOUNT: &str = "amount";
@@ -38,7 +44,10 @@ fn should_fail_unbonding_more_than_it_was_staked_ee_598_regression() {
         let account = GenesisAccount::account(
             public_key,
             Motes::new(GENESIS_VALIDATOR_STAKE.into()) * Motes::new(2.into()),
-            Motes::new(GENESIS_VALIDATOR_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(GENESIS_VALIDATOR_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
         tmp.push(account);
         tmp

--- a/execution_engine_testing/tests/src/test/step.rs
+++ b/execution_engine_testing/tests/src/test/step.rs
@@ -1,19 +1,23 @@
 use std::convert::TryFrom;
 
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::internal::{
     utils, InMemoryWasmTestBuilder, StepRequestBuilder, WasmTestBuilder, DEFAULT_ACCOUNTS,
 };
 use casper_execution_engine::{
-    core::engine_state::{genesis::GenesisAccount, RewardItem, SlashItem},
+    core::engine_state::{
+        genesis::{GenesisAccount, GenesisValidator},
+        RewardItem, SlashItem,
+    },
     shared::motes::Motes,
     storage::global_state::in_memory::InMemoryGlobalState,
 };
 use casper_types::{
     system::{
         auction::{
-            Bids, SeigniorageRecipientsSnapshot, BIDS_KEY, BLOCK_REWARD,
+            Bids, DelegationRate, SeigniorageRecipientsSnapshot, BIDS_KEY, BLOCK_REWARD,
             SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
         },
         mint::TOTAL_SUPPLY_KEY,
@@ -52,12 +56,18 @@ fn initialize_builder() -> WasmTestBuilder<InMemoryGlobalState> {
         let account_1 = GenesisAccount::account(
             *ACCOUNT_1_PK,
             Motes::new(ACCOUNT_1_BALANCE.into()),
-            Motes::new(ACCOUNT_1_BOND.into()),
+            Some(GenesisValidator::new(
+                Motes::new(ACCOUNT_1_BOND.into()),
+                DelegationRate::zero(),
+            )),
         );
         let account_2 = GenesisAccount::account(
             *ACCOUNT_2_PK,
             Motes::new(ACCOUNT_2_BALANCE.into()),
-            Motes::new(ACCOUNT_2_BOND.into()),
+            Some(GenesisValidator::new(
+                Motes::new(ACCOUNT_2_BOND.into()),
+                DelegationRate::zero(),
+            )),
         );
         tmp.push(account_1);
         tmp.push(account_2);

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -1,4 +1,5 @@
 use assert_matches::assert_matches;
+use num_traits::Zero;
 
 use casper_engine_test_support::{
     internal::{
@@ -11,7 +12,10 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::{
-        engine_state::{genesis::GenesisAccount, Error as EngineError},
+        engine_state::{
+            genesis::{GenesisAccount, GenesisValidator},
+            Error as EngineError,
+        },
         execution::Error,
     },
     shared::motes::Motes,
@@ -255,7 +259,10 @@ fn should_fail_unbonding_validator_with_locked_funds() {
         let account = GenesisAccount::account(
             account_1_public_key,
             Motes::new(account_1_balance),
-            Motes::new(GENESIS_VALIDATOR_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(GENESIS_VALIDATOR_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
         tmp.push(account);
         tmp

--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -10,13 +11,13 @@ use casper_engine_test_support::{
 };
 use casper_execution_engine::{
     core::engine_state::{
-        genesis::{ExecConfig, GenesisAccount},
+        genesis::{ExecConfig, GenesisAccount, GenesisValidator},
         run_genesis_request::RunGenesisRequest,
         SYSTEM_ACCOUNT_ADDR,
     },
     shared::{motes::Motes, stored_value::StoredValue},
 };
-use casper_types::{ProtocolVersion, PublicKey, SecretKey, U512};
+use casper_types::{system::auction::DelegationRate, ProtocolVersion, PublicKey, SecretKey, U512};
 
 const GENESIS_CONFIG_HASH: [u8; 32] = [127; 32];
 const ACCOUNT_1_BONDED_AMOUNT: u64 = 1_000_000;
@@ -38,7 +39,10 @@ static GENESIS_CUSTOM_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
         GenesisAccount::account(
             *ACCOUNT_1_PUBLIC_KEY,
             account_1_balance,
-            account_1_bonded_amount,
+            Some(GenesisValidator::new(
+                account_1_bonded_amount,
+                DelegationRate::zero(),
+            )),
         )
     };
     let account_2 = {
@@ -47,7 +51,10 @@ static GENESIS_CUSTOM_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
         GenesisAccount::account(
             *ACCOUNT_2_PUBLIC_KEY,
             account_2_balance,
-            account_2_bonded_amount,
+            Some(GenesisValidator::new(
+                account_2_bonded_amount,
+                DelegationRate::zero(),
+            )),
         )
     };
     vec![account_1, account_2]

--- a/execution_engine_testing/tests/src/test/system_costs.rs
+++ b/execution_engine_testing/tests/src/test/system_costs.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
@@ -9,7 +10,7 @@ use casper_engine_test_support::{
     AccountHash, DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
 use casper_execution_engine::{
-    core::engine_state::{upgrade::ActivationPoint, GenesisAccount},
+    core::engine_state::{genesis::GenesisValidator, upgrade::ActivationPoint, GenesisAccount},
     shared::{
         gas::Gas,
         host_function_costs::{Cost, HostFunction, HostFunctionCosts},
@@ -298,7 +299,10 @@ fn delegate_and_undelegate_have_expected_costs() {
         let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(VALIDATOR_1_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(VALIDATOR_1_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
 
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
@@ -422,7 +426,10 @@ fn upgraded_delegate_and_undelegate_have_expected_costs() {
         let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(VALIDATOR_1_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(VALIDATOR_1_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
 
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
@@ -540,7 +547,10 @@ fn mint_transfer_has_expected_costs() {
         let validator_1 = GenesisAccount::account(
             *VALIDATOR_1,
             Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE.into()),
-            Motes::new(VALIDATOR_1_STAKE.into()),
+            Some(GenesisValidator::new(
+                Motes::new(VALIDATOR_1_STAKE.into()),
+                DelegationRate::zero(),
+            )),
         );
 
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();

--- a/node/src/components/consensus/tests/utils.rs
+++ b/node/src/components/consensus/tests/utils.rs
@@ -1,11 +1,12 @@
+use num::Zero;
 use once_cell::sync::Lazy;
 
 use casper_execution_engine::shared::motes::Motes;
-use casper_types::{PublicKey, SecretKey, U512};
+use casper_types::{system::auction::DelegationRate, PublicKey, SecretKey, U512};
 
 use crate::{
     types::{
-        chainspec::{AccountConfig, AccountsConfig},
+        chainspec::{AccountConfig, AccountsConfig, ValidatorConfig},
         Chainspec, Timestamp,
     },
     utils::Loadable,
@@ -31,7 +32,8 @@ where
         .into_iter()
         .map(|(pk, stake)| {
             let motes = Motes::new(stake.into());
-            AccountConfig::new(pk, motes, motes)
+            let validator_config = ValidatorConfig::new(motes, DelegationRate::zero());
+            AccountConfig::new(pk, motes, Some(validator_config))
         })
         .collect();
     let delegators = vec![];

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -26,7 +26,7 @@ use casper_execution_engine::{
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 
 #[cfg(test)]
-pub(crate) use self::accounts_config::AccountConfig;
+pub(crate) use self::accounts_config::{AccountConfig, ValidatorConfig};
 pub(crate) use self::{
     accounts_config::AccountsConfig, core_config::CoreConfig, deploy_config::DeployConfig,
     global_state_update::GlobalStateUpdate, highway_config::HighwayConfig,

--- a/node/src/types/chainspec/accounts_config.rs
+++ b/node/src/types/chainspec/accounts_config.rs
@@ -2,6 +2,7 @@
 //! genesis, and set up auction contract with validators and delegators.
 mod account_config;
 mod delegator_config;
+mod validator_config;
 
 use std::path::Path;
 
@@ -18,6 +19,7 @@ use crate::utils::{self, Loadable};
 use super::error::ChainspecAccountsLoadError;
 pub use account_config::AccountConfig;
 pub use delegator_config::DelegatorConfig;
+pub use validator_config::ValidatorConfig;
 
 const CHAINSPEC_ACCOUNTS_FILENAME: &str = "accounts.toml";
 

--- a/node/src/types/chainspec/accounts_config.rs
+++ b/node/src/types/chainspec/accounts_config.rs
@@ -1,231 +1,25 @@
+//! The accounts config is a set of configuration options that is used to create accounts at
+//! genesis, and set up auction contract with validators and delegators.
+mod account_config;
+mod delegator_config;
+
 use std::path::Path;
 
 use datasize::DataSize;
-use num::Zero;
-#[cfg(test)]
-use rand::{distributions::Standard, prelude::*};
 use serde::{Deserialize, Serialize};
 
-use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
-use casper_types::{
-    bytesrepr::{self, FromBytes, ToBytes},
-    PublicKey,
-};
-#[cfg(test)]
-use casper_types::{SecretKey, U512};
+use casper_execution_engine::core::engine_state::GenesisAccount;
+use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 
 #[cfg(test)]
 use crate::testing::TestRng;
 use crate::utils::{self, Loadable};
 
 use super::error::ChainspecAccountsLoadError;
+pub use account_config::AccountConfig;
+pub use delegator_config::DelegatorConfig;
 
 const CHAINSPEC_ACCOUNTS_FILENAME: &str = "accounts.toml";
-
-#[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
-pub struct AccountConfig {
-    public_key: PublicKey,
-    balance: Motes,
-    bonded_amount: Motes,
-}
-
-impl AccountConfig {
-    pub fn new(public_key: PublicKey, balance: Motes, bonded_amount: Motes) -> Self {
-        Self {
-            public_key,
-            balance,
-            bonded_amount,
-        }
-    }
-
-    pub fn public_key(&self) -> PublicKey {
-        self.public_key
-    }
-
-    pub fn balance(&self) -> Motes {
-        self.balance
-    }
-
-    pub fn bonded_amount(&self) -> Motes {
-        self.bonded_amount
-    }
-
-    pub fn is_genesis_validator(&self) -> bool {
-        !self.bonded_amount.is_zero()
-    }
-
-    #[cfg(test)]
-    /// Generates a random instance using a `TestRng`.
-    pub fn random(rng: &mut TestRng) -> Self {
-        let public_key = PublicKey::from(&SecretKey::ed25519(rng.gen()));
-        let balance = Motes::new(U512::from(rng.gen::<u64>()));
-        let bonded_amount = Motes::new(U512::from(rng.gen::<u64>()));
-
-        AccountConfig {
-            public_key,
-            balance,
-            bonded_amount,
-        }
-    }
-}
-
-#[cfg(test)]
-impl Distribution<AccountConfig> for Standard {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AccountConfig {
-        let public_key = SecretKey::ed25519(rng.gen()).into();
-
-        let mut u512_array = [0u8; 64];
-        rng.fill_bytes(u512_array.as_mut());
-        let balance = Motes::new(U512::from(u512_array));
-
-        rng.fill_bytes(u512_array.as_mut());
-        let bonded_amount = Motes::new(U512::from(u512_array));
-
-        AccountConfig::new(public_key, balance, bonded_amount)
-    }
-}
-
-impl ToBytes for AccountConfig {
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        buffer.extend(self.public_key.to_bytes()?);
-        buffer.extend(self.balance.to_bytes()?);
-        buffer.extend(self.bonded_amount.to_bytes()?);
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        self.public_key.serialized_length()
-            + self.balance.serialized_length()
-            + self.bonded_amount.serialized_length()
-    }
-}
-
-impl FromBytes for AccountConfig {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (public_key, remainder) = FromBytes::from_bytes(bytes)?;
-        let (balance, remainder) = FromBytes::from_bytes(remainder)?;
-        let (bonded_amount, remainder) = FromBytes::from_bytes(remainder)?;
-        let account_config = AccountConfig {
-            public_key,
-            balance,
-            bonded_amount,
-        };
-        Ok((account_config, remainder))
-    }
-}
-
-#[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
-pub struct DelegatorConfig {
-    validator_public_key: PublicKey,
-    delegator_public_key: PublicKey,
-    balance: Motes,
-    delegated_amount: Motes,
-}
-
-impl DelegatorConfig {
-    pub fn new(
-        validator_public_key: PublicKey,
-        delegator_public_key: PublicKey,
-        balance: Motes,
-        delegated_amount: Motes,
-    ) -> Self {
-        Self {
-            validator_public_key,
-            delegator_public_key,
-            balance,
-            delegated_amount,
-        }
-    }
-
-    pub fn validator_public_key(&self) -> PublicKey {
-        self.validator_public_key
-    }
-
-    pub fn delegator_public_key(&self) -> PublicKey {
-        self.delegator_public_key
-    }
-
-    pub fn balance(&self) -> Motes {
-        self.balance
-    }
-
-    pub fn delegated_amount(&self) -> Motes {
-        self.delegated_amount
-    }
-
-    #[cfg(test)]
-    /// Generates a random instance using a `TestRng`.
-    pub fn random(rng: &mut TestRng) -> Self {
-        let validator_public_key = PublicKey::from(&SecretKey::ed25519(rng.gen()));
-        let delegator_public_key = PublicKey::from(&SecretKey::ed25519(rng.gen()));
-        let balance = Motes::new(U512::from(rng.gen::<u64>()));
-        let delegated_amount = Motes::new(U512::from(rng.gen::<u64>()));
-
-        DelegatorConfig {
-            validator_public_key,
-            delegator_public_key,
-            balance,
-            delegated_amount,
-        }
-    }
-}
-
-#[cfg(test)]
-impl Distribution<DelegatorConfig> for Standard {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> DelegatorConfig {
-        let validator_public_key = SecretKey::ed25519(rng.gen()).into();
-        let delegator_public_key = SecretKey::ed25519(rng.gen()).into();
-
-        let mut u512_array = [0u8; 64];
-        rng.fill_bytes(u512_array.as_mut());
-        let balance = Motes::new(U512::from(u512_array));
-
-        rng.fill_bytes(u512_array.as_mut());
-        let delegated_amount = Motes::new(U512::from(u512_array));
-
-        DelegatorConfig::new(
-            validator_public_key,
-            delegator_public_key,
-            balance,
-            delegated_amount,
-        )
-    }
-}
-
-impl ToBytes for DelegatorConfig {
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        buffer.extend(self.validator_public_key.to_bytes()?);
-        buffer.extend(self.delegator_public_key.to_bytes()?);
-        buffer.extend(self.balance.to_bytes()?);
-        buffer.extend(self.delegated_amount.to_bytes()?);
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        self.validator_public_key.serialized_length()
-            + self.delegator_public_key.serialized_length()
-            + self.balance.serialized_length()
-            + self.delegated_amount.serialized_length()
-    }
-}
-
-impl FromBytes for DelegatorConfig {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (validator_public_key, remainder) = FromBytes::from_bytes(bytes)?;
-        let (delegator_public_key, remainder) = FromBytes::from_bytes(remainder)?;
-        let (balance, remainder) = FromBytes::from_bytes(remainder)?;
-        let (delegated_amount, remainder) = FromBytes::from_bytes(remainder)?;
-        let delegator_config = DelegatorConfig {
-            validator_public_key,
-            delegator_public_key,
-            balance,
-            delegated_amount,
-        };
-        Ok((delegator_config, remainder))
-    }
-}
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Clone)]
 pub struct AccountsConfig {
@@ -313,20 +107,11 @@ impl From<AccountsConfig> for Vec<GenesisAccount> {
     fn from(accounts_config: AccountsConfig) -> Self {
         let mut genesis_accounts = Vec::with_capacity(accounts_config.accounts.len());
         for account_config in accounts_config.accounts {
-            let genesis_account = GenesisAccount::account(
-                account_config.public_key,
-                account_config.balance,
-                account_config.bonded_amount,
-            );
+            let genesis_account = account_config.into();
             genesis_accounts.push(genesis_account);
         }
         for delegator_config in accounts_config.delegators {
-            let genesis_account = GenesisAccount::delegator(
-                delegator_config.validator_public_key,
-                delegator_config.delegator_public_key,
-                delegator_config.balance,
-                delegator_config.delegated_amount,
-            );
+            let genesis_account = delegator_config.into();
             genesis_accounts.push(genesis_account);
         }
 

--- a/node/src/types/chainspec/accounts_config/account_config.rs
+++ b/node/src/types/chainspec/accounts_config/account_config.rs
@@ -1,0 +1,119 @@
+use datasize::DataSize;
+use num::Zero;
+#[cfg(test)]
+use rand::{distributions::Standard, prelude::*};
+use serde::{Deserialize, Serialize};
+
+use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    PublicKey,
+};
+#[cfg(test)]
+use casper_types::{SecretKey, U512};
+
+#[cfg(test)]
+use crate::testing::TestRng;
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
+pub struct AccountConfig {
+    pub(super) public_key: PublicKey,
+    balance: Motes,
+    bonded_amount: Motes,
+}
+
+impl AccountConfig {
+    pub fn new(public_key: PublicKey, balance: Motes, bonded_amount: Motes) -> Self {
+        Self {
+            public_key,
+            balance,
+            bonded_amount,
+        }
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        self.public_key
+    }
+
+    pub fn balance(&self) -> Motes {
+        self.balance
+    }
+
+    pub fn bonded_amount(&self) -> Motes {
+        self.bonded_amount
+    }
+
+    pub fn is_genesis_validator(&self) -> bool {
+        !self.bonded_amount.is_zero()
+    }
+
+    #[cfg(test)]
+    /// Generates a random instance using a `TestRng`.
+    pub fn random(rng: &mut TestRng) -> Self {
+        let public_key = PublicKey::from(&SecretKey::ed25519(rng.gen()));
+        let balance = Motes::new(U512::from(rng.gen::<u64>()));
+        let bonded_amount = Motes::new(U512::from(rng.gen::<u64>()));
+
+        AccountConfig {
+            public_key,
+            balance,
+            bonded_amount,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Distribution<AccountConfig> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AccountConfig {
+        let public_key = SecretKey::ed25519(rng.gen()).into();
+
+        let mut u512_array = [0u8; 64];
+        rng.fill_bytes(u512_array.as_mut());
+        let balance = Motes::new(U512::from(u512_array));
+
+        rng.fill_bytes(u512_array.as_mut());
+        let bonded_amount = Motes::new(U512::from(u512_array));
+
+        AccountConfig::new(public_key, balance, bonded_amount)
+    }
+}
+
+impl ToBytes for AccountConfig {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.extend(self.public_key.to_bytes()?);
+        buffer.extend(self.balance.to_bytes()?);
+        buffer.extend(self.bonded_amount.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.public_key.serialized_length()
+            + self.balance.serialized_length()
+            + self.bonded_amount.serialized_length()
+    }
+}
+
+impl FromBytes for AccountConfig {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (public_key, remainder) = FromBytes::from_bytes(bytes)?;
+        let (balance, remainder) = FromBytes::from_bytes(remainder)?;
+        let (bonded_amount, remainder) = FromBytes::from_bytes(remainder)?;
+        let account_config = AccountConfig {
+            public_key,
+            balance,
+            bonded_amount,
+        };
+        Ok((account_config, remainder))
+    }
+}
+
+impl From<AccountConfig> for GenesisAccount {
+    fn from(account_config: AccountConfig) -> Self {
+        GenesisAccount::account(
+            account_config.public_key,
+            account_config.balance,
+            account_config.bonded_amount,
+        )
+    }
+}

--- a/node/src/types/chainspec/accounts_config/delegator_config.rs
+++ b/node/src/types/chainspec/accounts_config/delegator_config.rs
@@ -1,0 +1,138 @@
+use datasize::DataSize;
+#[cfg(test)]
+use rand::{distributions::Standard, prelude::*};
+use serde::{Deserialize, Serialize};
+
+use casper_execution_engine::{core::engine_state::GenesisAccount, shared::motes::Motes};
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    PublicKey,
+};
+#[cfg(test)]
+use casper_types::{SecretKey, U512};
+
+#[cfg(test)]
+use crate::testing::TestRng;
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
+pub struct DelegatorConfig {
+    pub(super) validator_public_key: PublicKey,
+    delegator_public_key: PublicKey,
+    balance: Motes,
+    delegated_amount: Motes,
+}
+
+impl DelegatorConfig {
+    pub fn new(
+        validator_public_key: PublicKey,
+        delegator_public_key: PublicKey,
+        balance: Motes,
+        delegated_amount: Motes,
+    ) -> Self {
+        Self {
+            validator_public_key,
+            delegator_public_key,
+            balance,
+            delegated_amount,
+        }
+    }
+
+    pub fn validator_public_key(&self) -> PublicKey {
+        self.validator_public_key
+    }
+
+    pub fn delegator_public_key(&self) -> PublicKey {
+        self.delegator_public_key
+    }
+
+    pub fn balance(&self) -> Motes {
+        self.balance
+    }
+
+    pub fn delegated_amount(&self) -> Motes {
+        self.delegated_amount
+    }
+
+    #[cfg(test)]
+    /// Generates a random instance using a `TestRng`.
+    pub fn random(rng: &mut TestRng) -> Self {
+        let validator_public_key = PublicKey::from(&SecretKey::ed25519(rng.gen()));
+        let delegator_public_key = PublicKey::from(&SecretKey::ed25519(rng.gen()));
+        let balance = Motes::new(U512::from(rng.gen::<u64>()));
+        let delegated_amount = Motes::new(U512::from(rng.gen::<u64>()));
+
+        DelegatorConfig {
+            validator_public_key,
+            delegator_public_key,
+            balance,
+            delegated_amount,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Distribution<DelegatorConfig> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> DelegatorConfig {
+        let validator_public_key = SecretKey::ed25519(rng.gen()).into();
+        let delegator_public_key = SecretKey::ed25519(rng.gen()).into();
+
+        let mut u512_array = [0u8; 64];
+        rng.fill_bytes(u512_array.as_mut());
+        let balance = Motes::new(U512::from(u512_array));
+
+        rng.fill_bytes(u512_array.as_mut());
+        let delegated_amount = Motes::new(U512::from(u512_array));
+
+        DelegatorConfig::new(
+            validator_public_key,
+            delegator_public_key,
+            balance,
+            delegated_amount,
+        )
+    }
+}
+
+impl ToBytes for DelegatorConfig {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.extend(self.validator_public_key.to_bytes()?);
+        buffer.extend(self.delegator_public_key.to_bytes()?);
+        buffer.extend(self.balance.to_bytes()?);
+        buffer.extend(self.delegated_amount.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.validator_public_key.serialized_length()
+            + self.delegator_public_key.serialized_length()
+            + self.balance.serialized_length()
+            + self.delegated_amount.serialized_length()
+    }
+}
+
+impl FromBytes for DelegatorConfig {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (validator_public_key, remainder) = FromBytes::from_bytes(bytes)?;
+        let (delegator_public_key, remainder) = FromBytes::from_bytes(remainder)?;
+        let (balance, remainder) = FromBytes::from_bytes(remainder)?;
+        let (delegated_amount, remainder) = FromBytes::from_bytes(remainder)?;
+        let delegator_config = DelegatorConfig {
+            validator_public_key,
+            delegator_public_key,
+            balance,
+            delegated_amount,
+        };
+        Ok((delegator_config, remainder))
+    }
+}
+
+impl From<DelegatorConfig> for GenesisAccount {
+    fn from(delegator_config: DelegatorConfig) -> Self {
+        GenesisAccount::delegator(
+            delegator_config.validator_public_key,
+            delegator_config.delegator_public_key,
+            delegator_config.balance,
+            delegator_config.delegated_amount,
+        )
+    }
+}

--- a/node/src/types/chainspec/accounts_config/validator_config.rs
+++ b/node/src/types/chainspec/accounts_config/validator_config.rs
@@ -1,0 +1,101 @@
+use datasize::DataSize;
+use num::Zero;
+#[cfg(test)]
+use rand::{distributions::Standard, prelude::*};
+use serde::{Deserialize, Serialize};
+
+use casper_execution_engine::{
+    core::engine_state::genesis::GenesisValidator, shared::motes::Motes,
+};
+#[cfg(test)]
+use casper_types::U512;
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    system::auction::DelegationRate,
+};
+
+#[cfg(test)]
+use crate::testing::TestRng;
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
+pub struct ValidatorConfig {
+    bonded_amount: Motes,
+    #[serde(default = "DelegationRate::zero")]
+    delegation_rate: DelegationRate,
+}
+
+impl ValidatorConfig {
+    pub fn new(bonded_amount: Motes, delegation_rate: DelegationRate) -> Self {
+        Self {
+            bonded_amount,
+            delegation_rate,
+        }
+    }
+
+    pub fn delegation_rate(&self) -> DelegationRate {
+        self.delegation_rate
+    }
+
+    pub fn bonded_amount(&self) -> Motes {
+        self.bonded_amount
+    }
+
+    #[cfg(test)]
+    /// Generates a random instance using a `TestRng`.
+    pub fn random(rng: &mut TestRng) -> Self {
+        let bonded_amount = Motes::new(U512::from(rng.gen::<u64>()));
+        let delegation_rate = rng.gen();
+
+        ValidatorConfig {
+            bonded_amount,
+            delegation_rate,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Distribution<ValidatorConfig> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ValidatorConfig {
+        let mut u512_array = [0; 64];
+        rng.fill_bytes(u512_array.as_mut());
+        let bonded_amount = Motes::new(U512::from(u512_array));
+
+        let delegation_rate = rng.gen();
+
+        ValidatorConfig::new(bonded_amount, delegation_rate)
+    }
+}
+
+impl ToBytes for ValidatorConfig {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.extend(self.bonded_amount.to_bytes()?);
+        buffer.extend(self.delegation_rate.to_bytes()?);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.bonded_amount.serialized_length() + self.delegation_rate.serialized_length()
+    }
+}
+
+impl FromBytes for ValidatorConfig {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (bonded_amount, remainder) = FromBytes::from_bytes(bytes)?;
+        let (delegation_rate, remainder) = FromBytes::from_bytes(remainder)?;
+        let account_config = ValidatorConfig {
+            bonded_amount,
+            delegation_rate,
+        };
+        Ok((account_config, remainder))
+    }
+}
+
+impl From<ValidatorConfig> for GenesisValidator {
+    fn from(account_config: ValidatorConfig) -> Self {
+        GenesisValidator::new(
+            account_config.bonded_amount(),
+            account_config.delegation_rate,
+        )
+    }
+}

--- a/node/src/types/json_compatibility/auction_state.rs
+++ b/node/src/types/json_compatibility/auction_state.rs
@@ -3,6 +3,7 @@
 
 use std::collections::BTreeMap;
 
+use num_traits::Zero;
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -46,6 +47,7 @@ static BIDS: Lazy<Bids> = Lazy::new(|| {
         validator_public_key,
         bonding_purse,
         staked_amount,
+        DelegationRate::zero(),
         release_era,
     );
     let mut bids = BTreeMap::new();

--- a/resources/joiner/accounts.toml
+++ b/resources/joiner/accounts.toml
@@ -1,9 +1,10 @@
 [[accounts]]
 public_key = "01522ef6c89038019cb7af05c340623804392dd2bb1f4dab5e4a9c3ab752fc0179"
 balance = "1000000000000000000000000000"
-bonded_amount = "0"
 
 [[accounts]]
 public_key = "01f60bce2bb1059c41910eac1e7ee6c3ef4c8fcc63a901eb9603c1524cadfb0c18"
 balance = "1000000000000000000"
+
+[accounts.validator]
 bonded_amount = "500000000000000"

--- a/resources/local/accounts.toml
+++ b/resources/local/accounts.toml
@@ -1,27 +1,35 @@
 [[accounts]]
 public_key = "01522ef6c89038019cb7af05c340623804392dd2bb1f4dab5e4a9c3ab752fc0179"
 balance = "1000000000000000000000000000"
-bonded_amount = "0"
 
 [[accounts]]
 public_key = "01f60bce2bb1059c41910eac1e7ee6c3ef4c8fcc63a901eb9603c1524cadfb0c18"
 balance = "1000000000000000000"
+
+[accounts.validator]
 bonded_amount = "500000000000000"
 
 [[accounts]]
 public_key = "018f5a3ee4c1221686fcdbe6c0b6168acb24025c5485f59f7c4039ffc444fb7509"
 balance = "1000000000000000000"
+
+[accounts.validator]
 bonded_amount = "400000000000000"
 
 [[accounts]]
 public_key = "01449c5f751e465adabc9885fe8f33b522ab2c069997148e4b65fddde9c4440d31"
 balance = "1000000000000000000"
+
+[accounts.validator]
 bonded_amount = "300000000000000"
 
 [[accounts]]
 public_key = "01b3feeec1d91c7c2f070052315258eeaaf7c24029a80a1aea285814e9f9a20d36"
 balance = "1000000000000000000"
+
+[accounts.validator]
 bonded_amount = "200000000000000"
+delegation_rate = 10
 
 [[delegators]]
 validator_public_key = "01b3feeec1d91c7c2f070052315258eeaaf7c24029a80a1aea285814e9f9a20d36"

--- a/resources/production/accounts.toml
+++ b/resources/production/accounts.toml
@@ -1,27 +1,28 @@
 [[accounts]]
 public_key = "01054c929d687267a30341c759b4a9cab1238cb2de65546be43dad479c50745724"
 balance = "10000000000000000000000000000000000000"
-bonded_amount = "0"
 
 [[accounts]]
 public_key = "013f774a58f4d40bd9b6cce7e306e53646913860ef2a111d00f0fe7794010c4012"
 balance = "1000000000000000000000000"
+
+[accounts.validator]
 bonded_amount = "10000000000000000"
 
 [[accounts]]
 public_key = "01d62fc9b894218bfbe8eebcc4a28a1fc4cb3a5c6120bb0027207ba8214439929e"
 balance = "1000000000000000000000000"
+
+[accounts.validator]
 bonded_amount = "10000000000000000"
 
 [[accounts]]
 public_key = "018b15761be0c527117c79b87ca013b014a4628f01e382902a139529406723d86b"
 balance = "1000000000000000000000000"
-bonded_amount = "0"
 
 [[accounts]]
 public_key = "01524a5f3567d7b5ea17ca518c9d0320fb4a75a28a5eab58d06c755c388f20a19f"
 balance = "1000000000000000000000000"
-bonded_amount = "0"
 
 [[delegators]]
 validator_public_key = "01524a5f3567d7b5ea17ca518c9d0320fb4a75a28a5eab58d06c755c388f20a19f"

--- a/resources/production/validation.md5
+++ b/resources/production/validation.md5
@@ -1,2 +1,2 @@
-b708ca9777b1bb1862e84f241c3e38e1  accounts.toml
+f4f487eaff9b6ae052c9679b7baab882  accounts.toml
 18d28fc8abccfa080e0735ef3c88b557  chainspec.toml

--- a/resources/test/valid/0_9_0/accounts.toml
+++ b/resources/test/valid/0_9_0/accounts.toml
@@ -1,21 +1,29 @@
 [[accounts]]
 public_key = "0148bc7fdb0375d480fbd03e77f74ffedc30b9f3954455fe04da15843a0a6af0c7"
 balance = "1"
+
+[accounts.validator]
 bonded_amount = "10"
 
 [[accounts]]
 public_key = "011f66ea6321a48a935f66e97d4f7e60ee2d7fc9ccc62dfbe310f33b4839fc62eb"
 balance = "2"
+
+[accounts.validator]
 bonded_amount = "20"
 
 [[accounts]]
 public_key = "0189e744783c2d70902a5f2ef78e82e1f44102b5eb08ca6234241d95e50f615a6b"
 balance = "3"
+
+[accounts.validator]
 bonded_amount = "30"
 
 [[accounts]]
 public_key = "01569b41d574c46390212d698660b5326269ddb0a761d1294258897ac717b4958b"
 balance = "4"
+
+[accounts.validator]
 bonded_amount = "40"
 
 [[delegators]]

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -37,9 +37,9 @@ impl Bid {
         validator_public_key: PublicKey,
         bonding_purse: URef,
         staked_amount: U512,
+        delegation_rate: DelegationRate,
         release_timestamp_millis: u64,
     ) -> Self {
-        let delegation_rate = 0;
         let vesting_schedule = Some(VestingSchedule::new(release_timestamp_millis));
         let delegators = BTreeMap::new();
         let inactive = false;
@@ -329,6 +329,7 @@ mod tests {
         let validator_release_timestamp = TIMESTAMP_MILLIS;
         let validator_bonding_purse = URef::new([42; 32], AccessRights::ADD);
         let validator_staked_amount = U512::from(1000);
+        let validator_delegation_rate = 0;
 
         let delegator_1_release_timestamp = TIMESTAMP_MILLIS + 1;
         let delegator_1_bonding_purse = URef::new([52; 32], AccessRights::ADD);
@@ -358,6 +359,7 @@ mod tests {
             validator_pk,
             validator_bonding_purse,
             validator_staked_amount,
+            validator_delegation_rate,
             validator_release_timestamp,
         );
 

--- a/types/src/uint.rs
+++ b/types/src/uint.rs
@@ -11,6 +11,10 @@ use core::{
 
 use num_integer::Integer;
 use num_traits::{AsPrimitive, Bounded, Num, One, Unsigned, WrappingAdd, WrappingSub, Zero};
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use serde::{
     de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor},
     ser::{Serialize, SerializeStruct, Serializer},
@@ -410,6 +414,14 @@ macro_rules! impl_traits_for_uint {
         impl Sum for $type {
             fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
                 iter.fold($type::zero(), Add::add)
+            }
+        }
+
+        impl Distribution<$type> for Standard {
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $type {
+                let mut raw_bytes = [0u8; $total_bytes];
+                rng.fill_bytes(raw_bytes.as_mut());
+                $type::from(raw_bytes)
             }
         }
 

--- a/utils/nctl/sh/assets/setup.sh
+++ b/utils/nctl/sh/assets/setup.sh
@@ -84,7 +84,7 @@ function _set_net_chainspec()
 function _set_chainspec_account()
 {
     local PATH_TO_ACCOUNT_KEY=${1}
-    local INITIAL_BALANCE=${2}
+    local INITIAL_BALANCE=${2:-0}
     local INITIAL_WEIGHT=${3:-0}
     local ACCOUNT_KEY
     local PATH_TO_NET
@@ -96,11 +96,15 @@ function _set_chainspec_account()
 [[accounts]]
 public_key = "${ACCOUNT_KEY}"
 balance = "$INITIAL_BALANCE"
-
-[[accounts.validator]]
+EOM
+    
+    if [ "$INITIAL_WEIGHT" != '0' ]; then
+        cat >> "$PATH_TO_NET"/chainspec/accounts.toml <<- EOM
+[accounts.validator]
 bonded_amount = "$INITIAL_WEIGHT"
 
 EOM
+    fi
 }
 
 #######################################

--- a/utils/nctl/sh/assets/setup.sh
+++ b/utils/nctl/sh/assets/setup.sh
@@ -96,6 +96,8 @@ function _set_chainspec_account()
 [[accounts]]
 public_key = "${ACCOUNT_KEY}"
 balance = "$INITIAL_BALANCE"
+
+[[accounts.validator]]
 bonded_amount = "$INITIAL_WEIGHT"
 
 EOM
@@ -154,7 +156,6 @@ function _set_chainspec_account_for_user()
     cat >> "$PATH_TO_NET"/chainspec/accounts.toml <<- EOM
 [[accounts]]
 balance = "$BALANCE_OF_USER"
-bonded_amount = "0"
 public_key = "${ACCOUNT_KEY_OF_USER}"
 
 EOM

--- a/utils/nctl/sh/assets/setup_node.sh
+++ b/utils/nctl/sh/assets/setup_node.sh
@@ -44,7 +44,11 @@ function setup_node()
     if [ "$NODE_ID" -le "$COUNT_GENESIS_NODES" ]; then
         POS_WEIGHT=$(get_node_staking_weight "$NODE_ID")
     else
-        POS_WEIGHT=0
+        POS_WEIGHT="0"
+    fi
+
+    if [ "x$POS_WEIGHT" = 'x' ]; then
+        POS_WEIGHT="0"
     fi
 
     # Set chainspec account.
@@ -52,11 +56,14 @@ function setup_node()
 [[accounts]]
 public_key = "$(get_account_key "$NCTL_ACCOUNT_TYPE_NODE" "$NODE_ID")"
 balance = "$NCTL_INITIAL_BALANCE_VALIDATOR"
-
-[[accounts.validator]]
+EOM
+    if [ "$POS_WEIGHT" != '0' ]; then
+        cat >> "$PATH_TO_NET"/chainspec/accounts.toml <<- EOM
+[accounts.validator]
 bonded_amount = "$POS_WEIGHT"
 
 EOM
+    fi
 }
 
 #######################################

--- a/utils/nctl/sh/assets/setup_node.sh
+++ b/utils/nctl/sh/assets/setup_node.sh
@@ -52,6 +52,8 @@ function setup_node()
 [[accounts]]
 public_key = "$(get_account_key "$NCTL_ACCOUNT_TYPE_NODE" "$NODE_ID")"
 balance = "$NCTL_INITIAL_BALANCE_VALIDATOR"
+
+[[accounts.validator]]
 bonded_amount = "$POS_WEIGHT"
 
 EOM


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-942

This PR changes the structure of accounts.toml to separate `bonded_amount` so `delegation_rate` could be a part of it. If `[accounts.validator]` field in TOML is not specified for given array element, then such account would be normal user without stake. Otherwise it will be considered an account with a stake.

Thanks to this separation of stake related attributes both `bonded_amount` and `delegation_rate` can be properly validated.