### PR TITLE
Genesis setup for mainnet-release-test-1 network.

### DIFF
--- a/resources/production/accounts.toml
+++ b/resources/production/accounts.toml
@@ -1,31 +1,42 @@
 [[accounts]]
+# Faucet account
 public_key = "01054c929d687267a30341c759b4a9cab1238cb2de65546be43dad479c50745724"
-balance = "10000000000000000000000000000000000000"
+balance = "9950000000000000000"
 
 [[accounts]]
-public_key = "013f774a58f4d40bd9b6cce7e306e53646913860ef2a111d00f0fe7794010c4012"
-balance = "1000000000000000000000000"
+# mainnet-release-test-1
+public_key = "01c83b002c7a91d83c7313bda8c55ae9f8a1dab64e67c658e28013f4e79721caba"
+balance = "1000000000000"
 
 [accounts.validator]
-bonded_amount = "10000000000000000"
+bonded_amount = "9999000000000000"
 
 [[accounts]]
-public_key = "01d62fc9b894218bfbe8eebcc4a28a1fc4cb3a5c6120bb0027207ba8214439929e"
-balance = "1000000000000000000000000"
+# mainnet-release-test-2
+public_key = "010ee8c0e012eb8ec3fa2b8d05bf3298fa61850737130c84a66591ed6c86941344"
+balance = "1000000000000"
 
 [accounts.validator]
-bonded_amount = "10000000000000000"
+bonded_amount = "9999000000000000"
 
 [[accounts]]
-public_key = "018b15761be0c527117c79b87ca013b014a4628f01e382902a139529406723d86b"
-balance = "1000000000000000000000000"
+# mainnet-release-test-3
+public_key = "011e6d20756ceb84de9c2e96a849f7d35281f392ecf692f94da1b2f24a504ccdba"
+balance = "1000000000000"
+
+[accounts.validator]
+bonded_amount = "9999000000000000"
 
 [[accounts]]
-public_key = "01524a5f3567d7b5ea17ca518c9d0320fb4a75a28a5eab58d06c755c388f20a19f"
-balance = "1000000000000000000000000"
+# mainnet-release-test-4
+public_key = "0120ff90b4b2d7d346ecb7e2f0d0c0b7d2e672d18668c0a302aa1cba2e0b299a7f"
+balance = "1000000000000"
 
-[[delegators]]
-validator_public_key = "01524a5f3567d7b5ea17ca518c9d0320fb4a75a28a5eab58d06c755c388f20a19f"
-delegator_public_key = "018267d68f8d249b1430551ecc7b4c176d66f2ba2bf98d5547e7c3accc99375e53"
-balance = "0"
-delegated_amount = "100000000000001"
+[accounts.validator]
+bonded_amount = "9999000000000000"
+
+[[accounts]]
+# bitgo-test
+public_key = "018267d68f8d249b1430551ecc7b4c176d66f2ba2bf98d5547e7c3accc99375e53"
+balance = "10000000000000000"
+

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -12,12 +12,12 @@ era_id = 0
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
-name = 'casper-delta'
+name = 'mainnet-release-test-1'
 # Timestamp for the genesis block.  This is the beginning of era 0. By this time, a sufficient majority (> 50% + F/2 —
 # see finality_threshold_percent below) of validator nodes must be up and running to start the blockchain.  This
 # timestamp is also used in seeding the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
-timestamp = '2020-12-29T20:00:00Z'
+timestamp = '2021-03-02T01:00:00Z'
 
 [core]
 # Era duration.
@@ -48,7 +48,7 @@ round_seigniorage_rate = [185_334_351, 4_503_599_627_370_496]
 # It is the fraction of validators that would need to equivocate to make two honest nodes see two conflicting blocks as
 # finalized: A higher value F makes it safer to rely on finalized blocks.  It also makes it more difficult to finalize
 # blocks, however, and requires strictly more than (F + 1)/2 validators to be working correctly.
-finality_threshold_fraction = [1, 10]
+finality_threshold_fraction = [1, 3]
 # Integer between 0 and 255.  The power of two that is the number of milliseconds in the minimum round length, and
 # therefore the minimum delay between a block and its child.  E.g. 14 means 2^14 milliseconds, i.e. about 16 seconds.
 minimum_round_exponent = 16

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -65,7 +65,7 @@ bind_address = '0.0.0.0:35000'
 #
 # Multiple addresses can be given and the node will attempt to connect to each, requiring at least
 # one connection.
-known_addresses = ['18.144.176.168:35000', '13.57.200.251:35000']
+known_addresses = ['54.215.92.118:35000', '52.53.239.81:35000', '18.144.25.45:35000', '13.57.247.23:35000']
 
 # The interval (in milliseconds) between each fresh round of gossiping the node's public address.
 gossip_interval = 120_000

--- a/resources/production/validation.md5
+++ b/resources/production/validation.md5
@@ -1,2 +1,2 @@
-f4f487eaff9b6ae052c9679b7baab882  accounts.toml
-e2cf09f724df9cb3c10670d6d209efb6  chainspec.toml
+0ac33048efeb35c92a36fca9279de61e  accounts.toml
+f05fac2db9ca4c748d3d95fd9728c76d  chainspec.toml


### PR DESCRIPTION
Setup accounts.toml for 4 genesis validating nodes and preloading bitgo's balance.
Changed finality_threshold_fraction to [1, 3] instead of [1, 10] to match the changes Andreas made to local.

Total supply: 10_000_000_000 . 000_000_000  CSPR

This will test first full release of the protocol version by CI.