### PR TITLE
NDRS-955: Make tests include unbonding and dropping eras.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -51,6 +51,9 @@ pub(crate) use era_supervisor::{EraId, EraSupervisor};
 pub(crate) use protocols::highway::HighwayProtocol;
 use traits::NodeIdT;
 
+#[cfg(test)]
+pub(crate) use era_supervisor::oldest_bonded_era;
+
 #[derive(DataSize, Clone, Serialize, Deserialize)]
 pub enum ConsensusMessage {
     /// A protocol message, to be handled by the instance in the specified era.

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1240,5 +1240,7 @@ fn bonded_eras(protocol_config: &ProtocolConfig) -> u64 {
 /// The oldest era whose validators are still bonded.
 // This is public because it's used in reactor::validator::tests.
 pub(crate) fn oldest_bonded_era(protocol_config: &ProtocolConfig, current_era: EraId) -> EraId {
-    current_era.saturating_sub(bonded_eras(protocol_config))
+    current_era
+        .saturating_sub(bonded_eras(protocol_config))
+        .max(protocol_config.last_activation_point)
 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -389,10 +389,10 @@ where
         self.active_eras.get(&era_id).map_or(false, has_validator)
     }
 
-    /// Inspect the active eras.
+    /// Returns the most recent active era.
     #[cfg(test)]
-    pub(crate) fn active_eras(&self) -> &HashMap<EraId, Era<I>> {
-        &self.active_eras
+    pub(crate) fn current_era(&self) -> EraId {
+        self.current_era
     }
 
     /// To be called when we transition from the joiner to the validator reactor.

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -214,10 +214,11 @@ async fn run_equivocator_network() {
         .await
         .expect("network initialization failed");
 
-    // With an auction delay of 1 and an unbonding delay of 3, there are always 2 bonded active
-    // eras: the current one and the one before. The era supervisor keeps three active eras in
-    // memory — the oldest one without units, just for validating evidence if needed. So if we run
-    // this for five eras, the test can catch issues with unbonding and dropping obsolete eras.
+    // With an auction delay of 1 and an unbonding delay of 3, there are always 2 bonded past
+    // eras. The era supervisor keeps five active eras in memory — the oldest two without units,
+    // just for validating evidence if needed. So if we run this for five eras, the test can catch
+    // issues with unbonding and dropping obsolete eras: In era 5, the units from era 2 are
+    // dropped, and era 0 is dropped completely.
 
     info!("Waiting for Era 1 to end");
     net.settle_on(&mut rng, is_in_era(EraId(1)), Duration::from_secs(600))

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -222,25 +222,18 @@ async fn run_equivocator_network() {
     net.settle_on(&mut rng, is_in_era(EraId(1)), Duration::from_secs(600))
         .await;
 
-    info!("Waiting for Era 1 to end");
-    net.settle_on(&mut rng, is_in_era(EraId(2)), Duration::from_secs(90))
-        .await;
+    let last_era_number = 5;
+    let timeout = Duration::from_secs(90);
 
-    info!("Waiting for Era 2 to end");
-    net.settle_on(&mut rng, is_in_era(EraId(3)), Duration::from_secs(90))
-        .await;
-
-    info!("Waiting for Era 3 to end");
-    net.settle_on(&mut rng, is_in_era(EraId(4)), Duration::from_secs(90))
-        .await;
-
-    let last_era_id = EraId(5);
-    println!("Waiting for Era {} to end", last_era_id.0 - 1);
-    net.settle_on(&mut rng, is_in_era(last_era_id), Duration::from_secs(90))
-        .await;
+    for era_number in 2..last_era_number {
+        info!("Waiting for Era {} to end", era_number);
+        net.settle_on(&mut rng, is_in_era(EraId(era_number)), timeout)
+            .await;
+    }
 
     // Make sure we waited long enough for this test to include unbonding and dropping eras.
-    let oldest_bonded_era_id = consensus::oldest_bonded_era(&protocol_config, last_era_id);
+    let oldest_bonded_era_id =
+        consensus::oldest_bonded_era(&protocol_config, EraId(last_era_number));
     let oldest_evidence_era_id =
         consensus::oldest_bonded_era(&protocol_config, oldest_bonded_era_id);
     assert!(!oldest_evidence_era_id.is_genesis());

--- a/node/src/testing/multi_stage_test_reactor/test_chain.rs
+++ b/node/src/testing/multi_stage_test_reactor/test_chain.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use log::info;
 use num::Zero;
@@ -12,12 +12,12 @@ use casper_types::{system::auction::DelegationRate, PublicKey, SecretKey, U512};
 use crate::{
     components::{consensus::EraId, gossiper, small_network, storage, storage::Storage},
     crypto::AsymmetricKeyExt,
-    reactor::{validator, Runner},
+    reactor::validator,
     testing::{
         self,
         multi_stage_test_reactor::{InitializerReactorConfigWithChainspec, CONFIG_DIR},
         network::{Network, Nodes},
-        ConditionCheckReactor, MultiStageTestReactor,
+        MultiStageTestReactor,
     },
     types::{
         chainspec::{AccountConfig, AccountsConfig, ValidatorConfig},
@@ -121,6 +121,8 @@ impl TestChain {
         chainspec.core_config.minimum_era_height = 4;
         chainspec.highway_config.finality_threshold_fraction = Ratio::new(34, 100);
         chainspec.core_config.era_duration = 10.into();
+        chainspec.core_config.auction_delay = 1;
+        chainspec.core_config.unbonding_delay = 3;
 
         // Assign a port for the first node (TODO: this has a race condition)
         let first_node_port = testing::unused_port_on_localhost();
@@ -197,34 +199,17 @@ impl TestChain {
     }
 }
 
-/// Get the set of era IDs from a runner.
-fn era_ids(runner: &Runner<ConditionCheckReactor<MultiStageTestReactor>>) -> HashSet<EraId> {
-    if let Some(consensus) = runner.reactor().inner().consensus() {
-        consensus.active_eras().keys().cloned().collect()
-    } else {
-        HashSet::new()
-    }
-}
-
-/// Given an era number, return a predicate to check if all of the nodes are in that specified era.
-fn is_in_era(era_num: usize) -> impl Fn(&Nodes<MultiStageTestReactor>) -> bool {
+/// Given an era number, returns a predicate to check if all of the nodes are in the specified era.
+fn is_in_era(era_num: u64) -> impl Fn(&Nodes<MultiStageTestReactor>) -> bool {
     move |nodes: &Nodes<MultiStageTestReactor>| {
-        // check ee's era_validators against consensus' validators
-        let first_node = nodes.values().next().expect("need at least one node");
-
-        // Get a list of eras from the first node.
-        let expected_eras = era_ids(&first_node);
-
-        // Return if not in expected era yet.
-        if expected_eras.len() <= era_num {
-            return false;
-        }
-
-        // Ensure eras are all the same for all other nodes.
-        nodes
-            .values()
-            .map(era_ids)
-            .all(|eras| eras == expected_eras)
+        let era_id = EraId(era_num);
+        nodes.values().all(|runner| {
+            runner
+                .reactor()
+                .inner()
+                .consensus()
+                .map_or(false, |consensus| consensus.current_era() == era_id)
+        })
     }
 }
 
@@ -284,7 +269,7 @@ async fn run_equivocator_network() {
 }
 
 async fn get_switch_block_hash(
-    switch_block_era_num: usize,
+    switch_block_era_num: u64,
     net: &mut Network<MultiStageTestReactor>,
     rng: &mut NodeRng,
 ) -> BlockHash {
@@ -313,7 +298,7 @@ async fn get_switch_block_hash(
         .storage()
         .expect("Can not access storage of first node");
     let switch_block = storage
-        .transactional_get_switch_block_by_era_id(switch_block_era_num as u64)
+        .transactional_get_switch_block_by_era_id(switch_block_era_num)
         .expect("Could not find block for era num");
     let switch_block_hash = switch_block.hash();
     info!(


### PR DESCRIPTION
This changes the configuration used in the reactor tests so that the 5-era tests cause eras to become unbonded and dropped in the era validator.

This would have made the tests catch the bug fixed in https://github.com/CasperLabs/casper-node/pull/1038.

https://casperlabs.atlassian.net/browse/NDRS-955