### PR TITLE
NDRS-892: Remove the dependency on the Era Supervisor from the Linear Chain

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -378,9 +378,6 @@ where
             Event::GotUpgradeActivationPoint(activation_point) => {
                 handling_es.got_upgrade_activation_point(activation_point)
             }
-            Event::ConsensusRequest(ConsensusRequest::IsBondedValidator(era_id, pk, responder)) => {
-                handling_es.is_bonded_validator(era_id, pk, responder)
-            }
             Event::ConsensusRequest(ConsensusRequest::Status(responder)) => {
                 handling_es.status(responder)
             }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1243,21 +1243,6 @@ where
         Effects::new()
     }
 
-    /// Returns whether validator is bonded in an era.
-    pub(super) fn is_bonded_validator(
-        &self,
-        era_id: EraId,
-        vid: PublicKey,
-        responder: Responder<bool>,
-    ) -> Effects<Event<I>> {
-        let is_bonded = self
-            .era_supervisor
-            .active_eras
-            .get(&era_id)
-            .map_or(false, |cp| cp.is_bonded_validator(&vid));
-        responder.respond(is_bonded).ignore()
-    }
-
     pub(super) fn status(
         &self,
         responder: Responder<(PublicKey, Option<TimeDiff>)>,

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -32,20 +32,17 @@ use tracing::{debug, error, info, trace, warn};
 use casper_types::{AsymmetricType, ProtocolVersion, PublicKey, SecretKey, U512};
 
 use crate::{
-    components::{
-        consensus::{
-            candidate_block::CandidateBlock,
-            cl_context::{ClContext, Keypair},
-            config::ProtocolConfig,
-            consensus_protocol::{
-                BlockContext, ConsensusProtocol, EraReport, FinalizedBlock as CpFinalizedBlock,
-                ProtocolOutcome, ProtocolOutcomes,
-            },
-            metrics::ConsensusMetrics,
-            traits::NodeIdT,
-            ActionId, Config, ConsensusMessage, Event, ReactorEventT, TimerId,
+    components::consensus::{
+        candidate_block::CandidateBlock,
+        cl_context::{ClContext, Keypair},
+        config::ProtocolConfig,
+        consensus_protocol::{
+            BlockContext, ConsensusProtocol, EraReport, FinalizedBlock as CpFinalizedBlock,
+            ProtocolOutcome, ProtocolOutcomes,
         },
-        contract_runtime::EraValidatorsRequest,
+        metrics::ConsensusMetrics,
+        traits::NodeIdT,
+        ActionId, Config, ConsensusMessage, Event, ReactorEventT, TimerId,
     },
     crypto::hash::Digest,
     effect::{requests::StorageRequest, EffectBuilder, EffectExt, Effects, Responder},
@@ -216,40 +213,16 @@ where
                 // All eras can be initialized using the key blocks only.
                 (key_blocks, booking_blocks, Default::default())
             } else {
-                // We need the validator set for the activation era from some protocol state.
-                let state_root_hash = if activation_era_id == current_era {
-                    // The activation era is the current one, so the initial state root hash
-                    // contains its validator set.
-                    initial_state_root_hash
-                } else if activation_era_id.is_genesis() {
-                    // To initialize the first era, we can use the global state of the first block.
-                    *effect_builder
-                        .get_block_at_height_local(0)
-                        .await
-                        .expect("missing block in genesis era")
-                        .state_root_hash()
-                } else {
-                    // The first block in the activation era contains the validator set.
-                    let block_height = if activation_era_id.is_genesis() {
-                        0
-                    } else {
-                        &key_blocks[&activation_era_id].height() + 1
-                    };
-                    *effect_builder
-                        .get_block_at_height_local(block_height)
-                        .await
-                        .expect("missing block in activation era")
-                        .state_root_hash()
-                };
-                let validators_request =
-                    EraValidatorsRequest::new(state_root_hash.into(), protocol_version);
-                let validators = effect_builder
-                    .get_era_validators_from_contract_runtime(validators_request)
+                let activation_era_validators = effect_builder
+                    .get_era_validators(
+                        activation_era_id,
+                        activation_era_id,
+                        initial_state_root_hash,
+                        protocol_version,
+                    )
                     .await
-                    .expect("get validator map from global state")
-                    .remove(&activation_era_id.0)
-                    .expect("get validators for activation era");
-                (key_blocks, booking_blocks, validators)
+                    .unwrap_or_default();
+                (key_blocks, booking_blocks, activation_era_validators)
             }
         }
         .event(

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -244,7 +244,7 @@ where
                 let validators_request =
                     EraValidatorsRequest::new(state_root_hash.into(), protocol_version);
                 let validators = effect_builder
-                    .get_era_validators(validators_request)
+                    .get_era_validators_from_contract_runtime(validators_request)
                     .await
                     .expect("get validator map from global state")
                     .remove(&activation_era_id.0)

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -175,11 +175,6 @@ impl<I> Era<I> {
         &self.validators
     }
 
-    /// Returns whether validator identified with `public_key` is bonded in that era.
-    pub(crate) fn is_bonded_validator(&self, public_key: &PublicKey) -> bool {
-        self.validators.contains_key(public_key)
-    }
-
     /// Sets the pause status: While paused we don't create consensus messages other than pings.
     pub(crate) fn set_paused(&mut self, paused: bool) {
         self.consensus.set_paused(paused);

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -304,6 +304,7 @@ where
         + From<NetworkRequest<I, Message>>
         + From<LinearChainAnnouncement>
         + From<ContractRuntimeRequest>
+        + From<LinearChainRequest<I>>
         + Send,
     I: Display + Send + 'static,
 {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -12,10 +12,11 @@ use itertools::Itertools;
 use prometheus::{IntGauge, Registry};
 use tracing::{debug, error, info, warn};
 
-use casper_types::{ExecutionResult, ProtocolVersion, PublicKey, SemVer};
+use casper_types::{ExecutionResult, ProtocolVersion, PublicKey};
 
 use super::{consensus::EraId, Component};
 use crate::{
+    crypto::hash::Digest,
     effect::{
         announcements::LinearChainAnnouncement,
         requests::{
@@ -175,6 +176,9 @@ pub(crate) struct LinearChain<I> {
     /// Finality signatures to be inserted in a block once it is available.
     pending_finality_signatures: HashMap<PublicKey, HashMap<BlockHash, FinalitySignature>>,
     signature_cache: SignatureCache,
+    initial_state_root_hash: Digest,
+    activation_era_id: EraId,
+    protocol_version: ProtocolVersion,
 
     #[data_size(skip)]
     metrics: LinearChainMetrics,
@@ -183,12 +187,25 @@ pub(crate) struct LinearChain<I> {
 }
 
 impl<I> LinearChain<I> {
-    pub fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
+    pub fn new(
+        registry: &Registry,
+        initial_state_root_hash: Digest,
+        protocol_version: semver::Version,
+        activation_era_id: EraId,
+    ) -> Result<Self, prometheus::Error> {
         let metrics = LinearChainMetrics::new(registry)?;
+        let protocol_version = ProtocolVersion::from_parts(
+            protocol_version.major as u32,
+            protocol_version.minor as u32,
+            protocol_version.patch as u32,
+        );
         Ok(LinearChain {
             latest_block: None,
             pending_finality_signatures: HashMap::new(),
             signature_cache: SignatureCache::new(),
+            initial_state_root_hash,
+            activation_era_id,
+            protocol_version,
             metrics,
             _marker: PhantomData,
         })
@@ -444,22 +461,32 @@ where
                     self.signature_cache.insert(*signatures.clone());
                 }
                 // Check if the validator is bonded in the era in which the block was created.
-                effect_builder
-                    .is_bonded_validator(fs.era_id, fs.public_key)
-                    .map(|is_bonded| {
-                        if is_bonded {
-                            Ok((maybe_signatures, fs, is_bonded))
-                        } else {
-                            Err((maybe_signatures, fs))
-                        }
-                    })
+                // TODO: Use protocol version that is valid for the block's height.
+                let protocol_version = self.protocol_version;
+                let initial_state_root_hash = self.initial_state_root_hash;
+                let activation_era_id = self.activation_era_id;
+                async move {
+                    match effect_builder
+                        .is_bonded_validator(
+                            &fs.public_key,
+                            fs.era_id,
+                            activation_era_id,
+                            initial_state_root_hash,
+                            protocol_version,
+                        )
+                        .await
+                    {
+                        Some(is_bonded) => Ok((maybe_signatures, fs, is_bonded)),
+                        None => Err((maybe_signatures, fs)),
+                    }
+                }
+                .result(
+                    |(maybe_signatures, fs, is_bonded)| {
+                        Event::IsBonded(maybe_signatures, fs, is_bonded)
+                    },
+                    |(maybe_signatures, fs)| Event::IsBondedFutureEra(maybe_signatures, fs),
+                )
             }
-            .result(
-                |(maybe_signatures, fs, is_bonded)| {
-                    Event::IsBonded(maybe_signatures, fs, is_bonded)
-                },
-                |(maybe_signatures, fs)| Event::IsBondedFutureEra(maybe_signatures, fs),
-            ),
             Event::IsBondedFutureEra(maybe_signatures, fs) => {
                 match self.latest_block.as_ref() {
                     // If we don't have any block yet, we cannot determine who is bonded or not.
@@ -469,13 +496,12 @@ where
                     Some(block) => {
                         let latest_header = block.header();
                         let state_root_hash = latest_header.state_root_hash();
-                        // TODO: Use protocol version that is valid for the block's height.
-                        let protocol_version = ProtocolVersion::new(SemVer::V1_0_0);
                         effect_builder
                             .is_bonded_in_future_era(
                                 *state_root_hash,
                                 fs.era_id,
-                                protocol_version,
+                                // TODO: Use protocol version that is valid for the block's height.
+                                self.protocol_version,
                                 fs.public_key,
                             )
                             .map(|res| {
@@ -498,6 +524,7 @@ where
                 }
             }
             Event::IsBonded(Some(mut signatures), fs, true) => {
+                info!("FINSIG bonded {:?} {}", fs, signatures.proofs.len());
                 // Known block and signature from a bonded validator.
                 // Check if we had already seen this signature before.
                 let signature_known = signatures
@@ -531,13 +558,15 @@ where
                     effects
                 }
             }
-            Event::IsBonded(None, _, true) => {
+            Event::IsBonded(None, fs, true) => {
+                info!("FINSIG bonded, block unknown {:?}", fs);
                 // Unknown block but validator is bonded.
                 // We should finalize the same block eventually. Either in this or in the
                 // next era.
                 Effects::new()
             }
             Event::IsBonded(Some(_), fs, false) | Event::IsBonded(None, fs, false) => {
+                info!("FINSIG not bonded {:?}", fs);
                 self.remove_from_pending_fs(&fs);
                 // Unknown validator.
                 let FinalitySignature {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -524,7 +524,6 @@ where
                 }
             }
             Event::IsBonded(Some(mut signatures), fs, true) => {
-                info!("FINSIG bonded {:?} {}", fs, signatures.proofs.len());
                 // Known block and signature from a bonded validator.
                 // Check if we had already seen this signature before.
                 let signature_known = signatures
@@ -559,14 +558,12 @@ where
                 }
             }
             Event::IsBonded(None, fs, true) => {
-                info!("FINSIG bonded, block unknown {:?}", fs);
                 // Unknown block but validator is bonded.
                 // We should finalize the same block eventually. Either in this or in the
                 // next era.
                 Effects::new()
             }
             Event::IsBonded(Some(_), fs, false) | Event::IsBonded(None, fs, false) => {
-                info!("FINSIG not bonded {:?}", fs);
                 self.remove_from_pending_fs(&fs);
                 // Unknown validator.
                 let FinalitySignature {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -557,7 +557,7 @@ where
                     effects
                 }
             }
-            Event::IsBonded(None, fs, true) => {
+            Event::IsBonded(None, _fs, true) => {
                 // Unknown block but validator is bonded.
                 // We should finalize the same block eventually. Either in this or in the
                 // next era.

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -304,7 +304,6 @@ where
         + From<NetworkRequest<I, Message>>
         + From<LinearChainAnnouncement>
         + From<ContractRuntimeRequest>
-        + From<LinearChainRequest<I>>
         + Send,
     I: Display + Send + 'static,
 {

--- a/node/src/components/rpc_server.rs
+++ b/node/src/components/rpc_server.rs
@@ -153,7 +153,7 @@ impl RpcServer {
     ) -> Effects<Event> {
         let request = EraValidatorsRequest::new(state_root_hash.into(), protocol_version);
         effect_builder
-            .get_era_validators(request)
+            .get_era_validators_from_contract_runtime(request)
             .event(move |result| Event::QueryEraValidatorsResult {
                 result,
                 main_responder: responder,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1490,6 +1490,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Checks whether the given validator is bonded in the given era.
+    /// Returns `None` if a relevant block or global state hash couldn't be found.
     pub(crate) async fn is_bonded_validator(
         self,
         validator: &PublicKey,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -980,8 +980,6 @@ impl<I: Display> Display for LinearChainRequest<I> {
 #[must_use]
 /// Consensus component requests.
 pub enum ConsensusRequest {
-    /// Check whether validator identifying with the public key is bonded.
-    IsBondedValidator(EraId, PublicKey, Responder<bool>),
     /// Request for our public key, and if we're a validator, the next round length.
     Status(Responder<(PublicKey, Option<TimeDiff>)>),
 }

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -502,7 +502,16 @@ impl reactor::Reactor for Reactor {
             registry.clone(),
         );
 
-        let linear_chain = linear_chain::LinearChain::new(&registry)?;
+        let linear_chain = linear_chain::LinearChain::new(
+            &registry,
+            chainspec_loader.initial_state_root_hash(),
+            protocol_version.clone(),
+            chainspec_loader
+                .chainspec()
+                .protocol_config
+                .activation_point
+                .era_id(),
+        )?;
 
         let validator_weights: BTreeMap<PublicKey, U512> = chainspec_loader
             .chainspec()

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -473,7 +473,16 @@ impl reactor::Reactor for Reactor {
         )
         .with_parent_map(latest_block);
         let proto_block_validator = BlockValidator::new(Arc::clone(&chainspec_loader.chainspec()));
-        let linear_chain = LinearChain::new(registry)?;
+        let linear_chain = linear_chain::LinearChain::new(
+            &registry,
+            chainspec_loader.initial_state_root_hash(),
+            protocol_version.clone(),
+            chainspec_loader
+                .chainspec()
+                .protocol_config
+                .activation_point
+                .era_id(),
+        )?;
 
         effects.extend(reactor::wrap_effects(Event::Network, network_effects));
         effects.extend(reactor::wrap_effects(


### PR DESCRIPTION
This PR makes the Linear Chain check whether a validator is bonded with the Contract Runtime or the Storage, instead of the Era Supervisor. This way it will be able to function without an Era Supervisor present.