### PR TITLE
NO-TICKET: use actual exit code returned by validator reactor

### DIFF
--- a/node/src/app/main.rs
+++ b/node/src/app/main.rs
@@ -42,17 +42,20 @@ fn panic_hook(info: &PanicInfo) {
 }
 
 fn main() -> anyhow::Result<()> {
-    let mut runtime = Builder::new()
-        .threaded_scheduler()
-        .enable_all()
-        .max_threads(MAX_THREAD_COUNT)
-        .build()
-        .unwrap();
+    let exit_code = {
+        let mut runtime = Builder::new()
+            .threaded_scheduler()
+            .enable_all()
+            .max_threads(MAX_THREAD_COUNT)
+            .build()
+            .unwrap();
 
-    panic::set_hook(Box::new(panic_hook));
+        panic::set_hook(Box::new(panic_hook));
 
-    // Parse CLI args and run selected subcommand.
-    let opts = Cli::from_args();
+        // Parse CLI args and run selected subcommand.
+        let opts = Cli::from_args();
 
-    runtime.block_on(async { opts.run().await })
+        runtime.block_on(async { opts.run().await })?
+    };
+    process::exit(exit_code);
 }

--- a/node/src/app/main.rs
+++ b/node/src/app/main.rs
@@ -14,6 +14,7 @@ use std::{
 use backtrace::Backtrace;
 use structopt::StructOpt;
 use tokio::runtime::Builder;
+use tracing::info;
 
 use casper_node::MAX_THREAD_COUNT;
 
@@ -57,5 +58,6 @@ fn main() -> anyhow::Result<()> {
 
         runtime.block_on(async { opts.run().await })?
     };
+    info!(%exit_code, "exiting casper-node");
     process::exit(exit_code);
 }


### PR DESCRIPTION
This PR fixes an issue where the exit code returned by the validator reactor is ignored.

It also borrows code from #1070 which ensures all destructors are run before exiting `main`.