### PR TITLE
HWY-272: Log oldest seen panorama when syncing.

### DIFF
--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -80,6 +80,14 @@ impl<C: Context> Vertex<C> {
         }
     }
 
+    /// Returns the seq number of this vertex (if it is a unit).
+    pub(crate) fn unit_seq_number(&self) -> Option<u64> {
+        match self {
+            Vertex::Unit(swunit) => Some(swunit.wire_unit().seq_number),
+            _ => None,
+        }
+    }
+
     /// Returns whether this is evidence, as opposed to other types of vertices.
     pub(crate) fn is_evidence(&self) -> bool {
         matches!(self, Vertex::Evidence(_))

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -142,6 +142,25 @@ impl<VID: Ord + Hash + fmt::Debug> fmt::Display for Validators<VID> {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRef, From, Hash)]
 pub(crate) struct ValidatorMap<T>(Vec<T>);
 
+impl<T> fmt::Display for ValidatorMap<Option<T>>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let view = self
+            .0
+            .iter()
+            .map(|maybe_el| match maybe_el {
+                None => "N".to_string(),
+                Some(el) => format!("{}", el),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(f, "OldestSeen({})", view)?;
+        Ok(())
+    }
+}
+
 impl<T> DataSize for ValidatorMap<T>
 where
     T: DataSize,

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -87,6 +87,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         seed: u64,
         now: Timestamp,
     ) -> (Box<dyn ConsensusProtocol<I, C>>, ProtocolOutcomes<I, C>) {
+        let validators_count = validator_stakes.len();
         let sum_stakes: U512 = validator_stakes.iter().map(|(_, stake)| *stake).sum();
         assert!(
             !sum_stakes.is_zero(),
@@ -189,7 +190,11 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             finality_detector: FinalityDetector::new(ftt),
             highway: Highway::new(instance_id, validators, params),
             round_success_meter,
-            synchronizer: Synchronizer::new(config.pending_vertex_timeout, instance_id),
+            synchronizer: Synchronizer::new(
+                config.pending_vertex_timeout,
+                validators_count,
+                instance_id,
+            ),
             evidence_only: false,
         });
         (hw_proto, outcomes)

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -162,6 +162,8 @@ where
     pending_vertex_timeout: TimeDiff,
     /// Instance ID of an era for which this synchronizer is constructed for.
     era_id: C::InstanceId,
+    /// Keeps track of the lowest/oldest seen unit per validator when syncing.
+    /// Used only for logging.
     oldest_seen_panorama: ValidatorMap<Option<u64>>,
     /// Boolean flag indicating whether we're synchronizing current era.
     pub(crate) current_era: bool,
@@ -222,7 +224,16 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
             vertices_to_be_added = self.vertices_to_be_added_len(),
             "synchronizer queue lengths"
         );
-        debug!(oldest_panorama=%self.oldest_seen_panorama, "oldest seen unit per validator");
+        // All units seen have seq_number == 0.
+        let all_lowest = self
+            .oldest_seen_panorama
+            .iter()
+            .all(|entry| entry.map(|seq_num| seq_num == 0).unwrap_or(false));
+        if all_lowest {
+            debug!("all seen units while synchronization with seq_num=0");
+        } else {
+            debug!(oldest_panorama=%self.oldest_seen_panorama, "oldest seen unit per validator");
+        }
     }
 
     /// Store a (pre-validated) vertex which will be added later.  This creates a timer to be sent

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -39,7 +39,8 @@ fn purge_vertices() {
     let peer0 = NodeId(0);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
-    let mut sync = Synchronizer::<NodeId, TestContext>::new(0x20.into(), TEST_INSTANCE_ID);
+    let mut sync =
+        Synchronizer::<NodeId, TestContext>::new(0x20.into(), WEIGHTS.len(), TEST_INSTANCE_ID);
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
 
     // At time 0x20, we receive c2, b0 and b1 — the latter ahead of their timestamp.


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/HWY-272

Adds logging of the oldest (lowest sequence number) unit seen per validator while syncing. Shows the progress of synchronization per validator.