### PR TITLE
EEE-1188: Restore delegator slashing

### DIFF
--- a/types/src/system/auction/delegator.rs
+++ b/types/src/system/auction/delegator.rs
@@ -66,6 +66,11 @@ impl Delegator {
         &self.staked_amount
     }
 
+    /// Returns the mutable staked amount
+    pub fn staked_amount_mut(&mut self) -> &mut U512 {
+        &mut self.staked_amount
+    }
+
     /// Returns the bonding purse
     pub fn bonding_purse(&self) -> &URef {
         &self.bonding_purse

--- a/types/src/system/auction/mod.rs
+++ b/types/src/system/auction/mod.rs
@@ -326,6 +326,10 @@ pub trait Auction:
                 burned_amount += *bid.staked_amount();
                 *bid.staked_amount_mut() = U512::zero();
                 bid.deactivate();
+                // Reset delegator stakes when deactivating validator bid.
+                for delegator in bid.delegators_mut().values_mut() {
+                    *delegator.staked_amount_mut() = U512::zero();
+                }
                 self.write_bid(validator_account_hash, bid)?;
             };
 


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1188

- Sets all delegator stakes to 0 for slashed validator
- Adds a test that ensures delegators of a validator have their stake set to 0 after slashing