### PR TITLE
EE-1134: Fixed addresses minimal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5267,6 +5267,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-hashes"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -40,6 +40,7 @@ use casper_types::{
             TOTAL_SUPPLY_KEY,
         },
         standard_payment::METHOD_PAY,
+        SystemContractType,
     },
     AccessRights, CLType, CLTyped, CLValue, Contract, ContractHash, ContractPackage,
     ContractPackageHash, ContractWasm, ContractWasmHash, DeployHash, EntryPoint, EntryPointAccess,
@@ -835,11 +836,16 @@ where
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
 
-        let (_, mint_hash) = self.store_contract(access_key, named_keys, entry_points);
+        let contract_hash = self.store_system_contract(
+            SystemContractType::Mint,
+            access_key,
+            named_keys,
+            entry_points,
+        );
 
-        self.protocol_data = ProtocolData::partial_with_mint(mint_hash);
+        self.protocol_data = ProtocolData::partial_with_mint(contract_hash);
 
-        Ok(mint_hash)
+        Ok(contract_hash)
     }
 
     pub fn create_handle_payment(&self) -> Result<ContractHash, GenesisError> {
@@ -862,9 +868,14 @@ where
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
 
-        let (_, handle_payment_hash) = self.store_contract(access_key, named_keys, entry_points);
+        let contract_hash = self.store_system_contract(
+            SystemContractType::HandlePayment,
+            access_key,
+            named_keys,
+            entry_points,
+        );
 
-        Ok(handle_payment_hash)
+        Ok(contract_hash)
     }
 
     pub(crate) fn create_auction(&self) -> Result<ContractHash, GenesisError> {
@@ -1081,9 +1092,14 @@ where
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
 
-        let (_, auction_hash) = self.store_contract(access_key, named_keys, entry_points);
+        let contract_hash = self.store_system_contract(
+            SystemContractType::Auction,
+            access_key,
+            named_keys,
+            entry_points,
+        );
 
-        Ok(auction_hash)
+        Ok(contract_hash)
     }
 
     pub(crate) fn create_standard_payment(&self) -> ContractHash {
@@ -1096,9 +1112,12 @@ where
             .borrow_mut()
             .new_uref(AccessRights::READ_ADD_WRITE);
 
-        let (_, standard_payment_hash) = self.store_contract(access_key, named_keys, entry_points);
-
-        standard_payment_hash
+        self.store_system_contract(
+            SystemContractType::StandardPayment,
+            access_key,
+            named_keys,
+            entry_points,
+        )
     }
 
     pub(crate) fn create_accounts(&self) -> Result<(), GenesisError> {
@@ -1209,17 +1228,18 @@ where
         Ok(purse_uref)
     }
 
-    fn store_contract(
+    fn store_system_contract(
         &self,
+        contract_type: SystemContractType,
         access_key: URef,
         named_keys: NamedKeys,
         entry_points: EntryPoints,
-    ) -> (ContractPackageHash, ContractHash) {
+    ) -> ContractHash {
         let protocol_version = self.protocol_version;
+
+        let contract_hash = contract_type.into_contract_hash();
         let contract_wasm_hash =
             ContractWasmHash::new(self.hash_address_generator.borrow_mut().new_hash_address());
-        let contract_hash =
-            ContractHash::new(self.hash_address_generator.borrow_mut().new_hash_address());
         let contract_package_hash =
             ContractPackageHash::new(self.hash_address_generator.borrow_mut().new_hash_address());
 
@@ -1257,7 +1277,7 @@ where
             StoredValue::ContractPackage(contract_package),
         );
 
-        (contract_package_hash, contract_hash)
+        contract_hash
     }
 
     fn mint_entry_points(&self) -> EntryPoints {

--- a/execution_engine_testing/tests/src/test/system_contracts/mod.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/mod.rs
@@ -3,4 +3,5 @@ mod auction_bidding;
 mod genesis;
 mod handle_payment;
 mod standard_payment;
+mod system_hashes;
 mod upgrade;

--- a/execution_engine_testing/tests/src/test/system_contracts/system_hashes.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/system_hashes.rs
@@ -1,0 +1,24 @@
+use casper_engine_test_support::{
+    internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
+    DEFAULT_ACCOUNT_ADDR,
+};
+use casper_types::RuntimeArgs;
+
+const CONTRACT_SYSTEM_HASHES: &str = "system_hashes.wasm";
+
+#[ignore]
+#[test]
+fn should_verify_fixed_system_contract_hashes() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    let exec_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_SYSTEM_HASHES,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(exec_request).expect_success().commit();
+}

--- a/smart_contracts/contract_as/assembly/index.ts
+++ b/smart_contracts/contract_as/assembly/index.ts
@@ -36,7 +36,7 @@ export const enum SystemContract {
   /**
    * Mint contract.
    */
-  Mint = 0,
+  Mint = 1,
   /**
    * Auction contract.
    */

--- a/smart_contracts/contract_as/assembly/index.ts
+++ b/smart_contracts/contract_as/assembly/index.ts
@@ -38,17 +38,17 @@ export const enum SystemContract {
    */
   Mint = 0,
   /**
+   * Auction contract.
+   */
+  Auction = 2,
+  /**
    * Handle Payment contract.
    */
-  HandlePayment = 1,
+  HandlePayment = 3,
   /**
    * Standard Payment contract.
    */
-  StandardPayment = 2,
-  /**
-   * Auction contract.
-   */
-  Auction = 3,
+  StandardPayment = 4,
 }
 
 /**

--- a/smart_contracts/contracts/test/system-hashes/Cargo.toml
+++ b/smart_contracts/contracts/test/system-hashes/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "system-hashes"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "system_hashes"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[features]
+std = ["casper-contract/std", "casper-types/std"]
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/system-hashes/src/main.rs
+++ b/smart_contracts/contracts/test/system-hashes/src/main.rs
@@ -1,0 +1,29 @@
+#![no_std]
+#![no_main]
+
+use casper_contract::contract_api::system;
+use casper_types::ContractHash;
+
+const MINT_CONTRACT_HASH: ContractHash = ContractHash::new([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+]);
+const AUCTION_CONTRACT_HASH: ContractHash = ContractHash::new([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+]);
+const HANDLE_PAYMENT_CONTRACT_HASH: ContractHash = ContractHash::new([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
+]);
+const STANDARD_PAYMENT_CONTRACT_HASH: ContractHash = ContractHash::new([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4,
+]);
+
+#[no_mangle]
+pub extern "C" fn call() {
+    assert_eq!(MINT_CONTRACT_HASH, system::get_mint(),);
+    assert_eq!(AUCTION_CONTRACT_HASH, system::get_auction(),);
+    assert_eq!(HANDLE_PAYMENT_CONTRACT_HASH, system::get_handle_payment(),);
+    assert_eq!(
+        STANDARD_PAYMENT_CONTRACT_HASH,
+        system::get_standard_payment(),
+    );
+}

--- a/types/src/system/mod.rs
+++ b/types/src/system/mod.rs
@@ -57,7 +57,7 @@ mod system_contract_type {
         fmt::{self, Display, Formatter},
     };
 
-    use crate::{ApiError, ContractHash, HashAddr};
+    use crate::{ApiError, ContractHash, HashAddr, U256};
 
     /// System contract types.
     ///
@@ -66,31 +66,35 @@ mod system_contract_type {
     #[repr(u8)]
     pub enum SystemContractType {
         /// Mint contract.
-        Mint = 0,
-        /// Handle Payment contract.
-        HandlePayment = 1,
-        /// Standard Payment contract.
-        StandardPayment = 2,
+        Mint = 1,
         /// Auction contract.
-        Auction = 3,
+        Auction = 2,
+        /// Handle Payment contract.
+        HandlePayment = 3,
+        /// Standard Payment contract.
+        StandardPayment = 4,
     }
 
     /// Name of mint system contract
     pub const MINT: &str = "mint";
+    /// Name of auction system contract
+    pub const AUCTION: &str = "auction";
     /// Name of handle payment system contract
     pub const HANDLE_PAYMENT: &str = "handle payment";
     /// Name of standard payment system contract
     pub const STANDARD_PAYMENT: &str = "standard payment";
-    /// Name of auction system contract
-    pub const AUCTION: &str = "auction";
 
     impl SystemContractType {
+        fn into_address(self) -> HashAddr {
+            let address_value = U256::from(self as u8);
+            let mut address: HashAddr = Default::default();
+            address_value.to_big_endian(&mut address);
+            address
+        }
+
         /// Returns a fixed [`ContractHash`] value for given contract type.
         pub fn into_contract_hash(self) -> ContractHash {
-            let value = self as u8 + 1;
-            let mut address: HashAddr = Default::default();
-            address[address.len() - 1] = value;
-            ContractHash::new(address)
+            ContractHash::new(self.into_address())
         }
     }
 
@@ -104,12 +108,17 @@ mod system_contract_type {
     #[doc(hidden)]
     impl TryFrom<u32> for SystemContractType {
         type Error = ApiError;
+
         fn try_from(value: u32) -> Result<SystemContractType, Self::Error> {
             match value {
-                0 => Ok(SystemContractType::Mint),
-                1 => Ok(SystemContractType::HandlePayment),
-                2 => Ok(SystemContractType::StandardPayment),
-                3 => Ok(SystemContractType::Auction),
+                x if x == SystemContractType::Mint as u32 => Ok(SystemContractType::Mint),
+                x if x == SystemContractType::Auction as u32 => Ok(SystemContractType::Auction),
+                x if x == SystemContractType::StandardPayment as u32 => {
+                    Ok(SystemContractType::StandardPayment)
+                }
+                x if x == SystemContractType::HandlePayment as u32 => {
+                    Ok(SystemContractType::HandlePayment)
+                }
                 _ => Err(ApiError::InvalidSystemContract),
             }
         }
@@ -133,33 +142,153 @@ mod system_contract_type {
         use super::*;
 
         const MINT_CONTRACT_HASH: ContractHash = ContractHash::new([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            SystemContractType::Mint as u8,
         ]);
         const HANDLE_PAYMENT_CONTRACT_HASH: ContractHash = ContractHash::new([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 2,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            SystemContractType::HandlePayment as u8,
         ]);
         const STANDARD_PAYMENT_CONTRACT_HASH: ContractHash = ContractHash::new([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 3,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            SystemContractType::StandardPayment as u8,
         ]);
         const AUCTION_CONTRACT_HASH: ContractHash = ContractHash::new([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 4,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            SystemContractType::Auction as u8,
         ]);
 
         #[test]
         fn get_index_of_mint_contract() {
             let index: u32 = SystemContractType::Mint.into();
-            assert_eq!(index, 0u32);
+            assert_eq!(index, SystemContractType::Mint as u32);
             assert_eq!(SystemContractType::Mint.to_string(), MINT);
         }
 
         #[test]
         fn get_index_of_handle_payment_contract() {
             let index: u32 = SystemContractType::HandlePayment.into();
-            assert_eq!(index, 1u32);
+            assert_eq!(index, SystemContractType::HandlePayment as u32);
             assert_eq!(
                 SystemContractType::HandlePayment.to_string(),
                 HANDLE_PAYMENT
@@ -169,7 +298,7 @@ mod system_contract_type {
         #[test]
         fn get_index_of_standard_payment_contract() {
             let index: u32 = SystemContractType::StandardPayment.into();
-            assert_eq!(index, 2u32);
+            assert_eq!(index, SystemContractType::StandardPayment as u32);
             assert_eq!(
                 SystemContractType::StandardPayment.to_string(),
                 STANDARD_PAYMENT
@@ -179,7 +308,7 @@ mod system_contract_type {
         #[test]
         fn get_index_of_auction_contract() {
             let index: u32 = SystemContractType::Auction.into();
-            assert_eq!(index, 3u32);
+            assert_eq!(index, SystemContractType::Auction as u32);
             assert_eq!(SystemContractType::Auction.to_string(), AUCTION);
         }
 
@@ -209,7 +338,7 @@ mod system_contract_type {
 
         #[test]
         fn create_unknown_system_contract_variant() {
-            assert!(SystemContractType::try_from(4).is_err());
+            assert!(SystemContractType::try_from(6).is_err());
             assert!(SystemContractType::try_from(5).is_err());
             assert!(SystemContractType::try_from(10).is_err());
             assert!(SystemContractType::try_from(u32::max_value()).is_err());

--- a/types/src/system/mod.rs
+++ b/types/src/system/mod.rs
@@ -313,27 +313,26 @@ mod system_contract_type {
         }
 
         #[test]
+        fn create_invalid_variant_from_int() {
+            assert!(SystemContractType::try_from(0).is_err());
+        }
+
+        #[test]
         fn create_mint_variant_from_int() {
-            let mint = SystemContractType::try_from(0).ok().unwrap();
+            let mint = SystemContractType::try_from(1).ok().unwrap();
             assert_eq!(mint, SystemContractType::Mint);
         }
 
         #[test]
-        fn create_handle_payment_variant_from_int() {
-            let handle_payment = SystemContractType::try_from(1).ok().unwrap();
-            assert_eq!(handle_payment, SystemContractType::HandlePayment);
-        }
-
-        #[test]
-        fn create_standard_payment_variant_from_int() {
-            let handle_payment = SystemContractType::try_from(2).ok().unwrap();
-            assert_eq!(handle_payment, SystemContractType::StandardPayment);
-        }
-
-        #[test]
         fn create_auction_variant_from_int() {
-            let auction = SystemContractType::try_from(3).ok().unwrap();
+            let auction = SystemContractType::try_from(2).ok().unwrap();
             assert_eq!(auction, SystemContractType::Auction);
+        }
+
+        #[test]
+        fn create_handle_payment_from_int() {
+            let handle_payment = SystemContractType::try_from(3).ok().unwrap();
+            assert_eq!(handle_payment, SystemContractType::HandlePayment);
         }
 
         #[test]


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1134

Stripped down version of #1127 

This change introduces a fixed contract hashes only for system contracts without breaking any downstream users. Only genesis is affected.