### PR TITLE
NDRS-811/cleanup memory usage dump in logs

### DIFF
--- a/node/src/reactor.rs
+++ b/node/src/reactor.rs
@@ -764,6 +764,8 @@ impl Runner<InitializerReactor> {
             reactor,
             event_count: 0,
             metrics: RunnerMetrics::new(&registry)?,
+            // Calculate the `last_metrics` timestamp to be exactly one delay in the past. This will
+            // cause the runner to collect metrics at the first opportunity.
             last_metrics: now.checked_sub(event_metrics_min_delay).unwrap_or(now),
             event_metrics_min_delay,
             event_metrics_threshold: 1000,


### PR DESCRIPTION
This changes the behavior of memory metrics collection in the validator slightly. First, it removes the special casing for the `event_count == 0`, as `event_count % ANYTHING` should already cover this. Second, it simply subtracts the delay from the initial timestamp, if possible, to achieve the same effect.

A second change is that `last_metrics` is updated _after_ metrics collection; this skews the collection interval a bit but ensures that we are guaranteed to get `event_metrics_min_delay` time of uninterrupted (by memory metrics collection) event handling.