### PR TITLE
 EE-1192: store unbonds under Key::Withdraw

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -20,15 +20,14 @@ use casper_types::{
     system::{
         auction::{
             Bid, Bids, DelegationRate, Delegator, SeigniorageRecipient, SeigniorageRecipients,
-            SeigniorageRecipientsSnapshot, UnbondingPurses, ValidatorWeights, ARG_DELEGATION_RATE,
-            ARG_DELEGATOR, ARG_ERA_END_TIMESTAMP_MILLIS, ARG_PUBLIC_KEY, ARG_REWARD_FACTORS,
-            ARG_VALIDATOR, ARG_VALIDATOR_PUBLIC_KEY, AUCTION_DELAY_KEY,
-            DELEGATION_RATE_DENOMINATOR, ERA_END_TIMESTAMP_MILLIS_KEY, ERA_ID_KEY,
-            INITIAL_ERA_END_TIMESTAMP_MILLIS, INITIAL_ERA_ID, LOCKED_FUNDS_PERIOD_KEY,
-            METHOD_ACTIVATE_BID, METHOD_ADD_BID, METHOD_DELEGATE, METHOD_DISTRIBUTE,
-            METHOD_GET_ERA_VALIDATORS, METHOD_READ_ERA_ID, METHOD_RUN_AUCTION, METHOD_SLASH,
-            METHOD_UNDELEGATE, METHOD_WITHDRAW_BID, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
-            UNBONDING_DELAY_KEY, UNBONDING_PURSES_KEY, VALIDATOR_SLOTS_KEY,
+            SeigniorageRecipientsSnapshot, ValidatorWeights, ARG_DELEGATION_RATE, ARG_DELEGATOR,
+            ARG_ERA_END_TIMESTAMP_MILLIS, ARG_PUBLIC_KEY, ARG_REWARD_FACTORS, ARG_VALIDATOR,
+            ARG_VALIDATOR_PUBLIC_KEY, AUCTION_DELAY_KEY, DELEGATION_RATE_DENOMINATOR,
+            ERA_END_TIMESTAMP_MILLIS_KEY, ERA_ID_KEY, INITIAL_ERA_END_TIMESTAMP_MILLIS,
+            INITIAL_ERA_ID, LOCKED_FUNDS_PERIOD_KEY, METHOD_ACTIVATE_BID, METHOD_ADD_BID,
+            METHOD_DELEGATE, METHOD_DISTRIBUTE, METHOD_GET_ERA_VALIDATORS, METHOD_READ_ERA_ID,
+            METHOD_RUN_AUCTION, METHOD_SLASH, METHOD_UNDELEGATE, METHOD_WITHDRAW_BID,
+            SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_DELAY_KEY, VALIDATOR_SLOTS_KEY,
         },
         handle_payment::{
             self, ARG_ACCOUNT, METHOD_FINALIZE_PAYMENT, METHOD_GET_PAYMENT_PURSE,
@@ -1025,19 +1024,6 @@ where
                 StoredValue::Bid(Box::new(bid)),
             )
         }
-
-        let unbonding_purses_uref = self
-            .uref_address_generator
-            .borrow_mut()
-            .new_uref(AccessRights::READ_ADD_WRITE);
-        self.tracking_copy.borrow_mut().write(
-            unbonding_purses_uref.into(),
-            StoredValue::CLValue(
-                CLValue::from_t(UnbondingPurses::new())
-                    .map_err(|_| GenesisError::CLValue(UNBONDING_PURSES_KEY.to_string()))?,
-            ),
-        );
-        named_keys.insert(UNBONDING_PURSES_KEY.into(), unbonding_purses_uref.into());
 
         let validator_slots = self.exec_config.validator_slots();
         let validator_slots_uref = self

--- a/execution_engine/src/core/runtime/auction_internal.rs
+++ b/execution_engine/src/core/runtime/auction_internal.rs
@@ -6,7 +6,7 @@ use casper_types::{
     bytesrepr::{FromBytes, ToBytes},
     system::auction::{
         AccountProvider, Auction, Bid, EraInfo, Error, MintProvider, RuntimeProvider,
-        StorageProvider, SystemProvider,
+        StorageProvider, SystemProvider, UnbondingPurse,
     },
     CLTyped, CLValue, Key, KeyTag, TransferredTo, URef, BLAKE2B_DIGEST_LENGTH, U512,
 };
@@ -71,6 +71,32 @@ where
     fn write_bid(&mut self, account_hash: AccountHash, bid: Bid) -> Result<(), Error> {
         self.context
             .metered_write_gs_unsafe(Key::Bid(account_hash), StoredValue::Bid(Box::new(bid)))
+            .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::Storage))
+    }
+
+    fn read_withdraw(&mut self, account_hash: &AccountHash) -> Result<Vec<UnbondingPurse>, Error> {
+        match self.context.read_gs(&Key::Withdraw(*account_hash)) {
+            Ok(Some(StoredValue::Withdraw(unbonding_purses))) => Ok(unbonding_purses),
+            Ok(Some(_)) => Err(Error::Storage),
+            Ok(None) => Ok(Vec::new()),
+            Err(execution::Error::BytesRepr(_)) => Err(Error::Serialization),
+            // NOTE: This extra condition is needed to correctly propagate GasLimit to the user. See
+            // also [`Runtime::reverter`] and [`to_auction_error`]
+            Err(execution::Error::GasLimit) => Err(Error::GasLimit),
+            Err(_) => Err(Error::Storage),
+        }
+    }
+
+    fn write_withdraw(
+        &mut self,
+        account_hash: AccountHash,
+        unbonding_purses: Vec<UnbondingPurse>,
+    ) -> Result<(), Error> {
+        self.context
+            .metered_write_gs_unsafe(
+                Key::Withdraw(account_hash),
+                StoredValue::Withdraw(unbonding_purses),
+            )
             .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::Storage))
     }
 }

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -97,6 +97,7 @@ pub fn key_to_tuple(key: Key) -> Option<([u8; 32], AccessRights)> {
         Key::EraInfo(_) => None,
         Key::Balance(_) => None,
         Key::Bid(_) => None,
+        Key::Withdraw(_) => None,
     }
 }
 

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -256,6 +256,10 @@ where
                 self.named_keys.remove(name);
                 Ok(())
             }
+            Key::Withdraw(_) => {
+                self.named_keys.remove(name);
+                Ok(())
+            }
         }
     }
 
@@ -667,6 +671,7 @@ where
             Key::EraInfo(_) => true,
             Key::Balance(_) => false,
             Key::Bid(_) => true,
+            Key::Withdraw(_) => true,
         }
     }
 
@@ -680,6 +685,7 @@ where
             Key::EraInfo(_) => false,
             Key::Balance(_) => false,
             Key::Bid(_) => false,
+            Key::Withdraw(_) => false,
         }
     }
 
@@ -693,6 +699,7 @@ where
             Key::EraInfo(_) => false,
             Key::Balance(_) => false,
             Key::Bid(_) => false,
+            Key::Withdraw(_) => false,
         }
     }
 

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -583,6 +583,7 @@ where
             StoredValue::DeployInfo(_) => Ok(()),
             StoredValue::EraInfo(_) => Ok(()),
             StoredValue::Bid(_) => Ok(()),
+            StoredValue::Withdraw(_) => Ok(()),
         }
     }
 

--- a/execution_engine/src/core/tracking_copy/byte_size.rs
+++ b/execution_engine/src/core/tracking_copy/byte_size.rs
@@ -44,6 +44,7 @@ impl ByteSize for StoredValue {
                 StoredValue::Transfer(transfer) => transfer.serialized_length(),
                 StoredValue::EraInfo(era_info) => era_info.serialized_length(),
                 StoredValue::Bid(bid) => bid.serialized_length(),
+                StoredValue::Withdraw(unbonding_purses) => unbonding_purses.serialized_length(),
             }
     }
 }

--- a/execution_engine/src/core/tracking_copy/mod.rs
+++ b/execution_engine/src/core/tracking_copy/mod.rs
@@ -488,6 +488,9 @@ impl<R: StateReader<Key, StoredValue>> TrackingCopy<R> {
                 StoredValue::Bid(_) => {
                     return Ok(query.into_not_found_result(&"Bid value found."));
                 }
+                StoredValue::Withdraw(_) => {
+                    return Ok(query.into_not_found_result(&"UnbondingPurses value found."));
+                }
             }
         }
     }

--- a/execution_engine/src/shared/transform.rs
+++ b/execution_engine/src/shared/transform.rs
@@ -199,6 +199,11 @@ impl Transform {
                     let found = "Bid".to_string();
                     Err(TypeMismatch::new(expected, found).into())
                 }
+                StoredValue::Withdraw(_) => {
+                    let expected = "Contract or Account".to_string();
+                    let found = "Withdraw".to_string();
+                    Err(TypeMismatch::new(expected, found).into())
+                }
             },
             Transform::Failure(error) => Err(error),
         }
@@ -336,6 +341,9 @@ impl From<&Transform> for casper_types::Transform {
             }
             Transform::Write(StoredValue::Bid(bid)) => {
                 casper_types::Transform::WriteBid(bid.clone())
+            }
+            Transform::Write(StoredValue::Withdraw(unbonding_purses)) => {
+                casper_types::Transform::WriteWithdraw(unbonding_purses.clone())
             }
             Transform::AddInt32(value) => casper_types::Transform::AddInt32(*value),
             Transform::AddUInt64(value) => casper_types::Transform::AddUInt64(*value),

--- a/execution_engine_testing/tests/src/test/regression/ee_1119.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1119.rs
@@ -166,7 +166,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
-        .get(&VALIDATOR_1)
+        .get(&VALIDATOR_1_ADDR)
         .cloned()
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 2); // two entries in order: undelegate, and withdraw bid
@@ -190,7 +190,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
     assert_eq!(unbond_list[1].amount(), &unbond_amount);
 
     assert!(
-        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_PUBLIC_KEY),
+        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR),
         "should not be part of unbonds"
     );
 
@@ -238,12 +238,12 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
     assert_eq!(unbond_purses.len(), 0);
 
     assert!(
-        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_PUBLIC_KEY),
+        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR),
         "delegator should not be part of unbond list after slashing validator"
     );
 
     assert!(
-        !unbond_purses.contains_key(&VALIDATOR_1),
+        !unbond_purses.contains_key(&VALIDATOR_1_ADDR),
         "should not be a part of unbond list because delegator was slashed"
     );
 

--- a/execution_engine_testing/tests/src/test/regression/ee_1119.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1119.rs
@@ -19,7 +19,7 @@ use casper_types::{
     system::{
         auction::{
             Bids, DelegationRate, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR,
-            ARG_VALIDATOR_PUBLIC_KEYS, METHOD_SLASH, UNBONDING_PURSES_KEY,
+            ARG_VALIDATOR_PUBLIC_KEYS, METHOD_SLASH,
         },
         mint::TOTAL_SUPPLY_KEY,
     },
@@ -114,7 +114,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         U512::from(VALIDATOR_1_STAKE),
     );
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 0);
 
     //
@@ -162,7 +162,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
 
     builder.exec(withdraw_bid_request).expect_success().commit();
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
@@ -206,7 +206,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
 
     builder.exec(slash_request_1).expect_success().commit();
 
-    let unbond_purses_noop: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses_noop: UnbondingPurses = builder.get_withdraws();
     assert_eq!(
         unbond_purses, unbond_purses_noop,
         "slashing default validator should be noop because no unbonding was done"
@@ -234,18 +234,12 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
 
     builder.exec(slash_request_2).expect_success().commit();
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
-    assert_eq!(unbond_purses.len(), 0);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
+    assert_eq!(unbond_purses.len(), 1);
 
-    assert!(
-        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR),
-        "delegator should not be part of unbond list after slashing validator"
-    );
+    assert!(!unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR));
 
-    assert!(
-        !unbond_purses.contains_key(&VALIDATOR_1_ADDR),
-        "should not be a part of unbond list because delegator was slashed"
-    );
+    assert!(unbond_purses.get(&VALIDATOR_1_ADDR).unwrap().is_empty());
 
     let bids: Bids = builder.get_bids();
     let validator_1_bid = bids.get(&VALIDATOR_1).unwrap();

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -44,6 +44,7 @@ static DELEGATOR_1: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([5; SecretKey::ED25519_LENGTH]).into());
 
 static SYSTEM_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::new([0u8; ACCOUNT_HASH_LENGTH]));
+static VALIDATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_1));
 static VALIDATOR_2_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_2));
 static DELEGATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*DELEGATOR_1));
 
@@ -213,7 +214,7 @@ fn should_run_ee_1120_slash_delegators() {
     assert_eq!(unbond_purses_before.len(), 2);
 
     let validator_1_unbond_list_before = unbond_purses_before
-        .get(&VALIDATOR_1)
+        .get(&VALIDATOR_1_ADDR)
         .cloned()
         .expect("should have unbond");
     assert_eq!(validator_1_unbond_list_before.len(), 2); // two entries in order: undelegate, and withdraw bid
@@ -247,7 +248,7 @@ fn should_run_ee_1120_slash_delegators() {
     );
 
     let validator_2_unbond_list = unbond_purses_before
-        .get(&*VALIDATOR_2)
+        .get(&*VALIDATOR_2_ADDR)
         .cloned()
         .expect("should have unbond");
 
@@ -308,7 +309,7 @@ fn should_run_ee_1120_slash_delegators() {
     assert_ne!(unbond_purses_before, unbond_purses_after);
 
     let validator_1_unbond_list_after = unbond_purses_after
-        .get(&VALIDATOR_1)
+        .get(&VALIDATOR_1_ADDR)
         .expect("should have validator 1 entry");
     assert_eq!(validator_1_unbond_list_after.len(), 2);
     assert_eq!(

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -16,7 +16,7 @@ use casper_types::{
     runtime_args,
     system::auction::{
         Bids, DelegationRate, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR,
-        ARG_VALIDATOR_PUBLIC_KEYS, METHOD_SLASH, UNBONDING_PURSES_KEY,
+        ARG_VALIDATOR_PUBLIC_KEYS, METHOD_SLASH,
     },
     PublicKey, RuntimeArgs, SecretKey, U512,
 };
@@ -165,7 +165,7 @@ fn should_run_ee_1120_slash_delegators() {
         BTreeSet::from_iter(vec![*VALIDATOR_2, *VALIDATOR_1])
     );
 
-    let initial_unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let initial_unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(initial_unbond_purses.len(), 0);
 
     // DELEGATOR_1 partially unbonds from VALIDATOR_1
@@ -210,7 +210,7 @@ fn should_run_ee_1120_slash_delegators() {
 
     // Check unbonding purses before slashing
 
-    let unbond_purses_before: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses_before: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses_before.len(), 2);
 
     let validator_1_unbond_list_before = unbond_purses_before
@@ -305,7 +305,7 @@ fn should_run_ee_1120_slash_delegators() {
         .delegators()
         .contains_key(&DELEGATOR_1));
 
-    let unbond_purses_after: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses_after: UnbondingPurses = builder.get_withdraws();
     assert_ne!(unbond_purses_before, unbond_purses_after);
 
     let validator_1_unbond_list_after = unbond_purses_after
@@ -349,6 +349,13 @@ fn should_run_ee_1120_slash_delegators() {
     assert!(validator_1_bid.inactive());
     assert!(validator_1_bid.staked_amount().is_zero());
 
-    let unbond_purses_after: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
-    assert!(unbond_purses_after.is_empty());
+    let unbond_purses_after: UnbondingPurses = builder.get_withdraws();
+    assert!(unbond_purses_after
+        .get(&VALIDATOR_1_ADDR)
+        .unwrap()
+        .is_empty());
+    assert!(unbond_purses_after
+        .get(&VALIDATOR_2_ADDR)
+        .unwrap()
+        .is_empty());
 }

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -229,7 +229,7 @@ fn should_run_add_bid() {
     );
     let unbonding_purses: UnbondingPurses = builder.get_value(auction_hash, "unbonding_purses");
     let unbond_list = unbonding_purses
-        .get(&BID_ACCOUNT_1_PK)
+        .get(&BID_ACCOUNT_1_ADDR)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
     assert_eq!(unbond_list[0].unbonder_public_key(), &*BID_ACCOUNT_1_PK);
@@ -386,7 +386,7 @@ fn should_run_delegate_and_undelegate() {
     assert_eq!(unbonding_purses.len(), 1);
 
     let unbond_list = unbonding_purses
-        .get(&NON_FOUNDER_VALIDATOR_1_PK)
+        .get(&NON_FOUNDER_VALIDATOR_1_ADDR)
         .expect("should have unbonding purse for non founder validator");
     assert_eq!(unbond_list.len(), 1);
     assert_eq!(
@@ -1439,9 +1439,9 @@ fn should_undelegate_delegators_when_validator_unbonds() {
     // Validator partially unbonds and only one entry is present
     let unbonding_purses_before: UnbondingPurses =
         builder.get_value(auction, auction::UNBONDING_PURSES_KEY);
-    assert_eq!(unbonding_purses_before[&*VALIDATOR_1].len(), 1);
+    assert_eq!(unbonding_purses_before[&*VALIDATOR_1_ADDR].len(), 1);
     assert_eq!(
-        unbonding_purses_before[&*VALIDATOR_1][0].unbonder_public_key(),
+        unbonding_purses_before[&*VALIDATOR_1_ADDR][0].unbonder_public_key(),
         &*VALIDATOR_1
     );
 
@@ -1470,7 +1470,7 @@ fn should_undelegate_delegators_when_validator_unbonds() {
     assert_ne!(unbonding_purses_after, unbonding_purses_before);
 
     let validator_1_unbonding_purse = unbonding_purses_after
-        .get(&VALIDATOR_1)
+        .get(&VALIDATOR_1_ADDR)
         .expect("should have unbonding purse entry");
     assert_eq!(validator_1_unbonding_purse.len(), 4); // validator1, validator1, delegator1, delegator2
 
@@ -1683,7 +1683,7 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         builder.get_value(auction, auction::UNBONDING_PURSES_KEY);
 
     let validator_1_unbonding_purse = unbonding_purses_before
-        .get(&VALIDATOR_1)
+        .get(&VALIDATOR_1_ADDR)
         .expect("should have unbonding purse entry");
     assert_eq!(validator_1_unbonding_purse.len(), 3); // validator1, delegator1, delegator2
 

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -34,7 +34,6 @@ use casper_types::{
             self, Bids, DelegationRate, EraId, EraValidators, UnbondingPurses, ValidatorWeights,
             ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_PUBLIC_KEY, ARG_VALIDATOR,
             ARG_VALIDATOR_PUBLIC_KEY, ERA_ID_KEY, INITIAL_ERA_ID, METHOD_ACTIVATE_BID,
-            UNBONDING_PURSES_KEY,
         },
     },
     PublicKey, RuntimeArgs, SecretKey, U512,
@@ -168,7 +167,6 @@ fn should_run_add_bid() {
 
     builder.exec(exec_request_1).commit().expect_success();
 
-    let auction_hash = builder.get_auction_contract_hash();
     let bids: Bids = builder.get_bids();
 
     assert_eq!(bids.len(), 1);
@@ -227,7 +225,7 @@ fn should_run_add_bid() {
         // Since we don't pay out immediately `WITHDRAW_BID_AMOUNT_2` is locked in unbonding queue
         U512::from(ADD_BID_AMOUNT_1 + BID_AMOUNT_2)
     );
-    let unbonding_purses: UnbondingPurses = builder.get_value(auction_hash, "unbonding_purses");
+    let unbonding_purses: UnbondingPurses = builder.get_withdraws();
     let unbond_list = unbonding_purses
         .get(&BID_ACCOUNT_1_ADDR)
         .expect("should have unbond");
@@ -382,7 +380,7 @@ fn should_run_delegate_and_undelegate() {
         U512::from(DELEGATE_AMOUNT_1 + DELEGATE_AMOUNT_2 - UNDELEGATE_AMOUNT_1)
     );
 
-    let unbonding_purses: UnbondingPurses = builder.get_value(auction_hash, UNBONDING_PURSES_KEY);
+    let unbonding_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbonding_purses.len(), 1);
 
     let unbond_list = unbonding_purses
@@ -1412,7 +1410,6 @@ fn should_undelegate_delegators_when_validator_unbonds() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
-    let auction = builder.get_auction_contract_hash();
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
@@ -1437,8 +1434,7 @@ fn should_undelegate_delegators_when_validator_unbonds() {
     );
 
     // Validator partially unbonds and only one entry is present
-    let unbonding_purses_before: UnbondingPurses =
-        builder.get_value(auction, auction::UNBONDING_PURSES_KEY);
+    let unbonding_purses_before: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbonding_purses_before[&*VALIDATOR_1_ADDR].len(), 1);
     assert_eq!(
         unbonding_purses_before[&*VALIDATOR_1_ADDR][0].unbonder_public_key(),
@@ -1465,8 +1461,7 @@ fn should_undelegate_delegators_when_validator_unbonds() {
     assert!(validator_1_bid.inactive());
     assert!(validator_1_bid.staked_amount().is_zero());
 
-    let unbonding_purses_after: UnbondingPurses =
-        builder.get_value(auction, auction::UNBONDING_PURSES_KEY);
+    let unbonding_purses_after: UnbondingPurses = builder.get_withdraws();
     assert_ne!(unbonding_purses_after, unbonding_purses_before);
 
     let validator_1_unbonding_purse = unbonding_purses_after
@@ -1652,7 +1647,6 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
-    let auction = builder.get_auction_contract_hash();
 
     for request in post_genesis_requests {
         builder.exec(request).commit().expect_success();
@@ -1679,8 +1673,7 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
     assert!(validator_1_bid.inactive());
     assert!(validator_1_bid.staked_amount().is_zero());
 
-    let unbonding_purses_before: UnbondingPurses =
-        builder.get_value(auction, auction::UNBONDING_PURSES_KEY);
+    let unbonding_purses_before: UnbondingPurses = builder.get_withdraws();
 
     let validator_1_unbonding_purse = unbonding_purses_before
         .get(&VALIDATOR_1_ADDR)

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -130,7 +130,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
-        .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
+        .get(&*DEFAULT_ACCOUNT_ADDR)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
     assert_eq!(
@@ -151,7 +151,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
-        .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
+        .get(&*DEFAULT_ACCOUNT_ADDR)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
     assert_eq!(
@@ -185,7 +185,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
 
     let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
     assert!(
-        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_PUBLIC_KEY),
+        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR),
         "should remove slashed from unbonds"
     );
 
@@ -426,7 +426,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
-        .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
+        .get(&*DEFAULT_ACCOUNT_ADDR)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
     assert_eq!(
@@ -447,7 +447,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
-        .get(&default_public_key_arg)
+        .get(&DEFAULT_ACCOUNT_ADDR)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
     assert_eq!(
@@ -482,7 +482,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
 
     let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
     assert!(
-        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_PUBLIC_KEY),
+        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR),
         "Unbond entry should be removed"
     );
 
@@ -607,7 +607,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
-        .get(&*DEFAULT_ACCOUNT_PUBLIC_KEY)
+        .get(&*DEFAULT_ACCOUNT_ADDR)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
     assert_eq!(
@@ -626,7 +626,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
-        .get(&default_public_key_arg)
+        .get(&DEFAULT_ACCOUNT_ADDR)
         .expect("should have unbond");
     assert_eq!(unbond_list.len(), 1);
     assert_eq!(
@@ -676,7 +676,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
 
     let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
     assert!(
-        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_PUBLIC_KEY),
+        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR),
         "Unbond entry should be removed"
     );
 

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -25,7 +25,7 @@ use casper_types::{
     runtime_args,
     system::auction::{
         self, Bids, DelegationRate, UnbondingPurses, ARG_VALIDATOR_PUBLIC_KEYS, INITIAL_ERA_ID,
-        METHOD_SLASH, UNBONDING_PURSES_KEY,
+        METHOD_SLASH,
     },
     ApiError, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, U512,
 };
@@ -99,7 +99,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         GENESIS_ACCOUNT_STAKE.into()
     );
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 0);
 
     //
@@ -126,7 +126,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
 
     let account_balance_before = builder.get_purse_balance(unbonding_purse);
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
@@ -147,7 +147,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         DEFAULT_GENESIS_TIMESTAMP_MILLIS + DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
         Vec::new(),
     );
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
@@ -183,11 +183,11 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
 
     builder.exec(exec_request_5).expect_success().commit();
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
-    assert!(
-        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR),
-        "should remove slashed from unbonds"
-    );
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
+    assert!(unbond_purses
+        .get(&*DEFAULT_ACCOUNT_ADDR)
+        .unwrap()
+        .is_empty());
 
     let bids: Bids = builder.get_bids();
     let default_account_bid = bids.get(&DEFAULT_ACCOUNT_PUBLIC_KEY).unwrap();
@@ -373,8 +373,6 @@ fn should_run_successful_bond_and_unbond_with_release() {
         .get_account(*DEFAULT_ACCOUNT_ADDR)
         .expect("should get account 1");
 
-    let auction = builder.get_auction_contract_hash();
-
     let exec_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_ADD_BID,
@@ -396,7 +394,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
         GENESIS_ACCOUNT_STAKE.into()
     );
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 0);
 
     //
@@ -422,7 +420,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
 
     builder.exec(exec_request_2).expect_success().commit();
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
@@ -443,7 +441,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
 
     builder.run_auction(timestamp_millis, Vec::new());
     timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
@@ -480,11 +478,11 @@ fn should_run_successful_bond_and_unbond_with_release() {
         account_balance_before_auction + unbond_amount
     );
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
-    assert!(
-        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR),
-        "Unbond entry should be removed"
-    );
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
+    assert!(unbond_purses
+        .get(&*DEFAULT_ACCOUNT_ADDR)
+        .unwrap()
+        .is_empty());
 
     let bids: Bids = builder.get_bids();
     assert!(!bids.is_empty());
@@ -550,8 +548,6 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
         .get_account(*DEFAULT_ACCOUNT_ADDR)
         .expect("should get account 1");
 
-    let auction = builder.get_auction_contract_hash();
-
     let exec_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_ADD_BID,
@@ -574,7 +570,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
         GENESIS_ACCOUNT_STAKE.into()
     );
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 0);
 
     //
@@ -603,7 +599,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
 
     let account_balance_before_auction = builder.get_purse_balance(unbonding_purse);
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
@@ -622,7 +618,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
 
     builder.run_auction(timestamp_millis, Vec::new());
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
     assert_eq!(unbond_purses.len(), 1);
 
     let unbond_list = unbond_purses
@@ -674,11 +670,11 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
         account_balance_before_auction + unbond_amount
     );
 
-    let unbond_purses: UnbondingPurses = builder.get_value(auction, UNBONDING_PURSES_KEY);
-    assert!(
-        !unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR),
-        "Unbond entry should be removed"
-    );
+    let unbond_purses: UnbondingPurses = builder.get_withdraws();
+    assert!(unbond_purses
+        .get(&*DEFAULT_ACCOUNT_ADDR)
+        .unwrap()
+        .is_empty());
 
     let bids: Bids = builder.get_bids();
     assert!(!bids.is_empty());

--- a/node/src/types/json_compatibility/stored_value.rs
+++ b/node/src/types/json_compatibility/stored_value.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use casper_execution_engine::shared::stored_value::StoredValue as ExecutionEngineStoredValue;
 use casper_types::{
     bytesrepr::{self, ToBytes},
-    system::auction::{Bid, EraInfo},
+    system::auction::{Bid, EraInfo, UnbondingPurse},
     CLValue, DeployInfo, Transfer,
 };
 
@@ -43,6 +43,8 @@ pub enum StoredValue {
     EraInfo(EraInfo),
     /// A bid
     Bid(Box<Bid>),
+    /// A withdraw
+    Withdraw(Vec<UnbondingPurse>),
 }
 
 impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
@@ -67,6 +69,9 @@ impl TryFrom<&ExecutionEngineStoredValue> for StoredValue {
             }
             ExecutionEngineStoredValue::EraInfo(era_info) => StoredValue::EraInfo(era_info.clone()),
             ExecutionEngineStoredValue::Bid(bid) => StoredValue::Bid(bid.clone()),
+            ExecutionEngineStoredValue::Withdraw(unbonding_purses) => {
+                StoredValue::Withdraw(unbonding_purses.clone())
+            }
         };
 
         Ok(stored_value)

--- a/types/src/execution_result.rs
+++ b/types/src/execution_result.rs
@@ -31,7 +31,7 @@ use crate::KEY_HASH_LENGTH;
 use crate::{
     account::AccountHash,
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
-    system::auction::{Bid, EraInfo},
+    system::auction::{Bid, EraInfo, UnbondingPurse},
     CLValue, DeployInfo, NamedKey, Transfer, TransferAddr, U128, U256, U512,
 };
 
@@ -56,13 +56,14 @@ const TRANSFORM_WRITE_DEPLOY_INFO_TAG: u8 = 6;
 const TRANSFORM_WRITE_TRANSFER_TAG: u8 = 7;
 const TRANSFORM_WRITE_ERA_INFO_TAG: u8 = 8;
 const TRANSFORM_WRITE_BID_TAG: u8 = 9;
-const TRANSFORM_ADD_INT32_TAG: u8 = 10;
-const TRANSFORM_ADD_UINT64_TAG: u8 = 11;
-const TRANSFORM_ADD_UINT128_TAG: u8 = 12;
-const TRANSFORM_ADD_UINT256_TAG: u8 = 13;
-const TRANSFORM_ADD_UINT512_TAG: u8 = 14;
-const TRANSFORM_ADD_KEYS_TAG: u8 = 15;
-const TRANSFORM_FAILURE_TAG: u8 = 16;
+const TRANSFORM_WRITE_WITHDRAW_TAG: u8 = 10;
+const TRANSFORM_ADD_INT32_TAG: u8 = 11;
+const TRANSFORM_ADD_UINT64_TAG: u8 = 12;
+const TRANSFORM_ADD_UINT128_TAG: u8 = 13;
+const TRANSFORM_ADD_UINT256_TAG: u8 = 14;
+const TRANSFORM_ADD_UINT512_TAG: u8 = 15;
+const TRANSFORM_ADD_KEYS_TAG: u8 = 16;
+const TRANSFORM_FAILURE_TAG: u8 = 17;
 
 #[cfg(feature = "std")]
 static EXECUTION_RESULT: Lazy<ExecutionResult> = Lazy::new(|| {
@@ -452,6 +453,8 @@ pub enum Transform {
     WriteTransfer(Transfer),
     /// Writes the given Bid to global state.
     WriteBid(Box<Bid>),
+    /// Writes the given Withdraw to global state.
+    WriteWithdraw(Vec<UnbondingPurse>),
     /// Adds the given `i32`.
     AddInt32(i32),
     /// Adds the given `u64`.
@@ -501,6 +504,10 @@ impl ToBytes for Transform {
             Transform::WriteBid(bid) => {
                 buffer.insert(0, TRANSFORM_WRITE_BID_TAG);
                 buffer.extend(bid.to_bytes()?);
+            }
+            Transform::WriteWithdraw(unbonding_purses) => {
+                buffer.insert(0, TRANSFORM_WRITE_WITHDRAW_TAG);
+                buffer.extend(unbonding_purses.to_bytes()?);
             }
             Transform::AddInt32(value) => {
                 buffer.insert(0, TRANSFORM_ADD_INT32_TAG);

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -73,6 +73,7 @@ pub fn key_arb() -> impl Strategy<Value = Key> {
         any::<u64>().prop_map(Key::EraInfo),
         uref_arb().prop_map(|uref| Key::Balance(uref.addr())),
         account_hash_arb().prop_map(Key::Bid),
+        account_hash_arb().prop_map(Key::Withdraw),
     ]
 }
 

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -34,6 +34,7 @@ const DEPLOY_INFO_PREFIX: &str = "deploy-";
 const ERA_INFO_PREFIX: &str = "era-";
 const BALANCE_PREFIX: &str = "balance-";
 const BID_PREFIX: &str = "bid-";
+const WITHDRAW_PREFIX: &str = "withdraw-";
 
 /// The number of bytes in a Blake2b hash
 pub const BLAKE2B_DIGEST_LENGTH: usize = 32;
@@ -53,6 +54,7 @@ const KEY_DEPLOY_INFO_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + KEY_
 const KEY_ERA_INFO_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + U64_SERIALIZED_LENGTH;
 const KEY_BALANCE_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + UREF_ADDR_LENGTH;
 const KEY_BID_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + KEY_HASH_LENGTH;
+const KEY_WITHDRAW_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + KEY_HASH_LENGTH;
 
 /// An alias for [`Key`]s hash variant.
 pub type HashAddr = [u8; KEY_HASH_LENGTH];
@@ -75,6 +77,7 @@ pub enum KeyTag {
     EraInfo = 5,
     Balance = 6,
     Bid = 7,
+    Withdraw = 8,
 }
 
 /// The type under which data (e.g. [`CLValue`](crate::CLValue)s, smart contracts, user accounts)
@@ -99,6 +102,8 @@ pub enum Key {
     Balance(URefAddr),
     /// A `Key` under which we store bid information
     Bid(AccountHash),
+    /// A `Key` under which we store unbond information.
+    Withdraw(AccountHash),
 }
 
 #[derive(Debug)]
@@ -177,6 +182,7 @@ impl Key {
             Key::EraInfo(_) => String::from("Key::EraInfo"),
             Key::Balance(_) => String::from("Key::Balance"),
             Key::Bid(_) => String::from("Key::Bid"),
+            Key::Withdraw(_) => String::from("Key::Unbond"),
         }
     }
 
@@ -218,6 +224,9 @@ impl Key {
             Key::Bid(account_hash) => {
                 format!("{}{}", BID_PREFIX, base16::encode_lower(&account_hash))
             }
+            Key::Withdraw(account_hash) => {
+                format!("{}{}", WITHDRAW_PREFIX, base16::encode_lower(&account_hash))
+            }
         }
     }
 
@@ -245,6 +254,10 @@ impl Key {
             )?))
         } else if let Some(hex) = input.strip_prefix(BID_PREFIX) {
             Ok(Key::Bid(AccountHash::new(AccountHashBytes::try_from(
+                base16::decode(hex)?.as_ref(),
+            )?)))
+        } else if let Some(hex) = input.strip_prefix(WITHDRAW_PREFIX) {
+            Ok(Key::Withdraw(AccountHash::new(AccountHashBytes::try_from(
                 base16::decode(hex)?.as_ref(),
             )?)))
         } else {
@@ -306,6 +319,7 @@ impl Display for Key {
             Key::EraInfo(era_id) => write!(f, "Key::EraInfo({})", era_id),
             Key::Balance(uref_addr) => write!(f, "Key::Balance({})", HexFmt(uref_addr)),
             Key::Bid(account_hash) => write!(f, "Key::Bid({})", account_hash),
+            Key::Withdraw(account_hash) => write!(f, "Key::Withdraw({})", account_hash),
         }
     }
 }
@@ -327,6 +341,7 @@ impl Tagged<KeyTag> for Key {
             Key::EraInfo(_) => KeyTag::EraInfo,
             Key::Balance(_) => KeyTag::Balance,
             Key::Bid(_) => KeyTag::Bid,
+            Key::Withdraw(_) => KeyTag::Withdraw,
         }
     }
 }
@@ -403,6 +418,9 @@ impl ToBytes for Key {
             Key::Bid(account_hash) => {
                 result.append(&mut account_hash.to_bytes()?);
             }
+            Key::Withdraw(account_hash) => {
+                result.append(&mut account_hash.to_bytes()?);
+            }
         }
         Ok(result)
     }
@@ -419,6 +437,7 @@ impl ToBytes for Key {
             Key::EraInfo(_) => KEY_ERA_INFO_SERIALIZED_LENGTH,
             Key::Balance(_) => KEY_BALANCE_SERIALIZED_LENGTH,
             Key::Bid(_) => KEY_BID_SERIALIZED_LENGTH,
+            Key::Withdraw(_) => KEY_WITHDRAW_SERIALIZED_LENGTH,
         }
     }
 }
@@ -459,6 +478,10 @@ impl FromBytes for Key {
                 let (account_hash, rem) = AccountHash::from_bytes(remainder)?;
                 Ok((Key::Bid(account_hash), rem))
             }
+            tag if tag == KeyTag::Withdraw as u8 => {
+                let (account_hash, rem) = AccountHash::from_bytes(remainder)?;
+                Ok((Key::Withdraw(account_hash), rem))
+            }
             _ => Err(Error::Formatting),
         }
     }
@@ -466,7 +489,7 @@ impl FromBytes for Key {
 
 impl Distribution<Key> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Key {
-        match rng.gen_range(0, 6) {
+        match rng.gen_range(0, 8) {
             0 => Key::Account(rng.gen()),
             1 => Key::Hash(rng.gen()),
             2 => Key::URef(rng.gen()),
@@ -475,6 +498,7 @@ impl Distribution<Key> for Standard {
             5 => Key::EraInfo(rng.gen()),
             6 => Key::Balance(rng.gen()),
             7 => Key::Bid(rng.gen()),
+            8 => Key::Withdraw(rng.gen()),
             _ => unreachable!(),
         }
     }
@@ -493,6 +517,7 @@ mod serde_helpers {
         EraInfo(String),
         Balance(String),
         Bid(String),
+        Withdraw(String),
     }
 
     impl From<&Key> for HumanReadable {
@@ -507,6 +532,7 @@ mod serde_helpers {
                 Key::EraInfo(_) => HumanReadable::EraInfo(formatted_string),
                 Key::Balance(_) => HumanReadable::Balance(formatted_string),
                 Key::Bid(_) => HumanReadable::Bid(formatted_string),
+                Key::Withdraw(_) => HumanReadable::Withdraw(formatted_string),
             }
         }
     }
@@ -523,7 +549,8 @@ mod serde_helpers {
                 | HumanReadable::DeployInfo(formatted_string)
                 | HumanReadable::EraInfo(formatted_string)
                 | HumanReadable::Balance(formatted_string)
-                | HumanReadable::Bid(formatted_string) => {
+                | HumanReadable::Bid(formatted_string)
+                | HumanReadable::Withdraw(formatted_string) => {
                     Key::from_formatted_str(&formatted_string)
                 }
             }
@@ -540,6 +567,7 @@ mod serde_helpers {
         EraInfo(&'a u64),
         Balance(&'a URefAddr),
         Bid(&'a AccountHash),
+        Withdraw(&'a AccountHash),
     }
 
     impl<'a> From<&'a Key> for BinarySerHelper<'a> {
@@ -553,6 +581,7 @@ mod serde_helpers {
                 Key::EraInfo(era_id) => BinarySerHelper::EraInfo(era_id),
                 Key::Balance(uref_addr) => BinarySerHelper::Balance(uref_addr),
                 Key::Bid(account_hash) => BinarySerHelper::Bid(account_hash),
+                Key::Withdraw(account_hash) => BinarySerHelper::Withdraw(account_hash),
             }
         }
     }
@@ -567,6 +596,7 @@ mod serde_helpers {
         EraInfo(EraId),
         Balance(URefAddr),
         Bid(AccountHash),
+        Withdraw(AccountHash),
     }
 
     impl From<BinaryDeserHelper> for Key {
@@ -580,6 +610,7 @@ mod serde_helpers {
                 BinaryDeserHelper::EraInfo(era_id) => Key::EraInfo(era_id),
                 BinaryDeserHelper::Balance(uref_addr) => Key::Balance(uref_addr),
                 BinaryDeserHelper::Bid(account_hash) => Key::Bid(account_hash),
+                BinaryDeserHelper::Withdraw(account_hash) => Key::Withdraw(account_hash),
             }
         }
     }
@@ -848,6 +879,7 @@ mod tests {
         round_trip(&Key::EraInfo(42));
         round_trip(&Key::Balance(URef::new(array, AccessRights::READ).addr()));
         round_trip(&Key::Bid(AccountHash::new(array)));
+        round_trip(&Key::Withdraw(AccountHash::new(array)));
     }
 
     #[test]
@@ -867,7 +899,7 @@ mod tests {
         round_trip(&Key::DeployInfo(DeployHash::new(array)));
         round_trip(&Key::EraInfo(42));
         round_trip(&Key::Balance(URef::new(array, AccessRights::READ).addr()));
-        round_trip(&Key::Bid(AccountHash::new(array)));
+        round_trip(&Key::Withdraw(AccountHash::new(array)));
 
         let zeros = [0; BLAKE2B_DIGEST_LENGTH];
 
@@ -879,5 +911,6 @@ mod tests {
         round_trip(&Key::EraInfo(42));
         round_trip(&Key::Balance(URef::new(zeros, AccessRights::READ).addr()));
         round_trip(&Key::Bid(AccountHash::new(zeros)));
+        round_trip(&Key::Withdraw(AccountHash::new(zeros)));
     }
 }

--- a/types/src/system/auction/constants.rs
+++ b/types/src/system/auction/constants.rs
@@ -81,8 +81,6 @@ pub const METHOD_READ_ERA_ID: &str = "read_era_id";
 /// Named constant for method `activate_bid`.
 pub const METHOD_ACTIVATE_BID: &str = "activate_bid";
 
-/// Storage for `UnbondingPurses`
-pub const UNBONDING_PURSES_KEY: &str = "unbonding_purses";
 /// Storage for `EraId`.
 pub const ERA_ID_KEY: &str = "era_id";
 /// Storage for era-end timestamp.

--- a/types/src/system/auction/detail.rs
+++ b/types/src/system/auction/detail.rs
@@ -203,7 +203,7 @@ pub(crate) fn process_unbond_requests<P: Auction + ?Sized>(provider: &mut P) -> 
                     )
                     .map_err(|_| Error::TransferToUnbondingPurse)?;
             } else {
-                new_unbonding_list.push(*unbonding_purse);
+                new_unbonding_list.push(unbonding_purse.clone());
             }
         }
         *unbonding_list = new_unbonding_list;

--- a/types/src/system/auction/detail.rs
+++ b/types/src/system/auction/detail.rs
@@ -241,8 +241,9 @@ pub(crate) fn create_unbonding_purse<P: Auction + ?Sized>(
         era_of_creation,
         amount,
     );
+    let validator_account_hash = AccountHash::from(&validator_public_key);
     unbonding_purses
-        .entry(validator_public_key)
+        .entry(validator_account_hash)
         .or_default()
         .push(new_unbonding_purse);
     set_unbonding_purses(provider, unbonding_purses)?;

--- a/types/src/system/auction/detail.rs
+++ b/types/src/system/auction/detail.rs
@@ -73,7 +73,20 @@ pub fn get_unbonding_purses<P>(provider: &mut P) -> Result<UnbondingPurses, Erro
 where
     P: StorageProvider + RuntimeProvider + ?Sized,
 {
-    Ok(read_from(provider, UNBONDING_PURSES_KEY)?)
+    let withdraws_keys = provider.get_keys(&KeyTag::Withdraw)?;
+
+    let mut ret = BTreeMap::new();
+
+    for key in withdraws_keys {
+        let account_hash = match key {
+            Key::Withdraw(account_ash) => account_ash,
+            _ => return Err(Error::InvalidKeyVariant),
+        };
+        let unbonding_purses = provider.read_withdraw(&account_hash)?;
+        ret.insert(account_hash, unbonding_purses);
+    }
+
+    Ok(ret)
 }
 
 pub fn set_unbonding_purses<P>(
@@ -83,7 +96,10 @@ pub fn set_unbonding_purses<P>(
 where
     P: StorageProvider + RuntimeProvider + ?Sized,
 {
-    write_to(provider, UNBONDING_PURSES_KEY, unbonding_purses)
+    for (account_hash, unbonding_purses) in unbonding_purses.into_iter() {
+        provider.write_withdraw(account_hash, unbonding_purses)?;
+    }
+    Ok(())
 }
 
 pub fn get_era_id<P>(provider: &mut P) -> Result<EraId, Error>
@@ -209,12 +225,6 @@ pub(crate) fn process_unbond_requests<P: Auction + ?Sized>(provider: &mut P) -> 
         *unbonding_list = new_unbonding_list;
     }
 
-    // Prune empty entries
-    let unbonding_purses = unbonding_purses
-        .into_iter()
-        .filter(|(_k, unbonding_purses)| !unbonding_purses.is_empty())
-        .collect();
-
     set_unbonding_purses(provider, unbonding_purses)?;
     Ok(())
 }
@@ -232,7 +242,8 @@ pub(crate) fn create_unbonding_purse<P: Auction + ?Sized>(
         return Err(Error::UnbondTooLarge);
     }
 
-    let mut unbonding_purses: UnbondingPurses = get_unbonding_purses(provider)?;
+    let validator_account_hash = AccountHash::from(&validator_public_key);
+    let mut unbonding_purses = provider.read_withdraw(&validator_account_hash)?;
     let era_of_creation = provider.read_era_id()?;
     let new_unbonding_purse = UnbondingPurse::new(
         bonding_purse,
@@ -241,12 +252,8 @@ pub(crate) fn create_unbonding_purse<P: Auction + ?Sized>(
         era_of_creation,
         amount,
     );
-    let validator_account_hash = AccountHash::from(&validator_public_key);
-    unbonding_purses
-        .entry(validator_account_hash)
-        .or_default()
-        .push(new_unbonding_purse);
-    set_unbonding_purses(provider, unbonding_purses)?;
+    unbonding_purses.push(new_unbonding_purse);
+    provider.write_withdraw(validator_account_hash, unbonding_purses)?;
 
     Ok(())
 }

--- a/types/src/system/auction/mod.rs
+++ b/types/src/system/auction/mod.rs
@@ -48,7 +48,7 @@ pub type SeigniorageRecipients = BTreeMap<PublicKey, SeigniorageRecipient>;
 pub type SeigniorageRecipientsSnapshot = BTreeMap<EraId, SeigniorageRecipients>;
 
 /// Validators and delegators mapped to their unbonding purses.
-pub type UnbondingPurses = BTreeMap<PublicKey, Vec<UnbondingPurse>>;
+pub type UnbondingPurses = BTreeMap<AccountHash, Vec<UnbondingPurse>>;
 
 /// Bonding auction contract interface
 pub trait Auction:
@@ -329,8 +329,9 @@ pub trait Auction:
                 self.write_bid(validator_account_hash, bid)?;
             };
 
+            let validator_account_hash = AccountHash::from(&validator_public_key);
             // Update unbonding entries for given validator
-            if let Some(unbonding_list) = unbonding_purses.remove(&validator_public_key) {
+            if let Some(unbonding_list) = unbonding_purses.remove(&validator_account_hash) {
                 burned_amount += unbonding_list
                     .into_iter()
                     .map(|unbonding_purse| *unbonding_purse.amount())

--- a/types/src/system/auction/providers.rs
+++ b/types/src/system/auction/providers.rs
@@ -1,9 +1,9 @@
-use alloc::collections::BTreeSet;
+use alloc::{collections::BTreeSet, vec::Vec};
 
 use crate::{
     account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
-    system::auction::{Bid, EraId, EraInfo, Error},
+    system::auction::{Bid, EraId, EraInfo, Error, UnbondingPurse},
     CLTyped, Key, KeyTag, TransferredTo, URef, BLAKE2B_DIGEST_LENGTH, U512,
 };
 
@@ -35,6 +35,16 @@ pub trait StorageProvider {
 
     /// Writes given [`Bid`] at account hash derived from given public key
     fn write_bid(&mut self, account_hash: AccountHash, bid: Bid) -> Result<(), Error>;
+
+    /// Reads collection of [`UnbondingPurse`]s at account hash derived from given public key
+    fn read_withdraw(&mut self, account_hash: &AccountHash) -> Result<Vec<UnbondingPurse>, Error>;
+
+    /// Writes given [`UnbondingPurse`]s at account hash derived from given public key
+    fn write_withdraw(
+        &mut self,
+        account_hash: AccountHash,
+        unbonding_purses: Vec<UnbondingPurse>,
+    ) -> Result<(), Error>;
 }
 
 /// Provides functionality of a system module.

--- a/types/src/system/auction/unbonding_purse.rs
+++ b/types/src/system/auction/unbonding_purse.rs
@@ -1,4 +1,11 @@
+// TODO - remove once schemars stops causing warning.
+#![allow(clippy::field_reassign_with_default)]
+
 use alloc::vec::Vec;
+
+#[cfg(feature = "std")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes},
@@ -7,7 +14,9 @@ use crate::{
 };
 
 /// Unbonding purse.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "std", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct UnbondingPurse {
     /// Bonding Purse
     bonding_purse: URef,


### PR DESCRIPTION
This PR removes the `UnbondingPurses` map stored under the auction's `UNBONDING_PURSES_KEY` named key and instead persists bids directly in the state trie under `Key::Withdraw` keys.