### PR TITLE
NDRS-1031: Port back NDRS-1028 to `dev` branch.

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -9,6 +9,7 @@ use datasize::DataSize;
 use derive_more::From;
 use itertools::Itertools;
 use prometheus::{IntGauge, Registry};
+use semver::Version;
 use tracing::{debug, error, info, warn};
 
 use casper_types::{ExecutionResult, ProtocolVersion, PublicKey};
@@ -32,19 +33,13 @@ use crate::{
 /// waiting for their block.
 const MAX_PENDING_FINALITY_SIGNATURES_PER_VALIDATOR: usize = 1000;
 
-impl<I> From<Box<FinalitySignature>> for Event<I> {
-    fn from(fs: Box<FinalitySignature>) -> Self {
-        Event::FinalitySignatureReceived(fs)
-    }
-}
-
 #[derive(Debug, From)]
 pub enum Event<I> {
     /// A linear chain request issued by another node in the network.
     #[from]
     Request(LinearChainRequest<I>),
     /// New linear chain block has been produced.
-    LinearChainBlock {
+    NewLinearChainBlock {
         /// The block.
         block: Box<Block>,
         /// The deploys' execution results.
@@ -52,7 +47,7 @@ pub enum Event<I> {
     },
     /// Finality signature received.
     /// Not necessarily _new_ finality signature.
-    FinalitySignatureReceived(Box<FinalitySignature>),
+    FinalitySignatureReceived(Box<FinalitySignature>, bool),
     /// The result of putting a block to storage.
     PutBlockResult {
         /// The block.
@@ -70,13 +65,13 @@ impl<I: Display> Display for Event<I> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Event::Request(req) => write!(f, "linear chain request: {}", req),
-            Event::LinearChainBlock { block, .. } => {
+            Event::NewLinearChainBlock { block, .. } => {
                 write!(f, "linear chain new block: {}", block.hash())
             }
-            Event::FinalitySignatureReceived(fs) => write!(
+            Event::FinalitySignatureReceived(fs, gossiped) => write!(
                 f,
-                "linear-chain new finality signature for block: {}, from: {}",
-                fs.block_hash, fs.public_key,
+                "linear-chain new finality signature for block: {}, from: {}, external: {}",
+                fs.block_hash, fs.public_key, gossiped
             ),
             Event::PutBlockResult { .. } => write!(f, "linear-chain put-block result"),
             Event::GetStoredFinalitySignaturesResult(finality_signature, maybe_signatures) => {
@@ -156,16 +151,43 @@ impl SignatureCache {
 }
 
 #[derive(DataSize, Debug)]
+enum Signature {
+    Local(Box<FinalitySignature>),
+    External(Box<FinalitySignature>),
+}
+
+impl Signature {
+    fn to_inner(&self) -> &FinalitySignature {
+        match self {
+            Signature::Local(fs) => fs,
+            Signature::External(fs) => fs,
+        }
+    }
+
+    fn take(self) -> Box<FinalitySignature> {
+        match self {
+            Signature::Local(fs) | Signature::External(fs) => fs,
+        }
+    }
+
+    fn is_local(&self) -> bool {
+        matches!(self, Signature::Local(_))
+    }
+}
+
+#[derive(DataSize, Debug)]
 pub(crate) struct LinearChain<I> {
     /// The most recently added block.
     latest_block: Option<Block>,
     /// Finality signatures to be inserted in a block once it is available.
-    pending_finality_signatures: HashMap<PublicKey, HashMap<BlockHash, FinalitySignature>>,
+    pending_finality_signatures: HashMap<PublicKey, HashMap<BlockHash, Signature>>,
     signature_cache: SignatureCache,
     initial_state_root_hash: Digest,
     activation_era_id: EraId,
+    /// Current protocol version of the network.
     protocol_version: ProtocolVersion,
-
+    auction_delay: u64,
+    unbonding_delay: u64,
     #[data_size(skip)]
     metrics: LinearChainMetrics,
 
@@ -175,8 +197,10 @@ pub(crate) struct LinearChain<I> {
 impl<I> LinearChain<I> {
     pub fn new(
         registry: &Registry,
+        protocol_version: Version,
         initial_state_root_hash: Digest,
-        protocol_version: semver::Version,
+        auction_delay: u64,
+        unbonding_delay: u64,
         activation_era_id: EraId,
     ) -> Result<Self, prometheus::Error> {
         let metrics = LinearChainMetrics::new(registry)?;
@@ -192,6 +216,8 @@ impl<I> LinearChain<I> {
             initial_state_root_hash,
             activation_era_id,
             protocol_version,
+            auction_delay,
+            unbonding_delay,
             metrics,
             _marker: PhantomData,
         })
@@ -234,27 +260,40 @@ impl<I> LinearChain<I> {
         let pending_sigs = self
             .pending_finality_signatures
             .values_mut()
-            .filter_map(|sigs| sigs.remove(&block_hash).map(Box::new))
-            .filter(|fs| !known_signatures.proofs.contains_key(&fs.public_key))
+            .filter_map(|sigs| sigs.remove(&block_hash))
+            .filter(|signature| {
+                !known_signatures
+                    .proofs
+                    .contains_key(&signature.to_inner().public_key)
+            })
             .collect_vec();
         self.remove_empty_entries();
         // Add new signatures and send the updated block to storage.
-        for fs in pending_sigs {
-            if fs.era_id != block_era {
+        for signature in pending_sigs {
+            if signature.to_inner().era_id != block_era {
                 // finality signature was created with era id that doesn't match block's era.
                 // TODO: disconnect from the sender.
                 continue;
             }
-            known_signatures.insert_proof(fs.public_key, fs.signature);
-            let message = Message::FinalitySignature(fs.clone());
-            effects.extend(effect_builder.broadcast_message(message).ignore());
-            effects.extend(effect_builder.announce_finality_signature(fs).ignore());
+            known_signatures.insert_proof(
+                signature.to_inner().public_key,
+                signature.to_inner().signature,
+            );
+            if signature.is_local() {
+                let message = Message::FinalitySignature(Box::new(signature.to_inner().clone()));
+                effects.extend(effect_builder.broadcast_message(message).ignore());
+            }
+            effects.extend(
+                effect_builder
+                    .announce_finality_signature(signature.take())
+                    .ignore(),
+            );
         }
         (known_signatures, effects)
     }
 
     /// Adds finality signature to the collection of pending finality signatures.
-    fn add_pending_finality_signature(&mut self, fs: FinalitySignature) {
+    fn add_pending_finality_signature(&mut self, fs: FinalitySignature, gossiped: bool) {
         let FinalitySignature {
             block_hash,
             public_key,
@@ -273,12 +312,18 @@ impl<I> LinearChain<I> {
             );
             return;
         }
+
+        let signature = if gossiped {
+            Signature::External(Box::new(fs))
+        } else {
+            Signature::Local(Box::new(fs))
+        };
         // Add the pending signature.
-        let _ = sigs.insert(block_hash, fs);
+        let _ = sigs.insert(block_hash, signature);
     }
 
     /// Removes finality signature from the pending collection.
-    fn remove_from_pending_fs(&mut self, fs: &FinalitySignature) {
+    fn remove_from_pending_fs(&mut self, fs: &FinalitySignature) -> Option<Signature> {
         let FinalitySignature {
             block_hash,
             era_id: _era_id,
@@ -286,10 +331,14 @@ impl<I> LinearChain<I> {
             public_key,
         } = fs;
         debug!(%block_hash, %public_key, "removing finality signature from pending collection");
-        if let Some(validator_sigs) = self.pending_finality_signatures.get_mut(public_key) {
-            validator_sigs.remove(&block_hash);
-        }
+        let maybe_sig =
+            if let Some(validator_sigs) = self.pending_finality_signatures.get_mut(public_key) {
+                validator_sigs.remove(&block_hash)
+            } else {
+                None
+            };
         self.remove_empty_entries();
+        maybe_sig
     }
 }
 
@@ -350,7 +399,7 @@ where
                 }
             }
             .ignore(),
-            Event::LinearChainBlock {
+            Event::NewLinearChainBlock {
                 block,
                 execution_results,
             } => {
@@ -396,16 +445,35 @@ where
                 effects.extend(effect_builder.announce_block_added(block).ignore());
                 effects
             }
-            Event::FinalitySignatureReceived(fs) => {
+            Event::FinalitySignatureReceived(fs, gossiped) => {
                 let FinalitySignature {
                     block_hash,
                     public_key,
                     era_id,
                     ..
                 } = *fs;
-                if let Err(err) = fs.verify() {
-                    warn!(%block_hash, %public_key, %err, "received invalid finality signature");
-                    return Effects::new();
+                if let Some(latest_block) = self.latest_block.as_ref() {
+                    // If it's a switch block it has already forgotten its own era's validators,
+                    // unbonded some old validators, and determined new ones. In that case, we
+                    // should add 1 to last_block_era.
+                    let current_era = latest_block.header().era_id()
+                        + if latest_block.header().is_switch_block() {
+                            1
+                        } else {
+                            0
+                        };
+                    let lowest_acceptable_era_id =
+                        (current_era + self.auction_delay).saturating_sub(self.unbonding_delay);
+                    let highest_acceptable_era_id = current_era + self.auction_delay;
+                    if era_id < lowest_acceptable_era_id || era_id > highest_acceptable_era_id {
+                        warn!(
+                            ?era_id,
+                            ?public_key,
+                            ?block_hash,
+                            "received finality signature for not bonded era."
+                        );
+                        return Effects::new();
+                    }
                 }
                 if self.has_finality_signature(&fs) {
                     debug!(block_hash=%fs.block_hash, public_key=%fs.public_key,
@@ -417,7 +485,11 @@ where
                         "finality signature is already known");
                     return Effects::new();
                 }
-                self.add_pending_finality_signature(*fs.clone());
+                if let Err(err) = fs.verify() {
+                    warn!(%block_hash, %public_key, %err, "received invalid finality signature");
+                    return Effects::new();
+                }
+                self.add_pending_finality_signature(*fs.clone(), gossiped);
                 match self.signature_cache.get(&block_hash, era_id) {
                     None => effect_builder
                         .get_signatures_from_storage(block_hash)
@@ -483,19 +555,20 @@ where
                     self.remove_from_pending_fs(&*fs);
                     Effects::new()
                 } else {
-                    let message = Message::FinalitySignature(fs.clone());
-                    let mut effects = effect_builder.broadcast_message(message).ignore();
-                    effects.extend(
-                        effect_builder
-                            .announce_finality_signature(fs.clone())
-                            .ignore(),
-                    );
+                    let mut effects = effect_builder
+                        .announce_finality_signature(fs.clone())
+                        .ignore();
+                    if let Some(signature) = self.remove_from_pending_fs(&*fs) {
+                        if signature.is_local() {
+                            let message = Message::FinalitySignature(fs.clone());
+                            effects.extend(effect_builder.broadcast_message(message).ignore());
+                        }
+                    };
                     signatures.insert_proof(fs.public_key, fs.signature);
                     // Cache the results in case we receive the same finality signature before we
                     // manage to store it in the database.
                     self.signature_cache.insert(*signatures.clone());
                     debug!(hash=%signatures.block_hash, "storing finality signatures");
-                    self.remove_from_pending_fs(&*fs);
                     effects.extend(
                         effect_builder
                             .put_signatures_to_storage(*signatures)

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -509,8 +509,10 @@ impl reactor::Reactor for Reactor {
 
         let linear_chain = linear_chain::LinearChain::new(
             &registry,
-            chainspec_loader.initial_state_root_hash(),
             protocol_version.clone(),
+            chainspec_loader.initial_state_root_hash(),
+            chainspec_loader.chainspec().core_config.auction_delay,
+            chainspec_loader.chainspec().core_config.unbonding_delay,
             chainspec_loader
                 .chainspec()
                 .protocol_config
@@ -774,7 +776,7 @@ impl reactor::Reactor for Reactor {
                 let block_hash = *block.hash();
 
                 // send to linear chain
-                let reactor_event = Event::LinearChain(linear_chain::Event::LinearChainBlock {
+                let reactor_event = Event::LinearChain(linear_chain::Event::NewLinearChainBlock {
                     block: Box::new(block),
                     execution_results: execution_results
                         .iter()


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-1031

NDRS-1028: Optimize handling of finality signatures in the linear chain component. r=goral09 a=goral09

This PR makes a couple of changes that optimize how finality signatures are being handled by the node:
* We gossip finality signatures created only by our node
* We validate the cryptographic signature at the end (as it's the most expensive test)
* validator reactor will inform `LinearChain` when an already-exected block is finalized so that `LinearChain` can update its view about the tip of the chain and handle `IsBonded` queries properly.
