### PR TITLE
NDRS-892: Remove HandleLinearBlock request.

### DIFF
--- a/node/src/components/block_executor/event.rs
+++ b/node/src/components/block_executor/event.rs
@@ -17,14 +17,12 @@ use casper_types::ExecutionResult;
 use crate::{
     crypto::hash::Digest,
     effect::requests::BlockExecutorRequest,
-    types::{Block, BlockHash, Deploy, DeployHash, DeployHeader, FinalizedBlock},
+    types::{BlockHash, Deploy, DeployHash, DeployHeader, FinalizedBlock},
 };
 
 /// Block executor component event.
 #[derive(Debug, From)]
 pub enum Event {
-    /// Indicates that block has already been finalized and executed in the past.
-    BlockAlreadyExists(Box<Block>),
     /// Indicates that a block is not known yet, and needs to be executed.
     BlockIsNew(FinalizedBlock),
     /// A request made of the Block executor component.
@@ -152,9 +150,6 @@ impl Display for Event {
                 state.state_root_hash,
                 result
             ),
-            Event::BlockAlreadyExists(block) => {
-                write!(f, "Block at height {} was executed before", block.height())
-            }
             Event::BlockIsNew(fb) => write!(f, "Block at height {} is new", fb.height(),),
         }
     }

--- a/node/src/components/block_executor/event.rs
+++ b/node/src/components/block_executor/event.rs
@@ -17,12 +17,14 @@ use casper_types::ExecutionResult;
 use crate::{
     crypto::hash::Digest,
     effect::requests::BlockExecutorRequest,
-    types::{BlockHash, Deploy, DeployHash, DeployHeader, FinalizedBlock},
+    types::{Block, BlockHash, Deploy, DeployHash, DeployHeader, FinalizedBlock},
 };
 
 /// Block executor component event.
 #[derive(Debug, From)]
 pub enum Event {
+    /// Indicates that block has already been finalized and executed in the past.
+    BlockAlreadyExists(Box<Block>),
     /// Indicates that a block is not known yet, and needs to be executed.
     BlockIsNew(FinalizedBlock),
     /// A request made of the Block executor component.
@@ -150,6 +152,9 @@ impl Display for Event {
                 state.state_root_hash,
                 result
             ),
+            Event::BlockAlreadyExists(block) => {
+                write!(f, "Block at height {} was executed before", block.height())
+            }
             Event::BlockIsNew(fb) => write!(f, "Block at height {} is new", fb.height(),),
         }
     }

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -392,11 +392,7 @@ where
                 let mut effects = effect_builder
                     .put_execution_results_to_storage(block_hash, execution_results)
                     .ignore();
-                effects.extend(
-                    effect_builder
-                        .announce_block_added(block_hash, block)
-                        .ignore(),
-                );
+                effects.extend(effect_builder.announce_block_added(block).ignore());
                 effects
             }
             Event::FinalitySignatureReceived(fs) => {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -22,7 +22,7 @@ use crate::{
             ConsensusRequest, ContractRuntimeRequest, LinearChainRequest, NetworkRequest,
             StorageRequest,
         },
-        EffectBuilder, EffectExt, EffectOptionExt, EffectResultExt, Effects,
+        EffectBuilder, EffectExt, EffectResultExt, Effects,
     },
     protocol::Message,
     types::{
@@ -392,11 +392,6 @@ where
                 let mut effects = effect_builder
                     .put_execution_results_to_storage(block_hash, execution_results)
                     .ignore();
-                effects.extend(
-                    effect_builder
-                        .handle_linear_chain_block(*block.clone())
-                        .map_some(move |fs| Event::FinalitySignatureReceived(Box::new(fs))),
-                );
                 effects.extend(
                     effect_builder
                         .announce_block_added(block_hash, block)

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -203,7 +203,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         match &self.state {
             State::None | State::Done(_) => {
                 error!(state=?self.state, "block downloaded when in incorrect state.");
-                return fatal!(effect_builder, "block downloaded in incorrect state").ignore();
+                fatal!(effect_builder, "block downloaded in incorrect state").ignore()
             }
             State::SyncingTrustedHash {
                 highest_block_header,
@@ -269,7 +269,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         match curr_state {
             State::None | State::Done(_) => {
                 error!(state=?self.state, "block handled when in incorrect state.");
-                return fatal!(effect_builder, "block handled in incorrect state").ignore();
+                fatal!(effect_builder, "block handled in incorrect state").ignore()
             }
             // Keep syncing from genesis if we haven't reached the trusted block hash
             State::SyncingTrustedHash {
@@ -279,7 +279,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             } if highest_block_seen != block_height => {
                 match latest_block.as_ref() {
                     Some(expected) if expected != &block => {
-                        error!(?expected, got=?block, "block execution result doesn't match received block");
+                        error!(
+                            ?expected, got=?block,
+                            "block execution result doesn't match received block"
+                        );
                         return fatal!(effect_builder, "unexpected block execution result")
                             .ignore();
                     }
@@ -304,7 +307,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                 assert_eq!(highest_block_seen, block_height);
                 match latest_block.as_ref() {
                     Some(expected) if expected != &block => {
-                        error!(?expected, got=?block, "block execution result doesn't match received block");
+                        error!(
+                            ?expected, got=?block,
+                            "block execution result doesn't match received block"
+                        );
                         return fatal!(effect_builder, "unexpected block execution result")
                             .ignore();
                     }
@@ -327,7 +333,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                 ..
             } => {
                 if latest_block.as_ref() != &block {
-                    error!(expected=?*latest_block, got=?block, "block execution result doesn't match received block");
+                    error!(
+                        expected=?*latest_block, got=?block,
+                        "block execution result doesn't match received block"
+                    );
                     return fatal!(effect_builder, "unexpected block execution result").ignore();
                 }
                 if self.is_recent_block(&block) {
@@ -443,11 +452,11 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             }
             State::Done(_) | State::None => {
                 error!(state=?self.state, "tried fetching next block when in wrong state");
-                return fatal!(
+                fatal!(
                     effect_builder,
                     "tried fetching next block when in wrong state"
                 )
-                .ignore();
+                .ignore()
             }
         }
     }
@@ -546,14 +555,20 @@ where
                 match fetch_result {
                     BlockByHeightResult::Absent(peer) => {
                         self.metrics.observe_get_block_by_height();
-                        trace!(%block_height, %peer, "failed to download block by height. Trying next peer");
+                        trace!(
+                            %block_height, %peer,
+                            "failed to download block by height. Trying next peer"
+                        );
                         self.peers.failure(&peer);
                         match self.peers.random() {
                             None => {
                                 // `block_height` not found on any of the peers.
                                 // We have synchronized all, currently existing, descendants of
                                 // trusted hash.
-                                info!("finished synchronizing descendants of the trusted hash. cleaning state.");
+                                info!(
+                                    "finished synchronizing descendants of the trusted hash. \
+                                    cleaning state."
+                                );
                                 self.mark_done();
                                 Effects::new()
                             }
@@ -606,19 +621,25 @@ where
                 match fetch_result {
                     BlockByHashResult::Absent(peer) => {
                         self.metrics.observe_get_block_by_hash();
-                        trace!(%block_hash, %peer, "failed to download block by hash. Trying next peer");
+                        trace!(
+                            %block_hash, %peer,
+                            "failed to download block by hash. Trying next peer"
+                        );
                         self.peers.failure(&peer);
                         match self.peers.random() {
                             None if self.started_syncing => {
-                                error!(%block_hash, "could not download linear block from any of the peers.");
-                                return fatal!(
-                                    effect_builder,
-                                    "failed to synchronize linear chain"
-                                )
-                                .ignore();
+                                error!(
+                                    %block_hash,
+                                    "could not download linear block from any of the peers."
+                                );
+                                fatal!(effect_builder, "failed to synchronize linear chain")
+                                    .ignore()
                             }
                             None => {
-                                warn!("run out of peers before managed to start syncing. Resetting peers' list and continuing");
+                                warn!(
+                                    "run out of peers before managed to start syncing. \
+                                    Resetting peers' list and continuing"
+                                );
                                 self.peers.reset(rng);
                                 self.metrics.reset_start_time();
                                 fetch_block_by_hash(effect_builder, peer, block_hash)
@@ -685,17 +706,19 @@ where
                     }
                     event::DeploysResult::NotFound(block, peer) => {
                         let block_hash = block.hash();
-                        trace!(%block_hash, %peer, "deploy for linear chain block not found. Trying next peer");
+                        trace!(
+                            %block_hash, %peer,
+                            "deploy for linear chain block not found. Trying next peer"
+                        );
                         self.peers.failure(&peer);
                         match self.peers.random() {
                             None => {
-                                error!(%block_hash,
-                                "could not download deploys from linear chain block.");
-                                return fatal!(
-                                    effect_builder,
-                                    "failed to download linear chain deploys"
-                                )
-                                .ignore();
+                                error!(
+                                    %block_hash,
+                                    "could not download deploys from linear chain block."
+                                );
+                                fatal!(effect_builder, "failed to download linear chain deploys")
+                                    .ignore()
                             }
                             Some(peer) => {
                                 self.metrics.reset_start_time();

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1120,6 +1120,19 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
+    /// Announces that we created a new signature for an executed block.
+    pub(crate) async fn announce_created_finality_signature<I>(self, fs: FinalitySignature)
+    where
+        REv: From<ConsensusAnnouncement<I>>,
+    {
+        self.0
+            .schedule(
+                ConsensusAnnouncement::CreatedFinalitySignature(Box::new(fs)),
+                QueueKind::Regular,
+            )
+            .await
+    }
+
     pub(crate) async fn announce_block_handled<I>(self, block: Block)
     where
         REv: From<ConsensusAnnouncement<I>>,
@@ -1468,18 +1481,6 @@ impl<REv> EffectBuilder<REv> {
                 step_request,
                 responder,
             },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    /// Request consensus to sign a block from the linear chain and possibly start a new era.
-    pub(crate) async fn handle_linear_chain_block(self, block: Block) -> Option<FinalitySignature>
-    where
-        REv: From<ConsensusRequest>,
-    {
-        self.make_request(
-            |responder| ConsensusRequest::HandleLinearBlock(Box::new(block), responder),
             QueueKind::Regular,
         )
         .await

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1180,13 +1180,13 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// The linear chain has stored a newly-created block.
-    pub(crate) async fn announce_block_added(self, block_hash: BlockHash, block: Box<Block>)
+    pub(crate) async fn announce_block_added(self, block: Box<Block>)
     where
         REv: From<LinearChainAnnouncement>,
     {
         self.0
             .schedule(
-                LinearChainAnnouncement::BlockAdded { block_hash, block },
+                LinearChainAnnouncement::BlockAdded(block),
                 QueueKind::Regular,
             )
             .await

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -19,8 +19,7 @@ use crate::{
     },
     effect::Responder,
     types::{
-        Block, BlockHash, Deploy, DeployHash, DeployHeader, FinalitySignature, FinalizedBlock,
-        Item, Timestamp,
+        Block, Deploy, DeployHash, DeployHeader, FinalitySignature, FinalizedBlock, Item, Timestamp,
     },
     utils::Source,
 };
@@ -254,12 +253,7 @@ impl<T: Item> Display for GossiperAnnouncement<T> {
 #[derive(Debug)]
 pub enum LinearChainAnnouncement {
     /// A new block has been created and stored locally.
-    BlockAdded {
-        /// Block hash.
-        block_hash: BlockHash,
-        /// Block.
-        block: Box<Block>,
-    },
+    BlockAdded(Box<Block>),
     /// New finality signature received.
     NewFinalitySignature(Box<FinalitySignature>),
 }
@@ -267,9 +261,7 @@ pub enum LinearChainAnnouncement {
 impl Display for LinearChainAnnouncement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            LinearChainAnnouncement::BlockAdded { block_hash, .. } => {
-                write!(f, "block added {}", block_hash)
-            }
+            LinearChainAnnouncement::BlockAdded(block) => write!(f, "block added {}", block.hash()),
             LinearChainAnnouncement::NewFinalitySignature(fs) => {
                 write!(f, "new finality signature {}", fs.block_hash)
             }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -162,6 +162,8 @@ impl<I: Display> Display for DeployAcceptorAnnouncement<I> {
 pub enum ConsensusAnnouncement<I> {
     /// A block was finalized.
     Finalized(Box<FinalizedBlock>),
+    /// A finality signature was created.
+    CreatedFinalitySignature(Box<FinalitySignature>),
     /// A linear chain block has been handled.
     Handled(Box<Block>),
     /// An equivocation has been detected.
@@ -185,6 +187,9 @@ where
         match self {
             ConsensusAnnouncement::Finalized(block) => {
                 write!(formatter, "finalized proto block {}", block)
+            }
+            ConsensusAnnouncement::CreatedFinalitySignature(fs) => {
+                write!(formatter, "signed an executed block: {}", fs)
             }
             ConsensusAnnouncement::Handled(block) => write!(
                 formatter,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -51,8 +51,8 @@ use crate::{
     rpcs::chain::BlockIdentifier,
     types::{
         Block as LinearBlock, Block, BlockHash, BlockHeader, BlockSignatures, Chainspec,
-        ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
-        FinalizedBlock, Item, NodeId, ProtoBlock, StatusFeed, TimeDiff, Timestamp,
+        ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock, Item,
+        NodeId, ProtoBlock, StatusFeed, TimeDiff, Timestamp,
     },
     utils::DisplayIter,
 };
@@ -980,8 +980,6 @@ impl<I: Display> Display for LinearChainRequest<I> {
 #[must_use]
 /// Consensus component requests.
 pub enum ConsensusRequest {
-    /// Request for consensus to sign a new linear chain block and possibly start a new era.
-    HandleLinearBlock(Box<Block>, Responder<Option<FinalitySignature>>),
     /// Check whether validator identifying with the public key is bonded.
     IsBondedValidator(EraId, PublicKey, Responder<bool>),
     /// Request for our public key, and if we're a validator, the next round length.

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -944,10 +944,8 @@ impl reactor::Reactor for Reactor {
                 ));
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
-            Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded {
-                block_hash,
-                block,
-            }) => {
+            Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded(block)) => {
+                let block_hash = *block.hash();
                 let ess_event = Event::EventStreamServer(event_stream_server::Event::BlockAdded {
                     block_hash,
                     block: block.clone(),


### PR DESCRIPTION
We want to move the era supervisor out of the joiner reactor. One of the joiner's components depending on the era supervisor is the linear chain, because it calls `handle_linear_chain_block` and `is_bonded_validator`. This PR removes the former: While we are joining, we don't need the era supervisor to create new finality signatures or to initialize new eras. ~It also removes the call from the block executor: We used to make the request there if an executed block was already stored, to initialize a new era, but initial eras are now initialized all at once when transitioning from the joiner to the validator reactor.~

https://casperlabs.atlassian.net/browse/NDRS-892