### PR TITLE
NO-TICKET: fix gossip metrics

### DIFF
--- a/node/src/components/block_executor/metrics.rs
+++ b/node/src/components/block_executor/metrics.rs
@@ -1,15 +1,17 @@
 use prometheus::{IntGauge, Registry};
 
+use crate::unregister_metric;
+
 #[derive(Debug, Clone)]
-pub struct BlockExecutorMetrics {
+pub(super) struct BlockExecutorMetrics {
     /// The current chain height.
-    pub chain_height: IntGauge,
+    pub(super) chain_height: IntGauge,
     /// registry component.
     registry: Registry,
 }
 
 impl BlockExecutorMetrics {
-    pub fn new(registry: Registry) -> Result<Self, prometheus::Error> {
+    pub(super) fn new(registry: Registry) -> Result<Self, prometheus::Error> {
         let chain_height = IntGauge::new("chain_height", "current chain height")?;
         registry.register(Box::new(chain_height.clone()))?;
         Ok(BlockExecutorMetrics {
@@ -21,9 +23,7 @@ impl BlockExecutorMetrics {
 
 impl Drop for BlockExecutorMetrics {
     fn drop(&mut self) {
-        self.registry
-            .unregister(Box::new(self.chain_height.clone()))
-            .expect("did not expect deregistering chain_height to fail");
+        unregister_metric!(self.registry, self.chain_height);
     }
 }
 

--- a/node/src/components/block_proposer/metrics.rs
+++ b/node/src/components/block_proposer/metrics.rs
@@ -1,9 +1,11 @@
 use datasize::DataSize;
 use prometheus::{self, IntGauge, Registry};
 
+use crate::unregister_metric;
+
 /// Metrics for the block proposer.
 #[derive(DataSize, Debug, Clone)]
-pub struct BlockProposerMetrics {
+pub(super) struct BlockProposerMetrics {
     /// Amount of pending deploys
     #[data_size(skip)]
     pub(super) pending_deploys: IntGauge,
@@ -26,8 +28,6 @@ impl BlockProposerMetrics {
 
 impl Drop for BlockProposerMetrics {
     fn drop(&mut self) {
-        self.registry
-            .unregister(Box::new(self.pending_deploys.clone()))
-            .expect("did not expect deregistering pending_deploys to fail");
+        unregister_metric!(self.registry, self.pending_deploys);
     }
 }

--- a/node/src/components/gossiper.rs
+++ b/node/src/components/gossiper.rs
@@ -170,17 +170,17 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
         })
     }
 
-    /// Handles a new item received from a peer or client.
+    /// Handles a new item received from a peer or client for which we should begin gossiping.
+    ///
+    /// Note that this doesn't include items gossiped to us; those are handled in `handle_gossip()`.
     fn handle_item_received(
         &mut self,
         effect_builder: EffectBuilder<REv>,
         item_id: T::Id,
         source: Source<NodeId>,
     ) -> Effects<Event<T>> {
-        self.metrics.items_received.inc();
-
         if let Some(should_gossip) = self.table.new_complete_data(&item_id, source.node_id()) {
-            self.metrics.items_gossiped_onwards.inc();
+            self.metrics.items_received.inc();
             self.gossip(
                 effect_builder,
                 item_id,
@@ -218,6 +218,7 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
         requested_count: usize,
         peers: HashSet<NodeId>,
     ) -> Effects<Event<T>> {
+        self.metrics.times_gossiped.inc_by(peers.len() as i64);
         // We don't have any peers to gossip to, so pause the process, which will eventually result
         // in the entry being removed.
         if peers.is_empty() {
@@ -339,6 +340,7 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
 
         match action {
             GossipAction::ShouldGossip(should_gossip) => {
+                self.metrics.items_received.inc();
                 // Gossip the item ID.
                 let mut effects = self.gossip(
                     effect_builder,
@@ -365,6 +367,7 @@ impl<T: Item + 'static, REv: ReactorEventT<T>> Gossiper<T, REv> {
                 effects
             }
             GossipAction::GetRemainder { .. } => {
+                self.metrics.items_received.inc();
                 // Send a response to the sender indicating we want the full item from them, and set
                 // a timeout for this response.
                 let reply = Message::GossipResponse {

--- a/node/src/components/gossiper/metrics.rs
+++ b/node/src/components/gossiper/metrics.rs
@@ -1,5 +1,7 @@
 use prometheus::{IntCounter, IntGauge, Registry};
 
+use crate::unregister_metric;
+
 /// Metrics for the gossiper component.
 #[derive(Debug)]
 pub struct GossiperMetrics {
@@ -80,23 +82,11 @@ impl GossiperMetrics {
 
 impl Drop for GossiperMetrics {
     fn drop(&mut self) {
-        self.registry
-            .unregister(Box::new(self.items_received.clone()))
-            .expect("did not expect deregistering items_received to fail");
-        self.registry
-            .unregister(Box::new(self.times_gossiped.clone()))
-            .expect("did not expect deregistering times_gossiped to fail");
-        self.registry
-            .unregister(Box::new(self.times_ran_out_of_peers.clone()))
-            .expect("did not expect deregistering times_ran_out_of_peers to fail");
-        self.registry
-            .unregister(Box::new(self.table_items_paused.clone()))
-            .expect("did not expect deregistering table_items_paused to fail");
-        self.registry
-            .unregister(Box::new(self.table_items_current.clone()))
-            .expect("did not expect deregistering table_items_current to fail");
-        self.registry
-            .unregister(Box::new(self.table_items_finished.clone()))
-            .expect("did not expect deregistering table_items_finished to fail");
+        unregister_metric!(self.registry, self.items_received);
+        unregister_metric!(self.registry, self.times_gossiped);
+        unregister_metric!(self.registry, self.times_ran_out_of_peers);
+        unregister_metric!(self.registry, self.table_items_paused);
+        unregister_metric!(self.registry, self.table_items_current);
+        unregister_metric!(self.registry, self.table_items_finished);
     }
 }

--- a/node/src/components/gossiper/metrics.rs
+++ b/node/src/components/gossiper/metrics.rs
@@ -5,8 +5,8 @@ use prometheus::{IntCounter, IntGauge, Registry};
 pub struct GossiperMetrics {
     /// Total number of items received by the gossiper.
     pub(super) items_received: IntCounter,
-    /// Total number of items gossiped onwards after receiving.
-    pub(super) items_gossiped_onwards: IntCounter,
+    /// Total number of gossip requests sent to peers.
+    pub(super) times_gossiped: IntCounter,
     /// Number of times the process had to pause due to running out of peers.
     pub(super) times_ran_out_of_peers: IntCounter,
     /// Number of items in the gossip table that are paused.
@@ -24,22 +24,16 @@ impl GossiperMetrics {
     pub fn new(name: &str, registry: &Registry) -> Result<Self, prometheus::Error> {
         let items_received = IntCounter::new(
             format!("{}_items_received", name),
-            format!(
-                "number of items received by the {} gossiper component",
-                name
-            ),
+            format!("number of items received by the {}", name),
         )?;
-        let items_gossiped_onwards = IntCounter::new(
-            format!("{}_items_gossiped_onwards", name),
-            format!(
-                "number of items received by the {} that were received and gossiped onwards",
-                name
-            ),
+        let times_gossiped = IntCounter::new(
+            format!("{}_times_gossiped", name),
+            format!("number of times the {} sent gossip requests to peers", name),
         )?;
         let times_ran_out_of_peers = IntCounter::new(
             format!("{}_times_ran_out_of_peers", name),
             format!(
-                "number of times the {} gossiper ran out of peers and had to pause",
+                "number of times the {} ran out of peers and had to pause",
                 name
             ),
         )?;
@@ -66,7 +60,7 @@ impl GossiperMetrics {
         )?;
 
         registry.register(Box::new(items_received.clone()))?;
-        registry.register(Box::new(items_gossiped_onwards.clone()))?;
+        registry.register(Box::new(times_gossiped.clone()))?;
         registry.register(Box::new(times_ran_out_of_peers.clone()))?;
         registry.register(Box::new(table_items_paused.clone()))?;
         registry.register(Box::new(table_items_current.clone()))?;
@@ -74,7 +68,7 @@ impl GossiperMetrics {
 
         Ok(GossiperMetrics {
             items_received,
-            items_gossiped_onwards,
+            times_gossiped,
             times_ran_out_of_peers,
             table_items_paused,
             table_items_current,
@@ -90,8 +84,8 @@ impl Drop for GossiperMetrics {
             .unregister(Box::new(self.items_received.clone()))
             .expect("did not expect deregistering items_received to fail");
         self.registry
-            .unregister(Box::new(self.items_gossiped_onwards.clone()))
-            .expect("did not expect deregistering items_gossiped_onwards to fail");
+            .unregister(Box::new(self.times_gossiped.clone()))
+            .expect("did not expect deregistering times_gossiped to fail");
         self.registry
             .unregister(Box::new(self.times_ran_out_of_peers.clone()))
             .expect("did not expect deregistering times_ran_out_of_peers to fail");

--- a/node/src/components/networking_metrics.rs
+++ b/node/src/components/networking_metrics.rs
@@ -1,27 +1,29 @@
 use prometheus::{IntCounter, IntGauge, Registry};
 
+use crate::unregister_metric;
+
 /// Network-type agnostic networking metrics.
-pub(crate) struct NetworkingMetrics {
+pub(super) struct NetworkingMetrics {
     /// How often a request was made by a component to broadcast.
-    pub(crate) broadcast_requests: IntCounter,
+    pub(super) broadcast_requests: IntCounter,
     /// How often a request to send a message directly to a peer was made.
-    pub(crate) direct_message_requests: IntCounter,
+    pub(super) direct_message_requests: IntCounter,
     /// Current number of open connections.
-    pub(crate) open_connections: IntGauge,
+    pub(super) open_connections: IntGauge,
     /// Number of messages still waiting to be sent out (broadcast and direct).
-    pub(crate) queued_messages: IntGauge,
+    pub(super) queued_messages: IntGauge,
     /// Number of connected peers.
-    pub(crate) peers: IntGauge,
+    pub(super) peers: IntGauge,
 
     // Potentially temporary metrics, not supported by all networking components:
     /// Number of do-nothing futures that have not finished executing for read requests.
-    pub(crate) read_futures_in_flight: prometheus::Gauge,
+    pub(super) read_futures_in_flight: prometheus::Gauge,
     /// Number of do-nothing futures created total (read).
-    pub(crate) read_futures_total: prometheus::Gauge,
-    /// Number of do-nothing futures that have not finished executing for write reponses.
-    pub(crate) write_futures_in_flight: prometheus::Gauge,
+    pub(super) read_futures_total: prometheus::Gauge,
+    /// Number of do-nothing futures that have not finished executing for write responses.
+    pub(super) write_futures_in_flight: prometheus::Gauge,
     /// Number of do-nothing futures created total (write).
-    pub(crate) write_futures_total: prometheus::Gauge,
+    pub(super) write_futures_total: prometheus::Gauge,
 
     /// Registry instance.
     registry: Registry,
@@ -29,7 +31,7 @@ pub(crate) struct NetworkingMetrics {
 
 impl NetworkingMetrics {
     /// Creates a new instance of networking metrics.
-    pub fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
+    pub(super) fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
         let broadcast_requests =
             IntCounter::new("net_broadcast_requests", "number of broadcasting requests")?;
         let direct_message_requests = IntCounter::new(
@@ -89,33 +91,14 @@ impl NetworkingMetrics {
 
 impl Drop for NetworkingMetrics {
     fn drop(&mut self) {
-        self.registry
-            .unregister(Box::new(self.broadcast_requests.clone()))
-            .expect("did not expect deregistering broadcast_requests to fail");
-        self.registry
-            .unregister(Box::new(self.direct_message_requests.clone()))
-            .expect("did not expect deregistering direct_message_requests to fail");
-        self.registry
-            .unregister(Box::new(self.open_connections.clone()))
-            .expect("did not expect deregistering open_connnections to fail");
-        self.registry
-            .unregister(Box::new(self.queued_messages.clone()))
-            .expect("did not expect deregistering queued_direct_messages to fail");
-        self.registry
-            .unregister(Box::new(self.peers.clone()))
-            .expect("did not expect deregistering peers to fail");
-
-        self.registry
-            .unregister(Box::new(self.read_futures_in_flight.clone()))
-            .expect("did not expect deregistering in_flight_read_futures to fail");
-        self.registry
-            .unregister(Box::new(self.read_futures_total.clone()))
-            .expect("did not expect deregistering total_read_futures to fail");
-        self.registry
-            .unregister(Box::new(self.write_futures_in_flight.clone()))
-            .expect("did not expect deregistering in_flight_write_futures to fail");
-        self.registry
-            .unregister(Box::new(self.write_futures_total.clone()))
-            .expect("did not expect deregistering total_write_futures to fail");
+        unregister_metric!(self.registry, self.broadcast_requests);
+        unregister_metric!(self.registry, self.direct_message_requests);
+        unregister_metric!(self.registry, self.open_connections);
+        unregister_metric!(self.registry, self.queued_messages);
+        unregister_metric!(self.registry, self.peers);
+        unregister_metric!(self.registry, self.read_futures_in_flight);
+        unregister_metric!(self.registry, self.read_futures_total);
+        unregister_metric!(self.registry, self.write_futures_in_flight);
+        unregister_metric!(self.registry, self.write_futures_total);
     }
 }

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -48,7 +48,7 @@ use futures::{future::BoxFuture, FutureExt};
 use jemalloc_ctl::{epoch as jemalloc_epoch, stats::allocated as jemalloc_allocated};
 use once_cell::sync::Lazy;
 use prometheus::{self, Histogram, HistogramOpts, IntCounter, IntGauge, Registry};
-use quanta::IntoNanoseconds;
+use quanta::{Clock, IntoNanoseconds};
 use serde::Serialize;
 use signal_hook::consts::signal::{SIGINT, SIGQUIT, SIGTERM};
 use tokio::time::{Duration, Instant};
@@ -59,12 +59,12 @@ use utils::rlimit::{Limit, OpenFiles, ResourceLimit};
 use crate::{
     effect::{Effect, EffectBuilder, Effects},
     types::{ExitCode, Timestamp},
+    unregister_metric,
     utils::{self, WeightedRoundRobin},
     NodeRng, QUEUE_DUMP_REQUESTED, TERMINATION_REQUESTED,
 };
 #[cfg(test)]
 use crate::{reactor::initializer::Reactor as InitializerReactor, types::Chainspec};
-use quanta::Clock;
 pub use queue_kind::QueueKind;
 
 /// Optional upper threshold for total RAM allocated in mB before dumping queues to disk.
@@ -277,21 +277,16 @@ where
 struct RunnerMetrics {
     /// Total number of events processed.
     events: IntCounter,
-
     /// Histogram of how long it took to dispatch an event.
     event_dispatch_duration: Histogram,
-
-    /// Handle to the metrics registry, in case we need to unregister.
-    registry: Registry,
-
     /// Total allocated RAM in bytes, as reported by jemalloc.
     allocated_ram_bytes: IntGauge,
-
     /// Total consumed RAM in bytes, as reported by sys-info.
     consumed_ram_bytes: IntGauge,
-
     /// Total system RAM in bytes, as reported by sys-info.
     total_ram_bytes: IntGauge,
+    /// Handle to the metrics registry, in case we need to unregister.
+    registry: Registry,
 }
 
 impl RunnerMetrics {
@@ -353,21 +348,11 @@ impl RunnerMetrics {
 
 impl Drop for RunnerMetrics {
     fn drop(&mut self) {
-        self.registry
-            .unregister(Box::new(self.events.clone()))
-            .expect("did not expect deregistering events to fail");
-        self.registry
-            .unregister(Box::new(self.event_dispatch_duration.clone()))
-            .expect("did not expect deregistering event_dispatch_duration to fail");
-        self.registry
-            .unregister(Box::new(self.allocated_ram_bytes.clone()))
-            .expect("did not expect deregistering allocated_ram_bytes to fail");
-        self.registry
-            .unregister(Box::new(self.consumed_ram_bytes.clone()))
-            .expect("did not expect deregistering consumed_ram_bytes to fail");
-        self.registry
-            .unregister(Box::new(self.total_ram_bytes.clone()))
-            .expect("did not expect deregistering total_ram_bytes to fail");
+        unregister_metric!(self.registry, self.events);
+        unregister_metric!(self.registry, self.event_dispatch_duration);
+        unregister_metric!(self.registry, self.allocated_ram_bytes);
+        unregister_metric!(self.registry, self.consumed_ram_bytes);
+        unregister_metric!(self.registry, self.total_ram_bytes);
     }
 }
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -334,34 +334,34 @@ impl Display for Event {
 /// Joining node reactor.
 #[derive(DataSize)]
 pub struct Reactor {
-    pub(super) metrics: Metrics,
-    pub(super) network: Network<Event, Message>,
-    pub(super) small_network: SmallNetwork<Event, Message>,
-    pub(super) address_gossiper: Gossiper<GossipedAddress, Event>,
-    pub(super) config: validator::Config,
-    pub(super) chainspec_loader: ChainspecLoader,
-    pub(super) storage: Storage,
-    pub(super) contract_runtime: ContractRuntime,
-    pub(super) linear_chain_fetcher: Fetcher<Block>,
-    pub(super) linear_chain_sync: LinearChainSync<NodeId>,
-    pub(super) block_validator: BlockValidator<Block, NodeId>,
-    pub(super) deploy_fetcher: Fetcher<Deploy>,
-    pub(super) block_executor: BlockExecutor,
-    pub(super) linear_chain: linear_chain::LinearChain<NodeId>,
-    pub(super) consensus: EraSupervisor<NodeId>,
+    metrics: Metrics,
+    network: Network<Event, Message>,
+    small_network: SmallNetwork<Event, Message>,
+    address_gossiper: Gossiper<GossipedAddress, Event>,
+    config: validator::Config,
+    chainspec_loader: ChainspecLoader,
+    storage: Storage,
+    contract_runtime: ContractRuntime,
+    linear_chain_fetcher: Fetcher<Block>,
+    linear_chain_sync: LinearChainSync<NodeId>,
+    block_validator: BlockValidator<Block, NodeId>,
+    deploy_fetcher: Fetcher<Deploy>,
+    block_executor: BlockExecutor,
+    linear_chain: linear_chain::LinearChain<NodeId>,
+    consensus: EraSupervisor<NodeId>,
     // Handles request for linear chain block by height.
-    pub(super) block_by_height_fetcher: Fetcher<BlockByHeight>,
+    block_by_height_fetcher: Fetcher<BlockByHeight>,
     #[data_size(skip)]
-    pub(super) deploy_acceptor: DeployAcceptor,
+    deploy_acceptor: DeployAcceptor,
     #[data_size(skip)]
     event_queue_metrics: EventQueueMetrics,
     #[data_size(skip)]
-    pub(super) rest_server: RestServer,
+    rest_server: RestServer,
     #[data_size(skip)]
-    pub(super) event_stream_server: EventStreamServer,
+    event_stream_server: EventStreamServer,
     // Attach memory metrics for the joiner.
     #[data_size(skip)] // Never allocates data on the heap.
-    pub(super) memory_metrics: MemoryMetrics,
+    memory_metrics: MemoryMetrics,
 }
 
 impl reactor::Reactor for Reactor {

--- a/node/src/reactor/joiner/memory_metrics.rs
+++ b/node/src/reactor/joiner/memory_metrics.rs
@@ -1,12 +1,13 @@
 use datasize::DataSize;
 use prometheus::{self, Histogram, HistogramOpts, IntGauge, Registry};
-use tracing::{debug, warn};
+use tracing::debug;
 
 use super::Reactor;
+use crate::unregister_metric;
 
 ///Metrics for memory usage for the joiner
 #[derive(Debug)]
-pub struct MemoryMetrics {
+pub(super) struct MemoryMetrics {
     /// Total estimated heap memory usage.
     mem_total: IntGauge,
 
@@ -224,71 +225,22 @@ impl MemoryMetrics {
 
 impl Drop for MemoryMetrics {
     fn drop(&mut self) {
-        self.registry
-            .unregister(Box::new(self.mem_total.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect mem_total to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_metrics.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering joiner_mem_metrics to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_network.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering joiner_mem_network to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_small_network.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering joiner_mem_small_network to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_address_gossiper.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering joiner_mem_address_gossiper to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_config.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering joiner_mem_config to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_chainspec_loader.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering joiner_mem_chainspec_loader to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_storage.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering joiner_mem_storage to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_contract_runtime.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering joiner_mem_contract_runtime to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_linear_chain_fetcher.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering joiner_mem_linear_chain_fetcher to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_linear_chain_sync.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering joiner_mem_linear_chain_sync to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_block_validator.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering joiner_mem_block_validator to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_deploy_fetcher.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering joiner_mem_deploy_fetcher to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_block_executor.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering joiner_mem_block_executor to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_linear_chain.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering joiner_mem_linear_chain to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_consensus.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering joiner_mem_consensus to fail"),
-            );
+        unregister_metric!(self.registry, self.mem_total);
+        unregister_metric!(self.registry, self.mem_metrics);
+        unregister_metric!(self.registry, self.mem_network);
+        unregister_metric!(self.registry, self.mem_small_network);
+        unregister_metric!(self.registry, self.mem_address_gossiper);
+        unregister_metric!(self.registry, self.mem_config);
+        unregister_metric!(self.registry, self.mem_chainspec_loader);
+        unregister_metric!(self.registry, self.mem_storage);
+        unregister_metric!(self.registry, self.mem_contract_runtime);
+        unregister_metric!(self.registry, self.mem_linear_chain_fetcher);
+        unregister_metric!(self.registry, self.mem_linear_chain_sync);
+        unregister_metric!(self.registry, self.mem_block_validator);
+        unregister_metric!(self.registry, self.mem_deploy_fetcher);
+        unregister_metric!(self.registry, self.mem_block_executor);
+        unregister_metric!(self.registry, self.mem_linear_chain);
+        unregister_metric!(self.registry, self.mem_consensus);
+        unregister_metric!(self.registry, self.mem_estimator_runtime_s);
     }
 }

--- a/node/src/reactor/validator/memory_metrics.rs
+++ b/node/src/reactor/validator/memory_metrics.rs
@@ -2,11 +2,10 @@ use std::env;
 
 use datasize::DataSize;
 use prometheus::{self, Histogram, HistogramOpts, IntGauge, Registry};
-use tracing::{debug, warn};
-
-use crate::components::network::ENABLE_LIBP2P_NET_ENV_VAR;
+use tracing::debug;
 
 use super::Reactor;
+use crate::{components::network::ENABLE_LIBP2P_NET_ENV_VAR, unregister_metric};
 
 /// Metrics for memory usage.
 #[derive(Debug)]
@@ -237,78 +236,23 @@ impl MemoryMetrics {
 
 impl Drop for MemoryMetrics {
     fn drop(&mut self) {
-        self.registry
-            .unregister(Box::new(self.mem_total.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering mem_total, to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_metrics.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering mem_metrics, to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_net.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering mem_net, to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_address_gossiper.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_address_gossiper, to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_storage.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering mem_storage, to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_contract_runtime.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_contract_runtime, to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_rpc_server.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_rpc_server, to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_rest_server.clone()))
-            .expect("did not expect deregistering mem_rest_server, to fail");
-        self.registry
-            .unregister(Box::new(self.mem_event_stream_server.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_event_stream_server, to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_chainspec_loader.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_chainspec_loader, to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_consensus.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_consensus, to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_deploy_fetcher.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_deploy_fetcher, to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_deploy_gossiper.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_deploy_gossiper, to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_block_proposer.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_block_proposer, to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_block_executor.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_block_executor, to fail"),
-            );
-        self.registry
-            .unregister(Box::new(self.mem_proto_block_validator.clone()))
-            .unwrap_or_else(|err| warn!(%err, "did not expect deregistering mem_proto_block_validator, to fail"));
-        self.registry
-            .unregister(Box::new(self.mem_linear_chain.clone()))
-            .unwrap_or_else(
-                |err| warn!(%err, "did not expect deregistering mem_linear_chain, to fail"),
-            );
+        unregister_metric!(self.registry, self.mem_total);
+        unregister_metric!(self.registry, self.mem_metrics);
+        unregister_metric!(self.registry, self.mem_net);
+        unregister_metric!(self.registry, self.mem_address_gossiper);
+        unregister_metric!(self.registry, self.mem_storage);
+        unregister_metric!(self.registry, self.mem_contract_runtime);
+        unregister_metric!(self.registry, self.mem_rpc_server);
+        unregister_metric!(self.registry, self.mem_rest_server);
+        unregister_metric!(self.registry, self.mem_event_stream_server);
+        unregister_metric!(self.registry, self.mem_chainspec_loader);
+        unregister_metric!(self.registry, self.mem_consensus);
+        unregister_metric!(self.registry, self.mem_deploy_fetcher);
+        unregister_metric!(self.registry, self.mem_deploy_gossiper);
+        unregister_metric!(self.registry, self.mem_block_proposer);
+        unregister_metric!(self.registry, self.mem_block_executor);
+        unregister_metric!(self.registry, self.mem_proto_block_validator);
+        unregister_metric!(self.registry, self.mem_linear_chain);
+        unregister_metric!(self.registry, self.mem_estimator_runtime_s);
     }
 }

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -301,3 +301,18 @@ where
 {
     (numerator + denominator / T::from(2)) / denominator
 }
+
+/// Used to unregister a metric from the Prometheus registry.
+#[macro_export]
+macro_rules! unregister_metric {
+    ($registry:expr, $metric:expr) => {
+        $registry
+            .unregister(Box::new($metric.clone()))
+            .unwrap_or_else(|_| {
+                tracing::error!(
+                    "unregistering {} failed: was not registered",
+                    stringify!($metric)
+                )
+            });
+    };
+}


### PR DESCRIPTION
This PR fixes the gossiper metrics, some of which are fairly useless at the moment.

* `items_received` now correctly represents the total of all gossip items received, whether passed to the component by a client, by a different component (e.g. the small network in the case of starting a new round of gossiping its own address) or by a peer gossiping it.
* `items_gossiped_onwards` has been replaced by `times_gossiped` and now represents the total number of outbound gossip messages the node has sent.

It also standardises the unregistering of metrics from the Prometheus registry to remove the risky calls to `expect` in the `Drop` impls of many of the metrics structs.  If there are objections to the introduction of a macro to achieve this, I would be happy to change it back to normal function calls.

Tagging @sacherjj & @TomVasile for info.