### PR TITLE
EE-1186: persist bids directly in state trie

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -22,7 +22,7 @@ use casper_types::{
             Bid, Bids, DelegationRate, Delegator, SeigniorageRecipient, SeigniorageRecipients,
             SeigniorageRecipientsSnapshot, UnbondingPurses, ValidatorWeights, ARG_DELEGATION_RATE,
             ARG_DELEGATOR, ARG_ERA_END_TIMESTAMP_MILLIS, ARG_PUBLIC_KEY, ARG_REWARD_FACTORS,
-            ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY, AUCTION_DELAY_KEY, BIDS_KEY,
+            ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY, AUCTION_DELAY_KEY,
             ERA_END_TIMESTAMP_MILLIS_KEY, ERA_ID_KEY, INITIAL_ERA_END_TIMESTAMP_MILLIS,
             INITIAL_ERA_ID, LOCKED_FUNDS_PERIOD_KEY, METHOD_ACTIVATE_BID, METHOD_ADD_BID,
             METHOD_DELEGATE, METHOD_DISTRIBUTE, METHOD_GET_ERA_VALIDATORS, METHOD_READ_ERA_ID,
@@ -905,18 +905,13 @@ where
             initial_seigniorage_recipients_uref.into(),
         );
 
-        let bids_uref = self
-            .uref_address_generator
-            .borrow_mut()
-            .new_uref(AccessRights::READ_ADD_WRITE);
-        self.tracking_copy.borrow_mut().write(
-            bids_uref.into(),
-            StoredValue::CLValue(
-                CLValue::from_t(validators)
-                    .map_err(|_| GenesisError::CLValue(BIDS_KEY.to_string()))?,
-            ),
-        );
-        named_keys.insert(BIDS_KEY.into(), bids_uref.into());
+        for (validator_public_key, bid) in validators.into_iter() {
+            let validator_account_hash = AccountHash::from(&validator_public_key);
+            self.tracking_copy.borrow_mut().write(
+                Key::Bid(validator_account_hash),
+                StoredValue::Bid(Box::new(bid)),
+            )
+        }
 
         let unbonding_purses_uref = self
             .uref_address_generator

--- a/execution_engine/src/core/engine_state/query.rs
+++ b/execution_engine/src/core/engine_state/query.rs
@@ -1,4 +1,4 @@
-use casper_types::Key;
+use casper_types::{system::auction::Bids, Key};
 
 use crate::{
     core::tracking_copy::TrackingCopyQueryResult,
@@ -57,6 +57,40 @@ impl From<TrackingCopyQueryResult> for QueryResult {
                 let value = Box::new(value);
                 QueryResult::Success { value, proofs }
             }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetBidsRequest {
+    state_hash: Blake2bHash,
+}
+
+impl GetBidsRequest {
+    pub fn new(state_hash: Blake2bHash) -> Self {
+        GetBidsRequest { state_hash }
+    }
+
+    pub fn state_hash(&self) -> Blake2bHash {
+        self.state_hash
+    }
+}
+
+#[derive(Debug)]
+pub enum GetBidsResult {
+    RootNotFound,
+    Success { bids: Bids },
+}
+
+impl GetBidsResult {
+    pub fn success(bids: Bids) -> Self {
+        GetBidsResult::Success { bids }
+    }
+
+    pub fn bids(&self) -> Option<&Bids> {
+        match self {
+            GetBidsResult::RootNotFound => None,
+            GetBidsResult::Success { bids } => Some(bids),
         }
     }
 }

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -16,7 +16,7 @@ use casper_types::{
     contracts::NamedKeys,
     system::auction::EraInfo,
     AccessRights, BlockTime, CLType, CLValue, Contract, ContractPackage, ContractPackageHash,
-    DeployHash, DeployInfo, EntryPointAccess, EntryPointType, Key, Phase, ProtocolVersion,
+    DeployHash, DeployInfo, EntryPointAccess, EntryPointType, Key, KeyTag, Phase, ProtocolVersion,
     RuntimeArgs, Transfer, TransferAddr, URef, KEY_HASH_LENGTH,
 };
 
@@ -424,6 +424,13 @@ where
                 key, error
             ))
         })
+    }
+
+    pub fn get_keys(&mut self, key_tag: &KeyTag) -> Result<BTreeSet<Key>, Error> {
+        self.tracking_copy
+            .borrow_mut()
+            .get_keys(self.correlation_id, key_tag)
+            .map_err(Into::into)
     }
 
     pub fn read_account(&mut self, key: &Key) -> Result<Option<StoredValue>, Error> {

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -571,6 +571,7 @@ where
             StoredValue::Transfer(_) => Ok(()),
             StoredValue::DeployInfo(_) => Ok(()),
             StoredValue::EraInfo(_) => Ok(()),
+            StoredValue::Bid(_) => Ok(()),
         }
     }
 

--- a/execution_engine/src/core/tracking_copy/byte_size.rs
+++ b/execution_engine/src/core/tracking_copy/byte_size.rs
@@ -43,6 +43,7 @@ impl ByteSize for StoredValue {
                 StoredValue::DeployInfo(deploy_info) => deploy_info.serialized_length(),
                 StoredValue::Transfer(transfer) => transfer.serialized_length(),
                 StoredValue::EraInfo(era_info) => era_info.serialized_length(),
+                StoredValue::Bid(bid) => bid.serialized_length(),
             }
     }
 }

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -485,6 +485,9 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
                 StoredValue::EraInfo(_) => {
                     return Ok(query.into_not_found_result(&"EraInfo value found."));
                 }
+                StoredValue::Bid(_) => {
+                    return Ok(query.into_not_found_result(&"Bid value found."));
+                }
             }
         }
     }

--- a/execution_engine/src/shared/transform.rs
+++ b/execution_engine/src/shared/transform.rs
@@ -194,6 +194,11 @@ impl Transform {
                     let found = "EraInfo".to_string();
                     Err(TypeMismatch::new(expected, found).into())
                 }
+                StoredValue::Bid(_) => {
+                    let expected = "Contract or Account".to_string();
+                    let found = "Bid".to_string();
+                    Err(TypeMismatch::new(expected, found).into())
+                }
             },
             Transform::Failure(error) => Err(error),
         }
@@ -328,6 +333,9 @@ impl From<&Transform> for casper_types::Transform {
             }
             Transform::Write(StoredValue::EraInfo(era_info)) => {
                 casper_types::Transform::WriteEraInfo(era_info.clone())
+            }
+            Transform::Write(StoredValue::Bid(bid)) => {
+                casper_types::Transform::WriteBid(bid.clone())
             }
             Transform::AddInt32(value) => casper_types::Transform::AddInt32(*value),
             Transform::AddUInt64(value) => casper_types::Transform::AddUInt64(*value),

--- a/execution_engine_testing/tests/src/test/regression/ee_1119.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1119.rs
@@ -15,7 +15,7 @@ use casper_types::{
     system::{
         auction::{
             Bids, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEYS,
-            BIDS_KEY, METHOD_SLASH, UNBONDING_PURSES_KEY,
+            METHOD_SLASH, UNBONDING_PURSES_KEY,
         },
         mint::TOTAL_SUPPLY_KEY,
     },
@@ -99,7 +99,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         .expect_success()
         .commit();
 
-    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     let validator_1_bid = bids.get(&VALIDATOR_1).expect("should have bid");
     let bid_purse = validator_1_bid.bonding_purse();
     assert_eq!(
@@ -205,7 +205,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         "slashing default validator should be noop because no unbonding was done"
     );
 
-    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     assert!(!bids.is_empty());
     assert!(bids.contains_key(&VALIDATOR_1)); // still bid upon
 
@@ -240,7 +240,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         "should not be a part of unbond list because delegator was slashed"
     );
 
-    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     let validator_1_bid = bids.get(&VALIDATOR_1).unwrap();
     assert!(validator_1_bid.inactive());
     assert!(validator_1_bid.staked_amount().is_zero());

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -11,7 +11,7 @@ use casper_types::{
     account::{AccountHash, ACCOUNT_HASH_LENGTH},
     runtime_args,
     system::auction::{
-        Bids, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEYS, BIDS_KEY,
+        Bids, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEYS,
         METHOD_SLASH, UNBONDING_PURSES_KEY,
     },
     PublicKey, RuntimeArgs, SecretKey, U512,
@@ -148,7 +148,7 @@ fn should_run_ee_1120_slash_delegators() {
         .commit();
 
     // Ensure that initial bid entries exist for validator 1 and validator 2
-    let initial_bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let initial_bids: Bids = builder.get_bids();
     assert_eq!(
         initial_bids.keys().copied().collect::<BTreeSet<_>>(),
         BTreeSet::from_iter(vec![*VALIDATOR_2, *VALIDATOR_1])
@@ -257,7 +257,7 @@ fn should_run_ee_1120_slash_delegators() {
 
     // Check bids before slashing
 
-    let bids_before: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids_before: Bids = builder.get_bids();
     assert_eq!(
         bids_before.keys().collect::<Vec<_>>(),
         initial_bids.keys().collect::<Vec<_>>()
@@ -276,7 +276,7 @@ fn should_run_ee_1120_slash_delegators() {
     builder.exec(slash_request_1).expect_success().commit();
 
     // Compare bids after slashing validator 2
-    let bids_after: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids_after: Bids = builder.get_bids();
     assert_ne!(bids_before, bids_after);
     assert_eq!(bids_after.len(), 2);
     let validator_2_bid = bids_after.get(&VALIDATOR_2).unwrap();
@@ -332,7 +332,7 @@ fn should_run_ee_1120_slash_delegators() {
 
     builder.exec(slash_request_2).expect_success().commit();
 
-    let bids_after: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids_after: Bids = builder.get_bids();
     assert_eq!(bids_after.len(), 2);
     let validator_1_bid = bids_after.get(&VALIDATOR_1).unwrap();
     assert!(validator_1_bid.inactive());

--- a/execution_engine_testing/tests/src/test/step.rs
+++ b/execution_engine_testing/tests/src/test/step.rs
@@ -13,8 +13,7 @@ use casper_execution_engine::{
 use casper_types::{
     system::{
         auction::{
-            Bids, SeigniorageRecipientsSnapshot, BIDS_KEY, BLOCK_REWARD,
-            SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
+            Bids, SeigniorageRecipientsSnapshot, BLOCK_REWARD, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
         },
         mint::TOTAL_SUPPLY_KEY,
     },
@@ -88,14 +87,14 @@ fn should_step() {
     let before_auction_seigniorage: SeigniorageRecipientsSnapshot =
         builder.get_value(auction_hash, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY);
 
-    let bids_before_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids_before_slashing: Bids = builder.get_bids();
     assert!(
         bids_before_slashing.contains_key(&ACCOUNT_1_PK),
         "should have entry in the genesis bids table {:?}",
         bids_before_slashing
     );
 
-    let bids_before_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids_before_slashing: Bids = builder.get_bids();
     assert!(
         bids_before_slashing.contains_key(&ACCOUNT_1_PK),
         "should have entry in bids table before slashing {:?}",
@@ -104,12 +103,12 @@ fn should_step() {
 
     builder.step(step_request);
 
-    let bids_after_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids_after_slashing: Bids = builder.get_bids();
     let account_1_bid = bids_after_slashing.get(&ACCOUNT_1_PK).unwrap();
     assert!(account_1_bid.inactive());
     assert!(account_1_bid.staked_amount().is_zero());
 
-    let bids_after_slashing: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids_after_slashing: Bids = builder.get_bids();
     assert_ne!(
         bids_before_slashing, bids_after_slashing,
         "bids table should be different before and after slashing"

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -30,8 +30,8 @@ use casper_types::{
         auction::{
             self, Bids, DelegationRate, EraId, EraValidators, SeigniorageRecipients,
             UnbondingPurses, ValidatorWeights, ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR,
-            ARG_PUBLIC_KEY, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY, BIDS_KEY, ERA_ID_KEY,
-            INITIAL_ERA_ID, METHOD_ACTIVATE_BID, UNBONDING_PURSES_KEY,
+            ARG_PUBLIC_KEY, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY, ERA_ID_KEY, INITIAL_ERA_ID,
+            METHOD_ACTIVATE_BID, UNBONDING_PURSES_KEY,
         },
     },
     PublicKey, RuntimeArgs, SecretKey, U512,
@@ -172,7 +172,7 @@ fn should_run_add_bid() {
     builder.exec(exec_request_1).commit().expect_success();
 
     let auction_hash = builder.get_auction_contract_hash();
-    let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
 
     assert_eq!(bids.len(), 1);
 
@@ -197,7 +197,7 @@ fn should_run_add_bid() {
 
     builder.exec(exec_request_2).commit().expect_success();
 
-    let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
 
     assert_eq!(bids.len(), 1);
 
@@ -220,7 +220,7 @@ fn should_run_add_bid() {
     .build();
     builder.exec(exec_request_3).commit().expect_success();
 
-    let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
 
     assert_eq!(bids.len(), 1);
 
@@ -302,7 +302,7 @@ fn should_run_delegate_and_undelegate() {
 
     let auction_hash = builder.get_auction_contract_hash();
 
-    let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     assert_eq!(bids.len(), 1);
     let active_bid = bids.get(&NON_FOUNDER_VALIDATOR_1_PK).unwrap();
     assert_eq!(
@@ -332,7 +332,7 @@ fn should_run_delegate_and_undelegate() {
 
     builder.exec(exec_request_1).commit().expect_success();
 
-    let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     assert_eq!(bids.len(), 1);
     let delegators = bids[&NON_FOUNDER_VALIDATOR_1_PK].delegators();
     assert_eq!(delegators.len(), 1);
@@ -353,7 +353,7 @@ fn should_run_delegate_and_undelegate() {
 
     builder.exec(exec_request_2).commit().expect_success();
 
-    let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     assert_eq!(bids.len(), 1);
     let delegators = bids[&NON_FOUNDER_VALIDATOR_1_PK].delegators();
     assert_eq!(delegators.len(), 1);
@@ -375,7 +375,7 @@ fn should_run_delegate_and_undelegate() {
     .build();
     builder.exec(exec_request_3).commit().expect_success();
 
-    let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     assert_eq!(bids.len(), 1);
     let delegators = bids[&NON_FOUNDER_VALIDATOR_1_PK].delegators();
     assert_eq!(delegators.len(), 1);
@@ -458,7 +458,7 @@ fn should_calculate_era_validators() {
     .build();
 
     let auction_hash = builder.get_auction_contract_hash();
-    let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     assert_eq!(bids.len(), 2, "founding validators {:?}", bids);
 
     // Verify first era validators
@@ -595,8 +595,7 @@ fn should_get_first_seigniorage_recipients() {
     )
     .build();
 
-    let auction_hash = builder.get_auction_contract_hash();
-    let bids: Bids = builder.get_value(auction_hash, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     assert_eq!(bids.len(), 2);
 
     let founding_validator_1 = bids.get(&ACCOUNT_1_PK).expect("should have account 1 pk");
@@ -758,8 +757,6 @@ fn should_release_founder_stake() {
 
     builder.run_genesis(&run_genesis_request);
 
-    let auction = builder.get_auction_contract_hash();
-
     let fund_system_account = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
@@ -774,7 +771,7 @@ fn should_release_founder_stake() {
 
     // Check bid and its vesting schedule
     {
-        let bids: Bids = builder.get_value(auction, BIDS_KEY);
+        let bids: Bids = builder.get_bids();
         assert_eq!(bids.len(), 1);
 
         let entry = bids.get(&ACCOUNT_1_PK).unwrap();
@@ -798,7 +795,7 @@ fn should_release_founder_stake() {
 
     // Check bid and its vesting schedule
     {
-        let bids: Bids = builder.get_value(auction, BIDS_KEY);
+        let bids: Bids = builder.get_bids();
         assert_eq!(bids.len(), 1);
 
         let entry = bids.get(&ACCOUNT_1_PK).unwrap();
@@ -1429,8 +1426,7 @@ fn should_undelegate_delegators_when_validator_unbonds() {
         timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
     }
 
-    let bids_before: Bids =
-        builder.get_value(builder.get_auction_contract_hash(), auction::BIDS_KEY);
+    let bids_before: Bids = builder.get_bids();
     let validator_1_bid = bids_before
         .get(&*VALIDATOR_1)
         .expect("should have validator 1 bid");
@@ -1467,7 +1463,7 @@ fn should_undelegate_delegators_when_validator_unbonds() {
         .commit()
         .expect_success();
 
-    let bids_after: Bids = builder.get_value(auction, auction::BIDS_KEY);
+    let bids_after: Bids = builder.get_bids();
     let validator_1_bid = bids_after.get(&VALIDATOR_1).unwrap();
     assert!(validator_1_bid.inactive());
     assert!(validator_1_bid.staked_amount().is_zero());
@@ -1681,7 +1677,7 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         .commit()
         .expect_success();
 
-    let bids_after: Bids = builder.get_value(auction, auction::BIDS_KEY);
+    let bids_after: Bids = builder.get_bids();
     let validator_1_bid = bids_after.get(&VALIDATOR_1).unwrap();
     assert!(validator_1_bid.inactive());
     assert!(validator_1_bid.staked_amount().is_zero());
@@ -2063,9 +2059,7 @@ fn should_setup_genesis_delegators() {
         U512::from(DELEGATOR_1_BALANCE)
     );
 
-    let auction = builder.get_auction_contract_hash();
-
-    let bids: Bids = builder.get_value(auction, auction::BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     assert_eq!(
         bids.keys().cloned().collect::<BTreeSet<_>>(),
         BTreeSet::from_iter(vec![*ACCOUNT_1_PK, *ACCOUNT_2_PK,])
@@ -2277,8 +2271,7 @@ fn should_not_undelegate_vfta_holder_stake() {
     }
 
     {
-        let auction = builder.get_auction_contract_hash();
-        let bids: Bids = builder.get_value(auction, auction::BIDS_KEY);
+        let bids: Bids = builder.get_bids();
         let delegator = bids
             .get(&*VALIDATOR_1)
             .expect("should have validator")
@@ -2305,8 +2298,7 @@ fn should_not_undelegate_vfta_holder_stake() {
     .build();
 
     {
-        let auction = builder.get_auction_contract_hash();
-        let bids: Bids = builder.get_value(auction, auction::BIDS_KEY);
+        let bids: Bids = builder.get_bids();
         let delegator = bids
             .get(&*VALIDATOR_1)
             .expect("should have validator")
@@ -2441,8 +2433,6 @@ fn should_release_vfta_holder_stake() {
         .commit()
         .expect_success();
 
-    let auction = builder.get_auction_contract_hash();
-
     let fund_system_account = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
@@ -2457,7 +2447,7 @@ fn should_release_vfta_holder_stake() {
 
     // Check bid and its vesting schedule
     {
-        let bids: Bids = builder.get_value(auction, BIDS_KEY);
+        let bids: Bids = builder.get_bids();
         assert_eq!(bids.len(), 1);
 
         let bid_entry = bids.get(&ACCOUNT_1_PK).unwrap();
@@ -2483,7 +2473,7 @@ fn should_release_vfta_holder_stake() {
 
     // Check bid and its vesting schedule
     {
-        let bids: Bids = builder.get_value(auction, BIDS_KEY);
+        let bids: Bids = builder.get_bids();
         assert_eq!(bids.len(), 1);
 
         let bid_entry = bids.get(&ACCOUNT_1_PK).unwrap();

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -19,7 +19,7 @@ use casper_types::{
     system::auction::{
         self, Bid, Bids, DelegationRate, Delegator, SeigniorageAllocation, ARG_AMOUNT,
         ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_PUBLIC_KEY, ARG_REWARD_FACTORS, ARG_VALIDATOR,
-        BIDS_KEY, BLOCK_REWARD, DELEGATION_RATE_DENOMINATOR, METHOD_DISTRIBUTE,
+        BLOCK_REWARD, DELEGATION_RATE_DENOMINATOR, METHOD_DISTRIBUTE,
     },
     Key, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
@@ -61,8 +61,7 @@ static GENESIS_ROUND_SEIGNIORAGE_RATE: Lazy<Ratio<U512>> = Lazy::new(|| {
 });
 
 fn get_validator_bid(builder: &mut InMemoryWasmTestBuilder, validator: PublicKey) -> Option<Bid> {
-    let auction = builder.get_auction_contract_hash();
-    let mut bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let mut bids: Bids = builder.get_bids();
     bids.remove(&validator)
 }
 
@@ -124,9 +123,7 @@ fn get_delegator_staked_amount(
     validator: PublicKey,
     delegator: PublicKey,
 ) -> U512 {
-    let auction = builder.get_auction_contract_hash();
-
-    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     let validator_bid = bids.get(&validator).expect("should have validator entry");
 
     let delegator_entry = validator_bid

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -20,8 +20,8 @@ use casper_types::{
     account::AccountHash,
     runtime_args,
     system::auction::{
-        self, Bids, DelegationRate, UnbondingPurses, ARG_VALIDATOR_PUBLIC_KEYS, BIDS_KEY,
-        INITIAL_ERA_ID, METHOD_SLASH, UNBONDING_PURSES_KEY,
+        self, Bids, DelegationRate, UnbondingPurses, ARG_VALIDATOR_PUBLIC_KEYS, INITIAL_ERA_ID,
+        METHOD_SLASH, UNBONDING_PURSES_KEY,
     },
     ApiError, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
@@ -85,7 +85,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
 
     builder.exec(exec_request_1).expect_success().commit();
 
-    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     let default_account_bid = bids
         .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
         .expect("should have bid");
@@ -185,7 +185,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         "should remove slashed from unbonds"
     );
 
-    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     let default_account_bid = bids.get(&DEFAULT_ACCOUNT_PUBLIC_KEY).unwrap();
     assert!(default_account_bid.inactive());
     assert!(default_account_bid.staked_amount().is_zero());
@@ -381,7 +381,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
 
     builder.exec(exec_request_1).expect_success().commit();
 
-    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     let bid = bids.get(&default_public_key_arg).expect("should have bid");
     let bid_purse = *bid.bonding_purse();
     assert_eq!(
@@ -479,7 +479,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
         "Unbond entry should be removed"
     );
 
-    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     assert!(!bids.is_empty());
 
     let bid = bids.get(&default_public_key_arg).expect("should have bid");
@@ -559,7 +559,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
 
     builder.exec(exec_request_1).expect_success().commit();
 
-    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     let bid = bids.get(&default_public_key_arg).expect("should have bid");
     let bid_purse = *bid.bonding_purse();
     assert_eq!(
@@ -673,7 +673,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
         "Unbond entry should be removed"
     );
 
-    let bids: Bids = builder.get_value(auction, BIDS_KEY);
+    let bids: Bids = builder.get_bids();
     assert!(!bids.is_empty());
 
     let bid = bids.get(&default_public_key_arg).expect("should have bid");

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -27,7 +27,8 @@ use semver::Version;
 
 use casper_execution_engine::{
     core::engine_state::{
-        self, BalanceRequest, BalanceResult, GetEraValidatorsError, QueryRequest, QueryResult,
+        self, BalanceRequest, BalanceResult, GetBidsRequest, GetEraValidatorsError, QueryRequest,
+        QueryResult,
     },
     storage::protocol_data::ProtocolData,
 };
@@ -253,6 +254,18 @@ where
                 protocol_version,
                 responder,
             ),
+            Event::RpcRequest(RpcRequest::GetBids {
+                state_root_hash,
+                responder,
+            }) => {
+                let get_bids_request = GetBidsRequest::new(state_root_hash.into());
+                effect_builder
+                    .get_bids(get_bids_request)
+                    .event(move |result| Event::GetBidsResult {
+                        result,
+                        main_responder: responder,
+                    })
+            }
             Event::RpcRequest(RpcRequest::GetBalance {
                 state_root_hash,
                 purse_uref,
@@ -308,6 +321,10 @@ where
                 main_responder,
             } => main_responder.respond(result).ignore(),
             Event::QueryEraValidatorsResult {
+                result,
+                main_responder,
+            } => main_responder.respond(result).ignore(),
+            Event::GetBidsResult {
                 result,
                 main_responder,
             } => main_responder.respond(result).ignore(),

--- a/node/src/components/rpc_server/event.rs
+++ b/node/src/components/rpc_server/event.rs
@@ -6,7 +6,7 @@ use std::{
 use derive_more::From;
 
 use casper_execution_engine::{
-    core::engine_state::{self, BalanceResult, GetEraValidatorsError, QueryResult},
+    core::engine_state::{self, BalanceResult, GetBidsResult, GetEraValidatorsError, QueryResult},
     storage::protocol_data::ProtocolData,
 };
 use casper_types::{system::auction::EraValidators, Transfer};
@@ -42,6 +42,10 @@ pub enum Event {
     QueryEraValidatorsResult {
         result: Result<EraValidators, GetEraValidatorsError>,
         main_responder: Responder<Result<EraValidators, GetEraValidatorsError>>,
+    },
+    GetBidsResult {
+        result: Result<GetBidsResult, engine_state::Error>,
+        main_responder: Responder<Result<GetBidsResult, engine_state::Error>>,
     },
     GetDeployResult {
         hash: DeployHash,
@@ -96,6 +100,9 @@ impl Display for Event {
             }
             Event::QueryEraValidatorsResult { result, .. } => {
                 write!(formatter, "query era validators result: {:?}", result)
+            }
+            Event::GetBidsResult { result, .. } => {
+                write!(formatter, "get bids result: {:?}", result)
             }
             Event::GetBalanceResult { result, .. } => {
                 write!(formatter, "balance result: {:?}", result)

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -87,7 +87,8 @@ use casper_execution_engine::{
         put_trie::InsertedTrieKeyAndMissingDescendants,
         step::{StepRequest, StepResult},
         upgrade::{UpgradeConfig, UpgradeResult},
-        BalanceRequest, BalanceResult, QueryRequest, QueryResult, MAX_PAYMENT,
+        BalanceRequest, BalanceResult, GetBidsRequest, GetBidsResult, QueryRequest, QueryResult,
+        MAX_PAYMENT,
     },
     shared::{
         additive_map::AdditiveMap, newtypes::Blake2bHash, stored_value::StoredValue,
@@ -1426,6 +1427,24 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetEraValidators { request, responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Requests a query be executed on the Contract Runtime component.
+    pub(crate) async fn get_bids(
+        self,
+        get_bids_request: GetBidsRequest,
+    ) -> Result<GetBidsResult, engine_state::Error>
+    where
+        REv: From<ContractRuntimeRequest>,
+    {
+        self.make_request(
+            |responder| ContractRuntimeRequest::GetBids {
+                get_bids_request,
+                responder,
+            },
             QueueKind::Regular,
         )
         .await

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -540,6 +540,13 @@ pub enum RpcRequest<I> {
         /// Responder to call with the result.
         responder: Responder<Result<EraValidators, GetEraValidatorsError>>,
     },
+    /// Get the bids at the given root hash.
+    GetBids {
+        /// The global state hash.
+        state_root_hash: Digest,
+        /// Responder to call with the result.
+        responder: Responder<Result<GetBidsResult, engine_state::Error>>,
+    },
     /// Query the contract runtime for protocol version data.
     QueryProtocolData {
         /// The protocol version.
@@ -612,6 +619,11 @@ impl<I> Display for RpcRequest<I> {
             RpcRequest::QueryEraValidators {
                 state_root_hash, ..
             } => write!(formatter, "auction {}", state_root_hash),
+            RpcRequest::GetBids {
+                state_root_hash, ..
+            } => {
+                write!(formatter, "bids {}", state_root_hash)
+            }
             RpcRequest::GetBalance {
                 state_root_hash,
                 purse_uref,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -25,7 +25,7 @@ use casper_execution_engine::{
         execution_result::ExecutionResults,
         genesis::GenesisResult,
         put_trie::InsertedTrieKeyAndMissingDescendants,
-        query::{QueryRequest, QueryResult},
+        query::{GetBidsRequest, GetBidsResult, QueryRequest, QueryResult},
         step::{StepRequest, StepResult},
         upgrade::{UpgradeConfig, UpgradeResult},
     },
@@ -733,6 +733,14 @@ pub enum ContractRuntimeRequest {
         /// Responder to call with the result.
         responder: Responder<Result<Option<ValidatorWeights>, GetEraValidatorsError>>,
     },
+    /// Return bids at a given state root hash
+    GetBids {
+        /// Get bids request.
+        #[serde(skip_serializing)]
+        get_bids_request: GetBidsRequest,
+        /// Responder to call with the result.
+        responder: Responder<Result<GetBidsResult, engine_state::Error>>,
+    },
     /// Performs a step consisting of calculating rewards, slashing and running the auction at the
     /// end of an era.
     Step {
@@ -824,6 +832,12 @@ impl Display for ContractRuntimeRequest {
 
             ContractRuntimeRequest::GetValidatorWeightsByEraId { request, .. } => {
                 write!(formatter, "get validator weights: {:?}", request)
+            }
+
+            ContractRuntimeRequest::GetBids {
+                get_bids_request, ..
+            } => {
+                write!(formatter, "get bids request: {:?}", get_bids_request)
             }
 
             ContractRuntimeRequest::Step { step_request, .. } => {

--- a/node/src/types/json_compatibility/stored_value.rs
+++ b/node/src/types/json_compatibility/stored_value.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use casper_execution_engine::shared::stored_value::StoredValue as ExecutionEngineStoredValue;
 use casper_types::{
     bytesrepr::{self, ToBytes},
-    system::auction::EraInfo,
+    system::auction::{Bid, EraInfo},
     CLValue, DeployInfo, Transfer,
 };
 
@@ -41,6 +41,8 @@ pub enum StoredValue {
     DeployInfo(DeployInfo),
     /// Auction metadata
     EraInfo(EraInfo),
+    /// A bid
+    Bid(Box<Bid>),
 }
 
 impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
@@ -64,6 +66,7 @@ impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
                 StoredValue::DeployInfo(deploy_info.clone())
             }
             ExecutionEngineStoredValue::EraInfo(era_info) => StoredValue::EraInfo(era_info.clone()),
+            ExecutionEngineStoredValue::Bid(bid) => StoredValue::Bid(bid.clone()),
         };
 
         Ok(stored_value)

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -9,6 +9,7 @@
 
 use alloc::{
     format,
+    prelude::v1::Box,
     string::{String, ToString},
     vec,
     vec::Vec,
@@ -30,7 +31,7 @@ use crate::KEY_HASH_LENGTH;
 use crate::{
     account::AccountHash,
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
-    system::auction::EraInfo,
+    system::auction::{Bid, EraInfo},
     CLValue, DeployInfo, NamedKey, Transfer, TransferAddr, U128, U256, U512,
 };
 
@@ -54,13 +55,14 @@ const TRANSFORM_WRITE_CONTRACT_PACKAGE_TAG: u8 = 5;
 const TRANSFORM_WRITE_DEPLOY_INFO_TAG: u8 = 6;
 const TRANSFORM_WRITE_TRANSFER_TAG: u8 = 7;
 const TRANSFORM_WRITE_ERA_INFO_TAG: u8 = 8;
-const TRANSFORM_ADD_INT32_TAG: u8 = 9;
-const TRANSFORM_ADD_UINT64_TAG: u8 = 10;
-const TRANSFORM_ADD_UINT128_TAG: u8 = 11;
-const TRANSFORM_ADD_UINT256_TAG: u8 = 12;
-const TRANSFORM_ADD_UINT512_TAG: u8 = 13;
-const TRANSFORM_ADD_KEYS_TAG: u8 = 14;
-const TRANSFORM_FAILURE_TAG: u8 = 15;
+const TRANSFORM_WRITE_BID_TAG: u8 = 9;
+const TRANSFORM_ADD_INT32_TAG: u8 = 10;
+const TRANSFORM_ADD_UINT64_TAG: u8 = 11;
+const TRANSFORM_ADD_UINT128_TAG: u8 = 12;
+const TRANSFORM_ADD_UINT256_TAG: u8 = 13;
+const TRANSFORM_ADD_UINT512_TAG: u8 = 14;
+const TRANSFORM_ADD_KEYS_TAG: u8 = 15;
+const TRANSFORM_FAILURE_TAG: u8 = 16;
 
 #[cfg(feature = "std")]
 static EXECUTION_RESULT: Lazy<ExecutionResult> = Lazy::new(|| {
@@ -448,6 +450,8 @@ pub enum Transform {
     WriteEraInfo(EraInfo),
     /// Writes the given Transfer to global state.
     WriteTransfer(Transfer),
+    /// Writes the given Bid to global state.
+    WriteBid(Box<Bid>),
     /// Adds the given `i32`.
     AddInt32(i32),
     /// Adds the given `u64`.
@@ -493,6 +497,10 @@ impl ToBytes for Transform {
             Transform::WriteTransfer(transfer) => {
                 buffer.insert(0, TRANSFORM_WRITE_TRANSFER_TAG);
                 buffer.extend(transfer.to_bytes()?);
+            }
+            Transform::WriteBid(bid) => {
+                buffer.insert(0, TRANSFORM_WRITE_BID_TAG);
+                buffer.extend(bid.to_bytes()?);
             }
             Transform::AddInt32(value) => {
                 buffer.insert(0, TRANSFORM_ADD_INT32_TAG);

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -8,8 +8,8 @@
 #![allow(clippy::field_reassign_with_default)]
 
 use alloc::{
+    boxed::Box,
     format,
-    prelude::v1::Box,
     string::{String, ToString},
     vec,
     vec::Vec,

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -82,6 +82,11 @@ impl Bid {
         }
     }
 
+    /// Gets the validator public key of the provided bid
+    pub fn validator_public_key(&self) -> &PublicKey {
+        &self.validator_public_key
+    }
+
     /// Gets the bonding purse of the provided bid
     pub fn bonding_purse(&self) -> &URef {
         &self.bonding_purse

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -1,7 +1,12 @@
+// TODO - remove once schemars stops causing warning.
+#![allow(clippy::field_reassign_with_default)]
+
 mod vesting;
 
 use alloc::{collections::BTreeMap, vec::Vec};
 
+#[cfg(feature = "std")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -13,7 +18,9 @@ use crate::{
 pub use vesting::VestingSchedule;
 
 /// An entry in the validator map.
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Bid {
     /// Validator public key
     validator_public_key: PublicKey,

--- a/types/src/system/auction/bid/vesting.rs
+++ b/types/src/system/auction/bid/vesting.rs
@@ -1,6 +1,11 @@
+// TODO - remove once schemars stops causing warning.
+#![allow(clippy::field_reassign_with_default)]
+
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
+#[cfg(feature = "std")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -17,6 +22,8 @@ const WEEK_MILLIS: usize = DAYS_IN_WEEK * 24 * 60 * 60 * 1000;
 const LOCKED_AMOUNTS_LENGTH: usize = (VESTING_SCHEDULE_LENGTH_DAYS / DAYS_IN_WEEK) + 1;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct VestingSchedule {
     initial_release_timestamp_millis: u64,
     locked_amounts: Option<[U512; LOCKED_AMOUNTS_LENGTH]>,

--- a/types/src/system/auction/constants.rs
+++ b/types/src/system/auction/constants.rs
@@ -85,8 +85,6 @@ pub const METHOD_ACTIVATE_BID: &str = "activate_bid";
 
 /// Storage for `UnbondingPurses`
 pub const UNBONDING_PURSES_KEY: &str = "unbonding_purses";
-/// Storage for `Bids`.
-pub const BIDS_KEY: &str = "bids";
 /// Storage for `EraId`.
 pub const ERA_ID_KEY: &str = "era_id";
 /// Storage for era-end timestamp.

--- a/types/src/system/auction/delegator.rs
+++ b/types/src/system/auction/delegator.rs
@@ -3,6 +3,8 @@
 
 use alloc::vec::Vec;
 
+#[cfg(feature = "std")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -13,6 +15,8 @@ use crate::{
 
 /// Represents a party delegating their stake to a validator (or "delegatee")
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Delegator {
     delegator_public_key: PublicKey,
     staked_amount: U512,

--- a/types/src/system/auction/detail.rs
+++ b/types/src/system/auction/detail.rs
@@ -303,7 +303,7 @@ pub fn reinvest_validator_reward<P>(
     seigniorage_allocations: &mut Vec<SeigniorageAllocation>,
     validator_public_key: PublicKey,
     amount: U512,
-) -> Result<Option<URef>, Error>
+) -> Result<URef, Error>
 where
     P: StorageProvider,
 {
@@ -326,5 +326,5 @@ where
 
     provider.write_bid(validator_account_hash, bid)?;
 
-    Ok(Some(bonding_purse))
+    Ok(bonding_purse)
 }

--- a/types/src/system/auction/detail.rs
+++ b/types/src/system/auction/detail.rs
@@ -18,7 +18,7 @@ where
     P: StorageProvider + RuntimeProvider + ?Sized,
     T: FromBytes + CLTyped,
 {
-    let key = provider.get_key(name).ok_or(Error::MissingKey)?;
+    let key = provider.named_keys_get(name).ok_or(Error::MissingKey)?;
     let uref = key.into_uref().ok_or(Error::InvalidKeyVariant)?;
     let value: T = provider.read(uref)?.ok_or(Error::MissingValue)?;
     Ok(value)
@@ -29,7 +29,7 @@ where
     P: StorageProvider + RuntimeProvider + ?Sized,
     T: ToBytes + CLTyped,
 {
-    let key = provider.get_key(name).ok_or(Error::MissingKey)?;
+    let key = provider.named_keys_get(name).ok_or(Error::MissingKey)?;
     let uref = key.into_uref().ok_or(Error::InvalidKeyVariant)?;
     provider.write(uref, value)?;
     Ok(())

--- a/types/src/system/auction/mod.rs
+++ b/types/src/system/auction/mod.rs
@@ -112,30 +112,33 @@ pub trait Auction:
 
         let source = self.get_main_purse()?;
 
+        let account_hash = AccountHash::from(&public_key);
+
         // Update bids or stakes
-        let mut validators = detail::get_bids(self)?;
-        let new_amount = match validators.get_mut(&public_key) {
-            Some(bid) => {
+        let updated_amount = match self.read_bid(&account_hash)? {
+            Some(mut bid) => {
                 if bid.inactive() {
                     bid.activate();
                 }
                 self.transfer_purse_to_purse(source, *bid.bonding_purse(), amount)
                     .map_err(|_| Error::TransferToBidPurse)?;
-                bid.with_delegation_rate(delegation_rate)
-                    .increase_stake(amount)?
+                let updated_amount = bid
+                    .with_delegation_rate(delegation_rate)
+                    .increase_stake(amount)?;
+                self.write_bid(account_hash, bid)?;
+                updated_amount
             }
             None => {
                 let bonding_purse = self.create_purse()?;
                 self.transfer_purse_to_purse(source, bonding_purse, amount)
                     .map_err(|_| Error::TransferToBidPurse)?;
                 let bid = Bid::unlocked(public_key, bonding_purse, amount, delegation_rate);
-                validators.insert(public_key, bid);
+                self.write_bid(account_hash, bid)?;
                 amount
             }
         };
-        detail::set_bids(self, validators)?;
 
-        Ok(new_amount)
+        Ok(updated_amount)
     }
 
     /// For a non-founder validator, implements essentially the same logic as add_bid, but reducing
@@ -152,10 +155,9 @@ pub trait Auction:
             return Err(Error::InvalidPublicKey);
         }
 
-        // Update bids or stakes
-        let mut bids = detail::get_bids(self)?;
-
-        let bid = bids.get_mut(&public_key).ok_or(Error::ValidatorNotFound)?;
+        let mut bid = self
+            .read_bid(&account_hash)?
+            .ok_or(Error::ValidatorNotFound)?;
 
         let era_end_timestamp_millis = detail::get_era_end_timestamp_millis(self)?;
 
@@ -188,7 +190,7 @@ pub trait Auction:
             bid.deactivate();
         }
 
-        detail::set_bids(self, bids)?;
+        self.write_bid(account_hash, bid)?;
 
         Ok(updated_stake)
     }
@@ -215,15 +217,17 @@ pub trait Auction:
 
         let source = self.get_main_purse()?;
 
-        let mut bids = detail::get_bids(self)?;
+        let validator_account_hash = AccountHash::from(&validator_public_key);
 
-        let delegators = match bids.get_mut(&validator_public_key) {
-            Some(bid) => bid.delegators_mut(),
+        let mut bid = match self.read_bid(&validator_account_hash)? {
+            Some(bid) => bid,
             None => {
                 // Return early if target validator is not in `bids`
                 return Err(Error::ValidatorNotFound);
             }
         };
+
+        let delegators = bid.delegators_mut();
 
         let new_delegation_amount = match delegators.get_mut(&delegator_public_key) {
             Some(delegator) => {
@@ -247,7 +251,7 @@ pub trait Auction:
             }
         };
 
-        detail::set_bids(self, bids)?;
+        self.write_bid(validator_account_hash, bid)?;
 
         Ok(new_delegation_amount)
     }
@@ -269,15 +273,13 @@ pub trait Auction:
             return Err(Error::InvalidPublicKey);
         }
 
-        let mut bids = detail::get_bids(self)?;
-
-        let delegators = match bids.get_mut(&validator_public_key) {
-            Some(bid) => bid.delegators_mut(),
-            None => {
-                // Return early if target validator is not in `bids`
-                return Err(Error::ValidatorNotFound);
-            }
+        let validator_account_hash = AccountHash::from(&validator_public_key);
+        let mut bid = match self.read_bid(&validator_account_hash)? {
+            Some(bid) => bid,
+            None => return Err(Error::ValidatorNotFound),
         };
+
+        let delegators = bid.delegators_mut();
 
         let new_amount = match delegators.get_mut(&delegator_public_key) {
             Some(delegator) => {
@@ -299,7 +301,7 @@ pub trait Auction:
             None => return Err(Error::DelegatorNotFound),
         };
 
-        detail::set_bids(self, bids)?;
+        self.write_bid(validator_account_hash, bid)?;
 
         Ok(new_amount)
     }
@@ -314,18 +316,17 @@ pub trait Auction:
 
         let mut burned_amount: U512 = U512::zero();
 
-        let mut bids = detail::get_bids(self)?;
-        let mut bids_modified = false;
-
         let mut unbonding_purses: UnbondingPurses = detail::get_unbonding_purses(self)?;
         let mut unbonding_purses_modified = false;
+
         for validator_public_key in validator_public_keys {
             // Burn stake, deactivate
-            if let Some(bid) = bids.get_mut(&validator_public_key) {
+            let validator_account_hash = AccountHash::from(&validator_public_key);
+            if let Some(mut bid) = self.read_bid(&validator_account_hash)? {
                 burned_amount += *bid.staked_amount();
                 *bid.staked_amount_mut() = U512::zero();
                 bid.deactivate();
-                bids_modified = true;
+                self.write_bid(validator_account_hash, bid)?;
             };
 
             // Update unbonding entries for given validator
@@ -340,10 +341,6 @@ pub trait Auction:
 
         if unbonding_purses_modified {
             detail::set_unbonding_purses(self, unbonding_purses)?;
-        }
-
-        if bids_modified {
-            detail::set_bids(self, bids)?;
         }
 
         self.reduce_total_supply(burned_amount)?;
@@ -475,8 +472,6 @@ pub trait Auction:
         let mut era_info = EraInfo::new();
         let mut seigniorage_allocations = era_info.seigniorage_allocations_mut();
 
-        let mut bids = detail::get_bids(self)?;
-
         for (public_key, reward_factor) in reward_factors {
             let recipient = seigniorage_recipients
                 .get(&public_key)
@@ -517,7 +512,7 @@ pub trait Auction:
                         (*delegator_key, reward)
                     });
             let delegator_payouts = detail::reinvest_delegator_rewards(
-                &mut bids,
+                self,
                 &mut seigniorage_allocations,
                 public_key,
                 delegator_rewards,
@@ -530,7 +525,7 @@ pub trait Auction:
             let validators_part: Ratio<U512> = total_reward - Ratio::from(total_delegator_payout);
             let validator_reward = validators_part.to_integer();
             if let Some(validator_bonding_purse) = detail::reinvest_validator_reward(
-                &mut bids,
+                self,
                 &mut seigniorage_allocations,
                 public_key,
                 validator_reward,
@@ -561,7 +556,6 @@ pub trait Auction:
         }
 
         self.record_era_info(era_id, era_info)?;
-        detail::set_bids(self, bids)?;
 
         Ok(())
     }
@@ -579,16 +573,14 @@ pub trait Auction:
             return Err(Error::InvalidPublicKey);
         }
 
-        let mut bids = detail::get_bids(self)?;
-
-        let bid = match bids.get_mut(&validator_public_key) {
+        let mut bid = match self.read_bid(&account_hash)? {
             Some(bid) => bid,
             None => return Err(Error::ValidatorNotFound),
         };
 
         bid.activate();
 
-        detail::set_bids(self, bids)?;
+        self.write_bid(account_hash, bid)?;
 
         Ok(())
     }

--- a/types/src/system/auction/mod.rs
+++ b/types/src/system/auction/mod.rs
@@ -524,22 +524,21 @@ pub trait Auction:
 
             let validators_part: Ratio<U512> = total_reward - Ratio::from(total_delegator_payout);
             let validator_reward = validators_part.to_integer();
-            if let Some(validator_bonding_purse) = detail::reinvest_validator_reward(
+            let validator_bonding_purse = detail::reinvest_validator_reward(
                 self,
                 &mut seigniorage_allocations,
                 public_key,
                 validator_reward,
-            )? {
-                // TODO: add "mint into existing purse" facility
-                let tmp_validator_reward_purse =
-                    self.mint(validator_reward).map_err(|_| Error::MintReward)?;
-                self.transfer_purse_to_purse(
-                    tmp_validator_reward_purse,
-                    validator_bonding_purse,
-                    validator_reward,
-                )
-                .map_err(|_| Error::ValidatorRewardTransfer)?;
-            }
+            )?;
+            // TODO: add "mint into existing purse" facility
+            let tmp_validator_reward_purse =
+                self.mint(validator_reward).map_err(|_| Error::MintReward)?;
+            self.transfer_purse_to_purse(
+                tmp_validator_reward_purse,
+                validator_bonding_purse,
+                validator_reward,
+            )
+            .map_err(|_| Error::ValidatorRewardTransfer)?;
 
             // TODO: add "mint into existing purse" facility
             let tmp_delegator_reward_purse = self

--- a/types/src/system/auction/providers.rs
+++ b/types/src/system/auction/providers.rs
@@ -1,8 +1,10 @@
+use alloc::collections::BTreeSet;
+
 use crate::{
     account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
-    system::auction::{EraId, EraInfo, Error},
-    CLTyped, Key, TransferredTo, URef, BLAKE2B_DIGEST_LENGTH, U512,
+    system::auction::{Bid, EraId, EraInfo, Error},
+    CLTyped, Key, KeyTag, TransferredTo, URef, BLAKE2B_DIGEST_LENGTH, U512,
 };
 
 /// Provider of runtime host functionality.
@@ -11,7 +13,10 @@ pub trait RuntimeProvider {
     fn get_caller(&self) -> AccountHash;
 
     /// Gets named key under a `name`.
-    fn get_key(&self, name: &str) -> Option<Key>;
+    fn named_keys_get(&self, name: &str) -> Option<Key>;
+
+    /// Gets keys in a given keyspace
+    fn get_keys(&mut self, key_tag: &KeyTag) -> Result<BTreeSet<Key>, Error>;
 
     /// Returns a 32-byte BLAKE2b digest
     fn blake2b<T: AsRef<[u8]>>(&self, data: T) -> [u8; BLAKE2B_DIGEST_LENGTH];
@@ -24,6 +29,12 @@ pub trait StorageProvider {
 
     /// Writes data to [`URef].
     fn write<T: ToBytes + CLTyped>(&mut self, uref: URef, value: T) -> Result<(), Error>;
+
+    /// Reads [`Bid`] at account hash derived from given public key
+    fn read_bid(&mut self, account_hash: &AccountHash) -> Result<Option<Bid>, Error>;
+
+    /// Writes given [`Bid`] at account hash derived from given public key
+    fn write_bid(&mut self, account_hash: AccountHash, bid: Bid) -> Result<(), Error>;
 }
 
 /// Provides functionality of a system module.


### PR DESCRIPTION
This PR removes the `Bids` map stored under the auction's `BIDS_KEY` named key and instead persists bids directly in the state trie under `Key::Bid` keys.  It also adds `RpcRequest::GetBids` (and related) in service of `get-auction-info`.