### PR TITLE
NDRS-1023/add greeting before handshake

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -56,6 +56,7 @@ use std::{
 };
 
 use anyhow::Context;
+use casper_types::ProtocolVersion;
 use datasize::DataSize;
 use futures::{
     future::{select, BoxFuture, Either},
@@ -158,6 +159,8 @@ where
     /// Name of the network we participate in. We only remain connected to peers with the same
     /// network name as us.
     network_name: String,
+    /// The protocol version of the node.
+    protocol_version: ProtocolVersion,
     /// Channel signaling a shutdown of the small network.
     // Note: This channel is closed when `SmallNetwork` is dropped, signalling the receivers that
     // they should cease operation.
@@ -196,6 +199,7 @@ where
         registry: &Registry,
         small_network_identity: SmallNetworkIdentity,
         network_name: String,
+        protocol_version: ProtocolVersion,
         notify: bool,
     ) -> Result<(SmallNetwork<REv, P>, Effects<Event<P>>)> {
         let mut known_addresses = HashSet::new();
@@ -242,6 +246,7 @@ where
                 pending: HashMap::new(),
                 blocklist: HashMap::new(),
                 network_name,
+                protocol_version,
                 shutdown_sender: None,
                 shutdown_receiver: watch::channel(()).1,
                 server_join_handle: None,
@@ -306,6 +311,7 @@ where
             pending: HashMap::new(),
             blocklist: HashMap::new(),
             network_name,
+            protocol_version,
             shutdown_sender: Some(server_shutdown_sender),
             shutdown_receiver,
             server_join_handle: Some(server_join_handle),

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -1,5 +1,6 @@
 use std::{io, net::SocketAddr, result, time::SystemTimeError};
 
+use casper_types::bytesrepr;
 use openssl::error::ErrorStack;
 use serde::Serialize;
 use thiserror::Error;
@@ -87,6 +88,34 @@ pub enum Error {
         #[serde(skip_serializing)]
         #[source]
         ErrorStack,
+    ),
+    /// Failed to serialize the protocol version into bytes for greeting.
+    #[error("could not serialize protocol version for greeting")]
+    SerializeProtocolVersion(
+        #[serde(skip_serializing)]
+        #[source]
+        bytesrepr::Error,
+    ),
+    /// Failed to write greeting.
+    #[error("could not write greeting")]
+    WriteGreeting(
+        #[serde(skip_serializing)]
+        #[source]
+        io::Error,
+    ),
+    /// Failed to read greeting.
+    #[error("could not read greeting")]
+    ReadGreeting(
+        #[serde(skip_serializing)]
+        #[source]
+        io::Error,
+    ),
+    /// Could not deserialize protocol version from greeting.
+    #[error("could not deserialize protocol version from greeting")]
+    DeserializeProtocolVersion(
+        #[serde(skip_serializing)]
+        #[source]
+        bytesrepr::Error,
     ),
     /// Handshaking error.
     #[error("handshake error: {0}")]

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -10,6 +10,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use casper_types::ProtocolVersion;
 use derive_more::From;
 use pnet::datalink;
 use prometheus::Registry;
@@ -140,6 +141,7 @@ impl Reactor for TestReactor {
             registry,
             small_network_identity,
             "test_network".to_string(),
+            ProtocolVersion::V1_0_0,
             false,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -287,6 +287,14 @@ fn greeting_length_matches_version_serialization() {
     assert_eq!(GREETING_LENGTH, ProtocolVersion::V1_0_0.serialized_length());
 }
 
+#[test]
+fn serialized_version_is_sane() {
+    let expected = vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+    let pversion = ProtocolVersion::V1_0_0;
+    assert_eq!(pversion.to_bytes().expect("to bytes failed"), expected);
+}
+
 /// Run a two-node network five times.
 ///
 /// Ensures that network cleanup and basic networking works.

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -10,7 +10,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use casper_types::ProtocolVersion;
+use casper_types::{bytesrepr::ToBytes, ProtocolVersion};
 use derive_more::From;
 use pnet::datalink;
 use prometheus::Registry;
@@ -18,7 +18,7 @@ use reactor::ReactorEvent;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
-use super::{Config, Event as SmallNetworkEvent, GossipedAddress, SmallNetwork};
+use super::{Config, Event as SmallNetworkEvent, GossipedAddress, SmallNetwork, GREETING_LENGTH};
 use crate::{
     components::{
         gossiper::{self, Gossiper},
@@ -280,6 +280,11 @@ fn network_started(net: &Network<TestReactor>) -> bool {
         .iter()
         .map(|(_, runner)| runner.reactor().inner().net.peers())
         .all(|peers| !peers.is_empty())
+}
+
+#[test]
+fn greeting_length_matches_version_serialization() {
+    assert_eq!(GREETING_LENGTH, ProtocolVersion::V1_0_0.serialized_length());
 }
 
 /// Run a two-node network five times.

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -429,12 +429,14 @@ impl reactor::Reactor for Reactor {
             false,
         )?;
         let network_name = chainspec_loader.chainspec().network_config.name.clone();
+        let protocol_version = chainspec_loader.chainspec().protocol_version();
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network.clone(),
             registry,
             small_network_identity,
             network_name,
+            protocol_version,
             false,
         )?;
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -421,12 +421,15 @@ impl reactor::Reactor for Reactor {
             true,
         )?;
         let network_name = chainspec_loader.chainspec().network_config.name.clone();
+        let protocol_version = chainspec_loader.chainspec().protocol_version();
+
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network,
             registry,
             small_network_identity,
             network_name,
+            protocol_version,
             true,
         )?;
 

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -24,7 +24,10 @@ use casper_execution_engine::{
     core::engine_state::genesis::ExecConfig,
     shared::{system_config::SystemConfig, wasm_config::WasmConfig},
 };
-use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    ProtocolVersion,
+};
 
 #[cfg(test)]
 pub(crate) use self::accounts_config::{AccountConfig, ValidatorConfig};
@@ -93,6 +96,13 @@ impl Chainspec {
     /// Returns true if this chainspec has an activation_point specifying era ID 0.
     pub(crate) fn is_genesis(&self) -> bool {
         self.protocol_config.activation_point.is_genesis()
+    }
+
+    /// Returns the protocol version of the chainspec.
+    #[inline]
+    pub(crate) fn protocol_version(&self) -> ProtocolVersion {
+        let v = &self.protocol_config.version;
+        ProtocolVersion::from_parts(v.major as u32, v.minor as u32, v.patch as u32)
     }
 }
 

--- a/types/src/protocol_version.rs
+++ b/types/src/protocol_version.rs
@@ -54,6 +54,7 @@ impl ProtocolVersion {
     });
 
     /// Constructs a new `ProtocolVersion` from `version`.
+    #[inline]
     pub const fn new(version: SemVer) -> ProtocolVersion {
         ProtocolVersion(version)
     }


### PR DESCRIPTION
This adds a greeting to the networking protocol, which is 12 bytes in length and contains the SemVer protocol version.

While `V1_0_0` does nothing with this information, getting this merged into the final release ensures we can change the underlying networking protocol in an easier manner on upgrades.

**This change is not backwards compatible and will break in any existing network**