### PR TITLE
HWY-273: Add cache for prevalidated vertices.

### DIFF
--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -705,7 +705,7 @@ where
             TIMER_ID_PURGE_VERTICES => {
                 self.synchronizer.purge_vertices(now);
                 self.pvv_cache.clear();
-                let next_time = Timestamp::now() + self.synchronizer.pending_vertex_timeout();
+                let next_time = now + self.synchronizer.pending_vertex_timeout();
                 vec![ProtocolOutcome::ScheduleTimer(next_time, timer_id)]
             }
             TIMER_ID_LOG_PARTICIPATION => {


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/HWY-273

Adds a cache for pending prevalidated vertices (vertices that are currently being synchronized) and for every new vertex received, checks if it's already in that cache. If not, don't request it again.

Also, checks the node's protocol state if the incoming vertex is already known before trying to validate it.