### PR TITLE
HWY-267: Use higher stakes in test to catch overflow issues.

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -226,6 +226,7 @@ impl<C: Context> ActiveValidator<C> {
     /// Returns whether enough validators are online to finalize values with the target fault
     /// tolerance threshold, always counting this validator as online.
     fn enough_validators_online(&self, state: &State<C>, now: Timestamp) -> bool {
+        // We divide before adding, because  total_weight + target_fft  could overflow u64.
         let target_quorum = state.total_weight() / 2 + self.target_ftt / 2;
         let online_weight: Weight = state
             .weights()

--- a/node/src/reactor/validator/tests.rs
+++ b/node/src/reactor/validator/tests.rs
@@ -66,9 +66,9 @@ impl TestChain {
         // Override accounts with those generated from the keys.
         let accounts = stakes
             .into_iter()
-            .map(|(public_key, bounded_amount)| {
+            .map(|(public_key, bonded_amount)| {
                 let validator_config =
-                    ValidatorConfig::new(Motes::new(bounded_amount), DelegationRate::zero());
+                    ValidatorConfig::new(Motes::new(bonded_amount), DelegationRate::zero());
                 AccountConfig::new(
                     public_key,
                     Motes::new(U512::from(rng.gen_range(10000..99999999))),


### PR DESCRIPTION
This would have caught the overflow in HWY-267.

https://casperlabs.atlassian.net/browse/HWY-267