### PR TITLE
NO-TICKET: Only hard-reset blocks with old protocol versions

### DIFF
--- a/node/src/components/fetcher/tests.rs
+++ b/node/src/components/fetcher/tests.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use casper_node_macros::reactor;
 use futures::FutureExt;
+use semver::Version;
 use tempfile::TempDir;
 use thiserror::Error;
 use tokio::time;
@@ -73,6 +74,7 @@ reactor!(Reactor {
         storage = Storage(
             &WithDir::new(cfg.temp_dir.path(), cfg.storage_config),
             chainspec_loader.hard_reset_to_start_of_era(),
+            Version::new(1, 0, 0),
         );
         deploy_acceptor = infallible DeployAcceptor(cfg.deploy_acceptor_config, &*chainspec_loader.chainspec());
         deploy_fetcher = Fetcher::<Deploy>("deploy", cfg.fetcher_config, registry);

--- a/node/src/components/gossiper/tests.rs
+++ b/node/src/components/gossiper/tests.rs
@@ -9,6 +9,7 @@ use derive_more::From;
 use prometheus::Registry;
 use rand::Rng;
 use reactor::ReactorEvent;
+use semver::Version;
 use serde::Serialize;
 use tempfile::TempDir;
 use thiserror::Error;
@@ -161,7 +162,7 @@ impl reactor::Reactor for Reactor {
 
         let (storage_config, storage_tempdir) = storage::Config::default_for_tests();
         let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
-        let storage = Storage::new(&storage_withdir, None).unwrap();
+        let storage = Storage::new(&storage_withdir, None, Version::new(1, 0, 0)).unwrap();
 
         let contract_runtime_config = contract_runtime::Config::default();
         let contract_runtime =

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -303,7 +303,7 @@ impl Storage {
                 // versions - they were most likely created before the upgrade and should be
                 // reverted.
                 if block.era_id() >= invalid_era && block.protocol_version() < protocol_version {
-                    cursor.del(Default::default())?;
+                    cursor.del(WriteFlags::empty())?;
                     continue;
                 }
             }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -321,7 +321,7 @@ impl Storage {
         }
         info!("block store reindexing complete");
         drop(cursor);
-        drop(block_txn);
+        block_txn.commit()?;
 
         // Check the integrity of the block body database.
         check_block_body_db(&env, &block_body_db)?;

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -299,6 +299,9 @@ impl Storage {
         for (raw_key, raw_val) in cursor.iter() {
             let block: BlockHeader = lmdb_ext::deserialize(raw_val)?;
             if let Some(invalid_era) = hard_reset_to_start_of_era {
+                // Don't index blocks that are in to-be-upgraded eras, but have obsolete protocol
+                // versions - they were most likely created before the upgrade and should be
+                // reverted.
                 if block.era_id() >= invalid_era && block.protocol_version() < protocol_version {
                     continue;
                 }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -304,6 +304,7 @@ impl Storage {
                 // reverted.
                 if block.era_id() >= invalid_era && block.protocol_version() < protocol_version {
                     cursor.del(Default::default())?;
+                    continue;
                 }
             }
             // We use the opportunity for a small integrity check.

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -3,6 +3,7 @@
 use std::{borrow::Cow, collections::HashMap};
 
 use rand::{prelude::SliceRandom, Rng};
+use semver::Version;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use smallvec::smallvec;
 
@@ -42,8 +43,12 @@ fn new_config(harness: &ComponentHarness<UnitTestEvent>) -> Config {
 /// Panics if setting up the storage fixture fails.
 fn storage_fixture(harness: &ComponentHarness<UnitTestEvent>) -> Storage {
     let cfg = new_config(harness);
-    Storage::new(&WithDir::new(harness.tmp.path(), cfg), None)
-        .expect("could not create storage component fixture")
+    Storage::new(
+        &WithDir::new(harness.tmp.path(), cfg),
+        None,
+        Version::new(1, 0, 0),
+    )
+    .expect("could not create storage component fixture")
 }
 
 /// Storage component test fixture.
@@ -58,8 +63,12 @@ fn storage_fixture_with_hard_reset(
     reset_era_id: EraId,
 ) -> Storage {
     let cfg = new_config(harness);
-    Storage::new(&WithDir::new(harness.tmp.path(), cfg), Some(reset_era_id))
-        .expect("could not create storage component fixture")
+    Storage::new(
+        &WithDir::new(harness.tmp.path(), cfg),
+        Some(reset_era_id),
+        Version::new(1, 1, 0),
+    )
+    .expect("could not create storage component fixture")
 }
 
 /// Creates a random block with a specific block height.

--- a/node/src/reactor/initializer.rs
+++ b/node/src/reactor/initializer.rs
@@ -175,7 +175,11 @@ impl Reactor {
         let hard_reset_to_start_of_era = chainspec_loader.hard_reset_to_start_of_era();
 
         let storage_config = config.map_ref(|cfg| cfg.storage.clone());
-        let storage = Storage::new(&storage_config, hard_reset_to_start_of_era)?;
+        let storage = Storage::new(
+            &storage_config,
+            hard_reset_to_start_of_era,
+            chainspec_loader.chainspec().protocol_config.version.clone(),
+        )?;
 
         let contract_runtime =
             ContractRuntime::new(storage_config, &config.value().contract_runtime, registry)?;

--- a/node/src/reactor/initializer2.rs
+++ b/node/src/reactor/initializer2.rs
@@ -12,7 +12,8 @@ reactor!(Initializer {
     chainspec_loader = has_effects ChainspecLoader(cfg.dir(), effect_builder);
     storage = Storage(
         &cfg.map_ref(|cfg| cfg.storage.clone()),
-        chainspec_loader.hard_reset_to_start_of_era()
+        chainspec_loader.hard_reset_to_start_of_era(),
+        chainspec_loader.chainspec().protocol_config.version.clone(),
     );
     contract_runtime = ContractRuntime(cfg.map_ref(|cfg| cfg.storage.clone()),
 &cfg.value().contract_runtime, registry);   }


### PR DESCRIPTION
The idea behind hard-reset is to ignore blocks that might have been created in to-be-upgraded eras before an upgrade. If blocks were legitimately created after an upgrade, we shouldn't be trying to forget them. In order to differentiate the two situations, we'll check the protocol version - an old protocol version in the blocks will indicate that they are no longer valid and shouldn't be indexed. A current protocol version will indicate that they were created after the upgrade and thus can be safely re-indexed.