### PR TITLE
NDRS-1028: Optimize handling of finality signatures in the linear chain component.

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -477,7 +477,7 @@ where
                             0
                         };
                     let lowest_acceptable_era_id =
-                        current_era + self.auction_delay - self.unbonding_delay;
+                        (current_era + self.auction_delay).saturating_sub(self.unbonding_delay);
                     let highest_acceptable_era_id = current_era + self.auction_delay;
                     if era_id < lowest_acceptable_era_id || era_id > highest_acceptable_era_id {
                         warn!(

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -454,7 +454,7 @@ where
                 effects.extend(
                     effect_builder
                         .handle_linear_chain_block(*block.clone())
-                        .map_some(move |fs| Event::FinalitySignatureReceived(Box::new(fs), true)),
+                        .map_some(move |fs| Event::FinalitySignatureReceived(Box::new(fs), false)),
                 );
                 effects.extend(effect_builder.announce_block_added(block).ignore());
                 effects

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -175,7 +175,7 @@ enum Signature {
 }
 
 impl Signature {
-    fn to_inner(&self) -> &Box<FinalitySignature> {
+    fn to_inner(&self) -> &FinalitySignature {
         match self {
             Signature::Local(fs) => fs,
             Signature::External(fs) => fs,
@@ -288,7 +288,7 @@ impl<I> LinearChain<I> {
                 signature.to_inner().signature,
             );
             if signature.is_local() {
-                let message = Message::FinalitySignature(signature.to_inner().clone());
+                let message = Message::FinalitySignature(Box::new(signature.to_inner().clone()));
                 effects.extend(effect_builder.broadcast_message(message).ignore());
             }
             effects.extend(

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -439,8 +439,8 @@ where
                             ?block_hash,
                             "received finality signature for not bonded era."
                         );
-                    return Effects::new();
-                }
+                        return Effects::new();
+                    }
                 }
                 if self.has_finality_signature(&fs) {
                     debug!(block_hash=%fs.block_hash, public_key=%fs.public_key,

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -776,7 +776,7 @@ impl reactor::Reactor for Reactor {
                 let block_hash = *block.hash();
 
                 // send to linear chain
-                let reactor_event = Event::LinearChain(linear_chain::Event::LinearChainBlock {
+                let reactor_event = Event::LinearChain(linear_chain::Event::NewLinearChainBlock {
                     block: Box::new(block),
                     execution_results: execution_results
                         .iter()

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -502,7 +502,8 @@ impl reactor::Reactor for Reactor {
             registry.clone(),
         );
 
-        let linear_chain = linear_chain::LinearChain::new(&registry)?;
+        let linear_chain =
+            linear_chain::LinearChain::new(&registry, &chainspec_loader.chainspec())?;
 
         let validator_weights: BTreeMap<PublicKey, U512> = chainspec_loader
             .chainspec()

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -875,10 +875,9 @@ impl reactor::Reactor for Reactor {
                         effects
                     }
                     ConsensusAnnouncement::Handled(linear_chain_block) => {
-                        let event =
-                            Event::LinearChain(linear_chain::Event::KnownLinearChainBlock {
-                                block: linear_chain_block,
-                            });
+                        let event = Event::LinearChain(linear_chain::Event::KnownLinearChainBlock(
+                            linear_chain_block,
+                        ));
                         self.dispatch_event(effect_builder, rng, event)
                     }
                     ConsensusAnnouncement::Fault {

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -788,7 +788,9 @@ impl reactor::Reactor for Reactor {
                             return Effects::new();
                         }
                     },
-                    Message::FinalitySignature(fs) => Event::LinearChain(fs.into()),
+                    Message::FinalitySignature(fs) => {
+                        Event::LinearChain(linear_chain::Event::FinalitySignatureReceived(fs, true))
+                    }
                 };
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -473,7 +473,7 @@ impl reactor::Reactor for Reactor {
         )
         .with_parent_map(latest_block);
         let proto_block_validator = BlockValidator::new(Arc::clone(&chainspec_loader.chainspec()));
-        let linear_chain = LinearChain::new(registry)?;
+        let linear_chain = LinearChain::new(registry, &chainspec_loader.chainspec())?;
 
         effects.extend(reactor::wrap_effects(Event::Network, network_effects));
         effects.extend(reactor::wrap_effects(

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -874,9 +874,12 @@ impl reactor::Reactor for Reactor {
                         effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                         effects
                     }
-                    ConsensusAnnouncement::Handled(_) => {
-                        debug!("Ignoring `Handled` announcement in `validator` reactor.");
-                        Effects::new()
+                    ConsensusAnnouncement::Handled(linear_chain_block) => {
+                        let event =
+                            Event::LinearChain(linear_chain::Event::KnownLinearChainBlock {
+                                block: linear_chain_block,
+                            });
+                        self.dispatch_event(effect_builder, rng, event)
                     }
                     ConsensusAnnouncement::Fault {
                         era_id,
@@ -906,7 +909,7 @@ impl reactor::Reactor for Reactor {
                 let block_hash = *block.hash();
 
                 // send to linear chain
-                let reactor_event = Event::LinearChain(linear_chain::Event::LinearChainBlock {
+                let reactor_event = Event::LinearChain(linear_chain::Event::NewLinearChainBlock {
                     block: Box::new(block),
                     execution_results: execution_results
                         .iter()


### PR DESCRIPTION
This PR makes a couple of changes that optimize how finality signatures are being handled by the node:
* we gossip finality signatures created only by our node
* we validate the cryptographic signature at the end (as it's the most expensive test)
* validator reactor will inform `LinearChain` when a already-exected block is finalized, so that `LinearChain` can update its view about the tip of the chain and handle `IsBonded` queries properly.