### PR TITLE
HWY-271: Log synchronizer queue size.

### DIFF
--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -51,6 +51,8 @@ const TIMER_ID_VERTEX_WITH_FUTURE_TIMESTAMP: TimerId = TimerId(1);
 const TIMER_ID_PURGE_VERTICES: TimerId = TimerId(2);
 /// The timer for logging inactive validators.
 const TIMER_ID_LOG_PARTICIPATION: TimerId = TimerId(3);
+/// The timer for logging synchronizer queue size.
+const TIMER_ID_SYNCHRONIZER_QUEUE: TimerId = TimerId(4);
 
 /// The action of adding a vertex from the `vertices_to_be_added` queue.
 const ACTION_ID_VERTEX: ActionId = ActionId(0);
@@ -154,6 +156,10 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                 now + TimeDiff::from(60_000),
                 TIMER_ID_LOG_PARTICIPATION,
             ),
+            ProtocolOutcome::ScheduleTimer(
+                now + TimeDiff::from(5_000),
+                TIMER_ID_SYNCHRONIZER_QUEUE,
+            ),
         ];
 
         // If there's a chance that we start after the era is finished…
@@ -183,7 +189,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             finality_detector: FinalityDetector::new(ftt),
             highway: Highway::new(instance_id, validators, params),
             round_success_meter,
-            synchronizer: Synchronizer::new(config.pending_vertex_timeout),
+            synchronizer: Synchronizer::new(config.pending_vertex_timeout, instance_id),
             evidence_only: false,
         });
         (hw_proto, outcomes)
@@ -607,6 +613,15 @@ where
                     vec![]
                 }
             }
+            TIMER_ID_SYNCHRONIZER_QUEUE => {
+                self.synchronizer.log_len();
+                if !self.finalized_switch_block() {
+                    let next_timer = Timestamp::now() + TimeDiff::from(5_000);
+                    vec![ProtocolOutcome::ScheduleTimer(next_timer, timer_id)]
+                } else {
+                    vec![]
+                }
+            }
             _ => unreachable!("unexpected timer ID"),
         }
     }
@@ -760,6 +775,10 @@ where
             ProtocolOutcome::ScheduleTimer(
                 now + TimeDiff::from(60_000),
                 TIMER_ID_LOG_PARTICIPATION,
+            ),
+            ProtocolOutcome::ScheduleTimer(
+                now + TimeDiff::from(5_000),
+                TIMER_ID_SYNCHRONIZER_QUEUE,
             ),
         ];
 

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -39,7 +39,8 @@ fn purge_vertices() {
     let peer0 = NodeId(0);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
-    let mut sync = Synchronizer::<NodeId, TestContext>::new(0x20.into());
+    let mut sync =
+        Synchronizer::<NodeId, TestContext>::new(0x20.into(), TEST_INSTANCE_ID);
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
 
     // At time 0x20, we receive c2, b0 and b1 — the latter ahead of their timestamp.

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -39,8 +39,7 @@ fn purge_vertices() {
     let peer0 = NodeId(0);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
-    let mut sync =
-        Synchronizer::<NodeId, TestContext>::new(0x20.into(), TEST_INSTANCE_ID);
+    let mut sync = Synchronizer::<NodeId, TestContext>::new(0x20.into(), TEST_INSTANCE_ID);
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
 
     // At time 0x20, we receive c2, b0 and b1 — the latter ahead of their timestamp.

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -86,9 +86,12 @@ where
         0,
         start_timestamp,
     );
-    // We expect only the vertex purge timer and participation log timer outcomes.
+    // We expect for messages:
+    // * log participation timer,
+    // * log synchronizer queue length timer,
+    // * purge synchronizer queue timer,
     // If there are more, the tests might need to handle them.
-    assert_eq!(2, outcomes.len());
+    assert_eq!(3, outcomes.len());
     hw_proto
 }
 


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/HWY-271

Adds a new timer `TIMER_ID_SYNCHRONIZER_QUEUE` that is recreated every 5 seconds for every _unfinalized_ era. Upon handling the timer, lengths of synchronizer queues will be logged at the `debug` level. This is to aid in debugging the protocol state synchronization problems. Example:
```
{"timestamp":"Mar 19 00:00:18.685","level":"DEBUG","fields":{"message":"synchronizer queue lengths","era_id":"2c9fb42bf82a564db5ffde1f13dcce7c36ff9f66bf70b633f06ac083b2c022fa","vertices_to_be_added_later":0,"vertex_deps":0,"vertices_to_be_added":0},"target":"casper_node::components::consensus::protocols::highway::synchronizer"}
```
