### PR TITLE
NDRS-962: Add more stop conditions for syncing.

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -276,6 +276,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                 highest_block_seen,
                 trusted_hash,
                 ref latest_block,
+                maybe_switch_block,
                 ..
             } => {
                 assert_eq!(highest_block_seen, block_height);
@@ -289,7 +290,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                 info!(%block_height, "Finished synchronizing linear chain up until trusted hash.");
                 let peer = self.peers.random_unsafe();
                 // Kick off syncing trusted hash descendants.
-                self.state = State::sync_descendants(trusted_hash, block);
+                self.state = State::sync_descendants(trusted_hash, block, maybe_switch_block);
                 fetch_block_at_height(effect_builder, peer, block_height + 1)
             }
             State::SyncingDescendants {

--- a/node/src/components/linear_chain_sync/state.rs
+++ b/node/src/components/linear_chain_sync/state.rs
@@ -34,6 +34,9 @@ pub enum State {
         /// During synchronization we might see new eras being created.
         /// Track the highest height and wait until it's handled by consensus.
         highest_block_seen: u64,
+        /// Switch block of the current era.
+        /// Updated whenever we see a new switch block.
+        maybe_switch_block: Option<Box<Block>>,
     },
     /// Synchronizing done. The single field contains the highest block seen during the
     /// synchronization process.
@@ -88,6 +91,7 @@ impl State {
             trusted_hash,
             latest_block: Box::new(latest_block),
             highest_block_seen: 0,
+            maybe_switch_block: None,
         }
     }
 
@@ -116,5 +120,15 @@ impl State {
     /// Returns whether in `None` state.
     pub(crate) fn is_none(&self) -> bool {
         matches!(self, State::None)
+    }
+
+    /// Updates the state with a new switch block.
+    pub(crate) fn new_switch_block(&mut self, block: &Block) {
+        match self {
+            State::SyncingDescendants {
+                maybe_switch_block, ..
+            } => *maybe_switch_block = Some(Box::new(block.clone())),
+            _ => {}
+        }
     }
 }

--- a/node/src/types/chainspec/highway_config.rs
+++ b/node/src/types/chainspec/highway_config.rs
@@ -60,6 +60,12 @@ impl HighwayConfig {
     pub fn max_round_length(&self) -> TimeDiff {
         TimeDiff::from(1 << self.maximum_round_exponent)
     }
+
+    /// Returns the length of the shortest allowed round.
+    #[cfg(not(feature = "fast-sync"))]
+    pub fn min_round_length(&self) -> TimeDiff {
+        TimeDiff::from(1 << self.minimum_round_exponent)
+    }
 }
 
 #[cfg(test)]

--- a/node/src/types/chainspec/highway_config.rs
+++ b/node/src/types/chainspec/highway_config.rs
@@ -8,6 +8,8 @@ use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 
 #[cfg(test)]
 use crate::testing::TestRng;
+#[cfg(not(feature = "fast-sync"))]
+use crate::types::TimeDiff;
 
 #[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
@@ -51,6 +53,12 @@ impl HighwayConfig {
                 rrm = self.reduced_reward_multiplier
             );
         }
+    }
+
+    /// Returns the length of the longest allowed round.
+    #[cfg(not(feature = "fast-sync"))]
+    pub fn max_round_length(&self) -> TimeDiff {
+        TimeDiff::from(1 << self.maximum_round_exponent)
     }
 }
 

--- a/utils/nctl/sh/scenarios/sync_test.sh
+++ b/utils/nctl/sh/scenarios/sync_test.sh
@@ -56,7 +56,7 @@ function log_step() {
 
 function do_await_genesis_era_to_complete() {
     log_step "awaiting genesis era to complete"
-    while [ "$(get_chain_era)" -lt 1 ]; do
+    while [ "$(get_chain_era)" != "1" ]; do
         sleep 1.0
     done
 }


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-949

This PR adds two new stop conditions for when a node can consider being sync'd with the chain:
1. When a newly downloaded block has been created less than `max_round_length` ago. Works in situations when the network is running with the highest possible round exponent and otherwise there's a long list of known peers to ask for a new block.
2. When a newly downloaded block is a switch block of the currently active era. Works in situations when the finalization takes more than the longest possible round and condition **1** wouldn't kick in. 