### PR TITLE
EE-1131: Get rid of RootNotFound

### DIFF
--- a/execution_engine/src/core/engine_state/error.rs
+++ b/execution_engine/src/core/engine_state/error.rs
@@ -14,6 +14,8 @@ use crate::{
 
 #[derive(Clone, Error, Debug)]
 pub enum Error {
+    #[error("Root not found: {0}")]
+    RootNotFound(Blake2bHash),
     #[error("Invalid hash length: expected {expected}, actual {actual}")]
     InvalidHashLength { expected: usize, actual: usize },
     #[error("Invalid account hash length: expected {expected}, actual {actual}")]
@@ -92,18 +94,5 @@ impl DataSize for Error {
     #[inline]
     fn estimate_heap_size(&self) -> usize {
         12 // TODO: replace with some actual estimation depending on the variant
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct RootNotFound(Blake2bHash);
-
-impl RootNotFound {
-    pub fn new(hash: Blake2bHash) -> Self {
-        RootNotFound(hash)
-    }
-
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.0.as_ref().to_vec()
     }
 }

--- a/execution_engine/src/core/engine_state/execute_request.rs
+++ b/execution_engine/src/core/engine_state/execute_request.rs
@@ -2,14 +2,14 @@ use std::mem;
 
 use casper_types::{ProtocolVersion, PublicKey, SecretKey};
 
-use super::{deploy_item::DeployItem, execution_result::ExecutionResult};
+use super::deploy_item::DeployItem;
 use crate::shared::newtypes::Blake2bHash;
 
 #[derive(Debug)]
 pub struct ExecuteRequest {
     pub parent_state_hash: Blake2bHash,
     pub block_time: u64,
-    pub deploys: Vec<Result<DeployItem, ExecutionResult>>,
+    pub deploys: Vec<DeployItem>,
     pub protocol_version: ProtocolVersion,
     pub proposer: PublicKey,
 }
@@ -18,7 +18,7 @@ impl ExecuteRequest {
     pub fn new(
         parent_state_hash: Blake2bHash,
         block_time: u64,
-        deploys: Vec<Result<DeployItem, ExecutionResult>>,
+        deploys: Vec<DeployItem>,
         protocol_version: ProtocolVersion,
         proposer: PublicKey,
     ) -> Self {
@@ -31,11 +31,11 @@ impl ExecuteRequest {
         }
     }
 
-    pub fn take_deploys(&mut self) -> Vec<Result<DeployItem, ExecutionResult>> {
+    pub fn take_deploys(&mut self) -> Vec<DeployItem> {
         mem::replace(&mut self.deploys, vec![])
     }
 
-    pub fn deploys(&self) -> &Vec<Result<DeployItem, ExecutionResult>> {
+    pub fn deploys(&self) -> &Vec<DeployItem> {
         &self.deploys
     }
 }

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -431,28 +431,25 @@ where
         let mut results = ExecutionResults::with_capacity(deploys.len());
 
         for deploy_item in deploys {
-            let result = match deploy_item {
-                Err(exec_result) => Ok(exec_result),
-                Ok(deploy_item) => match deploy_item.session {
-                    ExecutableDeployItem::Transfer { .. } => self.transfer(
-                        correlation_id,
-                        &executor,
-                        exec_request.protocol_version,
-                        exec_request.parent_state_hash,
-                        BlockTime::new(exec_request.block_time),
-                        deploy_item,
-                        exec_request.proposer,
-                    ),
-                    _ => self.deploy(
-                        correlation_id,
-                        &executor,
-                        exec_request.protocol_version,
-                        exec_request.parent_state_hash,
-                        BlockTime::new(exec_request.block_time),
-                        deploy_item,
-                        exec_request.proposer,
-                    ),
-                },
+            let result = match deploy_item.session {
+                ExecutableDeployItem::Transfer { .. } => self.transfer(
+                    correlation_id,
+                    &executor,
+                    exec_request.protocol_version,
+                    exec_request.parent_state_hash,
+                    BlockTime::new(exec_request.block_time),
+                    deploy_item,
+                    exec_request.proposer,
+                ),
+                _ => self.deploy(
+                    correlation_id,
+                    &executor,
+                    exec_request.protocol_version,
+                    exec_request.parent_state_hash,
+                    BlockTime::new(exec_request.block_time),
+                    deploy_item,
+                    exec_request.proposer,
+                ),
             };
             match result {
                 Ok(result) => results.push_back(result),

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -50,7 +50,7 @@ pub use self::{
     deploy_item::DeployItem,
     engine_config::EngineConfig,
     era_validators::{GetEraValidatorsError, GetEraValidatorsRequest},
-    error::{Error, RootNotFound},
+    error::Error,
     executable_deploy_item::ExecutableDeployItem,
     execute_request::ExecuteRequest,
     execution::Error as ExecError,
@@ -424,7 +424,7 @@ where
         &self,
         correlation_id: CorrelationId,
         mut exec_request: ExecuteRequest,
-    ) -> Result<ExecutionResults, RootNotFound> {
+    ) -> Result<ExecutionResults, Error> {
         let executor = Executor::new(self.config);
 
         let deploys = exec_request.take_deploys();
@@ -524,7 +524,7 @@ where
         blocktime: BlockTime,
         deploy_item: DeployItem,
         proposer: PublicKey,
-    ) -> Result<ExecutionResult, RootNotFound> {
+    ) -> Result<ExecutionResult, Error> {
         let protocol_data = match self.state.get_protocol_data(protocol_version) {
             Ok(Some(protocol_data)) => protocol_data,
             Ok(None) => {
@@ -540,7 +540,7 @@ where
 
         let tracking_copy = match self.tracking_copy(prestate_hash) {
             Err(error) => return Ok(ExecutionResult::precondition_failure(error)),
-            Ok(None) => return Err(RootNotFound::new(prestate_hash)),
+            Ok(None) => return Err(Error::RootNotFound(prestate_hash)),
             Ok(Some(tracking_copy)) => Rc::new(RefCell::new(tracking_copy)),
         };
 
@@ -1054,7 +1054,7 @@ where
         blocktime: BlockTime,
         deploy_item: DeployItem,
         proposer: PublicKey,
-    ) -> Result<ExecutionResult, RootNotFound> {
+    ) -> Result<ExecutionResult, Error> {
         // spec: https://casperlabs.atlassian.net/wiki/spaces/EN/pages/123404576/Payment+code+execution+specification
 
         // Obtain current protocol data for given version
@@ -1082,7 +1082,7 @@ where
         // do this second; as there is no reason to proceed if the prestate hash is invalid
         let tracking_copy = match self.tracking_copy(prestate_hash) {
             Err(error) => return Ok(ExecutionResult::precondition_failure(error)),
-            Ok(None) => return Err(RootNotFound::new(prestate_hash)),
+            Ok(None) => return Err(Error::RootNotFound(prestate_hash)),
             Ok(Some(tracking_copy)) => Rc::new(RefCell::new(tracking_copy)),
         };
 

--- a/execution_engine_testing/test_support/src/internal/execute_request_builder.rs
+++ b/execution_engine_testing/test_support/src/internal/execute_request_builder.rs
@@ -30,7 +30,7 @@ impl ExecuteRequestBuilder {
     }
 
     pub fn push_deploy(mut self, deploy: DeployItem) -> Self {
-        self.execute_request.deploys.push(Ok(deploy));
+        self.execute_request.deploys.push(deploy);
         self
     }
 

--- a/execution_engine_testing/tests/src/test/deploy/receipts.rs
+++ b/execution_engine_testing/tests/src/test/deploy/receipts.rs
@@ -59,8 +59,6 @@ fn should_record_wasmless_transfer() {
         let deploy_items: Vec<DeployHash> = transfer_request
             .deploys()
             .iter()
-            .map(Result::as_ref)
-            .filter_map(Result::ok)
             .map(|deploy_item| deploy_item.deploy_hash)
             .collect();
         deploy_items[0]
@@ -127,8 +125,6 @@ fn should_record_wasm_transfer() {
         let deploy_items: Vec<DeployHash> = transfer_request
             .deploys()
             .iter()
-            .map(Result::as_ref)
-            .filter_map(Result::ok)
             .map(|deploy_item| deploy_item.deploy_hash)
             .collect();
         deploy_items[0]
@@ -195,8 +191,6 @@ fn should_record_wasm_transfer_with_id() {
         let deploy_items: Vec<DeployHash> = transfer_request
             .deploys()
             .iter()
-            .map(Result::as_ref)
-            .filter_map(Result::ok)
             .map(|deploy_item| deploy_item.deploy_hash)
             .collect();
         deploy_items[0]
@@ -277,8 +271,6 @@ fn should_record_wasm_transfers() {
         let deploy_items: Vec<DeployHash> = transfer_request
             .deploys()
             .iter()
-            .map(Result::as_ref)
-            .filter_map(Result::ok)
             .map(|deploy_item| deploy_item.deploy_hash)
             .collect();
         deploy_items[0]
@@ -425,8 +417,6 @@ fn should_record_wasm_transfers_with_subcall() {
         let deploy_items: Vec<DeployHash> = transfer_request
             .deploys()
             .iter()
-            .map(Result::as_ref)
-            .filter_map(Result::ok)
             .map(|deploy_item| deploy_item.deploy_hash)
             .collect();
         deploy_items[0]

--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -304,7 +304,7 @@ impl BlockExecutor {
         let execute_request = ExecuteRequest::new(
             state.state_root_hash.into(),
             state.finalized_block.timestamp().millis(),
-            vec![Ok(deploy_item)],
+            vec![deploy_item],
             self.protocol_version,
             state.finalized_block.proposer(),
         );

--- a/node/src/components/block_executor/event.rs
+++ b/node/src/components/block_executor/event.rs
@@ -8,7 +8,7 @@ use derive_more::From;
 use casper_execution_engine::{
     core::{
         engine_state,
-        engine_state::{step::StepResult, ExecutionResults, RootNotFound},
+        engine_state::{step::StepResult, ExecutionResults},
     },
     storage::global_state::CommitResult,
 };
@@ -55,7 +55,7 @@ pub enum Event {
         /// The header of the deploy currently being executed.
         deploy_header: DeployHeader,
         /// Result of deploy execution.
-        result: Result<ExecutionResults, RootNotFound>,
+        result: Result<ExecutionResults, engine_state::Error>,
     },
     /// The result of committing a single set of transforms after executing a single deploy.
     CommitExecutionEffects {

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1304,7 +1304,7 @@ impl<REv> EffectBuilder<REv> {
     pub(crate) async fn request_execute(
         self,
         execute_request: ExecuteRequest,
-    ) -> Result<ExecutionResults, engine_state::RootNotFound>
+    ) -> Result<ExecutionResults, engine_state::Error>
     where
         REv: From<ContractRuntimeRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -692,7 +692,7 @@ pub enum ContractRuntimeRequest {
         #[serde(skip_serializing)]
         execute_request: Box<ExecuteRequest>,
         /// Responder to call with the execution result.
-        responder: Responder<Result<ExecutionResults, engine_state::RootNotFound>>,
+        responder: Responder<Result<ExecutionResults, engine_state::Error>>,
     },
     /// A request to commit existing execution transforms.
     Commit {


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1131

This PR removes specialized "RootNotFound" struct-error which was moved into `engine_state::error::Error` as a separate variant.

Since RootNotFound is not a special case error anymore and now changed methods shares the same error type with other call sites there is still room for improvement in the error handling.