### PR TITLE
NDRS-349/fix tracing issues

### DIFF
--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -52,7 +52,7 @@ use quanta::{Clock, IntoNanoseconds};
 use serde::Serialize;
 use signal_hook::consts::signal::{SIGINT, SIGQUIT, SIGTERM};
 use tokio::time::{Duration, Instant};
-use tracing::{debug, debug_span, error, info, trace, warn};
+use tracing::{debug, debug_span, error, info, instrument, trace, warn};
 use tracing_futures::Instrument;
 
 #[cfg(target_os = "linux")]
@@ -496,11 +496,8 @@ where
     ///
     /// Returns `false` if processing should stop.
     #[inline]
+    #[instrument("crank", level = "debug", fields(ev = self.event_count), skip(self, rng))]
     pub async fn crank(&mut self, rng: &mut NodeRng) -> bool {
-        // Create another span for tracing the processing of one event.
-        let crank_span = debug_span!("crank", ev = self.event_count);
-        let _inner_enter = crank_span.enter();
-
         self.metrics.events.inc();
 
         let event_queue = EventQueueHandle::new(self.scheduler);

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -431,6 +431,7 @@ where
 
     /// Creates a new runner from a given configuration, using existing metrics.
     #[inline]
+    #[instrument("runner creation", level = "debug", skip(cfg, rng, registry))]
     pub async fn with_metrics(
         cfg: R::Config,
         rng: &mut NodeRng,

--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -453,9 +453,8 @@ where
         let (reactor, initial_effects) = R::new(cfg, registry, event_queue, rng)?;
 
         // Run all effects from component instantiation.
-        let span = debug_span!("process initial effects");
         process_effects(scheduler, initial_effects)
-            .instrument(span)
+            .instrument(debug_span!("process initial effects"))
             .await;
 
         info!("reactor main loop is ready");
@@ -485,9 +484,11 @@ where
 
         let effects = create_effects(effect_builder);
 
-        let effect_span = debug_span!("process injected effects", ev = self.event_count);
         process_effects(self.scheduler, effects)
-            .instrument(effect_span)
+            .instrument(debug_span!(
+                "process injected effects",
+                ev = self.event_count
+            ))
             .await;
     }
 

--- a/node/src/testing/network.rs
+++ b/node/src/testing/network.rs
@@ -131,8 +131,12 @@ where
         let runner = self.nodes.get_mut(node_id).expect("should find node");
 
         let node_id = runner.reactor().node_id();
-        let span = error_span!("crank", node_id = %node_id);
-        if runner.try_crank(rng).instrument(span).await.is_some() {
+        if runner
+            .try_crank(rng)
+            .instrument(error_span!("crank", node_id = %node_id))
+            .await
+            .is_some()
+        {
             1
         } else {
             0
@@ -188,8 +192,12 @@ where
         let mut event_count = 0;
         for node in self.nodes.values_mut() {
             let node_id = node.reactor().node_id();
-            let span = error_span!("crank", node_id = %node_id);
-            event_count += if node.try_crank(rng).instrument(span).await.is_some() {
+            event_count += if node
+                .try_crank(rng)
+                .instrument(error_span!("crank", node_id = %node_id))
+                .await
+                .is_some()
+            {
                 1
             } else {
                 0
@@ -303,10 +311,9 @@ where
     {
         let runner = self.nodes.get_mut(node_id).unwrap();
         let node_id = runner.reactor().node_id();
-        let span = error_span!("inject", node_id = %node_id);
         runner
             .process_injected_effects(create_effects)
-            .instrument(span)
+            .instrument(error_span!("inject", node_id = %node_id))
             .await
     }
 }


### PR DESCRIPTION
This PR does a little cleanup and fixes a few issues with `async` tracing instrumentation. It also adds an additional span around the runner initialization.

https://tracing.rs/tracing/struct.span#method.enter has some background information on why these changes were necessary.