### PR TITLE
NDRS-946: Make sure Chainspec::hash is the same for everyone

### DIFF
--- a/node/src/types/chainspec/accounts_config.rs
+++ b/node/src/types/chainspec/accounts_config.rs
@@ -7,7 +7,7 @@ mod validator_config;
 use std::path::Path;
 
 use datasize::DataSize;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use casper_execution_engine::core::engine_state::GenesisAccount;
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
@@ -23,10 +23,21 @@ pub use validator_config::ValidatorConfig;
 
 const CHAINSPEC_ACCOUNTS_FILENAME: &str = "accounts.toml";
 
+fn sorted_vec_deserializer<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    T: Deserialize<'de> + Ord,
+    D: Deserializer<'de>,
+{
+    let mut vec = Vec::<T>::deserialize(deserializer)?;
+    vec.sort_unstable();
+    Ok(vec)
+}
+
 #[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Clone)]
 pub struct AccountsConfig {
+    #[serde(deserialize_with = "sorted_vec_deserializer")]
     accounts: Vec<AccountConfig>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "sorted_vec_deserializer")]
     delegators: Vec<DelegatorConfig>,
 }
 

--- a/node/src/types/chainspec/accounts_config/account_config.rs
+++ b/node/src/types/chainspec/accounts_config/account_config.rs
@@ -17,7 +17,7 @@ use crate::testing::TestRng;
 
 use super::ValidatorConfig;
 
-#[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
+#[derive(PartialEq, Ord, PartialOrd, Eq, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
 pub struct AccountConfig {
     pub(super) public_key: PublicKey,
     balance: Motes,

--- a/node/src/types/chainspec/accounts_config/delegator_config.rs
+++ b/node/src/types/chainspec/accounts_config/delegator_config.rs
@@ -14,7 +14,7 @@ use casper_types::{SecretKey, U512};
 #[cfg(test)]
 use crate::testing::TestRng;
 
-#[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
+#[derive(PartialEq, Ord, PartialOrd, Eq, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
 pub struct DelegatorConfig {
     pub(super) validator_public_key: PublicKey,
     delegator_public_key: PublicKey,

--- a/node/src/types/chainspec/accounts_config/validator_config.rs
+++ b/node/src/types/chainspec/accounts_config/validator_config.rs
@@ -17,7 +17,7 @@ use casper_types::{
 #[cfg(test)]
 use crate::testing::TestRng;
 
-#[derive(PartialEq, Eq, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize, DataSize, Debug, Copy, Clone)]
 pub struct ValidatorConfig {
     bonded_amount: Motes,
     #[serde(default = "DelegationRate::zero")]

--- a/resources/test/valid/0_9_0_unordered/accounts.toml
+++ b/resources/test/valid/0_9_0_unordered/accounts.toml
@@ -1,16 +1,9 @@
-[[accounts]]
-public_key = "0148bc7fdb0375d480fbd03e77f74ffedc30b9f3954455fe04da15843a0a6af0c7"
-balance = "1"
+[[delegators]]
+validator_public_key = "011f66ea6321a48a935f66e97d4f7e60ee2d7fc9ccc62dfbe310f33b4839fc62eb"
+delegator_public_key = "020249c3a6d5006cd7634b54647f889265b85d36d837c066179548758b4eedab8186"
+balance = "0"
+delegated_amount = "20"
 
-[accounts.validator]
-bonded_amount = "10"
-
-[[accounts]]
-public_key = "011f66ea6321a48a935f66e97d4f7e60ee2d7fc9ccc62dfbe310f33b4839fc62eb"
-balance = "2"
-
-[accounts.validator]
-bonded_amount = "20"
 
 [[accounts]]
 public_key = "0189e744783c2d70902a5f2ef78e82e1f44102b5eb08ca6234241d95e50f615a6b"
@@ -32,8 +25,16 @@ delegator_public_key = "020248509e67db3127f82d5224c5c18eac00f96d1edeadbadc8eb2c8
 balance = "0"
 delegated_amount = "10"
 
-[[delegators]]
-validator_public_key = "011f66ea6321a48a935f66e97d4f7e60ee2d7fc9ccc62dfbe310f33b4839fc62eb"
-delegator_public_key = "020249c3a6d5006cd7634b54647f889265b85d36d837c066179548758b4eedab8186"
-balance = "0"
-delegated_amount = "20"
+[[accounts]]
+public_key = "011f66ea6321a48a935f66e97d4f7e60ee2d7fc9ccc62dfbe310f33b4839fc62eb"
+balance = "2"
+
+[accounts.validator]
+bonded_amount = "20"
+
+[[accounts]]
+public_key = "0148bc7fdb0375d480fbd03e77f74ffedc30b9f3954455fe04da15843a0a6af0c7"
+balance = "1"
+
+[accounts.validator]
+bonded_amount = "10"

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -1,0 +1,142 @@
+[protocol]
+version = '0.9.0'
+hard_reset = false
+
+[protocol.activation_point]
+era_id = 0
+
+[network]
+name = 'test-chain'
+timestamp = '2020-09-18T18:45:00Z'
+
+[core]
+era_duration = '3minutes'
+minimum_era_height = 9
+validator_slots = 5
+auction_delay = 3
+locked_funds_period = '90days'
+round_seigniorage_rate = [6_414, 623_437_335_209]
+unbonding_delay = 14
+
+[highway]
+finality_threshold_fraction = [2, 25]
+minimum_round_exponent = 14
+maximum_round_exponent = 19
+reduced_reward_multiplier = [1, 5]
+
+[deploys]
+max_payment_cost = '9'
+max_ttl = '10months'
+max_dependencies = 11
+max_block_size = 12
+block_max_deploy_count = 125
+block_max_transfer_count = 1000
+block_gas_limit = 13
+payment_args_max_length = 1024
+session_args_max_length = 1024
+native_transfer_minimum_motes = 2_500_000_000
+
+[wasm]
+max_memory = 17
+max_stack_height = 19
+
+[wasm.opcode_costs]
+bit = 13
+add = 14
+mul = 15
+div = 16
+load = 17
+store = 18
+const = 19
+local = 20
+global = 21
+control_flow = 22
+integer_comparsion = 23
+conversion = 24
+unreachable = 25
+nop = 26
+current_memory = 27
+grow_memory = 28
+regular = 29
+
+[wasm.storage_costs]
+gas_per_byte = 101
+
+[wasm.host_function_costs]
+add = { cost = 100, arguments = [0, 1, 2, 3] }
+add_associated_key = { cost = 101, arguments = [0, 1, 2] }
+add_contract_version = { cost = 102, arguments = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] }
+blake2b = { cost = 133, arguments = [0, 1, 2, 3] }
+call_contract = { cost = 104, arguments = [0, 1, 2, 3, 4, 5, 6] }
+call_versioned_contract = { cost = 105, arguments = [0, 1, 2, 3, 4, 5, 6, 7, 8] }
+create_contract_package_at_hash = { cost = 106, arguments = [0, 1] }
+create_contract_user_group = { cost = 107, arguments = [0, 1, 2, 3, 4, 5, 6, 7] }
+create_purse = { cost = 108, arguments = [0, 1] }
+disable_contract_version = { cost = 109, arguments = [0, 1, 2, 3] }
+get_balance = { cost = 110, arguments = [0, 1, 2] }
+get_blocktime = { cost = 111, arguments = [0] }
+get_caller = { cost = 112, arguments = [0] }
+get_key = { cost = 113, arguments = [0, 1, 2, 3, 4] }
+get_main_purse = { cost = 114, arguments = [0] }
+get_named_arg = { cost = 115, arguments = [0, 1, 2, 3] }
+get_named_arg_size = { cost = 116, arguments = [0, 1, 2] }
+get_phase = { cost = 117, arguments = [0] }
+get_system_contract = { cost = 118, arguments = [0, 1, 2] }
+has_key = { cost = 119, arguments = [0, 1] }
+is_valid_uref = { cost = 120, arguments = [0, 1] }
+load_named_keys = { cost = 121, arguments = [0, 1] }
+new_uref = { cost = 122, arguments = [0, 1, 2] }
+print = { cost = 123, arguments = [0, 1] }
+provision_contract_user_group_uref = { cost = 124, arguments = [0,1,2,3,4] }
+put_key = { cost = 125, arguments = [0, 1, 2, 3] }
+read_host_buffer = { cost = 126, arguments = [0, 1, 2] }
+read_value = { cost = 127, arguments = [0, 1, 0] }
+read_value_local = { cost = 128,  arguments = [0, 1, 0] }
+remove_associated_key = { cost = 129, arguments = [0, 1] }
+remove_contract_user_group = { cost = 130, arguments = [0, 1, 2, 3] }
+remove_contract_user_group_urefs = { cost = 131, arguments = [0,1,2,3,4,5] }
+remove_key = { cost = 132, arguments = [0, 1] }
+ret = { cost = 133, arguments = [0, 1] }
+revert = { cost = 134, arguments = [0] }
+set_action_threshold = { cost = 135, arguments = [0, 1] }
+transfer_from_purse_to_account = { cost = 136, arguments = [0, 1, 2, 3, 4, 5, 6, 7, 8] }
+transfer_from_purse_to_purse = { cost = 137, arguments = [0, 1, 2, 3, 4, 5, 6, 7] }
+transfer_to_account = { cost = 138, arguments = [0, 1, 2, 3, 4, 5, 6] }
+update_associated_key = { cost = 139, arguments = [0, 1, 2] }
+write = { cost = 140,  arguments = [0, 1, 0, 2] }
+write_local = { cost = 141, arguments = [0, 1, 2, 3] }
+
+[system_costs]
+wasmless_transfer_cost = 10_000
+
+[system_costs.auction_costs]
+get_era_validators = 10_000
+read_seigniorage_recipients = 10_000
+add_bid = 10_000
+withdraw_bid = 10_000
+delegate = 10_000
+undelegate = 10_000
+run_auction = 10_000
+slash = 10_000
+distribute = 10_000
+withdraw_delegator_reward = 10_000
+withdraw_validator_reward = 10_000
+read_era_id = 10_000
+activate_bid = 10_000
+
+[system_costs.mint_costs]
+mint = 10_000
+reduce_total_supply = 10_000
+create = 10_000
+balance = 10_000
+transfer = 10_000
+read_base_round_reward = 10_000
+
+[system_costs.handle_payment_costs]
+get_payment_purse = 10_000
+set_refund_purse = 10_000
+get_refund_purse = 10_000
+finalize_payment = 10_000
+
+[system_costs.standard_payment_costs]
+pay = 10_000


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-946

Changes the way AccountsConfig is deserialized so accounts and delegators are always sorted. Adds a test case that ensures that even with different accounts.toml both Chainspec objects are equal.