### PR TITLE
NDRS-1006: Add timeout-based sync failure.

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -284,7 +284,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                             .ignore();
                     }
                     None => {
-                        error!("block execution results recevied when not expected");
+                        error!("block execution results received when not expected");
                         return fatal!(effect_builder, "unexpected block execution results.")
                             .ignore();
                     }
@@ -309,7 +309,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                             .ignore();
                     }
                     None => {
-                        error!("block execution results recevied when not expected");
+                        error!("block execution results received when not expected");
                         return fatal!(effect_builder, "unexpected block execution results.")
                             .ignore();
                     }
@@ -618,7 +618,7 @@ where
                                 .ignore();
                             }
                             None => {
-                                warn!("run out of peers before managed to start syncing. Resetting peers' list and continueing");
+                                warn!("run out of peers before managed to start syncing. Resetting peers' list and continuing");
                                 self.peers.reset(rng);
                                 self.metrics.reset_start_time();
                                 fetch_block_by_hash(effect_builder, peer, block_hash)

--- a/node/src/components/linear_chain_sync/event.rs
+++ b/node/src/components/linear_chain_sync/event.rs
@@ -13,6 +13,8 @@ pub enum Event<I> {
     BlockHandled(Box<Block>),
     GotUpgradeActivationPoint(ActivationPoint),
     InitUpgradeShutdown,
+    /// An event instructing us to shutdown if we haven't downloaded any blocks.
+    InitializeTimeout,
     Shutdown(bool),
 }
 
@@ -72,6 +74,7 @@ where
                 "linear chain sync is ready for shutdown. upgrade: {}",
                 upgrade
             ),
+            Event::InitializeTimeout => write!(f, "Initialize timeout"),
         }
     }
 }

--- a/node/src/components/linear_chain_sync/traits.rs
+++ b/node/src/components/linear_chain_sync/traits.rs
@@ -1,7 +1,13 @@
-use crate::{effect::{announcements::ControlAnnouncement, requests::{
-        BlockExecutorRequest, BlockValidationRequest, FetcherRequest, StateStoreRequest,
-        StorageRequest,
-    }}, types::{Block, BlockByHeight}};
+use crate::{
+    effect::{
+        announcements::ControlAnnouncement,
+        requests::{
+            BlockExecutorRequest, BlockValidationRequest, FetcherRequest, StateStoreRequest,
+            StorageRequest,
+        },
+    },
+    types::{Block, BlockByHeight},
+};
 pub trait ReactorEventT<I>:
     From<StorageRequest>
     + From<FetcherRequest<I, Block>>

--- a/node/src/components/linear_chain_sync/traits.rs
+++ b/node/src/components/linear_chain_sync/traits.rs
@@ -1,10 +1,7 @@
-use crate::{
-    effect::requests::{
+use crate::{effect::{announcements::ControlAnnouncement, requests::{
         BlockExecutorRequest, BlockValidationRequest, FetcherRequest, StateStoreRequest,
         StorageRequest,
-    },
-    types::{Block, BlockByHeight},
-};
+    }}, types::{Block, BlockByHeight}};
 pub trait ReactorEventT<I>:
     From<StorageRequest>
     + From<FetcherRequest<I, Block>>
@@ -12,6 +9,7 @@ pub trait ReactorEventT<I>:
     + From<BlockValidationRequest<Block, I>>
     + From<BlockExecutorRequest>
     + From<StateStoreRequest>
+    + From<ControlAnnouncement>
     + Send
 {
 }
@@ -23,6 +21,7 @@ impl<I, REv> ReactorEventT<I> for REv where
         + From<BlockValidationRequest<Block, I>>
         + From<BlockExecutorRequest>
         + From<StateStoreRequest>
+        + From<ControlAnnouncement>
         + Send
 {
 }


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-1006

Instead of failing when we run out of peers before we manage to synchronize _any_ linear chain block, we will wait up to 5 minutes (same as in consensus). When we run out of peers, after we started syncing blocks, we will fail and exit. The behavior has been modified only for the "initial sync".

As part of the work in this PR, I've also removed some of the `panic!` calls from the `LinearChainSync` and replaced them with calls to `fatal!` macro that should allow the node to drop all components cleanly.