### PR TITLE
NO-TICKET: Add more logging to track block proposals. (Backport to 0.9.5)

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -208,6 +208,12 @@ impl<C: Context> ActiveValidator<C> {
                     if let Some(witness_unit) =
                         self.new_unit(panorama, timestamp, None, state, instance_id)
                     {
+                        if self
+                            .latest_unit(state)
+                            .map_or(true, |latest_unit| latest_unit.round_id() != r_id)
+                        {
+                            info!(round_id = %r_id, "sending witness in round with no proposal");
+                        }
                         effects.push(Effect::NewVertex(ValidVertex(Vertex::Unit(witness_unit))));
                         return effects;
                     }

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -113,7 +113,6 @@ impl<C: Context> ValidVertex<C> {
     pub(crate) fn is_proposal(&self) -> bool {
         self.0.value().is_some()
     }
-
     pub(crate) fn endorsements(&self) -> Option<&Endorsements<C>> {
         match &self.0 {
             Vertex::Endorsements(endorsements) => Some(endorsements),

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -118,6 +118,14 @@ impl<C: Context> Vertex<C> {
             Vertex::Ping(ping) => Dependency::Ping(ping.creator(), ping.timestamp()),
         }
     }
+
+    /// Returns a reference to the unit, or `None` if this is not a unit.
+    pub(crate) fn unit(&self) -> Option<&SignedWireUnit<C>> {
+        match self {
+            Vertex::Unit(signed_wire_unit) => Some(signed_wire_unit),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, DataSize, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]


### PR DESCRIPTION
This adds INFO-level logs for receiving and validating proposed blocks, and whenever we send a witness unit in a round where we didn't receive a block.

Backport of #1191 to 0.9.5.