### PR TITLE
HWY-266: Shut down era supervisor in case it hasn't received any messages for the last era in a while

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -131,8 +131,6 @@ pub enum Event<I> {
         /// validator set is read from the global state, not from a key block.
         validators: BTreeMap<PublicKey, U512>,
     },
-    /// An event instructing us to shutdown if the latest era received no votes.
-    Shutdown,
     /// An event fired when the joiner reactor transitions into validator.
     FinishedJoining(Timestamp),
     /// Got the result of checking for an upgrade activation point.
@@ -236,7 +234,6 @@ impl<I: Debug> Display for Event<I> {
                 booking_block_hash, block
             ),
             Event::InitializeEras { .. } => write!(f, "Starting eras should be initialized"),
-            Event::Shutdown => write!(f, "Shutdown if current era is inactive"),
             Event::FinishedJoining(timestamp) => {
                 write!(f, "The node finished joining the network at {}", timestamp)
             }
@@ -367,7 +364,6 @@ where
 
                 effects
             }
-            Event::Shutdown => handling_es.shutdown_if_necessary(),
             Event::FinishedJoining(timestamp) => handling_es.finished_joining(timestamp),
             Event::GotUpgradeActivationPoint(activation_point) => {
                 handling_es.got_upgrade_activation_point(activation_point)

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -130,7 +130,6 @@ pub enum Event<I> {
         /// This is empty except if the activation era still needs to be instantiated: Its
         /// validator set is read from the global state, not from a key block.
         validators: BTreeMap<PublicKey, U512>,
-        timestamp: Timestamp,
     },
     /// An event instructing us to shutdown if the latest era received no votes.
     Shutdown,
@@ -349,14 +348,9 @@ where
                 key_blocks,
                 booking_blocks,
                 validators,
-                timestamp,
             } => {
-                let mut effects = handling_es.handle_initialize_eras(
-                    key_blocks,
-                    booking_blocks,
-                    validators,
-                    timestamp,
-                );
+                let mut effects =
+                    handling_es.handle_initialize_eras(key_blocks, booking_blocks, validators);
 
                 // TODO: remove that when possible
                 // This is needed because we want to make sure that we only try to handle linear

--- a/node/src/components/consensus/config.rs
+++ b/node/src/components/consensus/config.rs
@@ -24,6 +24,10 @@ pub struct Config {
     pub unit_hashes_folder: PathBuf,
     /// The duration for which incoming vertices with missing dependencies are kept in a queue.
     pub pending_vertex_timeout: TimeDiff,
+    /// If the current era's protocol state has not progressed for this long, shut down.
+    pub standstill_timeout: TimeDiff,
+    /// Log inactive or faulty validators periodically, with this interval.
+    pub log_participation_interval: TimeDiff,
     /// The maximum number of blocks by which execution is allowed to lag behind finalization.
     /// If it is more than that, consensus will pause, and resume once the executor has caught up.
     pub max_execution_delay: u64,
@@ -35,6 +39,8 @@ impl Default for Config {
             secret_key_path: External::Missing,
             unit_hashes_folder: Default::default(),
             pending_vertex_timeout: "10sec".parse().unwrap(),
+            standstill_timeout: "1min".parse().unwrap(),
+            log_participation_interval: "10sec".parse().unwrap(),
             max_execution_delay: 3,
         }
     }

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -114,6 +114,8 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     /// Too many faulty validators. The protocol's fault tolerance threshold has been exceeded and
     /// consensus cannot continue.
     FttExceeded,
+    /// No progress has been made recently.
+    StandstillAlert,
     /// We want to disconnect from a sender of invalid data.
     Disconnect(I),
 }

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -128,7 +128,8 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
     fn as_any(&self) -> &dyn Any;
 
     /// Handles an incoming message (like NewUnit, RequestDependency).
-    fn handle_message(&mut self, sender: I, msg: Vec<u8>) -> ProtocolOutcomes<I, C>;
+    fn handle_message(&mut self, sender: I, msg: Vec<u8>, now: Timestamp)
+        -> ProtocolOutcomes<I, C>;
 
     /// Handles new connection to a peer.
     fn handle_new_peer(&mut self, peer_id: I) -> ProtocolOutcomes<I, C>;
@@ -137,13 +138,14 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
     fn handle_timer(&mut self, timestamp: Timestamp, timer_id: TimerId) -> ProtocolOutcomes<I, C>;
 
     /// Triggers a queued action.
-    fn handle_action(&mut self, action_id: ActionId) -> ProtocolOutcomes<I, C>;
+    fn handle_action(&mut self, action_id: ActionId, now: Timestamp) -> ProtocolOutcomes<I, C>;
 
     /// Proposes a new value for consensus.
     fn propose(
         &mut self,
         value: C::ConsensusValue,
         block_context: BlockContext,
+        now: Timestamp,
     ) -> ProtocolOutcomes<I, C>;
 
     /// Marks the `value` as valid or invalid, based on validation requested via
@@ -152,6 +154,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
         &mut self,
         value: &C::ConsensusValue,
         valid: bool,
+        now: Timestamp,
     ) -> ProtocolOutcomes<I, C>;
 
     /// Turns this instance into an active validator, that participates in the consensus protocol.
@@ -195,7 +198,7 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
 
     /// Returns the protocol outcomes for all the required timers.
     /// TODO: Remove this once the Joiner no longer has a consensus component.
-    fn recreate_timers(&self) -> ProtocolOutcomes<I, C>;
+    fn recreate_timers(&self, now: Timestamp) -> ProtocolOutcomes<I, C>;
 
     // TODO: Make this lees Highway-specific.
     fn next_round_length(&self) -> Option<TimeDiff>;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1210,26 +1210,6 @@ where
         }
     }
 
-    /// Emits a fatal error if the consensus state is still empty.
-    pub(super) fn shutdown_if_necessary(&self) -> Effects<Event<I>> {
-        let should_emit_error = self
-            .era_supervisor
-            .active_eras
-            .iter()
-            .all(|(_, era)| !era.consensus.has_received_messages());
-        if should_emit_error {
-            fatal!(
-                self.effect_builder,
-                "Consensus shutting down due to inability to participate in the network; \
-                inactive era = {}",
-                self.era_supervisor.current_era
-            )
-            .ignore()
-        } else {
-            Default::default()
-        }
-    }
-
     pub(crate) fn finished_joining(&mut self, now: Timestamp) -> Effects<Event<I>> {
         let outcomes = self.era_supervisor.finished_joining(now);
         self.handle_consensus_outcomes(self.era_supervisor.current_era, outcomes)

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -138,7 +138,6 @@ where
     /// Creates a new `EraSupervisor`, starting in the indicated current era.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new<REv: ReactorEventT<I>>(
-        timestamp: Timestamp,
         current_era: EraId,
         config: WithDir<Config>,
         effect_builder: EffectBuilder<REv>,
@@ -178,6 +177,8 @@ where
             protocol_config,
             config,
             new_consensus,
+            // TODO: Find a better way to decide whether to activate validator, or get the
+            // timestamp from when the process started.
             node_start_time: Timestamp::now(),
             next_block_height: 0,
             metrics,
@@ -257,7 +258,6 @@ where
                 key_blocks,
                 booking_blocks,
                 validators,
-                timestamp,
             },
         );
 
@@ -321,7 +321,7 @@ where
     fn new_era(
         &mut self,
         era_id: EraId,
-        timestamp: Timestamp,
+        now: Timestamp,
         validators: BTreeMap<PublicKey, U512>,
         newly_slashed: Vec<PublicKey>,
         slashed: HashSet<PublicKey>,
@@ -339,7 +339,7 @@ where
         info!(
             ?validators,
             %start_time,
-            %timestamp,
+            %now,
             %start_height,
             %instance_id,
             era = era_id.0,
@@ -373,7 +373,7 @@ where
             prev_era.map(|era| &*era.consensus),
             start_time,
             seed,
-            timestamp,
+            now,
         );
 
         if should_activate {
@@ -383,12 +383,7 @@ where
                 instance_id,
                 self.public_signing_key.to_hex()
             ));
-            outcomes.extend(consensus.activate_validator(
-                our_id,
-                secret,
-                timestamp,
-                Some(unit_hash_file),
-            ))
+            outcomes.extend(consensus.activate_validator(our_id, secret, now, Some(unit_hash_file)))
         }
 
         let era = Era::new(
@@ -494,7 +489,9 @@ where
     ) -> Effects<Event<I>> {
         let current_era = self.current_era;
         trace!(?current_era, "recreating timers");
-        let outcomes = self.active_eras[&current_era].consensus.recreate_timers();
+        let outcomes = self.active_eras[&current_era]
+            .consensus
+            .recreate_timers(Timestamp::now());
         self.handling_wrapper(effect_builder, rng)
             .handle_consensus_outcomes(current_era, outcomes)
     }
@@ -509,7 +506,6 @@ where
         key_blocks: HashMap<EraId, BlockHeader>,
         booking_blocks: HashMap<EraId, BlockHash>,
         activation_era_validators: BTreeMap<PublicKey, U512>,
-        timestamp: Timestamp,
     ) -> HashMap<EraId, ProtocolOutcomes<I, ClContext>> {
         let mut result_map = HashMap::new();
 
@@ -569,7 +565,7 @@ where
 
             let results = self.new_era(
                 era_id,
-                timestamp,
+                Timestamp::now(),
                 validators,
                 newly_slashed,
                 slashed,
@@ -731,7 +727,9 @@ where
         era_id: EraId,
         action_id: ActionId,
     ) -> Effects<Event<I>> {
-        self.delegate_to_era(era_id, move |consensus| consensus.handle_action(action_id))
+        self.delegate_to_era(era_id, move |consensus| {
+            consensus.handle_action(action_id, Timestamp::now())
+        })
     }
 
     pub(super) fn handle_message(&mut self, sender: I, msg: ConsensusMessage) -> Effects<Event<I>> {
@@ -741,7 +739,7 @@ where
                 // eras could depend on that.
                 trace!(era = era_id.0, "received a consensus message");
                 self.delegate_to_era(era_id, move |consensus| {
-                    consensus.handle_message(sender, payload)
+                    consensus.handle_message(sender, payload, Timestamp::now())
                 })
             }
             ConsensusMessage::EvidenceRequest { era_id, pub_key } => {
@@ -788,7 +786,7 @@ where
         let candidate_block =
             CandidateBlock::new(proto_block, block_context.timestamp(), accusations);
         self.delegate_to_era(era_id, move |consensus| {
-            consensus.propose(candidate_block, block_context)
+            consensus.propose(candidate_block, block_context, Timestamp::now())
         })
     }
 
@@ -878,14 +876,10 @@ where
         key_blocks: HashMap<EraId, BlockHeader>,
         booking_blocks: HashMap<EraId, BlockHash>,
         validators: BTreeMap<PublicKey, U512>,
-        timestamp: Timestamp,
     ) -> Effects<Event<I>> {
-        let result_map = self.era_supervisor.handle_initialize_eras(
-            key_blocks,
-            booking_blocks,
-            validators,
-            timestamp,
-        );
+        let result_map =
+            self.era_supervisor
+                .handle_initialize_eras(key_blocks, booking_blocks, validators);
 
         let effects = result_map
             .into_iter()
@@ -973,7 +967,7 @@ where
         };
         for candidate_block in candidate_blocks {
             effects.extend(self.delegate_to_era(era_id, |consensus| {
-                consensus.resolve_validity(&candidate_block, valid)
+                consensus.resolve_validity(&candidate_block, valid, Timestamp::now())
             }));
         }
         effects
@@ -1182,7 +1176,7 @@ where
                         };
                     for candidate_block in candidate_blocks {
                         effects.extend(self.delegate_to_era(e_id, |consensus| {
-                            consensus.resolve_validity(&candidate_block, true)
+                            consensus.resolve_validity(&candidate_block, true, Timestamp::now())
                         }));
                     }
                 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1205,6 +1205,14 @@ where
                     .then(move |_| fatal!(eb, "too many faulty validators"))
                     .ignore()
             }
+            ProtocolOutcome::StandstillAlert => {
+                if era_id == self.era_supervisor.current_era {
+                    warn!(era = %era_id.0, "current era is stalled; shutting down");
+                    fatal!(self.effect_builder, "current era is stalled; please retry").ignore()
+                } else {
+                    Effects::new()
+                }
+            }
         }
     }
 

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -115,7 +115,6 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             validators.ban(vid);
         }
 
-        // TODO: Apply all upgrades with a height less than or equal to the start height.
         let highway_config = &protocol_config.highway_config;
 
         let total_weight = u128::from(validators.total_weight());

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -71,6 +71,8 @@ where
         secret_key_path: Default::default(),
         unit_hashes_folder: Default::default(),
         pending_vertex_timeout: "1min".parse().unwrap(),
+        standstill_timeout: "30sec".parse().unwrap(),
+        log_participation_interval: "10sec".parse().unwrap(),
         max_execution_delay: 3,
     };
     // Timestamp of the genesis era start and test start.

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -86,9 +86,8 @@ where
         0,
         start_timestamp,
     );
-    // We expect only the vertex purge timer and participation log timer outcomes.
-    // If there are more, the tests might need to handle them.
-    assert_eq!(2, outcomes.len());
+    // We expect only the timer outcomes. If there are more, the tests might need to handle them.
+    assert_eq!(3, outcomes.len());
     hw_proto
 }
 

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -233,10 +233,11 @@ fn send_a_valid_wire_unit() {
     // If after another timeout, the state has not changed, an alert is raised.
     now += standstill_timeout;
     let outcomes = highway_protocol.handle_timer(now, TIMER_ID_STANDSTILL_ALERT);
-    match &*outcomes {
-        [ProtocolOutcome::StandstillAlert] => (),
-        _ => panic!("Unexpected outcomes: {:?}", outcomes),
-    }
+    assert!(
+        matches!(&*outcomes, [ProtocolOutcome::StandstillAlert]),
+        "Unexpected outcomes: {:?}",
+        outcomes
+    );
 }
 
 #[test]

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -546,11 +546,7 @@ impl reactor::Reactor for Reactor {
             init_sync_effects,
         ));
 
-        // Used to decide whether era should be activated.
-        let now = Timestamp::now();
-
         let (consensus, init_consensus_effects) = EraSupervisor::new(
-            now,
             chainspec_loader.initial_era(),
             WithDir::new(root, config.consensus.clone()),
             effect_builder,

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -37,6 +37,12 @@ unit_hashes_folder = "../node-storage"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '30min'
 
+# If the current era's protocol state has not progressed for this long, shut down.
+standstill_timeout = '5min'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
 # The maximum number of blocks by which execution is allowed to lag behind finalization.
 # If it is more than that, consensus will pause, and resume once the executor has caught up.
 max_execution_delay = 3

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -37,6 +37,12 @@ unit_hashes_folder = "/var/lib/casper/casper-node"
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '30min'
 
+# If the current era's protocol state has not progressed for this long, shut down.
+standstill_timeout = '5min'
+
+# Log inactive or faulty validators periodically, with this interval.
+log_participation_interval = '1min'
+
 # The maximum number of blocks by which execution is allowed to lag behind finalization.
 # If it is more than that, consensus will pause, and resume once the executor has caught up.
 max_execution_delay = 3


### PR DESCRIPTION
Right before an upgrade it can happen that some nodes lag behind and, since the others restart, fail to find peers who complete their protocol state so they can see the switch block finalized. This change will make them restart after a while, so they can download the finalized executed blocks and then trigger the upgrade as well.

https://casperlabs.atlassian.net/browse/HWY-266