### PR TITLE
HWY-268: Enable integer_arithmetic Clippy warnings to prevent overflows.

### DIFF
--- a/node/src/components/consensus/highway_core.rs
+++ b/node/src/components/consensus/highway_core.rs
@@ -27,6 +27,8 @@
 //! or with some other governance system that can add and remove validators, by starting a new
 //! protocol instance whenever the set of validators changes.
 
+#![warn(clippy::integer_arithmetic)]
+
 // This needs to come before the other modules, so the macros are available everywhere.
 #[cfg(test)]
 #[macro_use]

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -662,7 +662,7 @@ mod tests {
             let earliest_round_start = if start_time == current_round_id {
                 start_time
             } else {
-                current_round_id + (1 << state.params().init_round_exp()).into()
+                current_round_id + state::round_len(state.params().init_round_exp())
             };
             let target_ftt = state.total_weight() / 3;
             let active_validators = validators

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::integer_arithmetic)] // In tests, overflows panic anyway.
+
 use std::{
     collections::{hash_map::DefaultHasher, HashMap, VecDeque},
     fmt::{self, Debug, Display, Formatter},

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -17,7 +17,6 @@ pub(super) use unit::Unit;
 
 use std::{
     borrow::Borrow,
-    cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     convert::identity,
     iter,
@@ -683,9 +682,12 @@ impl<C: Context> State<C> {
         if block.height == height {
             return Some(hash);
         }
+        #[allow(clippy::integer_arithmetic)] // block.height > height, otherwise we returned.
         let diff = block.height - height;
         // We want to make the greatest step 2^i such that 2^i <= diff.
         let max_i = log2(diff) as usize;
+        // A block at height > 0 always has at least its parent entry in skip_idx.
+        #[allow(clippy::integer_arithmetic)]
         let i = max_i.min(block.skip_idx.len() - 1);
         self.find_ancestor(&block.skip_idx[i], height)
     }
@@ -797,7 +799,7 @@ impl<C: Context> State<C> {
     /// Returns `true` if the `bhash` is a block that can have no children.
     pub(crate) fn is_terminal_block(&self, bhash: &C::Hash) -> bool {
         self.blocks.get(bhash).map_or(false, |block| {
-            block.height + 1 >= self.params.end_height()
+            block.height.saturating_add(1) >= self.params.end_height()
                 && self.unit(bhash).timestamp >= self.params.end_timestamp()
         })
     }
@@ -813,13 +815,15 @@ impl<C: Context> State<C> {
     /// or `None` if the sequence number is higher than that of the unit with `hash`.
     fn find_in_swimlane<'a>(&'a self, hash: &'a C::Hash, seq_number: u64) -> Option<&'a C::Hash> {
         let unit = self.unit(hash);
-        match unit.seq_number.cmp(&seq_number) {
-            Ordering::Equal => Some(hash),
-            Ordering::Less => None,
-            Ordering::Greater => {
-                let diff = unit.seq_number - seq_number;
+        match unit.seq_number.checked_sub(seq_number) {
+            None => None,          // There is no unit with seq_number in our swimlane.
+            Some(0) => Some(hash), // The sequence number is the one we're looking for.
+            Some(diff) => {
                 // We want to make the greatest step 2^i such that 2^i <= diff.
-                let max_i = log2(diff) as usize;
+                let max_i = log2(diff) as usize; // Log is safe because diff is not zero.
+
+                // Diff is not zero, so the unit has a predecessor and skip_idx is not empty.
+                #[allow(clippy::integer_arithmetic)]
                 let i = max_i.min(unit.skip_idx.len() - 1);
                 self.find_in_swimlane(&unit.skip_idx[i], seq_number)
             }
@@ -1114,7 +1118,7 @@ impl<C: Context> State<C> {
 
 /// Returns the round length, given the round exponent.
 pub(super) fn round_len(round_exp: u8) -> TimeDiff {
-    TimeDiff::from(1 << round_exp)
+    TimeDiff::from(1_u64.checked_shl(round_exp.into()).unwrap_or(u64::MAX))
 }
 
 /// Returns the time at which the round with the given timestamp and round exponent began.
@@ -1128,18 +1132,21 @@ pub(crate) fn round_id(timestamp: Timestamp, round_exp: u8) -> Timestamp {
     (timestamp >> round_exp) << round_exp
 }
 
-/// Returns the base-2 logarithm of `x`, rounded down,
-/// i.e. the greatest `i` such that `2.pow(i) <= x`.
+/// Returns the base-2 logarithm of `x`, rounded down, i.e. the greatest `i` such that
+/// `2.pow(i) <= x`. If `x == 0`, it returns `0`.
 fn log2(x: u64) -> u32 {
-    // The least power of two that is strictly greater than x.
-    let next_pow2 = (x + 1).next_power_of_two();
-    // It's twice as big as the greatest power of two that is less or equal than x.
-    let prev_pow2 = next_pow2 >> 1;
-    // The number of trailing zeros is its base-2 logarithm.
-    prev_pow2.trailing_zeros()
+    // Find the least power of two strictly greater than x and count its trailing zeros.
+    // Then subtract 1 to get the zeros of the greatest power of two less or equal than x.
+    x.saturating_add(1)
+        .checked_next_power_of_two()
+        .unwrap_or(0)
+        .trailing_zeros()
+        .saturating_sub(1)
 }
 
 /// Returns a pseudorandom `u64` betweend `1` and `upper` (inclusive).
 fn leader_prng(upper: u64, seed: u64) -> u64 {
-    ChaCha8Rng::seed_from_u64(seed).gen_range(0..upper) + 1
+    ChaCha8Rng::seed_from_u64(seed)
+        .gen_range(0..upper)
+        .saturating_add(1)
 }

--- a/node/src/components/consensus/highway_core/state/block.rs
+++ b/node/src/components/consensus/highway_core/state/block.rs
@@ -31,6 +31,8 @@ impl<C: Context> Block<C> {
             None => return Block::initial(value),
             Some(hash) => (state.block(&hash), vec![hash]),
         };
+        // In a trillion years, we need to make block height u128.
+        #[allow(clippy::integer_arithmetic)]
         let height = parent.height + 1;
         for i in 0..height.trailing_zeros() as usize {
             let ancestor = state.block(&skip_idx[i]);

--- a/node/src/components/consensus/highway_core/state/panorama.rs
+++ b/node/src/components/consensus/highway_core/state/panorama.rs
@@ -142,6 +142,8 @@ impl<C: Context> Panorama<C> {
 
     /// Returns the correct sequence number for a new unit by `vidx` with this panorama.
     pub(crate) fn next_seq_num(&self, state: &State<C>, vidx: ValidatorIndex) -> u64 {
+        // In a trillion years, we need to make seq number u128.
+        #[allow(clippy::integer_arithmetic)]
         let add1 = |vh: &C::Hash| state.unit(vh).seq_number + 1;
         self[vidx].correct().map_or(0, add1)
     }

--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -95,6 +95,11 @@ impl Params {
         self.max_round_exp
     }
 
+    /// Returns the minimum round length, corresponding to the minimum round exponent.
+    pub(crate) fn min_round_length(&self) -> TimeDiff {
+        round_len(self.min_round_exp)
+    }
+
     /// Returns the maximum round length, corresponding to the maximum round exponent.
     pub(crate) fn max_round_length(&self) -> TimeDiff {
         round_len(self.max_round_exp)
@@ -127,10 +132,11 @@ impl Params {
         self.endorsement_evidence_limit
     }
 
-    /// Returns the minimum lenght of the era.
+    /// Returns the minimum length of the era.
     pub(crate) fn min_era_length(&self) -> TimeDiff {
-        (TimeDiff::from(1 << self.min_round_exp) * self.end_height)
-            .max(self.end_timestamp - self.start_timestamp)
+        self.min_round_length()
+            .saturating_mul(self.end_height)
+            .max(self.end_timestamp.saturating_diff(self.start_timestamp))
     }
 }
 

--- a/node/src/components/consensus/highway_core/state/tallies.rs
+++ b/node/src/components/consensus/highway_core/state/tallies.rs
@@ -152,6 +152,7 @@ impl<'a, C: Context> Tallies<'a, C> {
             // If any block received more than 50%, a decision can be made: Either that block is
             // the fork choice, or we can pick its highest scoring child from `prev_tally`.
             if h_tally.max_w() > total_weight / 2 {
+                #[allow(clippy::integer_arithmetic)] // height < max_height, so height < u64::MAX
                 return Some(
                     match prev_tally.filter_descendants(height, h_tally.max_bhash(), state) {
                         Some(filtered) => (height + 1, filtered.max_bhash()),

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -1,4 +1,5 @@
 #![allow(unused_qualifications)] // This is to suppress warnings originating in the test macros.
+#![allow(clippy::integer_arithmetic)] // Overflows in tests would panic anyway.
 
 use std::{
     collections::{hash_map::DefaultHasher, BTreeSet},
@@ -839,10 +840,14 @@ fn retain_evidence_only() -> Result<(), AddUnitError<TestContext>> {
 
 #[test]
 fn test_log2() {
+    assert_eq!(0, log2(0));
     assert_eq!(2, log2(0b100));
     assert_eq!(2, log2(0b101));
     assert_eq!(2, log2(0b111));
     assert_eq!(3, log2(0b1000));
+    assert_eq!(63, log2(u64::MAX));
+    assert_eq!(63, log2(1 << 63));
+    assert_eq!(62, log2((1 << 63) - 1));
 }
 
 #[test]

--- a/node/src/components/consensus/highway_core/state/weight.rs
+++ b/node/src/components/consensus/highway_core/state/weight.rs
@@ -31,19 +31,28 @@ impl Weight {
     pub fn checked_add(self, rhs: Weight) -> Option<Weight> {
         Some(Weight(self.0.checked_add(rhs.0)?))
     }
+
+    /// Saturating addition. Returns `Weight(u64::MAX)` if overflow would occur.
+    pub fn saturating_add(self, rhs: Weight) -> Weight {
+        Weight(self.0.saturating_add(rhs.0))
+    }
+
+    /// Returns `true` if this weight is zero.
+    pub fn is_zero(self) -> bool {
+        self.0 == 0
+    }
 }
 
 impl<'a> Sum<&'a Weight> for Weight {
     fn sum<I: Iterator<Item = &'a Weight>>(iter: I) -> Self {
-        let mut sum = 0u64;
-        iter.for_each(|w| sum += w.0);
-        Weight(sum)
+        Weight(iter.map(|w| w.0).sum())
     }
 }
 
 impl Mul<u64> for Weight {
     type Output = Self;
 
+    #[allow(clippy::integer_arithmetic)] // The caller needs to prevent overflows.
     fn mul(self, rhs: u64) -> Self {
         Weight(self.0 * rhs)
     }
@@ -52,6 +61,7 @@ impl Mul<u64> for Weight {
 impl Div<u64> for Weight {
     type Output = Self;
 
+    #[allow(clippy::integer_arithmetic)] // The caller needs to avoid dividing by zero.
     fn div(self, rhs: u64) -> Self {
         Weight(self.0 / rhs)
     }

--- a/node/src/components/consensus/highway_core/test_macros.rs
+++ b/node/src/components/consensus/highway_core/test_macros.rs
@@ -54,6 +54,7 @@ macro_rules! add_unit {
             .unwrap_or($state.params().start_timestamp());
         // If this is a block: Find the next time we're a leader.
         if value.is_some() {
+            #[allow(clippy::integer_arithmetic)]
             let r_len = TimeDiff::from(1 << round_exp);
             timestamp = state::round_id(timestamp + r_len - TimeDiff::from(1), round_exp);
             while $state.leader(timestamp) != creator {

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -247,6 +247,11 @@ impl TimeDiff {
     pub const fn from_seconds(seconds: u32) -> Self {
         TimeDiff(seconds as u64 * 1_000)
     }
+
+    /// Returns the product, or `TimeDiff(u64::MAX)` if it would overflow.
+    pub fn saturating_mul(self, rhs: u64) -> Self {
+        TimeDiff(self.0.saturating_mul(rhs))
+    }
 }
 
 impl Mul<u64> for TimeDiff {


### PR DESCRIPTION
This enables the warnings for all arithmetic operations in `highway_core` that could potentially overflow. It also replaces them with safe (e.g. saturating) operations in some places.

https://casperlabs.atlassian.net/browse/HWY-268