### PR TITLE
NDRS-964: (backport to 0.8.0) Remove outdated assertion on failed bootstrap connection

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -895,11 +895,6 @@ where
             } => {
                 warn!(our_id=%self.our_id, %peer_address, %error, "connection to known node failed");
 
-                let was_removed = self.pending.remove(&peer_address);
-                assert!(
-                    was_removed,
-                    "Bootstrap failed for node, but it was not in the set of pending connections"
-                );
                 self.terminate_if_isolated(effect_builder)
             }
             Event::IncomingNew {


### PR DESCRIPTION
Backport of https://github.com/CasperLabs/casper-node/pull/1041