### PR TITLE
NO-TICKET: avoid exiting if overwriting execution results with different ones

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -59,7 +59,7 @@ use static_assertions::const_assert;
 #[cfg(test)]
 use tempfile::TempDir;
 use thiserror::Error;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use super::Component;
 #[cfg(test)]
@@ -152,14 +152,6 @@ pub enum Error {
         first: BlockHash,
         /// Second block hash encountered at `era_id`.
         second: BlockHash,
-    },
-    /// Attempted to store a duplicate execution result.
-    #[error("duplicate execution result for deploy {deploy_hash} in block {block_hash}")]
-    DuplicateExecutionResult {
-        /// The deploy for which the result should be stored.
-        deploy_hash: DeployHash,
-        /// The block providing the context for the deploy's execution result.
-        block_hash: BlockHash,
     },
     /// LMDB error while operating.
     #[error("internal database error: {0}")]
@@ -530,17 +522,13 @@ impl Storage {
                         .get_deploy_metadata(&mut txn, &deploy_hash)?
                         .unwrap_or_default();
 
-                    // If we have a previous execution result, we enforce that it is the same.
+                    // If we have a previous execution result, we can continue if it is the same.
                     if let Some(prev) = metadata.execution_results.get(&block_hash) {
-                        if prev != &execution_result {
-                            return Err(Error::DuplicateExecutionResult {
-                                deploy_hash,
-                                block_hash: *block_hash,
-                            });
+                        if prev == &execution_result {
+                            continue;
+                        } else {
+                            debug!(%deploy_hash, %block_hash, "different execution result");
                         }
-
-                        // We can now skip adding, as the result is the same.
-                        continue;
                     }
 
                     if let ExecutionResult::Success { effect, .. } = execution_result.clone() {

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -616,7 +616,6 @@ fn store_random_execution_results() {
 }
 
 #[test]
-#[should_panic(expected = "duplicate execution result")]
 fn store_execution_results_twice_for_same_block_deploy_pair() {
     let mut harness = ComponentHarness::default();
     let mut storage = storage_fixture(&harness);


### PR DESCRIPTION
This PR changes the behaviour of the storage component to avoid returning an error in the case where we overwrite execution results with a different value.  There is no requirement for repeated executions of a given deploy to produce identical output under all circumstances, hence the previous behaviour was incorrect.