### PR TITLE
NDRS-1000/Restrict private key permissions

### DIFF
--- a/node/src/crypto/asymmetric_key_ext.rs
+++ b/node/src/crypto/asymmetric_key_ext.rs
@@ -103,7 +103,7 @@ impl AsymmetricKeyExt for SecretKey {
     }
 
     fn to_file<P: AsRef<Path>>(&self, file: P) -> Result<(), Error> {
-        utils::write_file(file, self.to_pem()?).map_err(Error::SecretKeySave)
+        utils::write_private_file(file, self.to_pem()?).map_err(Error::SecretKeySave)
     }
 
     fn from_file<P: AsRef<Path>>(file: P) -> Result<Self, Error> {


### PR DESCRIPTION
This change ensures that private keys generated by the casper-client are only read/writeable by the owner. Since keys are commonly generated using root, they are protected against regular user access this way.

**Note**: The documentation needs to be updated to reflect this (keys need to be either generated as `casper` or `chown`ed).