### PR TITLE
NO-TICKET/reconnect at all costs

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -637,7 +637,7 @@ where
         }
         if let Some(outgoing) = self.outgoing.remove(&peer_id) {
             trace!(our_id=%self.our_id, %peer_id, "removing peer from the outgoing connections");
-            let peer_ip = format!("{}", outgoing.peer_address.ip());
+            let peer_ip = outgoing.peer_address.to_string();
             if add_to_blocklist && !self.known_addresses.contains(&peer_ip) {
                 info!(our_id=%self.our_id, %peer_id, "blocklisting peer");
                 self.blocklist

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -364,8 +364,8 @@ where
         }
 
         // If any connection attempt succeeded, we will have a pending address, and thus are not
-        // isolated. However, should all DNS reconnection attempts fail, we want to retry
-        // resolving them as well, so we call `reconnect_if_isolated` again.
+        // isolated. However, should all DNS resolutions fail, we want to retry, so call
+        // `reconnect_if_isolated` again.
         effects.extend(self.reconnect_if_isolated(effect_builder));
 
         effects

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -818,7 +818,7 @@ where
     /// An isolated node has no chance of recovering a connection to the network and is not
     /// connected to any peer.
     fn is_isolated(&self) -> bool {
-        self.pending.is_empty() && self.outgoing.is_empty() && self.incoming.is_empty()
+        self.pending.is_empty() && self.outgoing.is_empty()
     }
 
     /// Returns the node id of this network node.

--- a/node/src/components/small_network/event.rs
+++ b/node/src/components/small_network/event.rs
@@ -25,6 +25,8 @@ pub enum Event<P> {
         peer_address: Box<SocketAddr>,
         error: Error,
     },
+    /// We were isolated and have waited the appropriate time.
+    IsolationReconnection,
     /// A new TCP connection has been established from an incoming connection.
     IncomingNew {
         #[serde(skip_serializing)]
@@ -106,6 +108,7 @@ impl<P: Display> Display for Event<P> {
                 "bootstrapping failed for node {}: {}",
                 peer_address, error
             ),
+            Event::IsolationReconnection => write!(f, "perform reconnection after isolation"),
             Event::IncomingNew { peer_address, .. } => {
                 write!(f, "incoming connection from {}", peer_address)
             }


### PR DESCRIPTION
This changes the logic and removes all instance of exiting the node, favoring infinite reconnection attempts to known nodes instead.  There is a hardcoded grace time of currently two seconds for this process, this could be made into a configuration variable instead.

This tries to handle most edge cases reasonably, but errs slightly on the side of not turning a node into a turbo reconnecting spammer. Some rare edge cases arise because of this, i.e. another isolated node connecting to use during the wait for reconnection.