### PR TITLE
HWY-268: Enable integer_arithmetic lints in the whole consensus component.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -1,5 +1,7 @@
 //! The consensus component. Provides distributed consensus among the nodes in the network.
 
+#![warn(clippy::integer_arithmetic)]
+
 mod candidate_block;
 mod cl_context;
 mod config;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -162,6 +162,7 @@ where
         );
         let activation_era_id = protocol_config.last_activation_point;
         let auction_delay = protocol_config.auction_delay;
+        #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
         let next_height = maybe_latest_block_header.map_or(0, |hdr| hdr.height() + 1);
 
         let era_supervisor = Self {
@@ -186,7 +187,7 @@ where
 
         let bonded_eras = era_supervisor.bonded_eras();
         let era_ids: Vec<EraId> = era_supervisor
-            .iter_past(current_era, era_supervisor.bonded_eras() * 3)
+            .iter_past(current_era, era_supervisor.bonded_eras().saturating_mul(3))
             .collect();
 
         // Asynchronously collect the information needed to initialize all recent eras.
@@ -206,7 +207,7 @@ where
             )
             .await;
 
-            if current_era > activation_era_id + bonded_eras * 2 {
+            if current_era > activation_era_id.saturating_add(bonded_eras.saturating_mul(2)) {
                 // All eras can be initialized using the key blocks only.
                 (key_blocks, booking_blocks, Default::default())
             } else {
@@ -283,6 +284,11 @@ where
             .max(era_id.saturating_sub(num_eras))
             .0..era_id.0)
             .map(EraId)
+    }
+
+    /// Returns an iterator over era IDs of `num_eras` future eras, plus the provided one.
+    fn iter_future(&self, era_id: EraId, num_eras: u64) -> impl Iterator<Item = EraId> {
+        (era_id.0..=era_id.0.saturating_add(num_eras)).map(EraId)
     }
 
     /// Starts a new era; panics if it already exists.
@@ -384,7 +390,7 @@ where
 
     /// Returns `true` if the specified era is active and bonded.
     fn is_bonded(&self, era_id: EraId) -> bool {
-        era_id.0 + self.bonded_eras() >= self.current_era.0 && era_id <= self.current_era
+        era_id.saturating_add(self.bonded_eras()) >= self.current_era && era_id <= self.current_era
     }
 
     /// Returns whether the validator with the given public key is bonded in that era.
@@ -405,6 +411,7 @@ where
 
     /// Updates `next_executed_height` based on the given block header, and unpauses consensus if
     /// block execution has caught up with finalization.
+    #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
     fn executed_block(&mut self, block_header: &BlockHeader) {
         self.next_executed_height = self.next_executed_height.max(block_header.height() + 1);
         self.update_consensus_pause();
@@ -431,7 +438,7 @@ where
     ) -> HashMap<EraId, ProtocolOutcomes<I, ClContext>> {
         let mut result_map = HashMap::new();
 
-        for era_id in self.iter_past(self.current_era, self.bonded_eras() * 2) {
+        for era_id in self.iter_past(self.current_era, self.bonded_eras().saturating_mul(2)) {
             let newly_slashed;
             let validators;
             let start_height;
@@ -442,6 +449,7 @@ where
                 .get(&era_id)
                 .expect("should have booking block");
 
+            #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
             if era_id.is_genesis() {
                 newly_slashed = vec![];
                 // The validator set was read from the global state: there's no key block for era 0.
@@ -843,6 +851,7 @@ where
             .chain(&newly_slashed)
             .cloned()
             .collect();
+        #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
         let outcomes = self.era_supervisor.new_era(
             era_id,
             Timestamp::now(), // TODO: This should be passed in.
@@ -915,6 +924,7 @@ where
         self.era_supervisor.active_eras.get_mut(&era_id).unwrap()
     }
 
+    #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
     fn handle_consensus_outcome(
         &mut self,
         era_id: EraId,
@@ -1081,7 +1091,10 @@ where
                     .effect_builder
                     .announce_fault_event(era_id, pub_key, Timestamp::now())
                     .ignore();
-                for e_id in (era_id.0..=(era_id.0 + self.era_supervisor.bonded_eras())).map(EraId) {
+                for e_id in self
+                    .era_supervisor
+                    .iter_future(era_id, self.era_supervisor.bonded_eras())
+                {
                     let candidate_blocks =
                         if let Some(era) = self.era_supervisor.active_eras.get_mut(&e_id) {
                             era.resolve_evidence(&pub_key)
@@ -1181,7 +1194,9 @@ fn instance_id(protocol_config: &ProtocolConfig, era_id: EraId) -> Digest {
 /// A node keeps `2 * bonded_eras` past eras around, because the oldest bonded era could still
 /// receive blocks that refer to `bonded_eras` before that.
 fn bonded_eras(protocol_config: &ProtocolConfig) -> u64 {
-    protocol_config.unbonding_delay - protocol_config.auction_delay
+    protocol_config
+        .unbonding_delay
+        .saturating_sub(protocol_config.auction_delay)
 }
 
 /// The oldest era whose validators are still bonded.

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -240,12 +240,12 @@ where
         };
 
         consensus_heap_size
-            + start_time.estimate_heap_size()
-            + start_height.estimate_heap_size()
-            + candidates.estimate_heap_size()
-            + newly_slashed.estimate_heap_size()
-            + slashed.estimate_heap_size()
-            + accusations.estimate_heap_size()
-            + validators.estimate_heap_size()
+            .saturating_add(start_time.estimate_heap_size())
+            .saturating_add(start_height.estimate_heap_size())
+            .saturating_add(candidates.estimate_heap_size())
+            .saturating_add(newly_slashed.estimate_heap_size())
+            .saturating_add(slashed.estimate_heap_size())
+            .saturating_add(accusations.estimate_heap_size())
+            .saturating_add(validators.estimate_heap_size())
     }
 }

--- a/node/src/components/consensus/era_supervisor/era_id.rs
+++ b/node/src/components/consensus/era_supervisor/era_id.rs
@@ -36,6 +36,7 @@ impl EraId {
         }
     }
 
+    #[allow(clippy::integer_arithmetic)] // The caller must make sure this doesn't overflow.
     pub(crate) fn successor(self) -> EraId {
         EraId(self.0 + 1)
     }
@@ -50,6 +51,11 @@ impl EraId {
         EraId(self.0.saturating_sub(x))
     }
 
+    /// Returns the current era plus `x`, or `u64::MAX` if that would be more than `u64::MAX`.
+    pub(crate) fn saturating_add(&self, x: u64) -> EraId {
+        EraId(self.0.saturating_add(x))
+    }
+
     /// Returns whether this is era 0.
     pub(crate) fn is_genesis(&self) -> bool {
         self.0 == 0
@@ -59,6 +65,7 @@ impl EraId {
 impl Add<u64> for EraId {
     type Output = EraId;
 
+    #[allow(clippy::integer_arithmetic)] // The caller must make sure this doesn't overflow.
     fn add(self, x: u64) -> EraId {
         EraId(self.0 + x)
     }
@@ -67,6 +74,7 @@ impl Add<u64> for EraId {
 impl Sub<u64> for EraId {
     type Output = EraId;
 
+    #[allow(clippy::integer_arithmetic)] // The caller must make sure this doesn't overflow.
     fn sub(self, x: u64) -> EraId {
         EraId(self.0 - x)
     }

--- a/node/src/components/consensus/highway_core.rs
+++ b/node/src/components/consensus/highway_core.rs
@@ -27,8 +27,6 @@
 //! or with some other governance system that can add and remove validators, by starting a new
 //! protocol instance whenever the set of validators changes.
 
-#![warn(clippy::integer_arithmetic)]
-
 // This needs to come before the other modules, so the macros are available everywhere.
 #[cfg(test)]
 #[macro_use]
@@ -45,4 +43,4 @@ mod evidence;
 #[cfg(test)]
 pub(crate) mod highway_testing;
 
-pub(crate) use state::{round_id, State, Weight};
+pub(crate) use state::{State, Weight};

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -1117,7 +1117,7 @@ impl<C: Context> State<C> {
 }
 
 /// Returns the round length, given the round exponent.
-pub(super) fn round_len(round_exp: u8) -> TimeDiff {
+pub(crate) fn round_len(round_exp: u8) -> TimeDiff {
     TimeDiff::from(1_u64.checked_shl(round_exp.into()).unwrap_or(u64::MAX))
 }
 

--- a/node/src/components/consensus/protocols/highway/participation.rs
+++ b/node/src/components/consensus/protocols/highway/participation.rs
@@ -62,6 +62,7 @@ where
 impl<C: Context> Participation<C> {
     /// Creates a new `Participation` map, showing validators seen as faulty or inactive by the
     /// Highway instance.
+    #[allow(clippy::integer_arithmetic)] // We use u128 to prevent overflows in weight calculation.
     pub(crate) fn new(highway: &Highway<C>) -> Self {
         let now = Timestamp::now();
         let state = highway.state();

--- a/node/src/components/consensus/protocols/highway/round_success_meter.rs
+++ b/node/src/components/consensus/protocols/highway/round_success_meter.rs
@@ -5,7 +5,7 @@ use tracing::trace;
 
 use crate::{
     components::consensus::{
-        highway_core::{finality_detector::FinalityDetector, round_id, State, Weight},
+        highway_core::{finality_detector::FinalityDetector, state, State, Weight},
         traits::Context,
     },
     types::Timestamp,
@@ -22,7 +22,7 @@ where
     // store whether a particular round was successful
     // index 0 is the last handled round, 1 is the second-to-last etc.
     rounds: VecDeque<bool>,
-    current_round_id: u64,
+    current_round_id: Timestamp,
     proposals: Vec<C::Hash>,
     min_round_exp: u8,
     max_round_exp: u8,
@@ -38,7 +38,7 @@ impl<C: Context> RoundSuccessMeter<C> {
         timestamp: Timestamp,
         config: Config,
     ) -> Self {
-        let current_round_id = round_id(timestamp, round_exp).millis();
+        let current_round_id = state::round_id(timestamp, round_exp);
         Self {
             rounds: VecDeque::with_capacity(config.num_rounds_to_consider as usize),
             current_round_id,
@@ -53,13 +53,14 @@ impl<C: Context> RoundSuccessMeter<C> {
     fn change_exponent(&mut self, new_exp: u8, timestamp: Timestamp) {
         self.rounds = VecDeque::with_capacity(self.config.num_rounds_to_consider as usize);
         self.current_round_exp = new_exp;
-        self.current_round_id = round_id(timestamp, new_exp).millis();
+        self.current_round_id = state::round_id(timestamp, new_exp);
         self.proposals = Vec::new();
     }
 
     fn check_proposals_success(&self, state: &State<C>, proposal_h: &C::Hash) -> bool {
         let total_w = state.total_weight();
 
+        #[allow(clippy::integer_arithmetic)] // FTT is less than 100%, so this can't overflow.
         let finality_detector = FinalityDetector::<C>::new(max(
             Weight(
                 (u128::from(total_w) * *self.config.acceleration_ftt.numer() as u128
@@ -76,7 +77,7 @@ impl<C: Context> RoundSuccessMeter<C> {
     /// be successful.
     pub fn new_proposal(&mut self, proposal_h: C::Hash, timestamp: Timestamp) {
         // only add proposals from within the current round
-        if round_id(timestamp, self.current_round_exp).millis() == self.current_round_id {
+        if state::round_id(timestamp, self.current_round_exp) == self.current_round_id {
             trace!(
                 %self.current_round_id,
                 timestamp = timestamp.millis(),
@@ -104,13 +105,13 @@ impl<C: Context> RoundSuccessMeter<C> {
     pub fn calculate_new_exponent(&mut self, state: &State<C>) -> u8 {
         let now = Timestamp::now();
         // if the round hasn't finished, just return whatever we have now
-        if round_id(now, self.current_round_exp).millis() <= self.current_round_id {
+        if state::round_id(now, self.current_round_exp) <= self.current_round_id {
             return self.new_exponent();
         }
 
         trace!(%self.current_round_id, "calculating exponent");
-        let current_round_index = self.current_round_id >> self.current_round_exp;
-        let new_round_index = now.millis() >> self.current_round_exp;
+        let current_round_index = round_index(self.current_round_id, self.current_round_exp);
+        let new_round_index = round_index(now, self.current_round_exp);
 
         if mem::take(&mut self.proposals)
             .into_iter()
@@ -125,12 +126,16 @@ impl<C: Context> RoundSuccessMeter<C> {
 
         // if we're just switching rounds and more than a single round has passed, all the
         // rounds since the last registered round have failed
-        for _ in 0..(new_round_index - current_round_index - 1) {
+        let failed_round_count = new_round_index
+            .saturating_sub(current_round_index)
+            .saturating_sub(1);
+        for _ in 0..failed_round_count {
             trace!("round failed");
             self.rounds.push_front(false);
         }
 
-        self.current_round_id = new_round_index << self.current_round_exp;
+        let round_len = state::round_len(self.current_round_exp);
+        self.current_round_id = Timestamp::zero() + round_len.saturating_mul(new_round_index);
 
         self.clean_old_rounds();
 
@@ -154,10 +159,9 @@ impl<C: Context> RoundSuccessMeter<C> {
 
     /// Returns an instance of `Self` for the new era: resetting the counters where appropriate.
     pub fn next_era(&self, era_start_timestamp: Timestamp) -> Self {
-        let current_round_id = round_id(era_start_timestamp, self.current_round_exp).millis();
         Self {
             rounds: self.rounds.clone(),
-            current_round_id,
+            current_round_id: state::round_id(era_start_timestamp, self.current_round_exp),
             proposals: Default::default(),
             min_round_exp: self.min_round_exp,
             max_round_exp: self.max_round_exp,
@@ -177,31 +181,41 @@ impl<C: Context> RoundSuccessMeter<C> {
     }
 
     fn new_exponent(&self) -> u8 {
-        let current_round_index = self.current_round_id >> self.current_round_exp;
+        let current_round_index = round_index(self.current_round_id, self.current_round_exp);
         let num_failures = self.count_failures() as u64;
+        #[allow(clippy::integer_arithmetic)] // The acceleration_parameter is not zero.
         if num_failures > self.config.max_failed_rounds()
             && self.current_round_exp < self.max_round_exp
         {
-            self.current_round_exp + 1
+            self.current_round_exp.saturating_add(1)
         } else if current_round_index % self.config.acceleration_parameter == 0
             && self.current_round_exp > self.min_round_exp
             // we will only accelerate if we collected data about enough rounds
             && self.rounds.len() as u64 == self.config.num_rounds_to_consider
             && num_failures < self.config.max_failures_for_acceleration()
         {
-            self.current_round_exp - 1
+            self.current_round_exp.saturating_sub(1)
         } else {
             self.current_round_exp
         }
     }
 }
 
+/// Returns the round index `i`, if `r_id` is the ID of the `i`-th round after the epoch.
+fn round_index(r_id: Timestamp, round_exp: u8) -> u64 {
+    r_id.millis().checked_shr(u32::from(round_exp)).unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
     use config::{Config, ACCELERATION_PARAMETER, MAX_FAILED_ROUNDS, NUM_ROUNDS_TO_CONSIDER};
 
-    use crate::components::consensus::{
-        cl_context::ClContext, protocols::highway::round_success_meter::config,
+    use crate::{
+        components::consensus::{
+            cl_context::ClContext,
+            protocols::highway::round_success_meter::{config, round_index},
+        },
+        types::TimeDiff,
     };
 
     const TEST_ROUND_EXP: u8 = 13;
@@ -267,12 +281,14 @@ mod tests {
         round_success_meter.rounds = vec![true; NUM_ROUNDS_TO_CONSIDER].into();
         // Increase our round index until we are at an acceleration round
         loop {
-            let current_round_index =
-                round_success_meter.current_round_id >> round_success_meter.current_round_exp;
+            let current_round_index = round_index(
+                round_success_meter.current_round_id,
+                round_success_meter.current_round_exp,
+            );
             if current_round_index % ACCELERATION_PARAMETER == 0 {
                 break;
             };
-            round_success_meter.current_round_id += 1;
+            round_success_meter.current_round_id += TimeDiff::from(1);
         }
         assert_eq!(round_success_meter.new_exponent(), TEST_ROUND_EXP - 1);
     }
@@ -292,12 +308,14 @@ mod tests {
         round_success_meter.rounds = vec![true; NUM_ROUNDS_TO_CONSIDER].into();
         // Increase our round index until we are at an acceleration round
         loop {
-            let current_round_index =
-                round_success_meter.current_round_id >> round_success_meter.current_round_exp;
+            let current_round_index = round_index(
+                round_success_meter.current_round_id,
+                round_success_meter.current_round_exp,
+            );
             if current_round_index % ACCELERATION_PARAMETER == 0 {
                 break;
             };
-            round_success_meter.current_round_id += 1;
+            round_success_meter.current_round_id += TimeDiff::from(1);
         }
         assert_eq!(round_success_meter.new_exponent(), TEST_MIN_ROUND_EXP);
     }

--- a/node/src/components/consensus/protocols/highway/round_success_meter/config.rs
+++ b/node/src/components/consensus/protocols/highway/round_success_meter/config.rs
@@ -51,13 +51,16 @@ impl Config {
     /// which we won't increase our round length. Exceeding this threshold will mean that we
     /// should slow down.
     pub(crate) fn max_failed_rounds(&self) -> u64 {
-        self.num_rounds_to_consider - self.num_rounds_slowdown - 1
+        self.num_rounds_to_consider
+            .saturating_sub(self.num_rounds_slowdown)
+            .saturating_sub(1)
     }
 
     /// The maximum number of failures with which we will attempt to accelerate (decrease the round
     /// exponent).
     pub(crate) fn max_failures_for_acceleration(&self) -> u64 {
-        self.num_rounds_to_consider - self.num_rounds_speedup
+        self.num_rounds_to_consider
+            .saturating_sub(self.num_rounds_speedup)
     }
 }
 

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -270,6 +270,14 @@ impl Div<u64> for TimeDiff {
     }
 }
 
+impl Div<TimeDiff> for TimeDiff {
+    type Output = u64;
+
+    fn div(self, rhs: TimeDiff) -> u64 {
+        self.0 / rhs.0
+    }
+}
+
 impl From<TimeDiff> for Duration {
     fn from(diff: TimeDiff) -> Duration {
         Duration::from_millis(diff.0)

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -324,7 +324,9 @@ impl<I: Display> Display for Source<I> {
     }
 }
 
-/// Divides `numerator` by `denominator` and rounds to the closest integer.
+/// Divides `numerator` by `denominator` and rounds to the closest integer (round half down).
+///
+/// `numerator + denominator / 2` must not overflow, and `denominator` must not be zero.
 pub(crate) fn div_round<T>(numerator: T, denominator: T) -> T
 where
     T: Add<Output = T> + Div<Output = T> + From<u8> + Copy,


### PR DESCRIPTION
This enables the warnings for all arithmetic operations in `consensus` that could potentially overflow. It also replaces them with safe (e.g. saturating) operations in some places.

https://casperlabs.atlassian.net/browse/HWY-268