### PR TITLE
NO-TICKET: change activation point to represent era ID or genesis timestamp

### DIFF
--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -152,7 +152,8 @@ impl Display for NextUpgrade {
         write!(
             formatter,
             "next upgrade to {} at start of era {}",
-            self.protocol_version, self.activation_point.era_id
+            self.protocol_version,
+            self.activation_point.era_id()
         )
     }
 }
@@ -313,7 +314,7 @@ impl ChainspecLoader {
         self.chainspec
             .protocol_config
             .hard_reset
-            .then(|| self.chainspec.protocol_config.activation_point.era_id)
+            .then(|| self.chainspec.protocol_config.activation_point.era_id())
     }
 
     fn handle_initialize<REv>(
@@ -367,7 +368,7 @@ impl ChainspecLoader {
         let cached_protocol_version =
             maybe_cached_protocol_version.unwrap_or_else(|| Version::new(1, 0, 0));
         let current_chainspec_activation_point =
-            self.chainspec.protocol_config.activation_point.era_id;
+            self.chainspec.protocol_config.activation_point.era_id();
 
         if highest_block_era_id.successor() == current_chainspec_activation_point {
             if highest_block.header().is_switch_block() {
@@ -404,7 +405,7 @@ impl ChainspecLoader {
         }
 
         let next_upgrade_activation_point = match self.next_upgrade {
-            Some(ref next_upgrade) => next_upgrade.activation_point.era_id,
+            Some(ref next_upgrade) => next_upgrade.activation_point.era_id(),
             None => {
                 // This is a valid run, restarted after an unplanned shutdown.
                 debug_assert!(cached_protocol_version == self.chainspec.protocol_config.version);
@@ -475,7 +476,7 @@ impl ChainspecLoader {
             new_version,
             Some(self.chainspec.wasm_config),
             Some(self.chainspec.system_costs_config),
-            Some(self.chainspec.protocol_config.activation_point.era_id.0),
+            Some(self.chainspec.protocol_config.activation_point.era_id().0),
             Some(self.chainspec.core_config.validator_slots),
             Some(self.chainspec.core_config.auction_delay),
             Some(self.chainspec.core_config.locked_funds_period.millis()),

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -122,7 +122,7 @@ pub enum Event<I> {
         /// validator set is read from the global state, not from a key block.
         validators: BTreeMap<PublicKey, U512>,
         timestamp: Timestamp,
-        genesis_start_time: Timestamp,
+        genesis_start_time: Option<Timestamp>,
     },
     /// An event instructing us to shutdown if the latest era received no votes.
     Shutdown,

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -58,8 +58,8 @@ pub(crate) struct ProtocolConfig {
     pub(crate) last_activation_point: EraId,
     /// Name of the network.
     pub(crate) name: String,
-    /// Genesis timestamp.
-    pub(crate) timestamp: Timestamp,
+    /// Genesis timestamp, if available.
+    pub(crate) genesis_timestamp: Option<Timestamp>,
     /// The chainspec hash: All nodes in the network agree on it, and it's unique to this network.
     pub(crate) chainspec_hash: Digest,
 }
@@ -73,9 +73,12 @@ impl From<&Chainspec> for ProtocolConfig {
             auction_delay: chainspec.core_config.auction_delay,
             unbonding_delay: chainspec.core_config.unbonding_delay,
             protocol_version: chainspec.protocol_config.version.clone(),
-            last_activation_point: chainspec.protocol_config.activation_point.era_id,
+            last_activation_point: chainspec.protocol_config.activation_point.era_id(),
             name: chainspec.network_config.name.clone(),
-            timestamp: chainspec.network_config.timestamp,
+            genesis_timestamp: chainspec
+                .protocol_config
+                .activation_point
+                .genesis_timestamp(),
             chainspec_hash: chainspec.hash(),
         }
     }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -529,12 +529,13 @@ where
             let start_height;
             let era_start_time;
 
-            if let Some(start_time) = genesis_start_time {
+            if era_id.is_genesis() {
                 newly_slashed = vec![];
                 // The validator set was read from the global state: there's no key block for era 0.
                 validators = activation_era_validators.clone();
                 start_height = 0;
-                era_start_time = start_time;
+                era_start_time =
+                    genesis_start_time.expect("must have genesis start time if era ID is 0");
             } else {
                 // If this is not era 0, there must be a key block for it.
                 let key_block = key_blocks.get(&era_id).expect("missing key block");

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -169,7 +169,7 @@ where
         let bonded_eras: u64 = protocol_config.unbonding_delay - protocol_config.auction_delay;
         let metrics = ConsensusMetrics::new(registry)
             .expect("failure to setup and register ConsensusMetrics");
-        let genesis_start_time = protocol_config.timestamp;
+        let genesis_start_time = protocol_config.genesis_timestamp;
         let protocol_version = ProtocolVersion::from_parts(
             protocol_config.protocol_version.major as u32,
             protocol_config.protocol_version.minor as u32,
@@ -519,7 +519,7 @@ where
         key_blocks: HashMap<EraId, BlockHeader>,
         activation_era_validators: BTreeMap<PublicKey, U512>,
         timestamp: Timestamp,
-        genesis_start_time: Timestamp,
+        genesis_start_time: Option<Timestamp>,
     ) -> HashMap<EraId, ProtocolOutcomes<I, ClContext>> {
         let mut result_map = HashMap::new();
 
@@ -529,12 +529,12 @@ where
             let start_height;
             let era_start_time;
 
-            if era_id.is_genesis() {
+            if let Some(start_time) = genesis_start_time {
                 newly_slashed = vec![];
                 // The validator set was read from the global state: there's no key block for era 0.
                 validators = activation_era_validators.clone();
                 start_height = 0;
-                era_start_time = genesis_start_time;
+                era_start_time = start_time;
             } else {
                 // If this is not era 0, there must be a key block for it.
                 let key_block = key_blocks.get(&era_id).expect("missing key block");
@@ -805,7 +805,7 @@ where
         key_blocks: HashMap<EraId, BlockHeader>,
         validators: BTreeMap<PublicKey, U512>,
         timestamp: Timestamp,
-        genesis_start_time: Timestamp,
+        genesis_start_time: Option<Timestamp>,
     ) -> Effects<Event<I>> {
         let result_map = self.era_supervisor.handle_initialize_eras(
             key_blocks,

--- a/node/src/components/consensus/tests/utils.rs
+++ b/node/src/components/consensus/tests/utils.rs
@@ -7,7 +7,7 @@ use casper_types::{system::auction::DelegationRate, PublicKey, SecretKey, U512};
 use crate::{
     types::{
         chainspec::{AccountConfig, AccountsConfig, ValidatorConfig},
-        Chainspec, Timestamp,
+        ActivationPoint, Chainspec, Timestamp,
     },
     utils::Loadable,
 };
@@ -38,7 +38,7 @@ where
         .collect();
     let delegators = vec![];
     chainspec.network_config.accounts_config = AccountsConfig::new(accounts, delegators);
-    chainspec.network_config.timestamp = Timestamp::now();
+    chainspec.protocol_config.activation_point = ActivationPoint::Genesis(Timestamp::now());
 
     // Every era has exactly two blocks.
     chainspec.core_config.minimum_era_height = 2;

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -439,15 +439,21 @@ impl reactor::Reactor for Reactor {
             None => {
                 let chainspec = chainspec_loader.chainspec();
                 let era_duration = chainspec.core_config.era_duration;
-                if Timestamp::now() > chainspec.network_config.timestamp + era_duration {
-                    error!(
-                        "Node started with no trusted hash after the expected end of \
-                         the genesis era! Please specify a trusted hash and restart. \
-                         Time: {}, End of genesis era: {}",
-                        Timestamp::now(),
-                        chainspec.network_config.timestamp + era_duration
-                    );
-                    panic!("should have trusted hash after genesis era")
+                if let Some(start_time) = chainspec
+                    .protocol_config
+                    .activation_point
+                    .genesis_timestamp()
+                {
+                    if Timestamp::now() > start_time + era_duration {
+                        error!(
+                            "Node started with no trusted hash after the expected end of \
+                             the genesis era! Please specify a trusted hash and restart. \
+                             Time: {}, End of genesis era: {}",
+                            Timestamp::now(),
+                            start_time + era_duration
+                        );
+                        panic!("should have trusted hash after genesis era")
+                    }
                 }
                 info!("No synchronization of the linear chain will be done.")
             }

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -476,7 +476,15 @@ impl reactor::Reactor for Reactor {
         // set timeout to 5 minutes after now, or 5 minutes after genesis, whichever is later
         let now = Timestamp::now();
         let five_minutes = TimeDiff::from_str("5minutes").unwrap();
-        let later_timestamp = cmp::max(now, chainspec_loader.chainspec().network_config.timestamp);
+        let later_timestamp = cmp::max(
+            now,
+            chainspec_loader
+                .chainspec()
+                .protocol_config
+                .activation_point
+                .genesis_timestamp()
+                .unwrap_or_else(Timestamp::zero),
+        );
         let timer_duration = later_timestamp + five_minutes - now;
         effects.extend(reactor::wrap_effects(
             Event::Consensus,

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -21,7 +21,7 @@ use crate::{
     testing::{self, network::Network, ConditionCheckReactor, TestRng},
     types::{
         chainspec::{AccountConfig, AccountsConfig, ValidatorConfig},
-        Chainspec, Timestamp,
+        ActivationPoint, Chainspec, Timestamp,
     },
     utils::{External, Loadable, WithDir, RESOURCES_PATH},
     NodeRng,
@@ -79,7 +79,8 @@ impl TestChain {
         chainspec.network_config.accounts_config = AccountsConfig::new(accounts, delegators);
 
         // Make the genesis timestamp 45 seconds from now, to allow for all validators to start up.
-        chainspec.network_config.timestamp = Timestamp::now() + 45000.into();
+        chainspec.protocol_config.activation_point =
+            ActivationPoint::Genesis(Timestamp::now() + 45000.into());
 
         chainspec.core_config.minimum_era_height = 1;
         chainspec.highway_config.finality_threshold_fraction = Ratio::new(34, 100);

--- a/node/src/testing/multi_stage_test_reactor/test_chain.rs
+++ b/node/src/testing/multi_stage_test_reactor/test_chain.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     types::{
         chainspec::{AccountConfig, AccountsConfig, ValidatorConfig},
-        BlockHash, Chainspec, NodeId, Timestamp,
+        ActivationPoint, BlockHash, Chainspec, NodeId, Timestamp,
     },
     utils::{External, Loadable, WithDir},
     NodeRng,
@@ -116,7 +116,8 @@ impl TestChain {
             AccountsConfig::new(genesis_accounts, delegators);
 
         // Make the genesis timestamp 45 seconds from now, to allow for all validators to start up.
-        chainspec.network_config.timestamp = Timestamp::now() + 45000.into();
+        chainspec.protocol_config.activation_point =
+            ActivationPoint::Genesis(Timestamp::now() + 45000.into());
 
         chainspec.core_config.minimum_era_height = 4;
         chainspec.highway_config.finality_threshold_fraction = Ratio::new(34, 100);

--- a/node/src/types/chainspec/activation_point.rs
+++ b/node/src/types/chainspec/activation_point.rs
@@ -1,0 +1,127 @@
+// TODO - remove once schemars stops causing warning.
+#![allow(clippy::field_reassign_with_default)]
+
+use std::fmt::{self, Display, Formatter};
+
+use datasize::DataSize;
+#[cfg(test)]
+use rand::Rng;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use casper_types::bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH};
+
+#[cfg(test)]
+use crate::testing::TestRng;
+use crate::{components::consensus::EraId, types::Timestamp};
+
+const ERA_ID_TAG: u8 = 0;
+const GENESIS_TAG: u8 = 1;
+
+/// The first era to which the associated protocol version applies.
+#[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(untagged)]
+pub enum ActivationPoint {
+    EraId(EraId),
+    Genesis(Timestamp),
+}
+
+impl ActivationPoint {
+    /// Returns whether we should upgrade the node due to the next era being at or after the upgrade
+    /// activation point.
+    pub(crate) fn should_upgrade(&self, era_being_deactivated: &EraId) -> bool {
+        match self {
+            ActivationPoint::EraId(era_id) => era_being_deactivated.0 + 1 >= era_id.0,
+            ActivationPoint::Genesis(_) => false,
+        }
+    }
+
+    /// Returns the Era ID if `self` is of `EraId` variant, or else 0 if `Genesis`.
+    pub(crate) fn era_id(&self) -> EraId {
+        match self {
+            ActivationPoint::EraId(era_id) => *era_id,
+            ActivationPoint::Genesis(_) => EraId(0),
+        }
+    }
+
+    /// Returns the timestamp if `self` is of `Genesis` variant, or else `None`.
+    pub(crate) fn genesis_timestamp(&self) -> Option<Timestamp> {
+        match self {
+            ActivationPoint::EraId(_) => None,
+            ActivationPoint::Genesis(timestamp) => Some(*timestamp),
+        }
+    }
+
+    /// Returns true if `self` is `Genesis`.
+    pub(crate) fn is_genesis(&self) -> bool {
+        match self {
+            ActivationPoint::EraId(_) => false,
+            ActivationPoint::Genesis(_) => true,
+        }
+    }
+}
+
+impl Display for ActivationPoint {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ActivationPoint::EraId(era_id) => write!(formatter, "activation point {}", era_id),
+            ActivationPoint::Genesis(timestamp) => {
+                write!(formatter, "activation point {}", timestamp)
+            }
+        }
+    }
+}
+
+impl ToBytes for ActivationPoint {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        match self {
+            ActivationPoint::EraId(era_id) => {
+                let mut buffer = vec![ERA_ID_TAG];
+                buffer.extend(era_id.to_bytes()?);
+                Ok(buffer)
+            }
+            ActivationPoint::Genesis(timestamp) => {
+                let mut buffer = vec![GENESIS_TAG];
+                buffer.extend(timestamp.to_bytes()?);
+                Ok(buffer)
+            }
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
+            + match self {
+                ActivationPoint::EraId(era_id) => era_id.serialized_length(),
+                ActivationPoint::Genesis(timestamp) => timestamp.serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for ActivationPoint {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            ERA_ID_TAG => {
+                let (era_id, remainder) = EraId::from_bytes(remainder)?;
+                Ok((ActivationPoint::EraId(era_id), remainder))
+            }
+            GENESIS_TAG => {
+                let (timestamp, remainder) = Timestamp::from_bytes(remainder)?;
+                Ok((ActivationPoint::Genesis(timestamp), remainder))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+#[cfg(test)]
+impl ActivationPoint {
+    /// Generates a random instance using a `TestRng`.
+    pub fn random(rng: &mut TestRng) -> Self {
+        if rng.gen() {
+            ActivationPoint::EraId(EraId(rng.gen::<u8>() as u64))
+        } else {
+            ActivationPoint::Genesis(Timestamp::random(rng))
+        }
+    }
+}

--- a/node/src/types/chainspec/network_config.rs
+++ b/node/src/types/chainspec/network_config.rs
@@ -12,14 +12,11 @@ use casper_types::{
 use super::AccountsConfig;
 #[cfg(test)]
 use crate::testing::TestRng;
-use crate::types::Timestamp;
 
 #[derive(Clone, DataSize, PartialEq, Eq, Serialize, Debug)]
 pub struct NetworkConfig {
     /// The network name.
     pub(crate) name: String,
-    /// The inception moment of the network.
-    pub(crate) timestamp: Timestamp,
     /// Validator accounts specified in the chainspec.
     pub(crate) accounts_config: AccountsConfig,
 }
@@ -46,14 +43,12 @@ impl NetworkConfig {
     /// Generates a random instance using a `TestRng`.
     pub fn random(rng: &mut TestRng) -> Self {
         let name = rng.gen::<char>().to_string();
-        let timestamp = Timestamp::random(rng);
         let accounts = vec![rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen()];
         let delegators = vec![rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen()];
         let accounts_config = AccountsConfig::new(accounts, delegators);
 
         NetworkConfig {
             name,
-            timestamp,
             accounts_config,
         }
     }
@@ -63,26 +58,21 @@ impl ToBytes for NetworkConfig {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         buffer.extend(self.name.to_bytes()?);
-        buffer.extend(self.timestamp.to_bytes()?);
         buffer.extend(self.accounts_config.to_bytes()?);
         Ok(buffer)
     }
 
     fn serialized_length(&self) -> usize {
-        self.name.serialized_length()
-            + self.timestamp.serialized_length()
-            + self.accounts_config.serialized_length()
+        self.name.serialized_length() + self.accounts_config.serialized_length()
     }
 }
 
 impl FromBytes for NetworkConfig {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (name, remainder) = String::from_bytes(bytes)?;
-        let (timestamp, remainder) = Timestamp::from_bytes(remainder)?;
         let (accounts_config, remainder) = FromBytes::from_bytes(remainder)?;
         let config = NetworkConfig {
             name,
-            timestamp,
             accounts_config,
         };
         Ok((config, remainder))

--- a/node/src/types/chainspec/parse_toml.rs
+++ b/node/src/types/chainspec/parse_toml.rs
@@ -14,21 +14,17 @@ use serde::{Deserialize, Serialize};
 use casper_execution_engine::shared::{system_config::SystemConfig, wasm_config::WasmConfig};
 
 use super::{
-    accounts_config::AccountsConfig, global_state_update::GlobalStateUpdateConfig,
-    protocol_config::ActivationPoint, Chainspec, CoreConfig, DeployConfig, Error,
-    GlobalStateUpdate, HighwayConfig, NetworkConfig, ProtocolConfig,
+    accounts_config::AccountsConfig, global_state_update::GlobalStateUpdateConfig, ActivationPoint,
+    Chainspec, CoreConfig, DeployConfig, Error, GlobalStateUpdate, HighwayConfig, NetworkConfig,
+    ProtocolConfig,
 };
-use crate::{
-    types::Timestamp,
-    utils::{self, Loadable},
-};
+use crate::utils::{self, Loadable};
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
 struct TomlNetwork {
     name: String,
-    timestamp: Timestamp,
 }
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
@@ -63,7 +59,6 @@ impl From<&Chainspec> for TomlChainspec {
         };
         let network = TomlNetwork {
             name: chainspec.network_config.name.clone(),
-            timestamp: chainspec.network_config.timestamp,
         };
         let core = chainspec.core_config;
         let deploys = chainspec.deploy_config;
@@ -97,7 +92,6 @@ pub(super) fn parse_toml<P: AsRef<Path>>(chainspec_path: P) -> Result<Chainspec,
 
     let network_config = NetworkConfig {
         name: toml_chainspec.network.name,
-        timestamp: toml_chainspec.network.timestamp,
         accounts_config,
     };
 

--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -1,42 +1,17 @@
 // TODO - remove once schemars stops causing warning.
 #![allow(clippy::field_reassign_with_default)]
 
-use std::fmt::{self, Display, Formatter};
-
 use datasize::DataSize;
 #[cfg(test)]
 use rand::Rng;
-use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
 use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 
-use super::GlobalStateUpdate;
-
-use crate::components::consensus::EraId;
+use super::{ActivationPoint, GlobalStateUpdate};
 #[cfg(test)]
 use crate::testing::TestRng;
-
-/// The first era to which the upgrade applies.
-#[derive(Copy, Clone, DataSize, PartialEq, Eq, Serialize, Deserialize, Debug, JsonSchema)]
-pub struct ActivationPoint {
-    pub(crate) era_id: EraId,
-}
-
-impl ActivationPoint {
-    /// Returns whether we should upgrade the node due to the next era being at or after the upgrade
-    /// activation point.
-    pub(crate) fn should_upgrade(&self, era_being_deactivated: &EraId) -> bool {
-        era_being_deactivated.0 + 1 >= self.era_id.0
-    }
-}
-
-impl Display for ActivationPoint {
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        write!(formatter, "upgrade activation point {}", self.era_id)
-    }
-}
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, Debug)]
 pub struct ProtocolConfig {
@@ -61,9 +36,7 @@ impl ProtocolConfig {
             rng.gen::<u8>() as u64,
             rng.gen::<u8>() as u64,
         );
-        let activation_point = ActivationPoint {
-            era_id: EraId(rng.gen::<u8>() as u64),
-        };
+        let activation_point = ActivationPoint::random(rng);
 
         ProtocolConfig {
             version: protocol_version,
@@ -79,7 +52,7 @@ impl ToBytes for ProtocolConfig {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         buffer.extend(self.version.to_string().to_bytes()?);
         buffer.extend(self.hard_reset.to_bytes()?);
-        buffer.extend(self.activation_point.era_id.to_bytes()?);
+        buffer.extend(self.activation_point.to_bytes()?);
         buffer.extend(self.global_state_update.to_bytes()?);
         Ok(buffer)
     }
@@ -87,7 +60,7 @@ impl ToBytes for ProtocolConfig {
     fn serialized_length(&self) -> usize {
         self.version.to_string().serialized_length()
             + self.hard_reset.serialized_length()
-            + self.activation_point.era_id.serialized_length()
+            + self.activation_point.serialized_length()
             + self.global_state_update.serialized_length()
     }
 }
@@ -98,8 +71,7 @@ impl FromBytes for ProtocolConfig {
         let protocol_version =
             Version::parse(&protocol_version_string).map_err(|_| bytesrepr::Error::Formatting)?;
         let (hard_reset, remainder) = bool::from_bytes(remainder)?;
-        let (era_id, remainder) = EraId::from_bytes(remainder)?;
-        let activation_point = ActivationPoint { era_id };
+        let (activation_point, remainder) = ActivationPoint::from_bytes(remainder)?;
         let (global_state_update, remainder) = Option::<GlobalStateUpdate>::from_bytes(remainder)?;
         let protocol_config = ProtocolConfig {
             version: protocol_version,
@@ -114,6 +86,13 @@ impl FromBytes for ProtocolConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn activation_point_bytesrepr_roundtrip() {
+        let mut rng = crate::new_rng();
+        let activation_point = ActivationPoint::random(&mut rng);
+        bytesrepr::test_serialization_roundtrip(&activation_point);
+    }
 
     #[test]
     fn protocol_config_bytesrepr_roundtrip() {

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -25,8 +25,7 @@ use crate::{
 };
 
 static CHAINSPEC_INFO: Lazy<ChainspecInfo> = Lazy::new(|| {
-    let next_upgrade =
-        NextUpgrade::new(ActivationPoint { era_id: EraId(42) }, Version::new(2, 0, 1));
+    let next_upgrade = NextUpgrade::new(ActivationPoint::EraId(EraId(42)), Version::new(2, 0, 1));
     ChainspecInfo {
         name: String::from("casper-example"),
         starting_state_root_hash: Digest::from([2u8; Digest::LENGTH]),

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -3,21 +3,21 @@
 version = '1.0.0'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = false
-
-[protocol.activation_point]
-# This protocol version becomes active at the start of this era.
-era_id = 0
+# This protocol version becomes active at this point.
+#
+# If it is a timestamp string, it represents the timestamp for the genesis block.  This is the beginning of era 0.  By
+# this time, a sufficient majority (> 50% + F/2 — see finality_threshold_fraction below) of validator nodes must be up
+# and running to start the blockchain.  This timestamp is also used in seeding the pseudo-random number generator used
+# in contract-runtime for computing genesis post-state hash.
+#
+# If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
+activation_point = '${TIMESTAMP}'
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper-example'
-# Timestamp for the genesis block.  This is the beginning of era 0. By this time, a sufficient majority (> 50% + F/2 —
-# see finality_threshold_percent below) of validator nodes must be up and running to start the blockchain.  This
-# timestamp is also used in seeding the pseudo-random number generator used in contract-runtime for computing genesis
-# post-state hash.
-timestamp = '${TIMESTAMP}'
 
 [core]
 # Era duration.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -3,21 +3,21 @@
 version = '1.0.0'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = false
-
-[protocol.activation_point]
-# This protocol version becomes active at the start of this era.
-era_id = 0
+# This protocol version becomes active at this point.
+#
+# If it is a timestamp string, it represents the timestamp for the genesis block.  This is the beginning of era 0.  By
+# this time, a sufficient majority (> 50% + F/2 — see finality_threshold_fraction below) of validator nodes must be up
+# and running to start the blockchain.  This timestamp is also used in seeding the pseudo-random number generator used
+# in contract-runtime for computing genesis post-state hash.
+#
+# If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
+activation_point = '2020-12-29T20:00:00Z'
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper-delta'
-# Timestamp for the genesis block.  This is the beginning of era 0. By this time, a sufficient majority (> 50% + F/2 —
-# see finality_threshold_percent below) of validator nodes must be up and running to start the blockchain.  This
-# timestamp is also used in seeding the pseudo-random number generator used in contract-runtime for computing genesis
-# post-state hash.
-timestamp = '2020-12-29T20:00:00Z'
 
 [core]
 # Era duration.

--- a/resources/production/validation.md5
+++ b/resources/production/validation.md5
@@ -1,2 +1,2 @@
 f4f487eaff9b6ae052c9679b7baab882  accounts.toml
-e2cf09f724df9cb3c10670d6d209efb6  chainspec.toml
+4a1276705c86aa26794a9a21dc46fafb  chainspec.toml

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -1,13 +1,10 @@
 [protocol]
 version = '0.9.0'
 hard_reset = false
-
-[protocol.activation_point]
-era_id = 0
+activation_point = '2020-09-18T18:45:00Z'
 
 [network]
 name = 'test-chain'
-timestamp = '2020-09-18T18:45:00Z'
 
 [core]
 era_duration = '3minutes'

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -1,13 +1,10 @@
 [protocol]
 version = '0.9.0'
 hard_reset = false
-
-[protocol.activation_point]
-era_id = 0
+activation_point = '2020-09-18T18:45:00Z'
 
 [network]
 name = 'test-chain'
-timestamp = '2020-09-18T18:45:00Z'
 
 [core]
 era_duration = '3minutes'

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -1,13 +1,10 @@
 [protocol]
 version = '1.0.0'
 hard_reset = false
-
-[protocol.activation_point]
-era_id = 1
+activation_point = 1
 
 [network]
 name = 'test-chain'
-timestamp = '2020-09-18T18:45:00Z'
 
 [core]
 era_duration = '3minutes'

--- a/utils/casper-tool/casper-tool.py
+++ b/utils/casper-tool/casper-tool.py
@@ -232,8 +232,8 @@ def create_chainspec(template, network_name, genesis_in, contract_paths):
 
     # Update the chainspec.
     show_val("Genesis", "{} (in {} seconds)".format(genesis_timestamp, genesis_in))
+    chainspec["protocol"]["activation_point"] = genesis_timestamp
     chainspec["network"]["name"] = network_name
-    chainspec["network"]["timestamp"] = genesis_timestamp
 
     # Setup WASM contracts.
     for contract in CONTRACTS:
@@ -304,7 +304,7 @@ def create_accounts_toml(output_file, pubkeys):
             'bonded_amount': f'{weight}'
         }
         accounts += [account]
-    
+
     toml.dump(accounts, output_file)
 
 

--- a/utils/nctl/sh/assets/setup.sh
+++ b/utils/nctl/sh/assets/setup.sh
@@ -32,7 +32,7 @@ function _set_net_bin()
 	for CONTRACT in "${NCTL_CONTRACTS_CLIENT[@]}"
 	do
         cp "$NCTL_CASPER_HOME"/target/wasm32-unknown-unknown/release/"$CONTRACT" "$PATH_TO_BIN"
-	done    
+	done
 }
 
 #######################################
@@ -64,8 +64,8 @@ function _set_net_chainspec()
     local SCRIPT=(
         "import toml;"
         "cfg=toml.load('$PATH_TO_CHAINSPEC_FILE');"
+        "cfg['protocol']['activation_point']='$(get_genesis_timestamp "$GENESIS_DELAY")';"
         "cfg['network']['name']='$(get_chain_name)';"
-        "cfg['network']['timestamp']='$(get_genesis_timestamp "$GENESIS_DELAY")';"
         "cfg['core']['validator_slots']=$((COUNT_GENESIS_NODES * 2));"
         "toml.dump(cfg, open('$PATH_TO_CHAINSPEC_FILE', 'w'));"
     )
@@ -98,7 +98,7 @@ function _set_chainspec_account()
 public_key = "${ACCOUNT_KEY}"
 balance = "$INITIAL_BALANCE"
 EOM
-    
+
     if [ "$INITIAL_WEIGHT" != '0' ]; then
         cat >> "$PATH_TO_NET"/chainspec/accounts.toml <<- EOM
 [accounts.validator]
@@ -230,7 +230,7 @@ function _set_net_users()
             "$NCTL_CASPER_HOME"/target/debug/casper-client keygen -f "$PATH_TO_NET"/users/user-"$USER_ID" > /dev/null 2>&1
         else
             "$NCTL_CASPER_HOME"/target/release/casper-client keygen -f "$PATH_TO_NET"/users/user-"$USER_ID" > /dev/null 2>&1
-        fi    
+        fi
     done
 
     # Set user accounts.
@@ -238,7 +238,7 @@ function _set_net_users()
     do
         _set_chainspec_account_for_user \
             "$PATH_TO_NET"/users/user-"$USER_ID"/public_key_hex \
-            "$NCTL_INITIAL_BALANCE_USER" 
+            "$NCTL_INITIAL_BALANCE_USER"
     done
 }
 
@@ -260,7 +260,7 @@ function _set_nodes()
     for NODE_ID in $(seq 1 $((COUNT_GENESIS_NODES * 2)))
     do
         setup_node "$NODE_ID" "$COUNT_GENESIS_NODES"
-    done   
+    done
 }
 
 #######################################


### PR DESCRIPTION
This PR unifies the genesis timestamp and upgrade activation point into a single enum type.

During a discussion with @EdHastingsCasperLabs, it was noted that genesis timestamps for all chainspecs after the genesis one become meaningless and could be omitted.  Conceptually, the genesis timestamp can be considered the activation point for the first version, hence it seems natural to absorb it into the activation point type.