### PR TITLE
[Delta] NDRS-962: Stop syncing early.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
     commands:
       - cargo install cargo-audit
       - cargo generate-lockfile
-      - cargo audit --ignore RUSTSEC-2020-0123
+      - cargo audit --ignore RUSTSEC-2020-0123 --ignore RUSTSEC-2020-0146
 
 trigger:
   branch:

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ lint:
 
 .PHONY: audit
 audit:
-	$(CARGO) audit --ignore RUSTSEC-2020-0123
+	$(CARGO) audit --ignore RUSTSEC-2020-0123 --ignore RUSTSEC-2020-0146
 
 .PHONY: build-docs-stable-rs
 build-docs-stable-rs: $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE)


### PR DESCRIPTION
This PR adds two new conditions for when to stop syncing and transition to an active node:
1. When the most recently downloaded block was created less than the longest possible round ago.
2. When the last downloaded block was a switch block of a currently active era.