### PR TITLE
HWY-270: Remove or document more expect/unwrap calls.

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -11,7 +11,7 @@ use tracing::{error, info, trace, warn};
 use super::{
     endorsement::{Endorsement, SignedEndorsement},
     evidence::Evidence,
-    highway::{Endorsements, Ping, ValidVertex, Vertex, WireUnit},
+    highway::{Ping, ValidVertex, Vertex, WireUnit},
     state::{self, Panorama, State, Unit, Weight},
     validators::ValidatorIndex,
 };
@@ -562,10 +562,7 @@ impl<C: Context> ActiveValidator<C> {
     fn endorse(&self, vhash: &C::Hash) -> Vertex<C> {
         let endorsement = Endorsement::new(*vhash, self.vidx);
         let signature = self.secret.sign(&endorsement.hash());
-        Vertex::Endorsements(Endorsements::new(vec![SignedEndorsement::new(
-            endorsement,
-            signature,
-        )]))
+        Vertex::Endorsements(SignedEndorsement::new(endorsement, signature).into())
     }
 
     /// Returns a panorama that is valid to use in our own unit at the given timestamp.

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -365,9 +365,7 @@ impl<C: Context> Highway<C> {
             },
             Dependency::Endorsement(hash) => match self.state.maybe_endorsements(hash) {
                 None => GetDepOutcome::None,
-                Some(e) => {
-                    GetDepOutcome::Vertex(ValidVertex(Vertex::Endorsements(Endorsements::new(e))))
-                }
+                Some(e) => GetDepOutcome::Vertex(ValidVertex(Vertex::Endorsements(e))),
             },
             Dependency::Ping(_, _) => GetDepOutcome::None, // We don't store ping signatures.
         }
@@ -675,8 +673,7 @@ pub(crate) mod tests {
             highway_core::{
                 evidence::{Evidence, EvidenceError},
                 highway::{
-                    Dependency, Endorsements, Highway, SignedWireUnit, UnitError, Vertex,
-                    VertexError, WireUnit,
+                    Dependency, Highway, SignedWireUnit, UnitError, Vertex, VertexError, WireUnit,
                 },
                 highway_testing::TEST_INSTANCE_ID,
                 state::{tests::*, Panorama, State},
@@ -768,7 +765,7 @@ pub(crate) mod tests {
             active_validator: None,
         };
 
-        let vertex_end_a = Vertex::Endorsements(Endorsements::new(end_a));
+        let vertex_end_a = Vertex::Endorsements(end_a);
         let pvv_a = highway.pre_validate_vertex(Vertex::Unit(wunit_a)).unwrap();
         let pvv_end_a = highway.pre_validate_vertex(vertex_end_a).unwrap();
         let pvv_ev_c = highway.pre_validate_vertex(Vertex::Evidence(ev_c)).unwrap();

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -277,18 +277,6 @@ where
 }
 
 impl<C: Context> Endorsements<C> {
-    pub fn new<I: IntoIterator<Item = SignedEndorsement<C>>>(endorsements: I) -> Self {
-        let mut iter = endorsements.into_iter().peekable();
-        let unit = *iter.peek().expect("non-empty iter").unit();
-        let endorsers = iter
-            .map(|e| {
-                assert_eq!(e.unit(), &unit, "endorsements for different units.");
-                (e.validator_idx(), *e.signature())
-            })
-            .collect();
-        Endorsements { unit, endorsers }
-    }
-
     /// Returns hash of the endorsed vode.
     pub fn unit(&self) -> &C::Hash {
         &self.unit
@@ -297,6 +285,15 @@ impl<C: Context> Endorsements<C> {
     /// Returns an iterator over validator indexes that endorsed the `unit`.
     pub fn validator_ids(&self) -> impl Iterator<Item = ValidatorIndex> + '_ {
         self.endorsers.iter().map(|(v, _)| *v)
+    }
+}
+
+impl<C: Context> From<SignedEndorsement<C>> for Endorsements<C> {
+    fn from(signed_e: SignedEndorsement<C>) -> Self {
+        Endorsements {
+            unit: *signed_e.unit(),
+            endorsers: vec![(signed_e.validator_idx(), *signed_e.signature())],
+        }
     }
 }
 

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -279,12 +279,10 @@ impl<C: Context> State<C> {
     }
 
     /// Returns endorsements for `unit`, if any.
-    pub(crate) fn maybe_endorsements(&self, unit: &C::Hash) -> Option<Vec<SignedEndorsement<C>>> {
-        self.endorsements.get(unit).map(|signatures| {
-            signatures
-                .iter_some()
-                .map(|(vidx, sig)| SignedEndorsement::new(Endorsement::new(*unit, vidx), *sig))
-                .collect()
+    pub(crate) fn maybe_endorsements(&self, unit: &C::Hash) -> Option<Endorsements<C>> {
+        self.endorsements.get(unit).map(|signatures| Endorsements {
+            unit: *unit,
+            endorsers: signatures.iter_some().map(|(i, sig)| (i, *sig)).collect(),
         })
     }
 

--- a/node/src/components/consensus/highway_core/state/unit.rs
+++ b/node/src/components/consensus/highway_core/state/unit.rs
@@ -72,7 +72,7 @@ impl<C: Context> Unit<C> {
             hash // A unit with a new block votes for itself.
         } else {
             // If the unit didn't introduce a new block, it votes for the fork choice itself.
-            // `Highway::add_unit` checks that the panorama is not empty.
+            // `pre_validate_unit` checks that the panorama has a `Correct` entry.
             fork_choice
                 .cloned()
                 .expect("nonempty panorama has nonempty fork choice")

--- a/node/src/components/consensus/highway_core/test_macros.rs
+++ b/node/src/components/consensus/highway_core/test_macros.rs
@@ -115,16 +115,13 @@ macro_rules! endorse {
         }
     };
     ($state: ident, $creator: expr, $vote: expr) => {{
-        use crate::components::consensus::highway_core::{
-            endorsement::{Endorsement, SignedEndorsement},
-            highway::Endorsements,
+        use crate::components::consensus::highway_core::endorsement::{
+            Endorsement, SignedEndorsement,
         };
 
         let endorsement: Endorsement<TestContext> = Endorsement::new($vote, ($creator));
         let signature = TestSecret(($creator).0).sign(&endorsement.hash());
-        let signed_endorsement = SignedEndorsement::new(endorsement, signature);
-        let endorsements: Endorsements<TestContext> =
-            Endorsements::new(vec![signed_endorsement].into_iter());
+        let endorsements = SignedEndorsement::new(endorsement, signature).into();
         let evidence = $state.find_conflicting_endorsements(&endorsements, &TEST_INSTANCE_ID);
         $state.add_endorsements(endorsements);
         for ev in evidence {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -237,7 +237,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         match effect {
             AvEffect::NewVertex(vv) => {
                 self.calculate_round_exponent(&vv, now);
-                self.process_new_vertex(vv.into())
+                self.process_new_vertex(vv)
             }
             AvEffect::ScheduleTimer(timestamp) => {
                 vec![ProtocolOutcome::ScheduleTimer(
@@ -262,18 +262,18 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         }
     }
 
-    fn process_new_vertex(&mut self, v: Vertex<C>) -> ProtocolOutcomes<I, C> {
+    fn process_new_vertex(&mut self, vv: ValidVertex<C>) -> ProtocolOutcomes<I, C> {
         let mut outcomes = Vec::new();
-        if let Vertex::Evidence(ev) = &v {
+        if let Vertex::Evidence(ev) = vv.inner() {
             let v_id = self
                 .highway
                 .validators()
                 .id(ev.perpetrator())
-                .expect("validator not found")
+                .expect("validator not found") // We already validated this vertex.
                 .clone();
             outcomes.push(ProtocolOutcome::NewEvidence(v_id));
         }
-        let msg = HighwayMessage::NewVertex(v);
+        let msg = HighwayMessage::NewVertex(vv.into());
         outcomes.push(ProtocolOutcome::CreatedGossipMessage(msg.serialize()));
         outcomes.extend(self.detect_finality());
         outcomes


### PR DESCRIPTION
We haven't seen any unexpected panics from these `unwrap`s/`expect`s, but it's still better to avoid them where possible, or thoroughly document them.

https://casperlabs.atlassian.net/browse/HWY-270