### PR TITLE
OP-1934: reorder the tests to help with non-determinism

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -27,6 +27,8 @@ function start_run_teardown() {
     local RUN_CMD=$1
     local RUN_CHAINSPEC=$2
     local RUN_ACCOUNTS=$3
+    # Really-really make sure nothing is leftover
+    nctl-assets-teardown
     echo "Setting up network: $RUN_CMD $RUN_CHAINSPEC $RUN_ACCOUNTS"
     if [ -z "$RUN_CHAINSPEC" ] && [ -z "$RUN_ACCOUNTS" ]; then
         nctl-assets-setup
@@ -50,13 +52,13 @@ function start_run_teardown() {
     sleep 1
 }
 
-start_run_teardown "sync_test.sh node=6 timeout=500"
-start_run_teardown "sync_upgrade_test.sh node=6 era=4 timeout=500"
 start_run_teardown "itst01.sh"
 start_run_teardown "itst02.sh"
 start_run_teardown "itst11.sh"
 start_run_teardown "itst13.sh" "itst13.chainspec.toml.in"
-#start_run_teardown "itst14.sh" "itst14.chainspec.toml.in" "itst14.accounts.toml"
+start_run_teardown "itst14.sh" "itst14.chainspec.toml.in" "itst14.accounts.toml"
+start_run_teardown "sync_test.sh node=6 timeout=500"
+start_run_teardown "sync_upgrade_test.sh node=6 era=4 timeout=500"
 
 # Clean up cloned repo
 popd


### PR DESCRIPTION
This is a quick fix which seems to work in my test forks drone setup.