### PR TITLE
HWY-267: Fix arithmetic overflow.

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -226,7 +226,7 @@ impl<C: Context> ActiveValidator<C> {
     /// Returns whether enough validators are online to finalize values with the target fault
     /// tolerance threshold, always counting this validator as online.
     fn enough_validators_online(&self, state: &State<C>, now: Timestamp) -> bool {
-        let target_quorum = (state.total_weight() + self.target_ftt) / 2;
+        let target_quorum = state.total_weight() / 2 + self.target_ftt / 2;
         let online_weight: Weight = state
             .weights()
             .enumerate()


### PR DESCRIPTION
When determining whether enough nodes are online, we can't use
```
    (total_weight + target_ftt) / 2
```
because `total_weight` could already be close to `u64::MAX`.

https://casperlabs.atlassian.net/browse/HWY-267