### PR TITLE
NO-TICKET: use bincode in small_network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4620,27 +4620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f10b46df14cf1ee1ac7baa4d2fbc2c52c0622a4b82fa8740e37bc452ac0184f"
-dependencies = [
- "byteorder",
- "num-traits",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce7d70c926fe472aed493b902010bccc17fa9f7284145cb8772fd22fdb052d8"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5433,11 +5412,11 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebdd897b01021779294eb09bb3b52b6e11b0747f9f7e333a84bef532b656de99"
 dependencies = [
+ "bincode",
  "bytes 0.5.6",
  "derivative",
  "futures",
  "pin-project 0.4.27",
- "rmp-serde",
  "serde",
 ]
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -80,7 +80,7 @@ tempfile = "3.1.0"
 thiserror = "1.0.18"
 tokio = { version = "0.2.20", features = ["blocking", "macros", "rt-threaded", "sync", "tcp", "time"] }
 tokio-openssl = "0.4.0"
-tokio-serde = { version = "0.6.1", features = ["messagepack"] }
+tokio-serde = { version = "0.6.1", features = ["bincode"] }
 tokio-util = { version = "0.3.1", features = ["codec"] }
 toml = "0.5.6"
 tower = "0.3.1"

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -60,7 +60,11 @@ pub(crate) use era_supervisor::oldest_bonded_era;
 #[derive(DataSize, Clone, Serialize, Deserialize)]
 pub enum ConsensusMessage {
     /// A protocol message, to be handled by the instance in the specified era.
-    Protocol { era_id: EraId, payload: Vec<u8> },
+    Protocol {
+        era_id: EraId,
+        #[serde(with = "serde_bytes")]
+        payload: Vec<u8>,
+    },
     /// A request for evidence against the specified validator, from any era that is still bonded
     /// in `era_id`.
     EvidenceRequest { era_id: EraId, pub_key: PublicKey },

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -78,7 +78,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_openssl::SslStream;
-use tokio_serde::{formats::SymmetricalMessagePack, SymmetricallyFramed};
+use tokio_serde::{formats::SymmetricalBincode, SymmetricallyFramed};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 use tracing::{debug, error, info, trace, warn};
 
@@ -1298,7 +1298,7 @@ type Transport = SslStream<TcpStream>;
 type FramedTransport<P> = SymmetricallyFramed<
     Framed<Transport, LengthDelimitedCodec>,
     Message<P>,
-    SymmetricalMessagePack<Message<P>>,
+    SymmetricalBincode<Message<P>>,
 >;
 
 /// Constructs a new framed transport on a stream.
@@ -1306,7 +1306,7 @@ fn framed<P>(stream: Transport) -> FramedTransport<P> {
     let length_delimited = Framed::new(stream, LengthDelimitedCodec::new());
     SymmetricallyFramed::new(
         length_delimited,
-        SymmetricalMessagePack::<Message<P>>::default(),
+        SymmetricalBincode::<Message<P>>::default(),
     )
 }
 


### PR DESCRIPTION
This PR swaps `rmp_serde` for `bincode` inside the small_network component.

This is in line with a similar replacement made in #348, and should have been changed at that stage for the same reasons.  However it was overlooked due to being a transitive dependency.

There is also a change to `ConsensusMessage` whereby it now uses [serde_bytes](https://github.com/serde-rs/bytes) to (de)serialize the `Vec<u8>` member variable, which should be significantly more efficient.