### PR TITLE
NO TICK: Correcting path to smart_contracts/contract_as.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -431,7 +431,7 @@ steps:
     email:
       from_secret: npm_email
     folder:
-    - "smart_contracts/contract-as"
+    - "smart_contracts/contract_as"
     fail_on_version_conflict:
     - true
     access:


### PR DESCRIPTION
Path was incorrect in .drone.yml step breaking CI tag.