### PR TITLE
EE-1190: remove entrypoint for read_seigniorage_recipients

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -26,10 +26,9 @@ use casper_types::{
             DELEGATION_RATE_DENOMINATOR, ERA_END_TIMESTAMP_MILLIS_KEY, ERA_ID_KEY,
             INITIAL_ERA_END_TIMESTAMP_MILLIS, INITIAL_ERA_ID, LOCKED_FUNDS_PERIOD_KEY,
             METHOD_ACTIVATE_BID, METHOD_ADD_BID, METHOD_DELEGATE, METHOD_DISTRIBUTE,
-            METHOD_GET_ERA_VALIDATORS, METHOD_READ_ERA_ID, METHOD_READ_SEIGNIORAGE_RECIPIENTS,
-            METHOD_RUN_AUCTION, METHOD_SLASH, METHOD_UNDELEGATE, METHOD_WITHDRAW_BID,
-            SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_DELAY_KEY, UNBONDING_PURSES_KEY,
-            VALIDATOR_SLOTS_KEY,
+            METHOD_GET_ERA_VALIDATORS, METHOD_READ_ERA_ID, METHOD_RUN_AUCTION, METHOD_SLASH,
+            METHOD_UNDELEGATE, METHOD_WITHDRAW_BID, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
+            UNBONDING_DELAY_KEY, UNBONDING_PURSES_KEY, VALIDATOR_SLOTS_KEY,
         },
         handle_payment::{
             self, ARG_ACCOUNT, METHOD_FINALIZE_PAYMENT, METHOD_GET_PAYMENT_PURSE,
@@ -1409,15 +1408,6 @@ where
             METHOD_GET_ERA_VALIDATORS,
             vec![],
             Option::<ValidatorWeights>::cl_type(),
-            EntryPointAccess::Public,
-            EntryPointType::Contract,
-        );
-        entry_points.add_entry_point(entry_point);
-
-        let entry_point = EntryPoint::new(
-            METHOD_READ_SEIGNIORAGE_RECIPIENTS,
-            vec![],
-            SeigniorageRecipients::cl_type(),
             EntryPointAccess::Public,
             EntryPointType::Contract,
         );

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -1639,16 +1639,6 @@ where
                 CLValue::from_t(result).map_err(Self::reverter)
             })(),
 
-            auction::METHOD_READ_SEIGNIORAGE_RECIPIENTS => (|| {
-                runtime.charge_system_contract_call(auction_costs.read_seigniorage_recipients)?;
-
-                let result = runtime
-                    .read_seigniorage_recipients()
-                    .map_err(Self::reverter)?;
-
-                CLValue::from_t(result).map_err(Self::reverter)
-            })(),
-
             auction::METHOD_ADD_BID => (|| {
                 runtime.charge_system_contract_call(auction_costs.add_bid)?;
 

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -31,20 +31,18 @@ use casper_types::{
     system::{
         self,
         auction::{
-            self, Bids, DelegationRate, EraId, EraValidators, SeigniorageRecipients,
-            UnbondingPurses, ValidatorWeights, ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR,
-            ARG_PUBLIC_KEY, ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY, ERA_ID_KEY, INITIAL_ERA_ID,
-            METHOD_ACTIVATE_BID, UNBONDING_PURSES_KEY,
+            self, Bids, DelegationRate, EraId, EraValidators, UnbondingPurses, ValidatorWeights,
+            ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_PUBLIC_KEY, ARG_VALIDATOR,
+            ARG_VALIDATOR_PUBLIC_KEY, ERA_ID_KEY, INITIAL_ERA_ID, METHOD_ACTIVATE_BID,
+            UNBONDING_PURSES_KEY,
         },
     },
     PublicKey, RuntimeArgs, SecretKey, U512,
 };
 
-const ARG_ENTRY_POINT: &str = "entry_point";
 const ARG_TARGET: &str = "target";
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
-const CONTRACT_AUCTION_BIDS: &str = "auction_bids.wasm";
 const CONTRACT_ADD_BID: &str = "add_bid.wasm";
 const CONTRACT_WITHDRAW_BID: &str = "withdraw_bid.wasm";
 const CONTRACT_DELEGATE: &str = "delegate.wasm";
@@ -59,8 +57,6 @@ const ADD_BID_DELEGATION_RATE_1: DelegationRate = 10;
 const BID_AMOUNT_2: u64 = 5_000;
 const ADD_BID_DELEGATION_RATE_2: DelegationRate = 15;
 const WITHDRAW_BID_AMOUNT_2: u64 = 15_000;
-
-const ARG_READ_SEIGNIORAGE_RECIPIENTS: &str = "read_seigniorage_recipients";
 
 const DELEGATE_AMOUNT_1: u64 = 125_000;
 const DELEGATE_AMOUNT_2: u64 = 15_000;
@@ -634,33 +630,6 @@ fn should_get_first_seigniorage_recipients() {
         DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
         Vec::new(),
     );
-
-    // read seigniorage recipients
-    let exec_request_2 = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
-        CONTRACT_AUCTION_BIDS,
-        runtime_args! {
-            ARG_ENTRY_POINT => ARG_READ_SEIGNIORAGE_RECIPIENTS,
-        },
-    )
-    .build();
-
-    builder.exec(exec_request_2).commit().expect_success();
-
-    let account = builder.get_account(SYSTEM_ADDR).unwrap();
-    let key = account
-        .named_keys()
-        .get("seigniorage_recipients_result")
-        .copied()
-        .unwrap();
-    let stored_value = builder.query(None, key, &[]).unwrap();
-    let seigniorage_recipients: SeigniorageRecipients = stored_value
-        .as_cl_value()
-        .cloned()
-        .unwrap()
-        .into_t()
-        .unwrap();
-    assert_eq!(seigniorage_recipients.len(), 2);
 
     let mut era_validators: EraValidators = builder.get_era_validators();
     let snapshot_size = DEFAULT_AUCTION_DELAY as usize + 1;

--- a/smart_contracts/contracts/test/auction-bids/src/main.rs
+++ b/smart_contracts/contracts/test/auction-bids/src/main.rs
@@ -5,14 +5,13 @@ extern crate alloc;
 
 use alloc::{collections::BTreeMap, string::String};
 
-use casper_contract::contract_api::{runtime, storage, system};
+use casper_contract::contract_api::{runtime, system};
 
 use casper_types::{
     runtime_args,
     system::auction::{
-        SeigniorageRecipients, ARG_DELEGATOR, ARG_ERA_END_TIMESTAMP_MILLIS, ARG_REWARD_FACTORS,
-        ARG_VALIDATOR, METHOD_DELEGATE, METHOD_DISTRIBUTE, METHOD_READ_SEIGNIORAGE_RECIPIENTS,
-        METHOD_RUN_AUCTION, METHOD_UNDELEGATE,
+        ARG_DELEGATOR, ARG_ERA_END_TIMESTAMP_MILLIS, ARG_REWARD_FACTORS, ARG_VALIDATOR,
+        METHOD_DELEGATE, METHOD_DISTRIBUTE, METHOD_RUN_AUCTION, METHOD_UNDELEGATE,
     },
     ApiError, PublicKey, RuntimeArgs, U512,
 };
@@ -22,7 +21,6 @@ const ARG_AMOUNT: &str = "amount";
 const ARG_DELEGATE: &str = "delegate";
 const ARG_UNDELEGATE: &str = "undelegate";
 const ARG_RUN_AUCTION: &str = "run_auction";
-const ARG_READ_SEIGNIORAGE_RECIPIENTS: &str = "read_seigniorage_recipients";
 
 #[repr(u16)]
 enum Error {
@@ -41,7 +39,6 @@ pub extern "C" fn call() {
             undelegate();
         }
         ARG_RUN_AUCTION => run_auction(),
-        ARG_READ_SEIGNIORAGE_RECIPIENTS => read_seigniorage_recipients(),
         METHOD_DISTRIBUTE => distribute(),
         _ => runtime::revert(ApiError::User(Error::UnknownCommand as u16)),
     };
@@ -81,15 +78,6 @@ fn run_auction() {
     let era_end_timestamp_millis: u64 = runtime::get_named_arg(ARG_ERA_END_TIMESTAMP_MILLIS);
     let args = runtime_args! { ARG_ERA_END_TIMESTAMP_MILLIS => era_end_timestamp_millis };
     runtime::call_contract::<()>(auction, METHOD_RUN_AUCTION, args);
-}
-
-fn read_seigniorage_recipients() {
-    let auction = system::get_auction();
-    let args = runtime_args! {};
-    let result: SeigniorageRecipients =
-        runtime::call_contract(auction, METHOD_READ_SEIGNIORAGE_RECIPIENTS, args);
-    let uref = storage::new_uref(result);
-    runtime::put_key("seigniorage_recipients_result", uref.into());
 }
 
 fn distribute() {

--- a/types/src/system/auction/constants.rs
+++ b/types/src/system/auction/constants.rs
@@ -62,8 +62,6 @@ pub const ARG_EVICTED_VALIDATORS: &str = "evicted_validators";
 
 /// Named constant for method `get_era_validators`.
 pub const METHOD_GET_ERA_VALIDATORS: &str = "get_era_validators";
-/// Named constant for method `read_seigniorage_recipients`.
-pub const METHOD_READ_SEIGNIORAGE_RECIPIENTS: &str = "read_seigniorage_recipients";
 /// Named constant for method `add_bid`.
 pub const METHOD_ADD_BID: &str = "add_bid";
 /// Named constant for method `withdraw_bid`.


### PR DESCRIPTION
`Auction::read_seigniorage_recipients` was not being used other than in tests.  Keeping it as a public auction entrypoint presents challenges for iterating on the `SeigniorageRecipient` structure and related.  This PR removes it as a public entrypoint to enable future changes.