### PR TITLE
NDRS-899: Set ulimit

### DIFF
--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -54,6 +54,7 @@ use signal_hook::consts::signal::{SIGINT, SIGQUIT, SIGTERM};
 use tokio::time::{Duration, Instant};
 use tracing::{debug, debug_span, error, info, trace, warn};
 use tracing_futures::Instrument;
+use utils::rlimit::{Limit, OpenFiles, ResourceLimit};
 
 use crate::{
     effect::{Effect, EffectBuilder, Effects},
@@ -80,6 +81,9 @@ static MEM_DUMP_THRESHOLD_MB: Lazy<Option<u64>> = Lazy::new(|| {
         })
         .ok()
 });
+
+/// The desired limit for open files.
+const TARGET_OPEN_FILES_LIMIT: Limit = 64_000;
 
 /// Default threshold for when an event is considered slow.  Can be overridden by setting the env
 /// var `CL_EVENT_MAX_MICROSECS=<MICROSECONDS>`.
@@ -390,6 +394,40 @@ where
         rng: &mut NodeRng,
         registry: &Registry,
     ) -> Result<Self, R::Error> {
+        // Ensure we have reasonable ulimits.
+        match ResourceLimit::<OpenFiles>::get() {
+            Err(err) => {
+                warn!(%err, "could not retrieve open files limit");
+            }
+
+            Ok(current_limit) => {
+                if current_limit.current() < TARGET_OPEN_FILES_LIMIT {
+                    let best_possible = if current_limit.max() < TARGET_OPEN_FILES_LIMIT {
+                        warn!(
+                            wanted = TARGET_OPEN_FILES_LIMIT,
+                            hard_limit = current_limit.max(),
+                            "settling for lower open files limit due to hard limit"
+                        );
+                        current_limit.max()
+                    } else {
+                        TARGET_OPEN_FILES_LIMIT
+                    };
+
+                    let new_limit = ResourceLimit::<OpenFiles>::fixed(best_possible);
+                    if let Err(err) = new_limit.set() {
+                        warn!(%err, current=current_limit.current(), target=best_possible, "did not succeed in raising open files limit")
+                    } else {
+                        debug!(?new_limit, "successfully increased open files limit");
+                    }
+                } else {
+                    debug!(
+                        ?current_limit,
+                        "not changing open files limit, already sufficient"
+                    );
+                }
+            }
+        }
+
         let event_size = mem::size_of::<R::Event>();
 
         // Check if the event is of a reasonable size. This only emits a runtime warning at startup

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -6,6 +6,7 @@ pub mod ds;
 mod external;
 mod median;
 pub mod milliseconds;
+pub(crate) mod rlimit;
 mod round_robin;
 
 use std::{

--- a/node/src/utils/rlimit.rs
+++ b/node/src/utils/rlimit.rs
@@ -1,0 +1,150 @@
+//! Limit retrieval and set.
+//!
+//! Allows retrieval and setting of resource limits.
+//!
+//! This module wraps a fair number of libc types to make external use as pleasant as possible.
+
+use std::{
+    any,
+    fmt::{self, Debug},
+    io,
+    marker::PhantomData,
+    mem::MaybeUninit,
+};
+
+use fmt::Formatter;
+
+/// A scalar limit.
+pub type Limit = libc::rlim_t;
+
+/// A kind of limit that can be set/retrieved.
+pub trait LimitKind {
+    /// The `resource` id use for libc calls.
+    const LIBC_RESOURCE: libc::__rlimit_resource_t;
+}
+
+/// Maximum number of open files (`ulimit -n`).
+#[derive(Copy, Clone, Debug)]
+pub struct OpenFiles;
+
+impl LimitKind for OpenFiles {
+    const LIBC_RESOURCE: libc::__rlimit_resource_t = libc::RLIMIT_NOFILE;
+}
+
+/// Infinite resource, i.e. no limit.
+#[allow(dead_code)]
+const INFINITE: Limit = libc::RLIM_INFINITY;
+
+/// Wrapper around libc resource limit type.
+#[derive(Copy, Clone)]
+pub struct ResourceLimit<T> {
+    limit: libc::rlimit,
+    kind: PhantomData<T>,
+}
+
+impl<T> Debug for ResourceLimit<T>
+where
+    T: Copy,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let name = format!("ResourceLimit<{}>", any::type_name::<T>());
+        f.debug_struct(&name)
+            .field("cur", &self.current())
+            .field("max", &self.max())
+            .finish()
+    }
+}
+
+impl<T> ResourceLimit<T> {
+    /// Creates a new resource limit.
+    #[inline]
+    pub fn new(current: Limit, max: Limit) -> Self {
+        ResourceLimit {
+            limit: libc::rlimit {
+                rlim_cur: current,
+                rlim_max: max,
+            },
+            kind: PhantomData,
+        }
+    }
+
+    /// Creates a new resource limit, setting hard and soft limit to the same value.
+    #[inline]
+    pub fn fixed(limit: Limit) -> Self {
+        Self::new(limit, limit)
+    }
+
+    /// The current or "soft" limit.
+    #[inline]
+    pub fn current(self) -> Limit {
+        self.limit.rlim_cur
+    }
+
+    /// The maximum allowed or "hard" limit .
+    #[inline]
+    pub fn max(self) -> Limit {
+        self.limit.rlim_max
+    }
+}
+
+impl<T> ResourceLimit<T>
+where
+    T: LimitKind,
+{
+    /// Retrieves the given resource limit from the operating system.
+    #[inline]
+    pub fn get() -> io::Result<Self> {
+        let mut dest: MaybeUninit<libc::rlimit> = MaybeUninit::zeroed();
+
+        let outcome = unsafe { libc::getrlimit(T::LIBC_RESOURCE, dest.as_mut_ptr()) };
+
+        match outcome {
+            -1 => Err(io::Error::last_os_error()),
+            0 => Ok(ResourceLimit {
+                limit: unsafe { dest.assume_init() },
+                kind: PhantomData,
+            }),
+            // This should never happen, so we notify the user.
+            _ => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("expected return value of -1 or 0, but got {}", outcome),
+            )),
+        }
+    }
+
+    /// Sets the specified limit via operation system.
+    pub fn set(self) -> io::Result<()> {
+        let outcome = unsafe { libc::setrlimit(T::LIBC_RESOURCE, &self.limit) };
+
+        match outcome {
+            -1 => Err(io::Error::last_os_error()),
+            0 => Ok(()),
+            // This should never happen, so we notify the user.
+            _ => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("expected return value of -1 or 0, but got {}", outcome),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OpenFiles, ResourceLimit};
+
+    #[test]
+    fn get_and_reset_ulimit() {
+        // Retrieve limit and set the exact same limit again.
+        let limit = ResourceLimit::<OpenFiles>::get().expect("could not retrieve initial limit");
+        println!("{:?}", limit);
+
+        // Note: We could change it to something different, but we do not want to risk influencing
+        // other tests, so this is safest.
+        limit.set().expect("could not re-set limit");
+
+        println!(
+            "{:?}",
+            ResourceLimit::<OpenFiles>::get().expect("could not retrieve limit a second time")
+        );
+    }
+}


### PR DESCRIPTION
To address issues with networks with > 400 connections, set the open files limit (`ulimit -n`) at the startup.

If this fails, settle for the closest possible maximum. This code will never panic or abort, but warn if the limit cannot be increased.