### PR TITLE
NO-TICKET: Fix Clippy warnings, formatting and remove a redundant argument.

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -397,11 +397,7 @@ where
                         .handle_linear_chain_block(*block.clone())
                         .map_some(move |fs| Event::FinalitySignatureReceived(Box::new(fs))),
                 );
-                effects.extend(
-                    effect_builder
-                        .announce_block_added(block_hash, block)
-                        .ignore(),
-                );
+                effects.extend(effect_builder.announce_block_added(block).ignore());
                 effects
             }
             Event::FinalitySignatureReceived(fs) => {

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -203,7 +203,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         match &self.state {
             State::None | State::Done(_) => {
                 error!(state=?self.state, "block downloaded when in incorrect state.");
-                return fatal!(effect_builder, "block downloaded in incorrect state").ignore();
+                fatal!(effect_builder, "block downloaded in incorrect state").ignore()
             }
             State::SyncingTrustedHash {
                 highest_block_header,
@@ -269,7 +269,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         match curr_state {
             State::None | State::Done(_) => {
                 error!(state=?self.state, "block handled when in incorrect state.");
-                return fatal!(effect_builder, "block handled in incorrect state").ignore();
+                fatal!(effect_builder, "block handled in incorrect state").ignore()
             }
             // Keep syncing from genesis if we haven't reached the trusted block hash
             State::SyncingTrustedHash {
@@ -279,7 +279,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             } if highest_block_seen != block_height => {
                 match latest_block.as_ref() {
                     Some(expected) if expected != &block => {
-                        error!(?expected, got=?block, "block execution result doesn't match received block");
+                        error!(
+                            ?expected, got=?block,
+                            "block execution result doesn't match received block"
+                        );
                         return fatal!(effect_builder, "unexpected block execution result")
                             .ignore();
                     }
@@ -304,7 +307,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                 assert_eq!(highest_block_seen, block_height);
                 match latest_block.as_ref() {
                     Some(expected) if expected != &block => {
-                        error!(?expected, got=?block, "block execution result doesn't match received block");
+                        error!(
+                            ?expected, got=?block,
+                            "block execution result doesn't match received block"
+                        );
                         return fatal!(effect_builder, "unexpected block execution result")
                             .ignore();
                     }
@@ -327,7 +333,10 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                 ..
             } => {
                 if latest_block.as_ref() != &block {
-                    error!(expected=?*latest_block, got=?block, "block execution result doesn't match received block");
+                    error!(
+                        expected=?*latest_block, got=?block,
+                        "block execution result doesn't match received block"
+                    );
                     return fatal!(effect_builder, "unexpected block execution result").ignore();
                 }
                 if self.is_recent_block(&block) {
@@ -443,11 +452,11 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             }
             State::Done(_) | State::None => {
                 error!(state=?self.state, "tried fetching next block when in wrong state");
-                return fatal!(
+                fatal!(
                     effect_builder,
                     "tried fetching next block when in wrong state"
                 )
-                .ignore();
+                .ignore()
             }
         }
     }
@@ -546,14 +555,20 @@ where
                 match fetch_result {
                     BlockByHeightResult::Absent(peer) => {
                         self.metrics.observe_get_block_by_height();
-                        trace!(%block_height, %peer, "failed to download block by height. Trying next peer");
+                        trace!(
+                            %block_height, %peer,
+                            "failed to download block by height. Trying next peer"
+                        );
                         self.peers.failure(&peer);
                         match self.peers.random() {
                             None => {
                                 // `block_height` not found on any of the peers.
                                 // We have synchronized all, currently existing, descendants of
                                 // trusted hash.
-                                info!("finished synchronizing descendants of the trusted hash. cleaning state.");
+                                info!(
+                                    "finished synchronizing descendants of the trusted hash. \
+                                    cleaning state."
+                                );
                                 self.mark_done();
                                 Effects::new()
                             }
@@ -606,19 +621,25 @@ where
                 match fetch_result {
                     BlockByHashResult::Absent(peer) => {
                         self.metrics.observe_get_block_by_hash();
-                        trace!(%block_hash, %peer, "failed to download block by hash. Trying next peer");
+                        trace!(
+                            %block_hash, %peer,
+                            "failed to download block by hash. Trying next peer"
+                        );
                         self.peers.failure(&peer);
                         match self.peers.random() {
                             None if self.started_syncing => {
-                                error!(%block_hash, "could not download linear block from any of the peers.");
-                                return fatal!(
-                                    effect_builder,
-                                    "failed to synchronize linear chain"
-                                )
-                                .ignore();
+                                error!(
+                                    %block_hash,
+                                    "could not download linear block from any of the peers."
+                                );
+                                fatal!(effect_builder, "failed to synchronize linear chain")
+                                    .ignore()
                             }
                             None => {
-                                warn!("run out of peers before managed to start syncing. Resetting peers' list and continuing");
+                                warn!(
+                                    "run out of peers before managed to start syncing. \
+                                    Resetting peers' list and continuing"
+                                );
                                 self.peers.reset(rng);
                                 self.metrics.reset_start_time();
                                 fetch_block_by_hash(effect_builder, peer, block_hash)
@@ -685,17 +706,19 @@ where
                     }
                     event::DeploysResult::NotFound(block, peer) => {
                         let block_hash = block.hash();
-                        trace!(%block_hash, %peer, "deploy for linear chain block not found. Trying next peer");
+                        trace!(
+                            %block_hash, %peer,
+                            "deploy for linear chain block not found. Trying next peer"
+                        );
                         self.peers.failure(&peer);
                         match self.peers.random() {
                             None => {
-                                error!(%block_hash,
-                                "could not download deploys from linear chain block.");
-                                return fatal!(
-                                    effect_builder,
-                                    "failed to download linear chain deploys"
-                                )
-                                .ignore();
+                                error!(
+                                    %block_hash,
+                                    "could not download deploys from linear chain block."
+                                );
+                                fatal!(effect_builder, "failed to download linear chain deploys")
+                                    .ignore()
                             }
                             Some(peer) => {
                                 self.metrics.reset_start_time();

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1167,13 +1167,13 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// The linear chain has stored a newly-created block.
-    pub(crate) async fn announce_block_added(self, block_hash: BlockHash, block: Box<Block>)
+    pub(crate) async fn announce_block_added(self, block: Box<Block>)
     where
         REv: From<LinearChainAnnouncement>,
     {
         self.0
             .schedule(
-                LinearChainAnnouncement::BlockAdded { block_hash, block },
+                LinearChainAnnouncement::BlockAdded(block),
                 QueueKind::Regular,
             )
             .await

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -19,8 +19,7 @@ use crate::{
     },
     effect::Responder,
     types::{
-        Block, BlockHash, Deploy, DeployHash, DeployHeader, FinalitySignature, FinalizedBlock,
-        Item, Timestamp,
+        Block, Deploy, DeployHash, DeployHeader, FinalitySignature, FinalizedBlock, Item, Timestamp,
     },
     utils::Source,
 };
@@ -249,12 +248,7 @@ impl<T: Item> Display for GossiperAnnouncement<T> {
 #[derive(Debug)]
 pub enum LinearChainAnnouncement {
     /// A new block has been created and stored locally.
-    BlockAdded {
-        /// Block hash.
-        block_hash: BlockHash,
-        /// Block.
-        block: Box<Block>,
-    },
+    BlockAdded(Box<Block>),
     /// New finality signature received.
     NewFinalitySignature(Box<FinalitySignature>),
 }
@@ -262,8 +256,8 @@ pub enum LinearChainAnnouncement {
 impl Display for LinearChainAnnouncement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            LinearChainAnnouncement::BlockAdded { block_hash, .. } => {
-                write!(f, "block added {}", block_hash)
+            LinearChainAnnouncement::BlockAdded(block) => {
+                write!(f, "block added {}", block.hash())
             }
             LinearChainAnnouncement::NewFinalitySignature(fs) => {
                 write!(f, "new finality signature {}", fs.block_hash)

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -869,17 +869,17 @@ impl reactor::Reactor for Reactor {
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
 
-            Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded {
-                block_hash,
-                block,
-            }) => reactor::wrap_effects(
-                Event::EventStreamServer,
-                self.event_stream_server.handle_event(
-                    effect_builder,
-                    rng,
-                    event_stream_server::Event::BlockAdded { block_hash, block },
-                ),
-            ),
+            Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded(block)) => {
+                let block_hash = *block.hash();
+                reactor::wrap_effects(
+                    Event::EventStreamServer,
+                    self.event_stream_server.handle_event(
+                        effect_builder,
+                        rng,
+                        event_stream_server::Event::BlockAdded { block_hash, block },
+                    ),
+                )
+            }
             Event::LinearChainAnnouncement(LinearChainAnnouncement::NewFinalitySignature(fs)) => {
                 let reactor_event =
                     Event::EventStreamServer(event_stream_server::Event::FinalitySignature(fs));

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -939,10 +939,8 @@ impl reactor::Reactor for Reactor {
                 ));
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
-            Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded {
-                block_hash,
-                block,
-            }) => {
+            Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded(block)) => {
+                let block_hash = *block.hash();
                 let reactor_event =
                     Event::EventStreamServer(event_stream_server::Event::BlockAdded {
                         block_hash,


### PR DESCRIPTION
Formatting in `linear_chain_sync.rs` was broken — if it can't fix it, `rustfmt` won't touch it —, there were Clippy warnings in that file, and `BlockAdded` had a redundant `block_hash` argument: Since the `Block` contains its hash and doesn't need to recompute it, this is not needed.
(Found while working on [NDRS-892](https://casperlabs.atlassian.net/browse/NDRS-892).)