### PR TITLE
NDRS-1010: Don't create a new era when we should shutdown for an upgrade. (backport to 0.9.3)

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -826,7 +826,7 @@ where
             trace!(era = era_id.0, "executed block in old era");
             return effects;
         }
-        if block.header().is_switch_block() {
+        if block.header().is_switch_block() && !self.should_upgrade_after(&era_id) {
             // if the block is a switch block, we have to get the validators for the new era and
             // create it, before we can say we handled the block
             let new_era_id = era_id.successor();


### PR DESCRIPTION
Backport of https://github.com/CasperLabs/casper-node/pull/1115.

https://casperlabs.atlassian.net/browse/NDRS-1010