### PR TITLE
HWY-{271,272}: Port additional synchronizer logging to `dev` branch.

### DIFF
--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -80,6 +80,14 @@ impl<C: Context> Vertex<C> {
         }
     }
 
+    /// Returns the seq number of this vertex (if it is a unit).
+    pub(crate) fn unit_seq_number(&self) -> Option<u64> {
+        match self {
+            Vertex::Unit(swunit) => Some(swunit.wire_unit().seq_number),
+            _ => None,
+        }
+    }
+
     /// Returns whether this is evidence, as opposed to other types of vertices.
     pub(crate) fn is_evidence(&self) -> bool {
         matches!(self, Vertex::Evidence(_))

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -9,8 +9,8 @@ use std::{
 
 use datasize::DataSize;
 use derive_more::{AsRef, From};
-use serde::{Deserialize, Serialize};
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 use super::Weight;
 use crate::utils::ds;

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -142,6 +142,25 @@ impl<VID: Ord + Hash + fmt::Debug> fmt::Display for Validators<VID> {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRef, From, Hash)]
 pub(crate) struct ValidatorMap<T>(Vec<T>);
 
+impl<T> fmt::Display for ValidatorMap<Option<T>>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let view = self
+            .0
+            .iter()
+            .map(|maybe_el| match maybe_el {
+                None => "N".to_string(),
+                Some(el) => format!("{}", el),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(f, "OldestSeen({})", view)?;
+        Ok(())
+    }
+}
+
 impl<T> DataSize for ValidatorMap<T>
 where
     T: DataSize,

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -10,6 +10,7 @@ use std::{
 use datasize::DataSize;
 use derive_more::{AsRef, From};
 use serde::{Deserialize, Serialize};
+use itertools::Itertools;
 
 use super::Weight;
 use crate::utils::ds;
@@ -154,9 +155,8 @@ where
                 None => "N".to_string(),
                 Some(el) => format!("{}", el),
             })
-            .collect::<Vec<_>>()
             .join(", ");
-        write!(f, "OldestSeen({})", view)?;
+        write!(f, "ValidatorMap({})", view)?;
         Ok(())
     }
 }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -56,7 +56,7 @@ const TIMER_ID_LOG_PARTICIPATION: TimerId = TimerId(3);
 /// The timer for an alert no progress was made in a long time.
 const TIMER_ID_STANDSTILL_ALERT: TimerId = TimerId(4);
 /// The timer for logging synchronizer queue size.
-const TIMER_ID_SYNCHRONIZER_QUEUE: TimerId = TimerId(5);
+const TIMER_ID_SYNCHRONIZER_LOG: TimerId = TimerId(5);
 
 /// The action of adding a vertex from the `vertices_to_be_added` queue.
 const ACTION_ID_VERTEX: ActionId = ActionId(0);
@@ -227,10 +227,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                 now.max(era_start_time) + highway_config.standstill_timeout,
                 TIMER_ID_STANDSTILL_ALERT,
             ),
-            ProtocolOutcome::ScheduleTimer(
-                now + TimeDiff::from(5_000),
-                TIMER_ID_SYNCHRONIZER_QUEUE,
-            ),
+            ProtocolOutcome::ScheduleTimer(now + TimeDiff::from(5_000), TIMER_ID_SYNCHRONIZER_LOG),
         ]
     }
 
@@ -699,7 +696,7 @@ where
                 }
             }
             TIMER_ID_STANDSTILL_ALERT => self.handle_standstill_alert_timer(now),
-            TIMER_ID_SYNCHRONIZER_QUEUE => {
+            TIMER_ID_SYNCHRONIZER_LOG => {
                 self.synchronizer.log_len();
                 if !self.finalized_switch_block() {
                     let next_timer = Timestamp::now() + TimeDiff::from(5_000);

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -55,6 +55,8 @@ const TIMER_ID_PURGE_VERTICES: TimerId = TimerId(2);
 const TIMER_ID_LOG_PARTICIPATION: TimerId = TimerId(3);
 /// The timer for an alert no progress was made in a long time.
 const TIMER_ID_STANDSTILL_ALERT: TimerId = TimerId(4);
+/// The timer for logging synchronizer queue size.
+const TIMER_ID_SYNCHRONIZER_QUEUE: TimerId = TimerId(5);
 
 /// The action of adding a vertex from the `vertices_to_be_added` queue.
 const ACTION_ID_VERTEX: ActionId = ActionId(0);
@@ -192,7 +194,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             finality_detector: FinalityDetector::new(ftt),
             highway,
             round_success_meter,
-            synchronizer: Synchronizer::new(config.highway.pending_vertex_timeout),
+            synchronizer: Synchronizer::new(config.highway.pending_vertex_timeout, instance_id),
             evidence_only: false,
             last_panorama,
             standstill_timeout: config.highway.standstill_timeout,
@@ -219,6 +221,10 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             ProtocolOutcome::ScheduleTimer(
                 now.max(era_start_time) + highway_config.standstill_timeout,
                 TIMER_ID_STANDSTILL_ALERT,
+            ),
+            ProtocolOutcome::ScheduleTimer(
+                now + TimeDiff::from(5_000),
+                TIMER_ID_SYNCHRONIZER_QUEUE,
             ),
         ]
     }
@@ -688,6 +694,15 @@ where
                 }
             }
             TIMER_ID_STANDSTILL_ALERT => self.handle_standstill_alert_timer(now),
+            TIMER_ID_SYNCHRONIZER_QUEUE => {
+                self.synchronizer.log_len();
+                if !self.finalized_switch_block() {
+                    let next_timer = Timestamp::now() + TimeDiff::from(5_000);
+                    vec![ProtocolOutcome::ScheduleTimer(next_timer, timer_id)]
+                } else {
+                    vec![]
+                }
+            }
             _ => unreachable!("unexpected timer ID"),
         }
     }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -99,6 +99,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         seed: u64,
         now: Timestamp,
     ) -> (Box<dyn ConsensusProtocol<I, C>>, ProtocolOutcomes<I, C>) {
+        let validators_count = validator_stakes.len();
         let sum_stakes: U512 = validator_stakes.iter().map(|(_, stake)| *stake).sum();
         assert!(
             !sum_stakes.is_zero(),
@@ -194,7 +195,11 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             finality_detector: FinalityDetector::new(ftt),
             highway,
             round_success_meter,
-            synchronizer: Synchronizer::new(config.highway.pending_vertex_timeout, instance_id),
+            synchronizer: Synchronizer::new(
+                config.highway.pending_vertex_timeout,
+                validators_count,
+                instance_id,
+            ),
             evidence_only: false,
             last_panorama,
             standstill_timeout: config.highway.standstill_timeout,

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -6,6 +6,7 @@ use std::{
 
 use datasize::DataSize;
 use itertools::Itertools;
+use tracing::debug;
 
 use crate::{
     components::consensus::{
@@ -75,6 +76,11 @@ impl<I: NodeIdT, C: Context> PendingVertices<I, C> {
     /// Drops all pending vertices other than evidence.
     pub(crate) fn retain_evidence_only(&mut self) {
         self.0.retain(|pvv, _| pvv.inner().is_evidence());
+    }
+
+    /// Returns number of unique vertices pending in the queue.
+    pub(crate) fn len(&self) -> u64 {
+        self.0.len() as u64
     }
 
     fn is_empty(&self) -> bool {
@@ -151,16 +157,22 @@ where
     vertices_to_be_added: PendingVertices<I, C>,
     /// The duration for which incoming vertices with missing dependencies are kept in a queue.
     pending_vertex_timeout: TimeDiff,
+    /// Instance ID of an era for which this synchronizer is constructed for.
+    era_id: C::InstanceId,
+    /// Boolean flag indicating whether we're synchronizing current era.
+    pub(crate) current_era: bool,
 }
 
 impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Creates a new synchronizer with the specified timeout for pending vertices.
-    pub(crate) fn new(pending_vertex_timeout: TimeDiff) -> Self {
+    pub(crate) fn new(pending_vertex_timeout: TimeDiff, era_id: C::InstanceId) -> Self {
         Synchronizer {
             vertex_deps: BTreeMap::new(),
             vertices_to_be_added_later: BTreeMap::new(),
             vertices_to_be_added: Default::default(),
             pending_vertex_timeout,
+            era_id,
+            current_era: true,
         }
     }
 
@@ -170,6 +182,35 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
         self.vertices_to_be_added.remove_expired(oldest);
         Self::remove_expired(&mut self.vertices_to_be_added_later, oldest);
         Self::remove_expired(&mut self.vertex_deps, oldest);
+    }
+
+    // Returns number of elements in the `verties_to_be_added_later` queue.
+    // Every pending vertex is counted once, even if it has multiple senders.
+    fn vertices_to_be_added_later_len(&self) -> u64 {
+        self.vertices_to_be_added_later
+            .iter()
+            .map(|(_, pv)| pv.len())
+            .sum()
+    }
+
+    // Returns number of elements in `vertex_deps` queue.
+    fn vertex_deps_len(&self) -> u64 {
+        self.vertex_deps.iter().map(|(_, pv)| pv.len()).sum()
+    }
+
+    // Returns number of elements in `vertices_to_be_added` queue.
+    fn vertices_to_be_added_len(&self) -> u64 {
+        self.vertices_to_be_added.len()
+    }
+
+    pub(crate) fn log_len(&self) {
+        debug!(
+            era_id = ?self.era_id,
+            vertices_to_be_added_later = self.vertices_to_be_added_later_len(),
+            vertex_deps = self.vertex_deps_len(),
+            vertices_to_be_added = self.vertices_to_be_added_len(),
+            "synchronizer queue lengths"
+        );
     }
 
     /// Store a (pre-validated) vertex which will be added later.  This creates a timer to be sent
@@ -274,7 +315,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     }
 
     /// Adds a vertex with a known missing dependency to the queue.
-    pub(crate) fn add_missing_dependency(&mut self, dep: Dependency<C>, pv: PendingVertex<I, C>) {
+    fn add_missing_dependency(&mut self, dep: Dependency<C>, pv: PendingVertex<I, C>) {
         self.vertex_deps.entry(dep).or_default().push(pv)
     }
 

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -11,7 +11,10 @@ use tracing::debug;
 use crate::{
     components::consensus::{
         consensus_protocol::ProtocolOutcome,
-        highway_core::highway::{Dependency, Highway, PreValidatedVertex, Vertex},
+        highway_core::{
+            highway::{Dependency, Highway, PreValidatedVertex, Vertex},
+            validators::ValidatorMap,
+        },
         traits::{Context, NodeIdT},
     },
     types::{TimeDiff, Timestamp},
@@ -159,18 +162,28 @@ where
     pending_vertex_timeout: TimeDiff,
     /// Instance ID of an era for which this synchronizer is constructed for.
     era_id: C::InstanceId,
+    /// Keeps track of the lowest/oldest seen unit per validator when syncing.
+    /// Used only for logging.
+    oldest_seen_panorama: ValidatorMap<Option<u64>>,
     /// Boolean flag indicating whether we're synchronizing current era.
     pub(crate) current_era: bool,
 }
 
 impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Creates a new synchronizer with the specified timeout for pending vertices.
-    pub(crate) fn new(pending_vertex_timeout: TimeDiff, era_id: C::InstanceId) -> Self {
+    pub(crate) fn new(
+        pending_vertex_timeout: TimeDiff,
+        validator_len: usize,
+        era_id: C::InstanceId,
+    ) -> Self {
         Synchronizer {
             vertex_deps: BTreeMap::new(),
             vertices_to_be_added_later: BTreeMap::new(),
             vertices_to_be_added: Default::default(),
             pending_vertex_timeout,
+            oldest_seen_panorama: ValidatorMap::from(
+                iter::repeat(None).take(validator_len).collect_vec(),
+            ),
             era_id,
             current_era: true,
         }
@@ -211,6 +224,16 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
             vertices_to_be_added = self.vertices_to_be_added_len(),
             "synchronizer queue lengths"
         );
+        // All units seen have seq_number == 0.
+        let all_lowest = self
+            .oldest_seen_panorama
+            .iter()
+            .all(|entry| entry.map(|seq_num| seq_num == 0).unwrap_or(false));
+        if all_lowest {
+            debug!("all seen units while synchronization with seq_num=0");
+        } else {
+            debug!(oldest_panorama=%self.oldest_seen_panorama, "oldest seen unit per validator");
+        }
     }
 
     /// Store a (pre-validated) vertex which will be added later.  This creates a timer to be sent
@@ -259,8 +282,17 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
         pvv: PreValidatedVertex<C>,
         now: Timestamp,
     ) -> ProtocolOutcomes<I, C> {
+        self.update_last_seen(&pvv);
         let pv = PendingVertex::new(sender, pvv, now);
         self.schedule_add_vertices(iter::once(pv))
+    }
+
+    fn update_last_seen(&mut self, pvv: &PreValidatedVertex<C>) {
+        let v = pvv.inner();
+        if let (Some(v_id), Some(seq_num)) = (v.creator(), v.unit_seq_number()) {
+            let prev_seq_num = self.oldest_seen_panorama[v_id].unwrap_or(u64::MAX);
+            self.oldest_seen_panorama[v_id] = Some(prev_seq_num.min(seq_num));
+        }
     }
 
     /// Moves all vertices whose known missing dependency is now satisfied into the

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -160,8 +160,8 @@ where
     vertices_to_be_added: PendingVertices<I, C>,
     /// The duration for which incoming vertices with missing dependencies are kept in a queue.
     pending_vertex_timeout: TimeDiff,
-    /// Instance ID of an era for which this synchronizer is constructed for.
-    era_id: C::InstanceId,
+    /// Instance ID of an era for which this synchronizer is constructed.
+    instance_id: C::InstanceId,
     /// Keeps track of the lowest/oldest seen unit per validator when syncing.
     /// Used only for logging.
     oldest_seen_panorama: ValidatorMap<Option<u64>>,
@@ -174,17 +174,15 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     pub(crate) fn new(
         pending_vertex_timeout: TimeDiff,
         validator_len: usize,
-        era_id: C::InstanceId,
+        instance_id: C::InstanceId,
     ) -> Self {
         Synchronizer {
             vertex_deps: BTreeMap::new(),
             vertices_to_be_added_later: BTreeMap::new(),
             vertices_to_be_added: Default::default(),
             pending_vertex_timeout,
-            oldest_seen_panorama: ValidatorMap::from(
-                iter::repeat(None).take(validator_len).collect_vec(),
-            ),
-            era_id,
+            oldest_seen_panorama: iter::repeat(None).take(validator_len).collect(),
+            instance_id,
             current_era: true,
         }
     }
@@ -218,7 +216,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
 
     pub(crate) fn log_len(&self) {
         debug!(
-            era_id = ?self.era_id,
+            era_id = ?self.instance_id,
             vertices_to_be_added_later = self.vertices_to_be_added_later_len(),
             vertex_deps = self.vertex_deps_len(),
             vertices_to_be_added = self.vertices_to_be_added_len(),

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -39,7 +39,7 @@ fn purge_vertices() {
     let peer0 = NodeId(0);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
-    let mut sync = Synchronizer::<NodeId, TestContext>::new(0x20.into());
+    let mut sync = Synchronizer::<NodeId, TestContext>::new(0x20.into(), TEST_INSTANCE_ID);
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
 
     // At time 0x20, we receive c2, b0 and b1 — the latter ahead of their timestamp.

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -39,7 +39,8 @@ fn purge_vertices() {
     let peer0 = NodeId(0);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
-    let mut sync = Synchronizer::<NodeId, TestContext>::new(0x20.into(), TEST_INSTANCE_ID);
+    let mut sync =
+        Synchronizer::<NodeId, TestContext>::new(0x20.into(), WEIGHTS.len(), TEST_INSTANCE_ID);
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
 
     // At time 0x20, we receive c2, b0 and b1 — the latter ahead of their timestamp.

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -99,9 +99,10 @@ where
     // * log participation timer,
     // * log synchronizer queue length timer,
     // * purge synchronizer queue timer,
-    // * inactivity timer.
+    // * inactivity timer,
+    // * latest state request.
     // If there are more, the tests might need to handle them.
-    assert_eq!(4, outcomes.len());
+    assert_eq!(5, outcomes.len());
     hw_proto
 }
 

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -95,7 +95,11 @@ where
         0,
         start_timestamp,
     );
-    // We expect only the vertex purge timer, participation log timer and `Ping` outcomes.
+    // We expect for messages:
+    // * log participation timer,
+    // * log synchronizer queue length timer,
+    // * purge synchronizer queue timer,
+    // * inactivity timer.
     // If there are more, the tests might need to handle them.
     assert_eq!(4, outcomes.len());
     hw_proto


### PR DESCRIPTION
Ports PRs that add additional logging to the Highway synchronizer.

https://github.com/CasperLabs/casper-node/pull/1172
https://github.com/CasperLabs/casper-node/pull/1173
