### PR TITLE
NDRS-1003: do not panic on dropped responder

### DIFF
--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -132,7 +132,7 @@ use requests::{
 };
 
 /// A resource that will never be available, thus trying to acquire it will wait forever.
-const UNOBTAINIUM: Lazy<Semaphore> = Lazy::new(|| Semaphore::new(0));
+static UNOBTAINIUM: Lazy<Semaphore> = Lazy::new(|| Semaphore::new(0));
 
 /// A pinned, boxed future that produces one or more events.
 pub type Effect<Ev> = BoxFuture<'static, Multiple<Ev>>;


### PR DESCRIPTION
Instead of crashing, quietly sweep a missing response under the rug. This will prevent us crashing on harmless drops, at the cost of potentially not crashing on an important one. Be extra vigilant for ERROR-level log entries.