### PR TITLE
NO-TICKET: remove failed bootstrap address from pending set

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -875,7 +875,12 @@ where
                 error,
             } => {
                 warn!(our_id=%self.our_id, %peer_address, %error, "connection to known node failed");
-
+                if !self.pending.remove(&peer_address) {
+                    warn!(
+                        %peer_address,
+                        "bootstrap failed, but it was not in the set of pending connections"
+                    );
+                }
                 self.terminate_if_isolated(effect_builder)
             }
             Event::IncomingNew {

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -1,17 +1,32 @@
-use std::fmt::{self, Debug, Display, Formatter};
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    net::SocketAddr,
+};
 
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Message<P> {
-    Handshake { network_name: String },
+    Handshake {
+        /// Network we are connected to.
+        network_name: String,
+        /// The public address of the node connecting.
+        public_address: SocketAddr,
+    },
     Payload(P),
 }
 
 impl<P: Display> Display for Message<P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Message::Handshake { network_name } => write!(f, "handshake: {}", network_name),
+            Message::Handshake {
+                network_name,
+                public_address,
+            } => write!(
+                f,
+                "handshake: {}, public addr: {}",
+                network_name, public_address
+            ),
             Message::Payload(payload) => write!(f, "payload: {}", payload),
         }
     }


### PR DESCRIPTION
This PR effectively reverts [0dd0fdd](https://github.com/CasperLabs/casper-node/commit/0dd0fdd9ea87e88213821732857fba0dd2be3fe8) which created an issue whereby failed bootstrap connections would live forever in the small_network's `pending` set, meaning these bootstrap peers could never be connected to in that session.