### PR TITLE
NDRS-1013 validate block size in BlockValidator

### DIFF
--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -30,6 +30,7 @@ use crate::{
     types::{BlockLike, Chainspec, Deploy, DeployHash, Timestamp},
     NodeRng,
 };
+use casper_types::bytesrepr::ToBytes;
 use keyed_counter::KeyedCounter;
 
 use super::fetcher::FetchResult;
@@ -42,8 +43,11 @@ pub enum Event<T, I> {
     Request(BlockValidationRequest<T, I>),
 
     /// A deploy has been successfully found.
-    #[display(fmt = "deploy {} found", _0)]
-    DeployFound(DeployHash),
+    #[display(fmt = "deploy {} found", deploy_hash)]
+    DeployFound {
+        deploy_hash: DeployHash,
+        deploy_size: usize,
+    },
 
     /// A request to find a specific deploy, potentially from a peer, failed.
     #[display(fmt = "deploy {} missing", _0)]
@@ -59,6 +63,9 @@ pub enum Event<T, I> {
 /// Tracks whether or not there are deploys still missing and who is interested in the final result.
 #[derive(DataSize, Debug)]
 pub(crate) struct BlockValidationState<T, I> {
+    /// Total running size of the deploys in the block, which is used to validate against the
+    /// chainspec's deploy.max_block_size.
+    deploy_size_running_total: usize,
     /// The deploys that have not yet been "crossed off" the list of potential misses.
     missing_deploys: HashSet<DeployHash>,
     /// A list of responders that are awaiting an answer.
@@ -194,6 +201,7 @@ where
                         effects.extend(fetch_effects);
 
                         entry.insert(BlockValidationState {
+                            deploy_size_running_total: 0,
                             missing_deploys,
                             responders: smallvec![responder],
                             sources: VecDeque::new(), /* This is empty b/c we create the first
@@ -203,26 +211,54 @@ where
                     }
                 }
             }
-            Event::DeployFound(deploy_hash) => {
+            Event::DeployFound {
+                deploy_hash,
+                deploy_size,
+            } => {
                 // We successfully found a hash. Decrease the number of outstanding requests.
                 self.in_flight.dec(&deploy_hash);
 
+                // If a deploy is received for a given block that makes that block invalid somehow,
+                // mark it for removal.
+                let mut invalid = Vec::new();
+
+                let max_block_size = self.chainspec.deploy_config.max_block_size as usize;
+
                 // Our first pass updates all validation states, crossing off the found deploy.
-                for state in self.validation_states.values_mut() {
-                    state.missing_deploys.remove(&deploy_hash);
+                for (key, state) in self.validation_states.iter_mut() {
+                    if state.missing_deploys.remove(&deploy_hash) {
+                        let valid_new_total = state
+                            .deploy_size_running_total
+                            .checked_add(deploy_size)
+                            .filter(|new_total| *new_total <= max_block_size);
+
+                        match valid_new_total {
+                            Some(new_total) => state.deploy_size_running_total = new_total,
+                            None => {
+                                // Notify everyone still waiting on it that all is lost.
+                                info!(block=?key, %deploy_hash, %max_block_size, "block size exceeded");
+                                invalid.push(key.clone());
+                            }
+                        }
+                    }
                 }
 
                 // Now we remove all states that have finished and notify the requestors.
                 self.validation_states.retain(|key, state| {
+                    if invalid.contains(key) {
+                        state.responders.drain(..).for_each(|responder| {
+                            effects.extend(responder.respond((false, key.clone())).ignore());
+                        });
+                        return false;
+                    }
                     if state.missing_deploys.is_empty() {
                         // This one is done and valid.
                         state.responders.drain(..).for_each(|responder| {
                             effects.extend(responder.respond((true, key.clone())).ignore());
                         });
-                        false
-                    } else {
-                        true
+                        return false;
                     }
+                    true
                 });
             }
             Event::DeployMissing(deploy_hash) => {
@@ -326,7 +362,11 @@ where
                 .header()
                 .is_valid(&chainspec.deploy_config, block_timestamp)
             {
-                Event::DeployFound(deploy_hash)
+                let deploy_size = deploy.serialized_length();
+                Event::DeployFound {
+                    deploy_hash,
+                    deploy_size,
+                }
             } else {
                 Event::DeployInvalid(deploy_hash)
             }

--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -108,15 +108,6 @@ pub enum DeployValidationFailure {
         got: String,
     },
 
-    /// Deploy is too large.
-    #[error("{deploy_size} deploy size exceeds block size limit of {max_block_size}")]
-    ExcessiveSize {
-        /// The block size limit.
-        max_block_size: u32,
-        /// The size of the deploy provided.
-        deploy_size: usize,
-    },
-
     /// Too many dependencies.
     #[error("{got} dependencies exceeds limit of {max_dependencies}")]
     ExcessiveDependencies {
@@ -124,6 +115,15 @@ pub enum DeployValidationFailure {
         max_dependencies: u8,
         /// The actual number of dependencies provided.
         got: usize,
+    },
+
+    /// Deploy is too large.
+    #[error("{deploy_size} deploy size exceeds block size limit of {max_block_size}")]
+    ExcessiveSize {
+        /// The block size limit.
+        max_block_size: u32,
+        /// The size of the deploy provided.
+        deploy_size: usize,
     },
 
     /// Excessive time-to-live.


### PR DESCRIPTION
This PR adds validation for the size of a block (as defined by the sum of `ToBytes::serialized_length()` of it's deploys) to the `BlockValidator`. Also included is a stop-gap fix for the `DeployAcceptor` to ensure no deploy can be larger than the allowed `max_block_size` in the chainspec.

Ref: https://casperlabs.atlassian.net/browse/NDRS-1013