### PR TITLE
NO-TICKET: avoid panicking on handling get responses

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
     commands:
       - cargo install cargo-audit
       - cargo generate-lockfile
-      - cargo audit --ignore RUSTSEC-2020-0123
+      - cargo audit --ignore RUSTSEC-2020-0123 --ignore RUSTSEC-2020-0146
 
 trigger:
   branch:

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ lint:
 
 .PHONY: audit
 audit:
-	$(CARGO) audit --ignore RUSTSEC-2020-0123
+	$(CARGO) audit --ignore RUSTSEC-2020-0123 --ignore RUSTSEC-2020-0146
 
 .PHONY: build-docs-stable-rs
 build-docs-stable-rs: $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE)

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -724,8 +724,14 @@ impl reactor::Reactor for Reactor {
                                 responder: None,
                             })
                         }
-                        Tag::Block => todo!("Handle GET block response"),
-                        Tag::BlockByHeight => todo!("Handle GET BlockByHeight response"),
+                        Tag::Block => {
+                            warn!("received get block response from {}", sender);
+                            return Effects::new();
+                        }
+                        Tag::BlockByHeight => {
+                            warn!("received get block by height response from {}", sender);
+                            return Effects::new();
+                        }
                         Tag::GossipedAddress => {
                             warn!("received get request for gossiped-address from {}", sender);
                             return Effects::new();

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -725,15 +725,15 @@ impl reactor::Reactor for Reactor {
                             })
                         }
                         Tag::Block => {
-                            warn!("received get block response from {}", sender);
+                            warn!(%sender, "received get block response");
                             return Effects::new();
                         }
                         Tag::BlockByHeight => {
-                            warn!("received get block by height response from {}", sender);
+                            warn!(%sender, "received get block by height response");
                             return Effects::new();
                         }
                         Tag::GossipedAddress => {
-                            warn!("received get request for gossiped-address from {}", sender);
+                            warn!(%sender, "received get request for gossiped-address");
                             return Effects::new();
                         }
                     },


### PR DESCRIPTION
This PR removes a couple of `todo!`s which could allow a malformed or more likely malicious message to cause the node to panic.