### PR TITLE
EE-1204: add activate-bid client contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "activate-bid"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "add-bid"
 version = "0.1.0"
 dependencies = [

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -33,7 +33,7 @@ use casper_types::{
         auction::{
             self, Bids, DelegationRate, EraId, EraValidators, UnbondingPurses, ValidatorWeights,
             ARG_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_PUBLIC_KEY, ARG_VALIDATOR,
-            ARG_VALIDATOR_PUBLIC_KEY, ERA_ID_KEY, INITIAL_ERA_ID, METHOD_ACTIVATE_BID,
+            ERA_ID_KEY, INITIAL_ERA_ID,
         },
     },
     PublicKey, RuntimeArgs, SecretKey, U512,
@@ -42,6 +42,7 @@ use casper_types::{
 const ARG_TARGET: &str = "target";
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
+const CONTRACT_ACTIVATE_BID: &str = "activate_bid.wasm";
 const CONTRACT_ADD_BID: &str = "add_bid.wasm";
 const CONTRACT_WITHDRAW_BID: &str = "withdraw_bid.wasm";
 const CONTRACT_DELEGATE: &str = "delegate.wasm";
@@ -1751,11 +1752,10 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
 #[test]
 fn should_handle_evictions() {
     let activate_bid = |builder: &mut InMemoryWasmTestBuilder, validator_public_key: PublicKey| {
-        let auction = builder.get_auction_contract_hash();
-        let run_request = ExecuteRequestBuilder::contract_call_by_hash(
+        const ARG_VALIDATOR_PUBLIC_KEY: &str = "validator_public_key";
+        let run_request = ExecuteRequestBuilder::standard(
             AccountHash::from(&validator_public_key),
-            auction,
-            METHOD_ACTIVATE_BID,
+            CONTRACT_ACTIVATE_BID,
             runtime_args! {
                 ARG_VALIDATOR_PUBLIC_KEY => validator_public_key,
             },

--- a/smart_contracts/contracts/client/activate-bid/Cargo.toml
+++ b/smart_contracts/contracts/client/activate-bid/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "activate-bid"
+version = "0.1.0"
+authors = ["Henry Till <henrytill@gmail.com>"]
+edition = "2018"
+
+[[bin]]
+name = "activate_bid"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[features]
+std = ["casper-contract/std", "casper-types/std"]
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/client/activate-bid/src/main.rs
+++ b/smart_contracts/contracts/client/activate-bid/src/main.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use casper_contract::contract_api::{runtime, system};
+use casper_types::{runtime_args, system::auction, PublicKey, RuntimeArgs};
+
+const ARG_VALIDATOR_PUBLIC_KEY: &str = "validator_public_key";
+
+fn activate_bid(public_key: PublicKey) {
+    let contract_hash = system::get_auction();
+    let args = runtime_args! {
+        auction::ARG_VALIDATOR_PUBLIC_KEY => public_key,
+    };
+    runtime::call_contract::<()>(contract_hash, auction::METHOD_ACTIVATE_BID, args);
+}
+
+// Accepts a public key. Issues an activate-bid bid to the auction contract.
+#[no_mangle]
+pub extern "C" fn call() {
+    let public_key: PublicKey = runtime::get_named_arg(ARG_VALIDATOR_PUBLIC_KEY);
+    activate_bid(public_key);
+}


### PR DESCRIPTION
This PR adds an `activate-bid` client contract, that:
* compiles to `activate_bid.wasm`,
* takes a single argument named `validator_public_key`,
* and must be deployed using the validator keys in question.

I replaced use of direct contract calls to `Auction::activate_bid` with calls to this contract in tests, so it has been confirmed to work.