### PR TITLE
NO-TICKET: Fix hex issue

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -191,6 +191,11 @@ steps:
   commands:
     - "./ci/build_update_package.sh"
 
+- name: dry-run-publish
+  image: casperlabs/node-build-u1804
+  commands:
+    - "cd types && cargo publish --dry-run"
+
 - name: upload-to-s3-genesis
   image: plugins/s3
   settings:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -44,7 +44,7 @@ version-sync = "0.9"
 serde_test = "1.0.117"
 
 [features]
-default = ["base16/alloc", "serde/alloc", "serde_json/alloc", "displaydoc"]
+default = ["base16/alloc", "hex/alloc", "serde/alloc", "serde_json/alloc", "displaydoc"]
 std = [
     "base16/std",
     "base64/std",


### PR DESCRIPTION
"hex" crate likely got updated as part of other batched deps update and `hex::encode` in newer version is hidden behind a feature switch. This PR fixes `cargo publish` failure that occurs in 

```
   Compiling casper-types v0.9.0 (/drone/src/target/package/casper-types-0.9.0)
error[E0425]: cannot find function `encode` in crate `hex`
  --> src/cl_value/jsonrepr.rs:58:30
   |
58 |             Some((json![hex::encode(bytes)], remainder))
   |                              ^^^^^^ not found in `hex`
```