### PR TITLE
NDRS-1051: Use highest block as an init state for components when no syncing is performed.

### DIFF
--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -161,7 +161,7 @@ pub struct ChainspecLoader {
     /// The initial state root hash for this session.
     initial_state_root_hash: Digest,
     next_upgrade: Option<NextUpgrade>,
-    initial_block_header: Option<BlockHeader>,
+    initial_block: Option<Block>,
 }
 
 impl ChainspecLoader {
@@ -245,7 +245,7 @@ impl ChainspecLoader {
             reactor_exit,
             initial_state_root_hash: Digest::default(),
             next_upgrade,
-            initial_block_header: None,
+            initial_block: None,
         };
 
         (chainspec_loader, effects)
@@ -271,7 +271,11 @@ impl ChainspecLoader {
     }
 
     pub(crate) fn initial_block_header(&self) -> Option<&BlockHeader> {
-        self.initial_block_header.as_ref()
+        self.initial_block.as_ref().map(|block| block.header())
+    }
+
+    pub(crate) fn initial_block(&self) -> Option<&Block> {
+        self.initial_block.as_ref()
     }
 
     pub(crate) fn initial_block_hash(&self) -> Option<BlockHash> {
@@ -311,7 +315,7 @@ impl ChainspecLoader {
     {
         let highest_block = match maybe_highest_block {
             Some(block) => {
-                self.initial_block_header = Some(block.header().clone());
+                self.initial_block = Some(*block.clone());
                 block
             }
             None => {

--- a/node/src/components/linear_chain_fast_sync.rs
+++ b/node/src/components/linear_chain_fast_sync.rs
@@ -51,7 +51,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainFastSync<I> {
         _chainspec: &Chainspec,
         _storage: &Storage,
         init_hash: Option<BlockHash>,
-        _highest_block_header: Option<BlockHeader>,
+        _highest_block: Option<Block>,
         genesis_validator_weights: BTreeMap<PublicKey, U512>,
         _next_upgrade_activation_point: Option<ActivationPoint>,
     ) -> Result<(Self, Effects<Event<I>>), Err>

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -521,7 +521,7 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             &storage,
             init_hash,
-            chainspec_loader.initial_block_header().cloned(),
+            chainspec_loader.initial_block().cloned(),
             validator_weights,
             maybe_next_activation_point,
         )?;


### PR DESCRIPTION
All components use `LinearChainSync`'s last known block as an initial state. In the case when there's was syncing performed they failed to initialize properly. We need to return the highest block when there's no synchronization.