### PR TITLE
NO-TICK: Disable nightly itst02

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -40,7 +40,7 @@ function start_run_teardown() {
 # start_run_teardown "sync_test.sh node=6 timeout=500"
 start_run_teardown "sync_upgrade_test.sh node=6 timeout=500"
 start_run_teardown "itst01.sh"
-start_run_teardown "itst02.sh"
+#start_run_teardown "itst02.sh"
 start_run_teardown "itst11.sh"
 
 


### PR DESCRIPTION
Currently hangs. Tracked with https://casperlabs.atlassian.net/browse/NDRS-966