### PR TITLE
NDRS-963: chainspec loader now gets the protocol version from the highest block

### DIFF
--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -164,16 +164,17 @@ impl Reactor {
         let contract_runtime =
             ContractRuntime::new(storage_config, &config.value().contract_runtime, registry)?;
 
-        if let Some(state_roots) = storage.get_state_root_hashes_for_trie_check() {
-            let missing_trie_keys = contract_runtime.trie_store_check(state_roots.clone());
-            if !missing_trie_keys.is_empty() {
-                panic!(
-                    "Fatal error! Trie-Key store is not empty.\n {:?}\n \
-                    Wipe the DB to ensure operations.\n Present state_roots: {:?}",
-                    missing_trie_keys, state_roots
-                )
-            }
-        }
+        // TODO - re-enable in some form after deciding how to reduce the time this takes
+        // if let Some(state_roots) = storage.get_state_root_hashes_for_trie_check() {
+        //     let missing_trie_keys = contract_runtime.trie_store_check(state_roots.clone());
+        //     if !missing_trie_keys.is_empty() {
+        //         panic!(
+        //             "Fatal error! Trie-Key store is not empty.\n {:?}\n \
+        //             Wipe the DB to ensure operations.\n Present state_roots: {:?}",
+        //             missing_trie_keys, state_roots
+        //         )
+        //     }
+        // }
 
         let effects = reactor::wrap_effects(Event::Chainspec, chainspec_effects);
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -712,11 +712,6 @@ impl BlockHeader {
         self.accumulated_seed
     }
 
-    /// The timestamp from when the proto block was proposed.
-    pub fn timestamp(&self) -> Timestamp {
-        self.timestamp
-    }
-
     /// Returns reward and slashing information if this is the era's last block.
     pub fn era_end(&self) -> Option<&EraReport> {
         match &self.era_end {
@@ -725,9 +720,9 @@ impl BlockHeader {
         }
     }
 
-    /// Returns `true` if this block is the last one in the current era.
-    pub fn is_switch_block(&self) -> bool {
-        self.era_end.is_some()
+    /// The timestamp from when the proto block was proposed.
+    pub fn timestamp(&self) -> Timestamp {
+        self.timestamp
     }
 
     /// Era ID in which this block was created.
@@ -738,6 +733,16 @@ impl BlockHeader {
     /// Returns the height of this block, i.e. the number of ancestors.
     pub fn height(&self) -> u64 {
         self.height
+    }
+
+    /// Returns the protocol version of the network from when this block was created.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
+
+    /// Returns `true` if this block is the last one in the current era.
+    pub fn is_switch_block(&self) -> bool {
+        self.era_end.is_some()
     }
 
     /// The validators for the upcoming era and their respective weights.
@@ -751,6 +756,13 @@ impl BlockHeader {
         }
     }
 
+    /// Hash of the block header.
+    pub fn hash(&self) -> BlockHash {
+        let serialized_header = Self::serialize(&self)
+            .unwrap_or_else(|error| panic!("should serialize block header: {}", error));
+        BlockHash::new(hash::hash(&serialized_header))
+    }
+
     /// Returns true if block is Genesis' child.
     /// Genesis child block is from era 0 and height 0.
     pub(crate) fn is_genesis_child(&self) -> bool {
@@ -760,13 +772,6 @@ impl BlockHeader {
     // Serialize the block header.
     fn serialize(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         self.to_bytes()
-    }
-
-    /// Hash of the block header.
-    pub fn hash(&self) -> BlockHash {
-        let serialized_header = Self::serialize(&self)
-            .unwrap_or_else(|error| panic!("should serialize block header: {}", error));
-        BlockHash::new(hash::hash(&serialized_header))
     }
 }
 


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-963

This PR fixes an issue whereby a restarting node on a network which has upgraded would call the contract runtime's `commit_upgrade()` with an incorrect `current_version`.  Rather than storing the protocol version in storage and using that on restart, we now use the protocol version from the highest block now that it is available to us.

The PR also temporarily disables the trie store check as it is too slow to support as is.  It will be re-enabled in some form once a decision on how to address this issue permanently has been made.