### PR TITLE
NO-TICKET: fix issue for deploy validation in deploy acceptor

### DIFF
--- a/node/src/components/deploy_acceptor.rs
+++ b/node/src/components/deploy_acceptor.rs
@@ -106,27 +106,26 @@ impl DeployAcceptor {
 
         let account_key = deploy.header().account().to_account_hash().into();
 
-        // skip account verification if deploy not received from client or node is configured to
-        // not verify accounts
-        if !source.from_peer() || !self.verify_accounts {
+        // Verify account if deploy received from client and node is configured to do so.
+        if source.from_client() && self.verify_accounts {
             return effect_builder
-                .immediately()
-                .event(move |_| Event::AccountVerificationResult {
+                .is_verified_account(account_key)
+                .event(move |verified| Event::AccountVerificationResult {
                     deploy,
                     source,
                     account_key,
-                    verified: Some(true),
+                    verified,
                     maybe_responder,
                 });
         }
 
         effect_builder
-            .is_verified_account(account_key)
-            .event(move |verified| Event::AccountVerificationResult {
+            .immediately()
+            .event(move |_| Event::AccountVerificationResult {
                 deploy,
                 source,
                 account_key,
-                verified,
+                verified: Some(true),
                 maybe_responder,
             })
     }

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -297,8 +297,8 @@ pub enum Source<I> {
 }
 
 impl<I> Source<I> {
-    pub(crate) fn from_peer(&self) -> bool {
-        matches!(self, Source::Peer(_))
+    pub(crate) fn from_client(&self) -> bool {
+        matches!(self, Source::Client)
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue introduced when the `Source` enum was extended to hold a third variant.  Account verification of deploys should only be performed when receiving a deploy from a client.