### PR TITLE
NO-TICKET: improve gossiper logging

### DIFF
--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -108,7 +108,7 @@ impl DeployAcceptor {
 
         // skip account verification if deploy not received from client or node is configured to
         // not verify accounts
-        if !source.from_client() || !self.verify_accounts {
+        if !source.from_peer() || !self.verify_accounts {
             return effect_builder
                 .immediately()
                 .event(move |_| Event::AccountVerificationResult {

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -347,7 +347,7 @@ where
                             peer,
                         )
                     }
-                    Source::Client => {
+                    Source::Client | Source::Ourself => {
                         // TODO - we could possibly also handle this case
                         Effects::new()
                     }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -193,7 +193,7 @@ impl Reactor for TestReactor {
             Event::NetworkAnnouncement(NetworkAnnouncement::GossipOurAddress(gossiped_address)) => {
                 let event = gossiper::Event::ItemReceived {
                     item_id: gossiped_address,
-                    source: Source::<NodeId>::Client,
+                    source: Source::<NodeId>::Ourself,
                 };
                 self.dispatch_event(effect_builder, rng, Event::AddressGossiper(event))
             }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -606,7 +606,7 @@ impl reactor::Reactor for Reactor {
             Event::NetworkAnnouncement(NetworkAnnouncement::GossipOurAddress(gossiped_address)) => {
                 let event = gossiper::Event::ItemReceived {
                     item_id: gossiped_address,
-                    source: Source::<NodeId>::Client,
+                    source: Source::<NodeId>::Ourself,
                 };
                 self.dispatch_event(effect_builder, rng, Event::AddressGossiper(event))
             }

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -795,7 +795,7 @@ impl reactor::Reactor for Reactor {
             Event::NetworkAnnouncement(NetworkAnnouncement::GossipOurAddress(gossiped_address)) => {
                 let event = gossiper::Event::ItemReceived {
                     item_id: gossiped_address,
-                    source: Source::<NodeId>::Client,
+                    source: Source::<NodeId>::Ourself,
                 };
                 self.dispatch_event(effect_builder, rng, Event::AddressGossiper(event))
             }

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -292,11 +292,13 @@ pub enum Source<I> {
     Peer(I),
     /// A client.
     Client,
+    /// This node.
+    Ourself,
 }
 
 impl<I> Source<I> {
-    pub(crate) fn from_client(&self) -> bool {
-        matches!(self, Source::Client)
+    pub(crate) fn from_peer(&self) -> bool {
+        matches!(self, Source::Peer(_))
     }
 }
 
@@ -305,7 +307,7 @@ impl<I: Clone> Source<I> {
     pub(crate) fn node_id(&self) -> Option<I> {
         match self {
             Source::Peer(node_id) => Some(node_id.clone()),
-            Source::Client => None,
+            Source::Client | Source::Ourself => None,
         }
     }
 }
@@ -315,6 +317,7 @@ impl<I: Display> Display for Source<I> {
         match self {
             Source::Peer(node_id) => Display::fmt(node_id, formatter),
             Source::Client => write!(formatter, "client"),
+            Source::Ourself => write!(formatter, "ourself"),
         }
     }
 }


### PR DESCRIPTION
This PR adds debug-level logging to the gossiper component and the gossip table.

It also adds a new variant `Ourself` to the `Source` enum to account for cases where the current node generates gossip items, for example when gossiping its own public address.