### PR TITLE
EE-{1197,1198}: add initial trie delete

### DIFF
--- a/execution_engine/src/storage/trie/mod.rs
+++ b/execution_engine/src/storage/trie/mod.rs
@@ -182,6 +182,10 @@ impl PointerBlock {
                     .map(|value| (index.try_into().expect(USIZE_EXCEEDS_U8), value.to_owned()))
             })
     }
+
+    pub fn child_count(&self) -> usize {
+        self.to_indexed_pointers().count()
+    }
 }
 
 impl From<PointerBlockArray> for PointerBlock {

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -333,8 +333,7 @@ where
             };
             if trie_key != hash_of_trie_value {
                 panic!(
-                    "Trie key {:?} has corrupted value {:?} (hash of value is {:?}); \
-                     adding to list of missing nodes",
+                    "Trie key {:?} has corrupted value {:?} (hash of value is {:?})",
                     trie_key, trie_value, hash_of_trie_value
                 );
             }

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -680,8 +680,8 @@ where
             // The parent is an extension and the new element is a pointer block.
             // The next element we add will be an extension to the pointer block we are going to
             // add.
-            (Some((trie_key, Trie::Node { .. })), Trie::Extension { affix, mut pointer }) => {
-                pointer = Pointer::NodePointer(*trie_key);
+            (Some((trie_key, Trie::Node { .. })), Trie::Extension { affix, .. }) => {
+                let pointer = Pointer::NodePointer(*trie_key);
                 let trie_extension = Trie::Extension { affix, pointer };
                 let trie_key = Blake2bHash::new(&trie_extension.to_bytes()?);
                 new_elements.push((trie_key, trie_extension))

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -688,12 +688,15 @@ where
             }
         }
     }
-    let mut root_hash: Blake2bHash = root.to_owned();
     for (hash, element) in new_elements.iter() {
         store.put(txn, hash, element)?;
-        root_hash = *hash;
     }
-    Ok(DeleteResult::Deleted(root_hash))
+    // The hash of the final trie in the new elements is the new root
+    let new_root = new_elements
+        .pop()
+        .map(|(hash, _)| hash)
+        .unwrap_or_else(|| root.to_owned());
+    Ok(DeleteResult::Deleted(new_root))
 }
 
 #[allow(clippy::type_complexity)]

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -606,20 +606,6 @@ where
                             Trie::Leaf { .. } => {
                                 panic!("Node pointer should not point to leaf")
                             }
-                            // The single sibling is a node, and the grandparent does not exist.
-                            // Therefore the parent is the root.  We output an extension to
-                            // replace the parent, with a single byte corresponding to the sibling
-                            // index.  In the next loop iteration, we will handle the case where
-                            // this extension might need to be combined with a grandparent
-                            // extension.
-                            Trie::Node { .. } => {
-                                let new_extension: Trie<K, V> = Trie::Extension {
-                                    affix: vec![sibling_idx].into(),
-                                    pointer: sibling_pointer,
-                                };
-                                let trie_key = Blake2bHash::new(&new_extension.to_bytes()?);
-                                new_elements.push((trie_key, new_extension))
-                            }
                             // The single sibling is a node, and there exists a grandparent.
                             // Therefore the parent is not the root.  We output an extension to
                             // replace the parent, with a single byte corresponding to the sibling

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -540,9 +540,9 @@ where
                     .to_indexed_pointers()
                     .find(|(jdx, _)| idx != *jdx)
                 {
-                    // There are zero siblings.  Elsewhere we maintain the invariant that only
-                    // the root node can contain a single leaf.  Therefore the parent is the
-                    // root node.  The resulting output is just the empty node and nothing else.
+                    // There are zero siblings.  Elsewhere we maintain the invariant that only the
+                    // root node can contain a single leaf.  Therefore the parent is the root node.
+                    // The resulting output is just the empty node and nothing else.
                     None => {
                         let trie_node = Trie::Node {
                             pointer_block: Box::new(PointerBlock::new()),
@@ -556,9 +556,8 @@ where
                 // There is one sibling.
                 match (sibling_pointer, parents.pop()) {
                     (_, Some((_, Trie::Leaf { .. }))) => panic!("Should not have leaf in scan"),
-                    // There is no grandparent.  Therefore the parent is the root node. Output
-                    // the root node with the index zeroed out.
-                    // TODO: unify me
+                    // There is no grandparent.  Therefore the parent is the root node.  Output the
+                    // root node with the index zeroed out.
                     (_, None) => {
                         pointer_block[idx as usize] = None;
                         let trie_node = Trie::Node { pointer_block };
@@ -622,9 +621,8 @@ where
                             }
                             // The single sibling is a extension.  We output an extension to replace
                             // the parent, prepending the sibling index to the sibling's affix.  In
-                            // the next loop iteration, we will handle
-                            // the case where this extension might need to
-                            // be combined with a grandparent extension.
+                            // the next loop iteration, we will handle the case where this extension
+                            // might need to be combined with a grandparent extension.
                             Trie::Extension {
                                 affix: extension_affix,
                                 pointer,
@@ -642,9 +640,9 @@ where
                     }
                 }
             }
-            // The parent is a pointer block, and we are propagating a node or extension upwards. It
-            // is impossible to propagate a leaf upwards.  Reseat the thing we are propagating into
-            // the parent.
+            // The parent is a pointer block, and we are propagating a node or extension upwards.
+            // It is impossible to propagate a leaf upwards.  Reseat the thing we are propagating
+            // into the parent.
             (Some((trie_key, _)), Trie::Node { mut pointer_block }) => {
                 let trie_node: Trie<K, V> = {
                     pointer_block[idx as usize] = Some(Pointer::NodePointer(*trie_key));
@@ -653,9 +651,9 @@ where
                 let trie_key = Blake2bHash::new(&trie_node.to_bytes()?);
                 new_elements.push((trie_key, trie_node))
             }
-            // The parent is an extension, and we are outputting an extension.  Prepend the
-            // parent affix to affix of the output extension, mutating the output in place.
-            // This is the only mutate-in-place.
+            // The parent is an extension, and we are outputting an extension.  Prepend the parent
+            // affix to affix of the output extension, mutating the output in place.  This is the
+            // only mutate-in-place.
             (
                 Some((
                     trie_key,
@@ -677,9 +675,8 @@ where
                     Blake2bHash::new(&new_extension.to_bytes()?)
                 }
             }
-            // The parent is an extension and the new element is a pointer block.
-            // The next element we add will be an extension to the pointer block we are going to
-            // add.
+            // The parent is an extension and the new element is a pointer block.  The next element
+            // we add will be an extension to the pointer block we are going to add.
             (Some((trie_key, Trie::Node { .. })), Trie::Extension { affix, .. }) => {
                 let pointer = Pointer::NodePointer(*trie_key);
                 let trie_extension = Trie::Extension { affix, pointer };

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -666,7 +666,7 @@ where
                 )),
                 Trie::Extension { affix, .. },
             ) => {
-                let mut new_affix: Vec<u8> = Vec::<u8>::from(affix);
+                let mut new_affix: Vec<u8> = affix.into();
                 new_affix.extend_from_slice(child_affix.as_slice());
                 *child_affix = new_affix.into();
                 *trie_key = {

--- a/execution_engine/src/storage/trie_store/operations/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/mod.rs
@@ -667,7 +667,7 @@ where
                 Trie::Extension { affix, .. },
             ) => {
                 let mut new_affix: Vec<u8> = Vec::<u8>::from(affix);
-                new_affix.extend(Vec::<u8>::from(child_affix.to_owned()));
+                new_affix.extend_from_slice(child_affix.as_slice());
                 *child_affix = new_affix.into();
                 *trie_key = {
                     let new_extension: Trie<K, V> = Trie::Extension {

--- a/execution_engine/src/storage/trie_store/operations/tests/delete.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/delete.rs
@@ -1,0 +1,454 @@
+use super::*;
+use crate::storage::{transaction_source::Writable, trie_store::operations::DeleteResult};
+
+fn checked_delete<K, V, T, S, E>(
+    correlation_id: CorrelationId,
+    txn: &mut T,
+    store: &S,
+    root: &Blake2bHash,
+    key_to_delete: &K,
+) -> Result<DeleteResult, E>
+where
+    K: ToBytes + FromBytes + Clone + std::fmt::Debug + Eq,
+    V: ToBytes + FromBytes + Clone + std::fmt::Debug,
+    T: Readable<Handle = S::Handle> + Writable<Handle = S::Handle>,
+    S: TrieStore<K, V>,
+    S::Error: From<T::Error>,
+    E: From<S::Error> + From<bytesrepr::Error>,
+{
+    let delete_result =
+        operations::delete::<K, V, T, S, E>(correlation_id, txn, store, root, key_to_delete)?;
+    if let DeleteResult::Deleted(new_root) = delete_result {
+        operations::check_integrity::<K, V, T, S, E>(correlation_id, txn, store, vec![new_root])?;
+    }
+    Ok(delete_result)
+}
+
+mod partial_tries {
+    use super::*;
+    use crate::storage::trie_store::operations::DeleteResult;
+
+    fn delete_from_partial_trie_had_expected_results<'a, K, V, R, S, E>(
+        correlation_id: CorrelationId,
+        environment: &'a R,
+        store: &S,
+        root: &Blake2bHash,
+        key_to_delete: &K,
+        expected_root_after_delete: &Blake2bHash,
+        expected_tries_after_delete: &[HashedTrie<K, V>],
+    ) -> Result<(), E>
+    where
+        K: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+        V: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+        R: TransactionSource<'a, Handle = S::Handle>,
+        S: TrieStore<K, V>,
+        S::Error: From<R::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+    {
+        let mut txn = environment.create_read_write_txn()?;
+        assert_eq!(store.get(&txn, &expected_root_after_delete)?, None); // this only works with partial tries
+        let root_after_delete = match checked_delete::<K, V, _, _, E>(
+            correlation_id,
+            &mut txn,
+            store,
+            root,
+            key_to_delete,
+        )? {
+            DeleteResult::Deleted(root_after_delete) => root_after_delete,
+            DeleteResult::DoesNotExist => panic!("key did not exist"),
+            DeleteResult::RootNotFound => panic!("root should be found"),
+        };
+        assert_eq!(root_after_delete, *expected_root_after_delete);
+        for HashedTrie { hash, trie } in expected_tries_after_delete {
+            assert_eq!(store.get(&txn, &hash)?, Some(trie.clone()));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn lmdb_delete_from_partial_trie_had_expected_results() {
+        for i in 0..TEST_LEAVES_LENGTH {
+            let correlation_id = CorrelationId::new();
+            let (initial_root_hash, initial_tries) = TEST_TRIE_GENERATORS[i + 1]().unwrap();
+            let (updated_root_hash, updated_tries) = TEST_TRIE_GENERATORS[i]().unwrap();
+            let key_to_delete = &TEST_LEAVES[i];
+            let context = LmdbTestContext::new(&initial_tries).unwrap();
+
+            delete_from_partial_trie_had_expected_results::<TestKey, TestValue, _, _, error::Error>(
+                correlation_id,
+                &context.environment,
+                &context.store,
+                &initial_root_hash,
+                key_to_delete.key().unwrap(),
+                &updated_root_hash,
+                updated_tries.as_slice(),
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn in_memory_delete_from_partial_trie_had_expected_results() {
+        for i in 0..TEST_LEAVES_LENGTH {
+            let correlation_id = CorrelationId::new();
+            let (initial_root_hash, initial_tries) = TEST_TRIE_GENERATORS[i + 1]().unwrap();
+            let (updated_root_hash, updated_tries) = TEST_TRIE_GENERATORS[i]().unwrap();
+            let key_to_delete = &TEST_LEAVES[i];
+            let context = InMemoryTestContext::new(&initial_tries).unwrap();
+
+            delete_from_partial_trie_had_expected_results::<TestKey, TestValue, _, _, error::Error>(
+                correlation_id,
+                &context.environment,
+                &context.store,
+                &initial_root_hash,
+                key_to_delete.key().unwrap(),
+                &updated_root_hash,
+                updated_tries.as_slice(),
+            )
+            .unwrap();
+        }
+    }
+
+    fn delete_non_existent_key_from_partial_trie_should_return_does_not_exist<'a, K, V, R, S, E>(
+        correlation_id: CorrelationId,
+        environment: &'a R,
+        store: &S,
+        root: &Blake2bHash,
+        key_to_delete: &K,
+    ) -> Result<(), E>
+    where
+        K: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+        V: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+        R: TransactionSource<'a, Handle = S::Handle>,
+        S: TrieStore<K, V>,
+        S::Error: From<R::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+    {
+        let mut txn = environment.create_read_write_txn()?;
+        match checked_delete::<K, V, _, _, E>(correlation_id, &mut txn, store, root, key_to_delete)?
+        {
+            DeleteResult::Deleted(_) => panic!("should not delete"),
+            DeleteResult::DoesNotExist => Ok(()),
+            DeleteResult::RootNotFound => panic!("root should be found"),
+        }
+    }
+
+    #[test]
+    fn lmdb_delete_non_existent_key_from_partial_trie_should_return_does_not_exist() {
+        for i in 0..TEST_LEAVES_LENGTH {
+            let correlation_id = CorrelationId::new();
+            let (initial_root_hash, initial_tries) = TEST_TRIE_GENERATORS[i]().unwrap();
+            let key_to_delete = &TEST_LEAVES_ADJACENTS[i];
+            let context = LmdbTestContext::new(&initial_tries).unwrap();
+
+            delete_non_existent_key_from_partial_trie_should_return_does_not_exist::<
+                TestKey,
+                TestValue,
+                _,
+                _,
+                error::Error,
+            >(
+                correlation_id,
+                &context.environment,
+                &context.store,
+                &initial_root_hash,
+                key_to_delete.key().unwrap(),
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn in_memory_delete_non_existent_key_from_partial_trie_should_return_does_not_exist() {
+        for i in 0..TEST_LEAVES_LENGTH {
+            let correlation_id = CorrelationId::new();
+            let (initial_root_hash, initial_tries) = TEST_TRIE_GENERATORS[i]().unwrap();
+            let key_to_delete = &TEST_LEAVES_ADJACENTS[i];
+            let context = InMemoryTestContext::new(&initial_tries).unwrap();
+
+            delete_non_existent_key_from_partial_trie_should_return_does_not_exist::<
+                TestKey,
+                TestValue,
+                _,
+                _,
+                error::Error,
+            >(
+                correlation_id,
+                &context.environment,
+                &context.store,
+                &initial_root_hash,
+                key_to_delete.key().unwrap(),
+            )
+            .unwrap();
+        }
+    }
+}
+
+mod full_tries {
+    use std::ops::RangeInclusive;
+
+    use proptest::{collection, proptest};
+
+    use casper_types::{
+        bytesrepr::{self, FromBytes, ToBytes},
+        gens::colliding_key_arb,
+        Key,
+    };
+
+    use crate::{
+        shared::{
+            newtypes::{Blake2bHash, CorrelationId},
+            stored_value::{gens::stored_value_arb, StoredValue},
+        },
+        storage::{
+            error,
+            transaction_source::TransactionSource,
+            trie_store::{
+                operations::{
+                    delete,
+                    tests::{
+                        InMemoryTestContext, LmdbTestContext, TestKey, TestValue,
+                        TEST_TRIE_GENERATORS,
+                    },
+                    write, DeleteResult, WriteResult,
+                },
+                TrieStore,
+            },
+        },
+    };
+
+    fn serially_insert_and_delete<'a, K, V, R, S, E>(
+        correlation_id: CorrelationId,
+        environment: &'a R,
+        store: &S,
+        root: &Blake2bHash,
+        pairs: &[(K, V)],
+    ) -> Result<(), E>
+    where
+        K: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+        V: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+        R: TransactionSource<'a, Handle = S::Handle>,
+        S: TrieStore<K, V>,
+        S::Error: From<R::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+    {
+        let mut txn = environment.create_read_write_txn()?;
+        let mut roots = Vec::new();
+        // Insert the key-value pairs, keeping track of the roots as we go
+        for (key, value) in pairs.iter() {
+            if let WriteResult::Written(new_root) = write::<K, V, _, _, E>(
+                correlation_id,
+                &mut txn,
+                store,
+                roots.last().unwrap_or(&root),
+                key,
+                value,
+            )? {
+                roots.push(new_root);
+            } else {
+                panic!("Could not write pair")
+            }
+        }
+        // Delete the key-value pairs, checking the resulting roots as we go
+        let mut current_root = roots.pop().unwrap_or_else(|| root.to_owned());
+        for (key, _value) in pairs.iter().rev() {
+            if let DeleteResult::Deleted(new_root) =
+                delete::<K, V, _, _, E>(correlation_id, &mut txn, store, &current_root, key)?
+            {
+                current_root = roots.pop().unwrap_or_else(|| root.to_owned());
+                assert_eq!(new_root, current_root);
+            } else {
+                panic!("Could not delete")
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn lmdb_serially_insert_and_delete() {
+        let correlation_id = CorrelationId::new();
+        let (empty_root_hash, empty_trie) = TEST_TRIE_GENERATORS[0]().unwrap();
+        let context = LmdbTestContext::new(&empty_trie).unwrap();
+
+        serially_insert_and_delete::<TestKey, TestValue, _, _, error::Error>(
+            correlation_id,
+            &context.environment,
+            &context.store,
+            &empty_root_hash,
+            &[
+                (TestKey([1u8; 7]), TestValue([1u8; 6])),
+                (TestKey([0u8; 7]), TestValue([0u8; 6])),
+                (TestKey([0u8, 1, 1, 1, 1, 1, 1]), TestValue([2u8; 6])),
+                (TestKey([2u8; 7]), TestValue([2u8; 6])),
+            ],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn in_memory_serially_insert_and_delete() {
+        let correlation_id = CorrelationId::new();
+        let (empty_root_hash, empty_trie) = TEST_TRIE_GENERATORS[0]().unwrap();
+        let context = InMemoryTestContext::new(&empty_trie).unwrap();
+
+        serially_insert_and_delete::<TestKey, TestValue, _, _, error::Error>(
+            correlation_id,
+            &context.environment,
+            &context.store,
+            &empty_root_hash,
+            &[
+                (TestKey([1u8; 7]), TestValue([1u8; 6])),
+                (TestKey([0u8; 7]), TestValue([0u8; 6])),
+                (TestKey([0u8, 1, 1, 1, 1, 1, 1]), TestValue([2u8; 6])),
+                (TestKey([2u8; 7]), TestValue([2u8; 6])),
+            ],
+        )
+        .unwrap();
+    }
+
+    const INTERLEAVED_INSERT_AND_DELETE_TEST_LEAVES_1: [(TestKey, TestValue); 3] = [
+        (TestKey([1u8; 7]), TestValue([1u8; 6])),
+        (TestKey([0u8; 7]), TestValue([0u8; 6])),
+        (TestKey([0u8, 1, 1, 1, 1, 1, 1]), TestValue([2u8; 6])),
+    ];
+
+    const INTERLEAVED_DELETE_TEST_KEYS_1: [TestKey; 1] = [TestKey([1u8; 7])];
+
+    fn interleaved_insert_and_delete<'a, K, V, R, S, E>(
+        correlation_id: CorrelationId,
+        environment: &'a R,
+        store: &S,
+        root: &Blake2bHash,
+        pairs_to_insert: &[(K, V)],
+        keys_to_delete: &[K],
+    ) -> Result<(), E>
+    where
+        K: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+        V: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+        R: TransactionSource<'a, Handle = S::Handle>,
+        S: TrieStore<K, V>,
+        S::Error: From<R::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
+    {
+        let mut txn = environment.create_read_write_txn()?;
+        let mut expected_root = *root;
+        // Insert the key-value pairs, keeping track of the roots as we go
+        for (key, value) in pairs_to_insert.iter() {
+            if let WriteResult::Written(new_root) =
+                write::<K, V, _, _, E>(correlation_id, &mut txn, store, &expected_root, key, value)?
+            {
+                expected_root = new_root;
+            } else {
+                panic!("Could not write pair")
+            }
+        }
+        for key in keys_to_delete.iter() {
+            match delete::<K, V, _, _, E>(correlation_id, &mut txn, store, &expected_root, key)? {
+                DeleteResult::Deleted(new_root) => {
+                    expected_root = new_root;
+                }
+                DeleteResult::DoesNotExist => {}
+                DeleteResult::RootNotFound => panic!("should find root"),
+            }
+        }
+
+        let pairs_to_insert_less_deleted: Vec<(K, V)> = pairs_to_insert
+            .iter()
+            .rev()
+            .cloned()
+            .filter(|(key, _value)| !keys_to_delete.contains(key))
+            .collect();
+
+        let mut actual_root = *root;
+        for (key, value) in pairs_to_insert_less_deleted.iter() {
+            if let WriteResult::Written(new_root) =
+                write::<K, V, _, _, E>(correlation_id, &mut txn, store, &actual_root, key, value)?
+            {
+                actual_root = new_root;
+            } else {
+                panic!("Could not write pair")
+            }
+        }
+
+        assert_eq!(expected_root, actual_root, "Expected did not match actual");
+
+        Ok(())
+    }
+
+    #[test]
+    fn lmdb_interleaved_insert_and_delete() {
+        let correlation_id = CorrelationId::new();
+        let (empty_root_hash, empty_trie) = TEST_TRIE_GENERATORS[0]().unwrap();
+        let context = LmdbTestContext::new(&empty_trie).unwrap();
+
+        interleaved_insert_and_delete::<TestKey, TestValue, _, _, error::Error>(
+            correlation_id,
+            &context.environment,
+            &context.store,
+            &empty_root_hash,
+            &INTERLEAVED_INSERT_AND_DELETE_TEST_LEAVES_1,
+            &INTERLEAVED_DELETE_TEST_KEYS_1,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn in_memory_interleaved_insert_and_delete() {
+        let correlation_id = CorrelationId::new();
+        let (empty_root_hash, empty_trie) = TEST_TRIE_GENERATORS[0]().unwrap();
+        let context = InMemoryTestContext::new(&empty_trie).unwrap();
+
+        interleaved_insert_and_delete::<TestKey, TestValue, _, _, error::Error>(
+            correlation_id,
+            &context.environment,
+            &context.store,
+            &empty_root_hash,
+            &INTERLEAVED_INSERT_AND_DELETE_TEST_LEAVES_1,
+            &INTERLEAVED_DELETE_TEST_KEYS_1,
+        )
+        .unwrap();
+    }
+
+    const DEFAULT_MIN_LENGTH: usize = 1;
+
+    const DEFAULT_MAX_LENGTH: usize = 6;
+
+    fn get_range() -> RangeInclusive<usize> {
+        let start = option_env!("CL_TRIE_TEST_VECTOR_MIN_LENGTH")
+            .and_then(|s| str::parse::<usize>(s).ok())
+            .unwrap_or(DEFAULT_MIN_LENGTH);
+        let end = option_env!("CL_TRIE_TEST_VECTOR_MAX_LENGTH")
+            .and_then(|s| str::parse::<usize>(s).ok())
+            .unwrap_or(DEFAULT_MAX_LENGTH);
+        RangeInclusive::new(start, end)
+    }
+
+    proptest! {
+        #[test]
+        fn prop_in_memory_interleaved_insert_and_delete(
+            pairs_to_insert in collection::vec((colliding_key_arb(), stored_value_arb()), get_range())
+        ) {
+            let correlation_id = CorrelationId::new();
+            let (empty_root_hash, empty_trie) = TEST_TRIE_GENERATORS[0]().unwrap();
+            let context = InMemoryTestContext::new(&empty_trie).unwrap();
+
+            let keys_to_delete = {
+                let mut tmp = Vec::new();
+                for i in (0..pairs_to_insert.len()).step_by(2) {
+                    tmp.push(pairs_to_insert[i].0)
+                }
+                tmp
+            };
+
+            interleaved_insert_and_delete::<Key, StoredValue, _, _, error::Error>(
+                correlation_id,
+                &context.environment,
+                &context.store,
+                &empty_root_hash,
+                &pairs_to_insert,
+                &keys_to_delete,
+            )
+            .unwrap();
+        }
+    }
+}

--- a/execution_engine/src/storage/trie_store/operations/tests/delete.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/delete.rs
@@ -236,7 +236,7 @@ mod full_tries {
         let mut txn = environment.create_read_write_txn()?;
         let mut roots = Vec::new();
         // Insert the key-value pairs, keeping track of the roots as we go
-        for (key, value) in pairs.iter() {
+        for (key, value) in pairs {
             if let WriteResult::Written(new_root) = write::<K, V, _, _, E>(
                 correlation_id,
                 &mut txn,

--- a/execution_engine/src/storage/trie_store/operations/tests/delete.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/delete.rs
@@ -46,7 +46,8 @@ mod partial_tries {
         E: From<R::Error> + From<S::Error> + From<bytesrepr::Error>,
     {
         let mut txn = environment.create_read_write_txn()?;
-        assert_eq!(store.get(&txn, &expected_root_after_delete)?, None); // this only works with partial tries
+        // The assert below only works with partial tries
+        assert_eq!(store.get(&txn, &expected_root_after_delete)?, None);
         let root_after_delete = match checked_delete::<K, V, _, _, E>(
             correlation_id,
             &mut txn,

--- a/execution_engine/src/storage/trie_store/operations/tests/mod.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/mod.rs
@@ -1,3 +1,4 @@
+mod delete;
 mod keys;
 mod proptests;
 mod read;

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -17,6 +17,7 @@ use crate::{
     contracts::{
         ContractPackageStatus, ContractVersions, DisabledVersions, Groups, NamedKeys, Parameters,
     },
+    transfer::TransferAddr,
     AccessRights, CLType, CLValue, Contract, ContractHash, ContractPackage, ContractVersionKey,
     ContractWasm, EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Group, Key, NamedArg,
     Parameter, Phase, ProtocolVersion, SemVer, URef, U128, U256, U512,
@@ -30,6 +31,15 @@ pub fn u8_slice_32() -> impl Strategy<Value = [u8; 32]> {
         let mut res = [0u8; 32];
         res.clone_from_slice(b.as_slice());
         res
+    })
+}
+
+pub fn u2_slice_32() -> impl Strategy<Value = [u8; 32]> {
+    array::uniform32(any::<u8>()).prop_map(|mut arr| {
+        for byte in arr.iter_mut() {
+            *byte &= 0b11;
+        }
+        arr
     })
 }
 
@@ -74,6 +84,15 @@ pub fn key_arb() -> impl Strategy<Value = Key> {
         uref_arb().prop_map(|uref| Key::Balance(uref.addr())),
         account_hash_arb().prop_map(Key::Bid),
         account_hash_arb().prop_map(Key::Withdraw),
+    ]
+}
+
+pub fn colliding_key_arb() -> impl Strategy<Value = Key> {
+    prop_oneof![
+        u2_slice_32().prop_map(|bytes| Key::Account(AccountHash::new(bytes))),
+        u2_slice_32().prop_map(Key::Hash),
+        u2_slice_32().prop_map(|bytes| Key::URef(URef::new(bytes, AccessRights::NONE))),
+        u2_slice_32().prop_map(|bytes| Key::Transfer(TransferAddr::new(bytes))),
     ]
 }
 


### PR DESCRIPTION
This PR introduces a `delete` operation to the trie, along with tests validating its behavior.  Future work will surface this through the `TrackingCopy` up to the Contract API.