### PR TITLE
NDRS-927: work around blocks not holding protocol version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
     commands:
       - cargo install cargo-audit
       - cargo generate-lockfile
-      - cargo audit --ignore RUSTSEC-2020-0123
+      - cargo audit --ignore RUSTSEC-2020-0123 --ignore RUSTSEC-2020-0146
 
 trigger:
   branch:

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ lint:
 
 .PHONY: audit
 audit:
-	$(CARGO) audit --ignore RUSTSEC-2020-0123
+	$(CARGO) audit --ignore RUSTSEC-2020-0123 --ignore RUSTSEC-2020-0146
 
 .PHONY: build-docs-stable-rs
 build-docs-stable-rs: $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE)


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-927

This PR is a workaround for the lack of protocol version in block headers.  Currently, when we restart after an upgrade from the delta network where the upgrade was a hard-reset, the joining node will start with a cached/stored version > 1.0.0.  When the second binary is started, this causes it to attempt to call the EE `commit_upgrade` passing the same version for the current and new protocols.

To get round this, we simply ignore the cached/stored version when calling `commit_upgrade`.  Instead we use a hard-coded `1.0.0` for the current version and the one provided in the chainspec as the new version.  This will need extended if we end up running 0.8.0 nodes on delta in order to be able to upgrade from those.  Hopefully this will not be needed, and it certainly won't be needed in master where we can avoid caching/storing the protocol version in the chainspec loader as it will be available in the block headers.