### PR TITLE
NDRS-893: Make the syncing process not depend on the Era Supervisor

### DIFF
--- a/node/src/components/block_executor.rs
+++ b/node/src/components/block_executor.rs
@@ -530,9 +530,9 @@ impl<REv: ReactorEventT> Component<REv> for BlockExecutor {
                         )
                     })
             }
-            Event::BlockAlreadyExists(block) => {
-                effect_builder.handle_linear_chain_block(*block).ignore()
-            }
+            Event::BlockAlreadyExists(block) => effect_builder
+                .announce_block_already_executed(*block)
+                .ignore(),
             // If we haven't executed the block before in the past (for example during
             // joining), do it now.
             Event::BlockIsNew(finalized_block) => self.get_deploys(effect_builder, finalized_block),

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -99,6 +99,8 @@ pub enum Event<I> {
     },
     #[from]
     ConsensusRequest(ConsensusRequest),
+    /// A new block has been added to the linear chain.
+    BlockAdded(Box<Block>),
     /// The proto-block has been validated.
     ResolveValidity {
         era_id: EraId,
@@ -198,6 +200,11 @@ impl<I: Debug> Display for Event<I> {
                 f,
                 "A request for consensus component hash been receieved: {:?}",
                 request
+            ),
+            Event::BlockAdded(block) => write!(
+                f,
+                "A block has been added to the linear chain: {}",
+                block.hash()
             ),
             Event::ResolveValidity {
                 era_id,
@@ -304,9 +311,7 @@ where
                 proto_block,
                 block_context,
             } => handling_es.handle_new_proto_block(era_id, proto_block, block_context),
-            Event::ConsensusRequest(ConsensusRequest::HandleLinearBlock(block, responder)) => {
-                handling_es.handle_linear_chain_block(*block, responder)
-            }
+            Event::BlockAdded(block) => handling_es.handle_block_added(*block),
             Event::ResolveValidity {
                 era_id,
                 sender,
@@ -358,11 +363,11 @@ where
                 // chain blocks once the eras are initialized. It's possible that we will get
                 // events with linear chain blocks before that - in such a case we cache the
                 // requests and only handle them here.
-                for queued_request in mem::take(&mut handling_es.era_supervisor.enqueued_requests) {
+                for queued_event in mem::take(&mut handling_es.era_supervisor.enqueued_events) {
                     effects.extend(handling_es.era_supervisor.handle_event(
                         effect_builder,
                         handling_es.rng,
-                        queued_request.into(),
+                        queued_event,
                     ));
                 }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -48,10 +48,7 @@ use crate::{
         contract_runtime::EraValidatorsRequest,
     },
     crypto::hash::Digest,
-    effect::{
-        requests::{ConsensusRequest, StorageRequest},
-        EffectBuilder, EffectExt, Effects, Responder,
-    },
+    effect::{requests::StorageRequest, EffectBuilder, EffectExt, Effects, Responder},
     fatal,
     types::{
         ActivationPoint, Block, BlockHash, BlockHeader, BlockLike, FinalitySignature,
@@ -124,7 +121,7 @@ pub struct EraSupervisor<I> {
     /// component.
     is_initialized: bool,
     /// TODO: Remove once the era supervisor is removed from the Joiner reactor.
-    pub(crate) enqueued_requests: VecDeque<ConsensusRequest>,
+    pub(crate) enqueued_events: VecDeque<Event<I>>,
 }
 
 impl<I> Debug for EraSupervisor<I> {
@@ -190,7 +187,7 @@ where
             stop_for_upgrade: false,
             next_executed_height: 0,
             is_initialized: false,
-            enqueued_requests: Default::default(),
+            enqueued_events: Default::default(),
         };
 
         let bonded_eras = era_supervisor.bonded_eras();
@@ -795,33 +792,32 @@ where
         })
     }
 
-    pub(super) fn handle_linear_chain_block(
-        &mut self,
-        block: Block,
-        responder: Responder<Option<FinalitySignature>>,
-    ) -> Effects<Event<I>> {
+    pub(super) fn handle_block_added(&mut self, block: Block) -> Effects<Event<I>> {
         // TODO: Delete once `EraSupervisor` gets removed from the joiner reactor.
         if !self.era_supervisor.is_initialized() {
             // enqueue
             self.era_supervisor
-                .enqueued_requests
-                .push_back(ConsensusRequest::HandleLinearBlock(
-                    Box::new(block),
-                    responder,
-                ));
+                .enqueued_events
+                .push_back(Event::BlockAdded(Box::new(block)));
             return Effects::new();
         }
         let our_pk = self.era_supervisor.public_signing_key;
         let our_sk = self.era_supervisor.secret_signing_key.clone();
         let era_id = block.header().era_id();
         self.era_supervisor.executed_block(block.header());
-        let maybe_fin_sig = if self.era_supervisor.is_validator_in(&our_pk, era_id) {
+        let mut effects = if self.era_supervisor.is_validator_in(&our_pk, era_id) {
             let block_hash = block.hash();
-            Some(FinalitySignature::new(*block_hash, era_id, &our_sk, our_pk))
+            self.effect_builder
+                .announce_created_finality_signature(FinalitySignature::new(
+                    *block_hash,
+                    era_id,
+                    &our_sk,
+                    our_pk,
+                ))
+                .ignore()
         } else {
-            None
+            Effects::new()
         };
-        let mut effects = responder.respond(maybe_fin_sig).ignore();
         if era_id < self.era_supervisor.current_era {
             trace!(era = era_id.0, "executed block in old era");
             return effects;
@@ -841,9 +837,6 @@ where
                 booking_block_hash: Ok(booking_block_hash),
             });
             effects.extend(effect);
-        } else {
-            // if it's not a switch block, we can already declare it handled
-            effects.extend(self.effect_builder.announce_block_handled(block).ignore());
         }
         effects
     }
@@ -952,13 +945,7 @@ where
             switch_block.header().timestamp(),
             switch_block.height() + 1,
         );
-        let mut effects = self.handle_consensus_outcomes(era_id, outcomes);
-        effects.extend(
-            self.effect_builder
-                .announce_block_handled(switch_block)
-                .ignore(),
-        );
-        effects
+        self.handle_consensus_outcomes(era_id, outcomes)
     }
 
     pub(super) fn resolve_validity(

--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -91,8 +91,8 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         match event {
-            Event::BlockAdded { block_hash, block } => self.broadcast(SseData::BlockAdded {
-                block_hash,
+            Event::BlockAdded(block) => self.broadcast(SseData::BlockAdded {
+                block_hash: *block.hash(),
                 block: Box::new(*block),
             }),
             Event::DeployProcessed {

--- a/node/src/components/event_stream_server/event.rs
+++ b/node/src/components/event_stream_server/event.rs
@@ -9,10 +9,7 @@ use crate::{
 
 #[derive(Debug)]
 pub enum Event {
-    BlockAdded {
-        block_hash: BlockHash,
-        block: Box<Block>,
-    },
+    BlockAdded(Box<Block>),
     DeployProcessed {
         deploy_hash: DeployHash,
         deploy_header: Box<DeployHeader>,
@@ -30,7 +27,7 @@ pub enum Event {
 impl Display for Event {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
-            Event::BlockAdded { block_hash, .. } => write!(formatter, "block added {}", block_hash),
+            Event::BlockAdded(block) => write!(formatter, "block added {}", block.hash()),
             Event::DeployProcessed { deploy_hash, .. } => {
                 write!(formatter, "deploy processed {}", deploy_hash)
             }

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -22,7 +22,7 @@ use crate::{
             ConsensusRequest, ContractRuntimeRequest, LinearChainRequest, NetworkRequest,
             StorageRequest,
         },
-        EffectBuilder, EffectExt, EffectOptionExt, EffectResultExt, Effects,
+        EffectBuilder, EffectExt, EffectResultExt, Effects,
     },
     protocol::Message,
     types::{
@@ -392,11 +392,6 @@ where
                 let mut effects = effect_builder
                     .put_execution_results_to_storage(block_hash, execution_results)
                     .ignore();
-                effects.extend(
-                    effect_builder
-                        .handle_linear_chain_block(*block.clone())
-                        .map_some(move |fs| Event::FinalitySignatureReceived(Box::new(fs))),
-                );
                 effects.extend(
                     effect_builder
                         .announce_block_added(block_hash, block)

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -203,7 +203,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         match &self.state {
             State::None | State::Done(_) => {
                 error!(state=?self.state, "block downloaded when in incorrect state.");
-                return fatal!(effect_builder, "block downloaded in incorrect state").ignore();
+                fatal!(effect_builder, "block downloaded in incorrect state").ignore()
             }
             State::SyncingTrustedHash {
                 highest_block_header,
@@ -269,7 +269,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         match curr_state {
             State::None | State::Done(_) => {
                 error!(state=?self.state, "block handled when in incorrect state.");
-                return fatal!(effect_builder, "block handled in incorrect state").ignore();
+                fatal!(effect_builder, "block handled in incorrect state").ignore()
             }
             // Keep syncing from genesis if we haven't reached the trusted block hash
             State::SyncingTrustedHash {
@@ -443,11 +443,11 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
             }
             State::Done(_) | State::None => {
                 error!(state=?self.state, "tried fetching next block when in wrong state");
-                return fatal!(
+                fatal!(
                     effect_builder,
                     "tried fetching next block when in wrong state"
                 )
-                .ignore();
+                .ignore()
             }
         }
     }
@@ -611,11 +611,8 @@ where
                         match self.peers.random() {
                             None if self.started_syncing => {
                                 error!(%block_hash, "could not download linear block from any of the peers.");
-                                return fatal!(
-                                    effect_builder,
-                                    "failed to synchronize linear chain"
-                                )
-                                .ignore();
+                                fatal!(effect_builder, "failed to synchronize linear chain")
+                                    .ignore()
                             }
                             None => {
                                 warn!("run out of peers before managed to start syncing. Resetting peers' list and continuing");
@@ -691,11 +688,8 @@ where
                             None => {
                                 error!(%block_hash,
                                 "could not download deploys from linear chain block.");
-                                return fatal!(
-                                    effect_builder,
-                                    "failed to download linear chain deploys"
-                                )
-                                .ignore();
+                                fatal!(effect_builder, "failed to download linear chain deploys")
+                                    .ignore()
                             }
                             Some(peer) => {
                                 self.metrics.reset_start_time();

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -674,6 +674,19 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
+    /// Announce that a block had been executed before.
+    pub(crate) async fn announce_block_already_executed(self, block: Block)
+    where
+        REv: From<BlockExecutorAnnouncement>,
+    {
+        self.0
+            .schedule(
+                BlockExecutorAnnouncement::BlockAlreadyExecuted { block },
+                QueueKind::Regular,
+            )
+            .await
+    }
+
     /// Announce upgrade activation point read.
     pub(crate) async fn announce_upgrade_activation_point_read(self, next_upgrade: NextUpgrade)
     where
@@ -1120,13 +1133,16 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
-    pub(crate) async fn announce_block_handled<I>(self, block: Block)
-    where
+    /// Announces that a finality signature has been created.
+    pub(crate) async fn announce_created_finality_signature<I>(
+        self,
+        finality_signature: FinalitySignature,
+    ) where
         REv: From<ConsensusAnnouncement<I>>,
     {
         self.0
             .schedule(
-                ConsensusAnnouncement::Handled(Box::new(block)),
+                ConsensusAnnouncement::CreatedFinalitySignature(Box::new(finality_signature)),
                 QueueKind::Regular,
             )
             .await
@@ -1468,18 +1484,6 @@ impl<REv> EffectBuilder<REv> {
                 step_request,
                 responder,
             },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    /// Request consensus to sign a block from the linear chain and possibly start a new era.
-    pub(crate) async fn handle_linear_chain_block(self, block: Block) -> Option<FinalitySignature>
-    where
-        REv: From<ConsensusRequest>,
-    {
-        self.make_request(
-            |responder| ConsensusRequest::HandleLinearBlock(Box::new(block), responder),
             QueueKind::Regular,
         )
         .await

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -681,7 +681,7 @@ impl<REv> EffectBuilder<REv> {
     {
         self.0
             .schedule(
-                BlockExecutorAnnouncement::BlockAlreadyExecuted { block },
+                BlockExecutorAnnouncement::BlockAlreadyExecuted(block),
                 QueueKind::Regular,
             )
             .await

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -215,10 +215,7 @@ pub enum BlockExecutorAnnouncement {
         execution_results: HashMap<DeployHash, (DeployHeader, ExecutionResult)>,
     },
     /// A block was requested to be executed, but it had been executed before.
-    BlockAlreadyExecuted {
-        /// The block.
-        block: Block,
-    },
+    BlockAlreadyExecuted(Block),
 }
 
 impl Display for BlockExecutorAnnouncement {
@@ -227,7 +224,7 @@ impl Display for BlockExecutorAnnouncement {
             BlockExecutorAnnouncement::LinearChainBlock { block, .. } => {
                 write!(f, "created linear chain block {}", block.hash())
             }
-            BlockExecutorAnnouncement::BlockAlreadyExecuted { block } => {
+            BlockExecutorAnnouncement::BlockAlreadyExecuted(block) => {
                 write!(f, "block had been executed before: {}", block.hash())
             }
         }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -162,8 +162,8 @@ impl<I: Display> Display for DeployAcceptorAnnouncement<I> {
 pub enum ConsensusAnnouncement<I> {
     /// A block was finalized.
     Finalized(Box<FinalizedBlock>),
-    /// A linear chain block has been handled.
-    Handled(Box<Block>),
+    /// A finality signature was created.
+    CreatedFinalitySignature(Box<FinalitySignature>),
     /// An equivocation has been detected.
     Fault {
         /// The Id of the era in which the equivocation was detected
@@ -186,12 +186,9 @@ where
             ConsensusAnnouncement::Finalized(block) => {
                 write!(formatter, "finalized proto block {}", block)
             }
-            ConsensusAnnouncement::Handled(block) => write!(
-                formatter,
-                "Linear chain block has been handled by consensus, height={}, hash={}",
-                block.height(),
-                block.hash()
-            ),
+            ConsensusAnnouncement::CreatedFinalitySignature(fs) => {
+                write!(formatter, "signed an executed block: {}", fs)
+            }
             ConsensusAnnouncement::Fault {
                 era_id,
                 public_key,
@@ -218,6 +215,11 @@ pub enum BlockExecutorAnnouncement {
         /// The results of executing the deploys in this block.
         execution_results: HashMap<DeployHash, (DeployHeader, ExecutionResult)>,
     },
+    /// A block was requested to be executed, but it had been executed before.
+    BlockAlreadyExecuted {
+        /// The block.
+        block: Block,
+    },
 }
 
 impl Display for BlockExecutorAnnouncement {
@@ -225,6 +227,9 @@ impl Display for BlockExecutorAnnouncement {
         match self {
             BlockExecutorAnnouncement::LinearChainBlock { block, .. } => {
                 write!(f, "created linear chain block {}", block.hash())
+            }
+            BlockExecutorAnnouncement::BlockAlreadyExecuted { block } => {
+                write!(f, "block had been executed before: {}", block.hash())
             }
         }
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -51,8 +51,8 @@ use crate::{
     rpcs::chain::BlockIdentifier,
     types::{
         Block as LinearBlock, Block, BlockHash, BlockHeader, BlockSignatures, Chainspec,
-        ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
-        FinalizedBlock, Item, NodeId, ProtoBlock, StatusFeed, TimeDiff, Timestamp,
+        ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock, Item,
+        NodeId, ProtoBlock, StatusFeed, TimeDiff, Timestamp,
     },
     utils::DisplayIter,
 };
@@ -980,8 +980,6 @@ impl<I: Display> Display for LinearChainRequest<I> {
 #[must_use]
 /// Consensus component requests.
 pub enum ConsensusRequest {
-    /// Request for consensus to sign a new linear chain block and possibly start a new era.
-    HandleLinearBlock(Box<Block>, Responder<Option<FinalitySignature>>),
     /// Check whether validator identifying with the public key is bonded.
     IsBondedValidator(EraId, PublicKey, Responder<bool>),
     /// Request for our public key, and if we're a validator, the next round length.

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -799,9 +799,9 @@ impl reactor::Reactor for Reactor {
 
                 effects
             }
-            Event::BlockExecutorAnnouncement(BlockExecutorAnnouncement::BlockAlreadyExecuted {
+            Event::BlockExecutorAnnouncement(BlockExecutorAnnouncement::BlockAlreadyExecuted(
                 block,
-            }) => {
+            )) => {
                 let mut effects = self.dispatch_event(
                     effect_builder,
                     rng,
@@ -882,16 +882,12 @@ impl reactor::Reactor for Reactor {
             }
 
             Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded(block)) => {
-                let block_hash = *block.hash();
                 let mut effects = reactor::wrap_effects(
                     Event::EventStreamServer,
                     self.event_stream_server.handle_event(
                         effect_builder,
                         rng,
-                        event_stream_server::Event::BlockAdded {
-                            block_hash,
-                            block: block.clone(),
-                        },
+                        event_stream_server::Event::BlockAdded(block.clone()),
                     ),
                 );
                 let reactor_event =

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -930,9 +930,9 @@ impl reactor::Reactor for Reactor {
 
                 effects
             }
-            Event::BlockExecutorAnnouncement(BlockExecutorAnnouncement::BlockAlreadyExecuted {
-                block: _,
-            }) => {
+            Event::BlockExecutorAnnouncement(BlockExecutorAnnouncement::BlockAlreadyExecuted(
+                _,
+            )) => {
                 debug!("Ignoring `BlockAlreadyExecuted` announcement in `validator` reactor.");
                 Effects::new()
             }
@@ -947,12 +947,8 @@ impl reactor::Reactor for Reactor {
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
             Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded(block)) => {
-                let block_hash = *block.hash();
                 let reactor_event =
-                    Event::EventStreamServer(event_stream_server::Event::BlockAdded {
-                        block_hash,
-                        block: block.clone(),
-                    });
+                    Event::EventStreamServer(event_stream_server::Event::BlockAdded(block.clone()));
                 let mut effects = self.dispatch_event(effect_builder, rng, reactor_event);
                 let reactor_event = Event::Consensus(consensus::Event::BlockAdded(block));
                 effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));


### PR DESCRIPTION
This rewires events used during syncing so that they do not have to pass through the Era Supervisor anymore:
- removes `ConsensusRequest::HandleLinearBlock`
- removes `ConsensusAnnouncement::Handled`
- makes `LinearChainSync` progress on either `LinearChainAnnouncement::BlockAdded` or `BlockExecutorAnnouncement::BlockAlreadyExecuted` (a new announcement type)
- adds `ConsensusAnnouncement::CreatedFinalitySignature`, triggered by `LinearChainAnnouncement::BlockAdded` and replacing the response to `ConsensusRequest::HandleLinearBlock` for the purposes of collection of finality signatures.