### PR TITLE
OP-1913: testing new repo

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -277,6 +277,37 @@ steps:
     event:
       - push
 
+- name: publish-repo-test
+  image: casperlabs/aptly:latest
+  failure: ignore
+  environment:
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: APTLY_SECRET_KEY
+    AWS_ACCESS_KEY_ID:
+      from_secret: APTLY_KEY_ID
+  settings:
+    repo_name:
+      from_secret: APTLY_REPO_NAME
+    region:
+      from_secret: APTLY_REGION
+    gpg_key:
+      from_secret: APTLY_GPG_KEY
+    gpg_pass:
+      from_secret: APTLY_GPG_PASS
+    distribution_id:
+      from_secret: APTLY_DISTRIBUTION_ID
+    acl: 'public-read'
+    prefix: 'releases'
+    deb_path: './target/debian'
+    deb_name: '*.deb'
+  when:
+    branch:
+      - master
+      - dev
+      - "release-*"
+    event:
+      - push
+
 depends_on:
   - cargo-test
   - package


### PR DESCRIPTION
This adds the new repo steps for test packages. Right now it will go to my test repo but I will switch it over to prod once I confirm it works as expected.