### PR TITLE
NDRS-964: Remove outdated assertion on failed bootstrap connection

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -869,11 +869,6 @@ where
             } => {
                 warn!(our_id=%self.our_id, %peer_address, %error, "connection to known node failed");
 
-                let was_removed = self.pending.remove(&peer_address);
-                assert!(
-                    was_removed,
-                    "Bootstrap failed for node, but it was not in the set of pending connections"
-                );
                 self.terminate_if_isolated(effect_builder)
             }
             Event::IncomingNew {


### PR DESCRIPTION
The assertion in the code is causing crashes in the wild right now, as it is based on an otherwise harmless-if-failed assertion. It used to check for a double-deletion from a list of pending connections, but failing to remove the value should have no ill effects otherwise.

The code was built when we supported only a single initial node to connect to - either two nodes racing or a duplicate entry in the list of bootstrap are likely what could triggers this (although @sacherjj has not been able to reproduce the latter issue quickly).