### PR TITLE
Update cbindgen dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.15.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df6a11bba1d7cab86c166cecf4cf8acd7d02b7b65924d81b33d27197f22ee35"
+checksum = "97449daf9b8c245bcad10bbc7c9f4a37c06172c18dd5f9fac340deefc309b957"
 dependencies = [
  "clap",
  "heck",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -41,7 +41,7 @@ thiserror = "1.0.20"
 tokio = { version = "0.2.20", features = ["macros", "rt-threaded", "sync", "tcp", "time", "blocking"] }
 
 [build-dependencies]
-cbindgen = { version = "0.15", optional = true }
+cbindgen = { version = "0.18", optional = true }
 
 [features]
 default = ["ffi"]


### PR DESCRIPTION
REF: https://casperlabs.atlassian.net/browse/NDRS-987

CHANGELOG: 

- Updated `cbindgen` build dependency in `casper-client` from `0.15` to the latest version `0.18`