### PR TITLE
NO-TICKET: Fix unnecessary pausing

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -132,7 +132,7 @@ pub enum Event<I> {
         validators: BTreeMap<PublicKey, U512>,
     },
     /// An event fired when the joiner reactor transitions into validator.
-    FinishedJoining(Timestamp),
+    FinishedJoining(Timestamp, Option<Box<BlockHeader>>),
     /// Got the result of checking for an upgrade activation point.
     GotUpgradeActivationPoint(ActivationPoint),
 }
@@ -234,7 +234,7 @@ impl<I: Debug> Display for Event<I> {
                 booking_block_hash, block
             ),
             Event::InitializeEras { .. } => write!(f, "Starting eras should be initialized"),
-            Event::FinishedJoining(timestamp) => {
+            Event::FinishedJoining(timestamp, _) => {
                 write!(f, "The node finished joining the network at {}", timestamp)
             }
             Event::GotUpgradeActivationPoint(activation_point) => {
@@ -364,7 +364,9 @@ where
 
                 effects
             }
-            Event::FinishedJoining(timestamp) => handling_es.finished_joining(timestamp),
+            Event::FinishedJoining(timestamp, maybe_header) => {
+                handling_es.finished_joining(timestamp, maybe_header)
+            }
             Event::GotUpgradeActivationPoint(activation_point) => {
                 handling_es.got_upgrade_activation_point(activation_point)
             }


### PR DESCRIPTION
If a node was restarted during normal operation of the network and managed to sync before new blocks were proposed, its `next_executed_height` would stay at 0, while `next_block_height` would be correct, leading to the node pausing itself. If the node was additionally a whale holding most of the network's stake, this would stall the network, as it would be the leader of most rounds and wouldn't propose a block.

This quick fix uses the block height of the latest block to reset the values to something reasonable upon switching to the validator reactor.

It will get superseded by #1148.