### PR TITLE
NDRS-1043: change trigger for upgrade checks to timed interval

### DIFF
--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -16,6 +16,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
+    time::Duration,
 };
 
 use datasize::DataSize;
@@ -56,6 +57,8 @@ use crate::{
     utils::{self, Loadable},
     NodeRng,
 };
+
+const UPGRADE_CHECK_INTERVAL: Duration = Duration::from_secs(60);
 
 /// `ChainspecHandler` events.
 #[derive(Debug, From, Serialize)]
@@ -227,7 +230,7 @@ impl ChainspecLoader {
         // In case this is a version which should be immediately replaced by the next version, don't
         // create any effects so we exit cleanly for an upgrade without touching the storage
         // component.  Otherwise create effects which will allow us to initialize properly.
-        let effects = if should_stop {
+        let mut effects = if should_stop {
             Effects::new()
         } else {
             effect_builder
@@ -236,6 +239,13 @@ impl ChainspecLoader {
                     maybe_highest_block: highest_block.map(Box::new),
                 })
         };
+
+        // Start regularly checking for the next upgrade.
+        effects.extend(
+            effect_builder
+                .set_timeout(UPGRADE_CHECK_INTERVAL)
+                .event(|_| Event::CheckForNextUpgrade),
+        );
 
         let reactor_exit = should_stop.then(|| ReactorExit::ProcessShouldExit(ExitCode::Success));
 
@@ -249,6 +259,20 @@ impl ChainspecLoader {
         };
 
         (chainspec_loader, effects)
+    }
+
+    /// This is a workaround while we have multiple reactors.  It should be used in the joiner and
+    /// validator reactors' constructors to start the recurring task of checking for upgrades.  The
+    /// recurring tasks of the previous reactors will be cancelled when the relevant reactor is
+    /// destroyed during transition.
+    pub(crate) fn start_checking_for_upgrades<REv>(
+        &self,
+        effect_builder: EffectBuilder<REv>,
+    ) -> Effects<Event>
+    where
+        REv: From<ChainspecLoaderAnnouncement> + Send,
+    {
+        self.check_for_next_upgrade(effect_builder)
     }
 
     pub(crate) fn reactor_exit(&self) -> Option<ReactorExit> {
@@ -544,7 +568,7 @@ impl ChainspecLoader {
     {
         let root_dir = self.root_dir.clone();
         let current_version = self.chainspec.protocol_config.version.clone();
-        async move {
+        let mut effects = async move {
             let maybe_next_upgrade =
                 task::spawn_blocking(move || next_upgrade(root_dir, current_version))
                     .await
@@ -558,7 +582,15 @@ impl ChainspecLoader {
                     .await
             }
         }
-        .ignore()
+        .ignore();
+
+        effects.extend(
+            effect_builder
+                .set_timeout(UPGRADE_CHECK_INTERVAL)
+                .event(|_| Event::CheckForNextUpgrade),
+        );
+
+        effects
     }
 
     fn handle_got_next_upgrade(&mut self, next_upgrade: NextUpgrade) -> Effects<Event> {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -529,6 +529,10 @@ impl reactor::Reactor for Reactor {
             Event::LinearChainSync,
             init_sync_effects,
         ));
+        effects.extend(reactor::wrap_effects(
+            Event::ChainspecLoader,
+            chainspec_loader.start_checking_for_upgrades(effect_builder),
+        ));
 
         Ok((
             Self {
@@ -825,9 +829,6 @@ impl reactor::Reactor for Reactor {
                 );
                 let reactor_event =
                     Event::LinearChainSync(linear_chain_sync::Event::BlockHandled(block));
-                effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
-                let reactor_event =
-                    Event::ChainspecLoader(chainspec_loader::Event::CheckForNextUpgrade);
                 effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                 effects
             }

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -501,6 +501,10 @@ impl reactor::Reactor for Reactor {
             Event::SmallNetwork,
             small_network_effects,
         ));
+        effects.extend(reactor::wrap_effects(
+            Event::ChainspecLoader,
+            chainspec_loader.start_checking_for_upgrades(effect_builder),
+        ));
 
         Ok((
             Reactor {
@@ -956,12 +960,7 @@ impl reactor::Reactor for Reactor {
                                 block: block.proto_block().clone(),
                                 height: block.height(),
                             });
-                        let mut effects = self.dispatch_event(effect_builder, rng, reactor_event);
-
-                        let reactor_event =
-                            Event::ChainspecLoader(chainspec_loader::Event::CheckForNextUpgrade);
-                        effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
-                        effects
+                        self.dispatch_event(effect_builder, rng, reactor_event)
                     }
                     ConsensusAnnouncement::CreatedFinalitySignature(fs) => self.dispatch_event(
                         effect_builder,


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1043.

This PR changes the trigger for the chainspec loader to check for the next installed version of the chainspec.  The current trigger is the announcement of a new block; with this PR it is on a repeating minute timer.

With this being on a regular timed interval now, an upgrade will be detected even if block production has stalled.

I don't believe we need the interval to be a config setting, but if reviewers disagree, that can be changed.

I have tested this works via the `nctl-upgrade-protocol` command.