### PR TITLE
NDRS-{1050,1051}: Delta-11 fixes.

### DIFF
--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -128,7 +128,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                     * chainspec.core_config.minimum_era_height,
                 chainspec.core_config.era_duration,
             );
-            let state = init_hash.map_or(State::None, |init_hash| {
+            let state = init_hash.map_or(State::Done(None), |init_hash| {
                 State::sync_trusted_hash(init_hash, highest_block_header)
             });
             let state_key = create_state_key(&chainspec);

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -688,11 +688,6 @@ where
                         // We shouldn't get invalid data from the storage.
                         // If we do, it's a bug.
                         assert_eq!(*block.hash(), block_hash, "Block hash mismatch.");
-                        assert_eq!(
-                            block.protocol_version(),
-                            self.protocol_version,
-                            "block protocol version mismatch"
-                        );
                         trace!(%block_hash, "Linear block found in the local storage.");
                         // We hit a block that we already had in the storage - which should mean
                         // that we also have all of its ancestors, so we switch to traversing the
@@ -714,24 +709,6 @@ where
                                 header_hash,
                                 block.hash(),
                                 peer
-                            );
-                            // NOTE: Signal misbehaving validator to networking layer.
-                            self.peers.ban(&peer);
-                            return self.handle_event(
-                                effect_builder,
-                                rng,
-                                Event::GetBlockHashResult(
-                                    block_hash,
-                                    BlockByHashResult::Absent(peer),
-                                ),
-                            );
-                        }
-                        if block.protocol_version() != self.protocol_version {
-                            warn!(
-                                %peer,
-                                protocol_version = ?self.protocol_version,
-                                block_version = ?block.protocol_version(),
-                                "block protocol version mismatch",
                             );
                             // NOTE: Signal misbehaving validator to networking layer.
                             self.peers.ban(&peer);

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -179,7 +179,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
 
     /// Returns `true` if we have finished syncing linear chain.
     pub fn is_synced(&self) -> bool {
-        matches!(self.state, State::None | State::Done(_))
+        matches!(self.state, State::Done(_))
     }
 
     /// Returns `true` if we should stop for upgrade.

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -688,6 +688,11 @@ where
                         // We shouldn't get invalid data from the storage.
                         // If we do, it's a bug.
                         assert_eq!(*block.hash(), block_hash, "Block hash mismatch.");
+                        assert_eq!(
+                            block.protocol_version(),
+                            self.protocol_version,
+                            "block protocol version mismatch"
+                        );
                         trace!(%block_hash, "Linear block found in the local storage.");
                         // We hit a block that we already had in the storage - which should mean
                         // that we also have all of its ancestors, so we switch to traversing the
@@ -709,6 +714,24 @@ where
                                 header_hash,
                                 block.hash(),
                                 peer
+                            );
+                            // NOTE: Signal misbehaving validator to networking layer.
+                            self.peers.ban(&peer);
+                            return self.handle_event(
+                                effect_builder,
+                                rng,
+                                Event::GetBlockHashResult(
+                                    block_hash,
+                                    BlockByHashResult::Absent(peer),
+                                ),
+                            );
+                        }
+                        if block.protocol_version() != self.protocol_version {
+                            warn!(
+                                %peer,
+                                protocol_version = ?self.protocol_version,
+                                block_version = ?block.protocol_version(),
+                                "block protocol version mismatch",
                             );
                             // NOTE: Signal misbehaving validator to networking layer.
                             self.peers.ban(&peer);

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1128,6 +1128,11 @@ impl Block {
         self.header.height()
     }
 
+    /// The protocol version of the block.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.header.protocol_version
+    }
+
     /// Check the integrity of a block by hashing its body and header
     pub fn verify(&self) -> Result<(), BlockValidationError> {
         let actual_body_hash = self.body.hash();


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-1051
https://casperlabs.atlassian.net/browse/NDRS-1050

`LinearChainSync` does no longer consider `State::None` as a trigger for finishing syncing.
When downloading linear chain blocks by height, we compare the block's protocol version with the version this node is running with.