### PR TITLE
HWY-274: Request protocol state only for the latest era.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -81,8 +81,6 @@ pub struct ActionId(pub u8);
 pub enum Event<I> {
     /// An incoming network message.
     MessageReceived { sender: I, msg: ConsensusMessage },
-    /// We connected to a peer.
-    NewPeer(I),
     /// A scheduled event to be handled by a specified era.
     Timer {
         era_id: EraId,
@@ -169,7 +167,6 @@ impl<I: Debug> Display for Event<I> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Event::MessageReceived { sender, msg } => write!(f, "msg from {:?}: {}", sender, msg),
-            Event::NewPeer(peer_id) => write!(f, "new peer connected: {:?}", peer_id),
             Event::Timer {
                 era_id,
                 timestamp,
@@ -294,7 +291,6 @@ where
             } => handling_es.handle_timer(era_id, timestamp, timer_id),
             Event::Action { era_id, action_id } => handling_es.handle_action(era_id, action_id),
             Event::MessageReceived { sender, msg } => handling_es.handle_message(sender, msg),
-            Event::NewPeer(_peer_id) => Effects::new(),
             Event::NewProtoBlock {
                 era_id,
                 proto_block,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -294,7 +294,7 @@ where
             } => handling_es.handle_timer(era_id, timestamp, timer_id),
             Event::Action { era_id, action_id } => handling_es.handle_action(era_id, action_id),
             Event::MessageReceived { sender, msg } => handling_es.handle_message(sender, msg),
-            Event::NewPeer(peer_id) => handling_es.handle_new_peer(peer_id),
+            Event::NewPeer(_peer_id) => Effects::new(),
             Event::NewProtoBlock {
                 era_id,
                 proto_block,

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -131,8 +131,8 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
     fn handle_message(&mut self, sender: I, msg: Vec<u8>, now: Timestamp)
         -> ProtocolOutcomes<I, C>;
 
-    /// Handles new connection to a peer.
-    fn handle_new_peer(&mut self, peer_id: I) -> ProtocolOutcomes<I, C>;
+    /// Current instance of consensus protocol is latest era.
+    fn handle_is_current(&self) -> ProtocolOutcomes<I, C>;
 
     /// Triggers consensus' timer.
     fn handle_timer(&mut self, timestamp: Timestamp, timer_id: TimerId) -> ProtocolOutcomes<I, C>;

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -505,7 +505,13 @@ where
             );
             result_map.insert(era_id, results);
         }
-
+        let active_era_outcomes = self.active_eras[&self.current_era]
+            .consensus
+            .handle_is_current();
+        result_map
+            .entry(self.current_era)
+            .or_default()
+            .extend(active_era_outcomes);
         self.is_initialized = true;
         self.next_block_height = self.active_eras[&self.current_era].start_height;
         result_map
@@ -689,12 +695,6 @@ where
         }
     }
 
-    pub(super) fn handle_new_peer(&mut self, peer_id: I) -> Effects<Event<I>> {
-        self.delegate_to_era(self.era_supervisor.current_era, move |consensus| {
-            consensus.handle_new_peer(peer_id)
-        })
-    }
-
     pub(super) fn handle_new_proto_block(
         &mut self,
         era_id: EraId,
@@ -852,7 +852,7 @@ where
             .cloned()
             .collect();
         #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
-        let outcomes = self.era_supervisor.new_era(
+        let mut outcomes = self.era_supervisor.new_era(
             era_id,
             Timestamp::now(), // TODO: This should be passed in.
             next_era_validators_weights.clone(),
@@ -861,6 +861,11 @@ where
             seed,
             switch_block.header().timestamp(),
             switch_block.height() + 1,
+        );
+        outcomes.extend(
+            self.era_supervisor.active_eras[&era_id]
+                .consensus
+                .handle_is_current(),
         );
         self.handle_consensus_outcomes(era_id, outcomes)
     }

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -143,7 +143,7 @@ where
     C: Context,
 {
     /// The protocol instance ID. This needs to be unique, to prevent replay attacks.
-    instance_id: C::InstanceId,
+    pub(crate) instance_id: C::InstanceId,
     /// The validator IDs and weight map.
     validators: Validators<C::ValidatorId>,
     /// The abstract protocol state.

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -143,7 +143,7 @@ where
     C: Context,
 {
     /// The protocol instance ID. This needs to be unique, to prevent replay attacks.
-    pub(crate) instance_id: C::InstanceId,
+    instance_id: C::InstanceId,
     /// The validator IDs and weight map.
     validators: Validators<C::ValidatorId>,
     /// The abstract protocol state.

--- a/node/src/components/consensus/highway_core/validators.rs
+++ b/node/src/components/consensus/highway_core/validators.rs
@@ -107,11 +107,6 @@ impl<VID: Eq + Hash> Validators<VID> {
             |(idx, v): (usize, &'a Validator<VID>)| (ValidatorIndex::from(idx as u32), v.id());
         self.iter().enumerate().map(to_idx)
     }
-
-    /// Returns the size of validator list.
-    pub(crate) fn len(&self) -> usize {
-        self.validators.len()
-    }
 }
 
 impl<VID: Ord + Hash + Clone, W: Into<Weight>> FromIterator<(VID, W)> for Validators<VID> {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -498,7 +498,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
 
     /// Creates a message to be gossiped that sends the validator's panorama.
     fn latest_panorama_request(&self) -> ProtocolOutcomes<I, C> {
-        trace!(instance_id=?self.highway.instance_id, "creating latest state request");
+        trace!(instance_id=?self.highway.instance_id(), "creating latest state request");
         let request = HighwayMessage::LatestStateRequest(self.highway.state().panorama().clone());
         vec![ProtocolOutcome::CreatedGossipMessage(
             (&request).serialize(),

--- a/node/src/components/consensus/protocols/highway/config.rs
+++ b/node/src/components/consensus/protocols/highway/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub unit_hashes_folder: PathBuf,
     /// The duration for which incoming vertices with missing dependencies are kept in a queue.
     pub pending_vertex_timeout: TimeDiff,
+    /// The frequency at which we will ask peers for their latest state.
+    pub request_latest_state_timeout: TimeDiff,
     /// If the current era's protocol state has not progressed for this long, shut down.
     pub standstill_timeout: TimeDiff,
     /// Log inactive or faulty validators periodically, with this interval.
@@ -31,6 +33,7 @@ impl Default for Config {
         Config {
             unit_hashes_folder: Default::default(),
             pending_vertex_timeout: "10sec".parse().unwrap(),
+            request_latest_state_timeout: "5sec".parse().unwrap(),
             standstill_timeout: "1min".parse().unwrap(),
             log_participation_interval: "10sec".parse().unwrap(),
             max_execution_delay: 3,

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -160,6 +160,8 @@ where
     vertices_to_be_added: PendingVertices<I, C>,
     /// The duration for which incoming vertices with missing dependencies are kept in a queue.
     pending_vertex_timeout: TimeDiff,
+    /// The duration between two consecutive requests of the latest state.
+    request_latest_state_timeout: TimeDiff,
     /// Instance ID of an era for which this synchronizer is constructed.
     instance_id: C::InstanceId,
     /// Keeps track of the lowest/oldest seen unit per validator when syncing.
@@ -173,6 +175,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Creates a new synchronizer with the specified timeout for pending vertices.
     pub(crate) fn new(
         pending_vertex_timeout: TimeDiff,
+        request_latest_state_timeout: TimeDiff,
         validator_len: usize,
         instance_id: C::InstanceId,
     ) -> Self {
@@ -181,6 +184,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
             vertices_to_be_added_later: BTreeMap::new(),
             vertices_to_be_added: Default::default(),
             pending_vertex_timeout,
+            request_latest_state_timeout,
             oldest_seen_panorama: iter::repeat(None).take(validator_len).collect(),
             instance_id,
             current_era: true,
@@ -364,6 +368,11 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Returns the timeout for pending vertices: Entries older than this are purged periodically.
     pub(crate) fn pending_vertex_timeout(&self) -> TimeDiff {
         self.pending_vertex_timeout
+    }
+
+    /// Returns the duration between two consecutive requests of the latest state.
+    pub(crate) fn request_latest_state_timeout(&self) -> TimeDiff {
+        self.request_latest_state_timeout
     }
 
     /// Drops all vertices that (directly or indirectly) have the specified dependencies, and

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -39,8 +39,12 @@ fn purge_vertices() {
     let peer0 = NodeId(0);
 
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
-    let mut sync =
-        Synchronizer::<NodeId, TestContext>::new(0x20.into(), WEIGHTS.len(), TEST_INSTANCE_ID);
+    let mut sync = Synchronizer::<NodeId, TestContext>::new(
+        0x20.into(),
+        0x20.into(),
+        WEIGHTS.len(),
+        TEST_INSTANCE_ID,
+    );
     let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
 
     // At time 0x20, we receive c2, b0 and b1 — the latter ahead of their timestamp.

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -80,6 +80,7 @@ where
             log_participation_interval: "10sec".parse().unwrap(),
             max_execution_delay: 3,
             round_success_meter: Default::default(),
+            request_latest_state_timeout: "10sec".parse().unwrap(),
         },
     };
     // Timestamp of the genesis era start and test start.

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -101,9 +101,8 @@ where
     // * log synchronizer queue length timer,
     // * purge synchronizer queue timer,
     // * inactivity timer,
-    // * latest state request.
     // If there are more, the tests might need to handle them.
-    assert_eq!(5, outcomes.len());
+    assert_eq!(4, outcomes.len());
     hw_proto
 }
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -20,7 +20,7 @@ use derive_more::From;
 use prometheus::Registry;
 use reactor::ReactorEvent;
 use serde::Serialize;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 #[cfg(test)]
 use crate::testing::network::NetworkedReactor;
@@ -888,9 +888,9 @@ impl reactor::Reactor for Reactor {
                 };
                 self.dispatch_event(effect_builder, rng, Event::AddressGossiper(event))
             }
-            Event::NetworkAnnouncement(NetworkAnnouncement::NewPeer(peer_id)) => {
-                let event = consensus::Event::NewPeer(peer_id);
-                self.dispatch_event(effect_builder, rng, Event::Consensus(event))
+            Event::NetworkAnnouncement(NetworkAnnouncement::NewPeer(_peer_id)) => {
+                trace!("new peer announcement not handled in the validator reactor");
+                return Effects::new();
             }
             Event::RpcServerAnnouncement(RpcServerAnnouncement::DeployReceived {
                 deploy,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -890,7 +890,7 @@ impl reactor::Reactor for Reactor {
             }
             Event::NetworkAnnouncement(NetworkAnnouncement::NewPeer(_peer_id)) => {
                 trace!("new peer announcement not handled in the validator reactor");
-                return Effects::new();
+                Effects::new()
             }
             Event::RpcServerAnnouncement(RpcServerAnnouncement::DeployReceived {
                 deploy,

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -39,7 +39,9 @@ secret_key_path = 'secret_key.pem'
 unit_hashes_folder = "../node-storage"
 
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
-pending_vertex_timeout = '30min'
+pending_vertex_timeout = '1min'
+
+request_latest_state_timeout = '30sec'
 
 # If the current era's protocol state has not progressed for this long, shut down.
 standstill_timeout = '5min'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -38,7 +38,9 @@ secret_key_path = '/etc/casper/validator_keys/secret_key.pem'
 unit_hashes_folder = "/var/lib/casper/casper-node"
 
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
-pending_vertex_timeout = '30min'
+pending_vertex_timeout = '1min'
+
+request_latest_state_timeout = '30sec'
 
 # If the current era's protocol state has not progressed for this long, shut down.
 standstill_timeout = '5min'


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/HWY-274

Tested locally with `nctl`:
```mateusz@mateusz-XPS-15-9560:~/work/casperlabs/casper-node$ nctl-view-chain-era node=1
2021-03-23T13:42:55.083255 [INFO] [164287] NCTL :: chain era @ node-1 = 11
mateusz@mateusz-XPS-15-9560:~/work/casperlabs/casper-node$ nctl-view-chain-lfb node=1
2021-03-23T13:42:57.995937 [INFO] [164287] NCTL :: last finalized block hash @ node-1 = afa3941cf566bb5fe0bc7552e9d53ecce74152029cbdc48534d41a540904ee07
mateusz@mateusz-XPS-15-9560:~/work/casperlabs/casper-node$ nctl-start node=7 hash=afa3941cf566bb5fe0bc7552e9d53ecce74152029cbdc48534d41a540904ee07
2021-03-23T13:43:04.890631 [INFO] [164287] NCTL :: node-7: starting ...
2021-03-23T13:43:04.896021 [INFO] [164287] NCTL :: trusted hash = afa3941cf566bb5fe0bc7552e9d53ecce74152029cbdc48534d41a540904ee07
validators-3:casper-net-1-node-7   RUNNING   pid 242197, uptime 0:00:02
mateusz@mateusz-XPS-15-9560:~/work/casperlabs/casper-node$ cat utils/nctl/assets/net-1/nodes/node-1/logs/stdout.log | grep "starting era" | jq -c '.fields.instance_id'
"6f7e..270c"
"99ef..7ca2"
"2753..e8cb"
"e85e..8e80"
"9ba9..5af3"
"ce52..10ba"
"5708..4176"
"0c46..f77a"
"0583..833a"
"9ba0..100f"
"5e0d..00d6"
"64f4..00dd"
"256d..051f"
mateusz@mateusz-XPS-15-9560:~/work/casperlabs/casper-node$ cat utils/nctl/assets/net-1/nodes/node-7/logs/stdout.log | grep "latest state request"
{"timestamp":"Mar 23 13:43:11.002","fields":{"message":"latest state request","instance_id":"64f4088b7aa17e77d48bc7e3cbecafc5e17fcd03a5794ac02ad3a5ed994700dd"},"target":"casper_node::components::consensus::protocols::highway"}
{"timestamp":"Mar 23 13:43:13.823","fields":{"message":"latest state request","instance_id":"256db5bb283ee5a6c438d4fe868cdb86f79b16c64abdfe801319a0077c08051f"},"target":"casper_node::components::consensus::protocols::highway"}
```

As you can see above, there are multiple eras created but the joining node sends the request only for the latest one.