### PR TITLE
NDRS-945: Compute instance IDs from chainspec hash and era ID.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -31,7 +31,6 @@ use casper_types::{PublicKey, U512};
 
 use crate::{
     components::Component,
-    crypto::hash::Digest,
     effect::{
         announcements::ConsensusAnnouncement,
         requests::{
@@ -120,7 +119,6 @@ pub enum Event<I> {
     InitializeEras {
         key_blocks: HashMap<EraId, BlockHeader>,
         validators: BTreeMap<PublicKey, U512>,
-        state_root_hash: Digest,
         timestamp: Timestamp,
         genesis_start_time: Timestamp,
     },
@@ -326,14 +324,12 @@ where
             Event::InitializeEras {
                 key_blocks,
                 validators,
-                state_root_hash,
                 timestamp,
                 genesis_start_time,
             } => {
                 let mut effects = handling_es.handle_initialize_eras(
                     key_blocks,
                     validators,
-                    state_root_hash,
                     timestamp,
                     genesis_start_time,
                 );

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -8,6 +8,7 @@ use casper_types::SecretKey;
 
 use crate::{
     components::consensus::EraId,
+    crypto::hash::Digest,
     types::{chainspec::HighwayConfig, Chainspec, TimeDiff, Timestamp},
     utils::External,
 };
@@ -59,6 +60,8 @@ pub(crate) struct ProtocolConfig {
     pub(crate) name: String,
     /// Genesis timestamp.
     pub(crate) timestamp: Timestamp,
+    /// The chainspec hash: All nodes in the network agree on it, and it's unique to this network.
+    pub(crate) chainspec_hash: Digest,
 }
 
 impl From<&Chainspec> for ProtocolConfig {
@@ -73,6 +76,7 @@ impl From<&Chainspec> for ProtocolConfig {
             last_activation_point: chainspec.protocol_config.activation_point.era_id,
             name: chainspec.network_config.name.clone(),
             timestamp: chainspec.network_config.timestamp,
+            chainspec_hash: chainspec.hash(),
         }
     }
 }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -514,7 +514,6 @@ impl reactor::Reactor for Reactor {
             effect_builder,
             validator_weights,
             chainspec_loader.chainspec().as_ref().into(),
-            chainspec_loader.initial_state_root_hash(),
             maybe_next_activation_point,
             registry,
             Box::new(HighwayProtocol::new_boxed),


### PR DESCRIPTION
Don't use the state root hash for computing new era's instance IDs anymore: It's unnecessary since the chainspec and era ID should make it unique, and it's not necessarily available at that point in the code.

(It is still important that all instance IDs are unique: If you participate with the same key in two different instances with the same ID, your messages could be combined to provide a valid proof of an equivocation.)

https://casperlabs.atlassian.net/browse/NDRS-945