### PR TITLE
HWY-273: Add cache for prevalidated vertices.

### DIFF
--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -429,20 +429,15 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     fn pre_validate_vertex(
         &mut self,
         v: Vertex<C>,
-    ) -> Result<PreValidationStatus<C>, (Vertex<C>, VertexError)> {
+    ) -> Result<PreValidatedVertex<C>, (Vertex<C>, VertexError)> {
         let id = v.id();
         if let Some(prev_pvv) = self.pvv_cache.get(&id) {
-            return Ok(PreValidationStatus::Known(prev_pvv.clone()));
+            return Ok(prev_pvv.clone());
         }
         let pvv = self.highway.pre_validate_vertex(v)?;
         self.pvv_cache.insert(id, pvv.clone());
-        Ok(PreValidationStatus::New(pvv))
+        Ok(pvv)
     }
-}
-
-enum PreValidationStatus<C: Context> {
-    New(PreValidatedVertex<C>),
-    Known(PreValidatedVertex<C>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -507,49 +502,37 @@ where
                         .collect();
                     }
                 };
+                let is_faulty = match pvv.inner().creator() {
+                    Some(creator) => self.highway.state().is_faulty(creator),
+                    None => false,
+                };
 
-                match pvv {
-                    PreValidationStatus::New(pvv) => {
-                        trace!(id=?pvv.inner().id(), "new vertex received");
-                        let is_faulty = match pvv.inner().creator() {
-                            Some(creator) => self.highway.state().is_faulty(creator),
-                            None => false,
-                        };
+                if is_faulty && !self.synchronizer.is_dependency(&pvv.inner().id()) {
+                    trace!("received a vertex from a faulty validator; dropping");
+                    return vec![];
+                }
 
-                        if is_faulty && !self.synchronizer.is_dependency(&pvv.inner().id()) {
-                            trace!("received a vertex from a faulty validator; dropping");
-                            return vec![];
-                        }
-
-                        let now = Timestamp::now();
-                        match pvv.timestamp() {
-                            Some(timestamp)
-                                if timestamp > now + self.synchronizer.pending_vertex_timeout() =>
-                            {
-                                trace!("received a vertex with a timestamp far in the future; dropping");
-                                vec![]
-                            }
-                            Some(timestamp) if timestamp > now => {
-                                // If it's not from an equivocator and from the future, add to queue
-                                trace!("received a vertex from the future; storing for later");
-                                self.synchronizer
-                                    .store_vertex_for_addition_later(timestamp, now, sender, pvv);
-                                let timer_id = TIMER_ID_VERTEX_WITH_FUTURE_TIMESTAMP;
-                                vec![ProtocolOutcome::ScheduleTimer(timestamp, timer_id)]
-                            }
-                            _ => {
-                                // If it's not from an equivocator or it is a transitive dependency,
-                                // add the vertex
-                                trace!("received a valid vertex");
-                                self.synchronizer.schedule_add_vertex(sender, pvv, now)
-                            }
-                        }
-                    }
-                    PreValidationStatus::Known(pvv) => {
-                        trace!(hash=?pvv.inner().id(), "vertex already pending synchronization");
-                        self.synchronizer
-                            .alternative_source(pvv, sender, Timestamp::now());
+                let now = Timestamp::now();
+                match pvv.timestamp() {
+                    Some(timestamp)
+                        if timestamp > now + self.synchronizer.pending_vertex_timeout() =>
+                    {
+                        trace!("received a vertex with a timestamp far in the future; dropping");
                         vec![]
+                    }
+                    Some(timestamp) if timestamp > now => {
+                        // If it's not from an equivocator and from the future, add to queue
+                        trace!("received a vertex from the future; storing for later");
+                        self.synchronizer
+                            .store_vertex_for_addition_later(timestamp, now, sender, pvv);
+                        let timer_id = TIMER_ID_VERTEX_WITH_FUTURE_TIMESTAMP;
+                        vec![ProtocolOutcome::ScheduleTimer(timestamp, timer_id)]
+                    }
+                    _ => {
+                        // If it's not from an equivocator or it is a transitive dependency, add the
+                        // vertex
+                        trace!("received a valid vertex");
+                        self.synchronizer.schedule_add_vertex(sender, pvv, now)
                     }
                 }
             }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -425,7 +425,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     }
 
     /// Prevalidates the vertex but checks the cache for previously validated vertices.
-    /// Avoids multiplate validation of the same vertex.
+    /// Avoids multiple validation of the same vertex.
     fn pre_validate_vertex(
         &mut self,
         v: Vertex<C>,

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -6,7 +6,7 @@ use std::{
 
 use datasize::DataSize;
 use itertools::Itertools;
-use tracing::debug;
+use tracing::{debug, error};
 
 use crate::{
     components::consensus::{
@@ -84,6 +84,22 @@ impl<I: NodeIdT, C: Context> PendingVertices<I, C> {
     /// Returns number of unique vertices pending in the queue.
     pub(crate) fn len(&self) -> u64 {
         self.0.len() as u64
+    }
+
+    /// Adds alternative source to download the vertex from.
+    /// Returns error if vertex was not known.
+    pub(crate) fn alternative_source(
+        &mut self,
+        pvv: PreValidatedVertex<C>,
+        sender: I,
+        time_received: Timestamp,
+    ) -> Result<(), (PreValidatedVertex<C>, I)> {
+        if !self.0.contains_key(&pvv) {
+            Err((pvv, sender))
+        } else {
+            self.add(sender, pvv, time_received);
+            Ok(())
+        }
     }
 
     fn is_empty(&self) -> bool {
@@ -393,6 +409,27 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
         self.vertex_deps.clear();
         self.vertices_to_be_added_later.clear();
         self.vertices_to_be_added.retain_evidence_only();
+    }
+
+    /// Adds `sender` as alternative source for downloading vertex.
+    /// Returns protocol outcomes scheduled as a result of this action.
+    pub(crate) fn alternative_source(
+        &mut self,
+        pvv: PreValidatedVertex<C>,
+        sender: I,
+        now: Timestamp,
+    ) -> ProtocolOutcomes<I, C> {
+        match self
+            .vertices_to_be_added
+            .alternative_source(pvv, sender, now)
+        {
+            Ok(_) => vec![],
+            Err((pvv, sender)) => {
+                let id = pvv.inner().id();
+                error!(?id, "vertex not known. This most probably mean a corrupted state of pending vertices cache.");
+                self.schedule_add_vertex(sender, pvv, now)
+            }
+        }
     }
 
     /// Schedules vertices to be added to the protocol state.


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/HWY-273

Adds a cache for pending prevalidated vertices (vertices that are currently being synchronized) and for every new vertex received, checks if it's already in that cache. If not, don't request it again.

Also, checks the node's protocol state if the incoming vertex is already known before trying to validate it.