### PR TITLE
NDRS-1052: Reconstruct `BlockProposerDeploySets` state from the block storage.

### DIFF
--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -42,10 +42,20 @@ impl Default for BlockProposerDeploySets {
 }
 
 impl BlockProposerDeploySets {
-    pub(super) fn with_next_finalized(self, next_finalized: BlockHeight) -> Self {
+    /// Constructs the instance of `BlockProposerDeploySets` from the list of finalized deploys.
+    pub(super) fn from_finalized(
+        stored_deploys: Vec<(DeployHash, DeployHeader)>,
+        next_finalized_height: u64,
+    ) -> BlockProposerDeploySets {
+        let mut finalized_deploys: HashMap<DeployHash, DeployHeader> = HashMap::new();
+        for (hash, header) in stored_deploys.into_iter() {
+            finalized_deploys.insert(hash, header);
+        }
         BlockProposerDeploySets {
-            next_finalized,
-            ..self
+            pending: HashMap::new(),
+            finalized_deploys,
+            next_finalized: next_finalized_height,
+            finalization_queue: Default::default(),
         }
     }
 }

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -42,7 +42,6 @@ impl Default for BlockProposerDeploySets {
 }
 
 impl BlockProposerDeploySets {
-    
     /// Constructs the instance of `BlockProposerDeploySets` from the list of finalized deploys.
     pub(super) fn from_finalized(
         finalized_deploys: Vec<(DeployHash, DeployHeader)>,

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -42,18 +42,15 @@ impl Default for BlockProposerDeploySets {
 }
 
 impl BlockProposerDeploySets {
+    
     /// Constructs the instance of `BlockProposerDeploySets` from the list of finalized deploys.
     pub(super) fn from_finalized(
-        stored_deploys: Vec<(DeployHash, DeployHeader)>,
+        finalized_deploys: Vec<(DeployHash, DeployHeader)>,
         next_finalized_height: u64,
     ) -> BlockProposerDeploySets {
-        let mut finalized_deploys: HashMap<DeployHash, DeployHeader> = HashMap::new();
-        for (hash, header) in stored_deploys.into_iter() {
-            finalized_deploys.insert(hash, header);
-        }
         BlockProposerDeploySets {
             pending: HashMap::new(),
-            finalized_deploys,
+            finalized_deploys: finalized_deploys.into_iter().collect(),
             next_finalized: next_finalized_height,
             finalization_queue: Default::default(),
         }

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -5,7 +5,7 @@ use derive_more::From;
 use fmt::Display;
 use serde::{Deserialize, Serialize};
 
-use super::{BlockHeight, BlockProposerDeploySets};
+use super::BlockHeight;
 use crate::{
     effect::requests::BlockProposerRequest,
     types::{DeployHash, DeployHeader, ProtoBlock},
@@ -81,8 +81,8 @@ pub enum Event {
     Request(BlockProposerRequest),
     /// The chainspec and previous sets have been successfully loaded from storage.
     Loaded {
-        /// Loaded previously stored block proposer sets.
-        sets: Option<BlockProposerDeploySets>,
+        /// Previously finalized deploys.
+        finalized_deploys: Vec<(DeployHash, DeployHeader)>,
         /// The height of the next expected finalized block.
         next_finalized_block: BlockHeight,
     },
@@ -105,20 +105,11 @@ impl Display for Event {
         match self {
             Event::Request(req) => write!(f, "block-proposer request: {}", req),
             Event::Loaded {
-                sets: Some(sets),
                 next_finalized_block,
+                ..
             } => write!(
                 f,
-                "loaded block-proposer deploy sets: {}; expected next finalized block: {}",
-                sets, next_finalized_block
-            ),
-            Event::Loaded {
-                sets: None,
-                next_finalized_block,
-            } => write!(
-                f,
-                "loaded block-proposer deploy sets, none found in storage; \
-                expected next finalized block: {}",
+                "loaded block-proposer finalized deploys; expected next finalized block: {}",
                 next_finalized_block
             ),
             Event::BufferDeploy { hash, .. } => write!(f, "block-proposer add {}", hash),

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -766,7 +766,8 @@ impl Storage {
                     .get_deploy_header(&mut txn, &deploy_hash)?
                     .expect("deploy to exist in storage");
                 // If block's deploy has already expired, ignore it.
-                // It may happen that deploy was not expired at the time of proposing a block but it is now.
+                // It may happen that deploy was not expired at the time of proposing a block but it
+                // is now.
                 if deploy_header.timestamp().elapsed() > ttl {
                     continue;
                 }

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -720,7 +720,7 @@ impl Storage {
 
     /// Returns vector blocks that satisfy the predicate, starting from the latest one and following
     /// the ancestry chain.
-    fn get_blocks_until<F, Tx: Transaction>(
+    fn get_blocks_while<F, Tx: Transaction>(
         &self,
         txn: &mut Tx,
         predicate: F,
@@ -755,18 +755,22 @@ impl Storage {
         // We're interested in deploys whose TTL hasn't expired yet.
         let ttl_expired = |block: &Block| block.timestamp().elapsed() < ttl;
         let mut deploys = Vec::new();
-        for block in self.get_blocks_until(&mut txn, ttl_expired)? {
-            for deploy_hash in block.body().deploy_hashes() {
+        for block in self.get_blocks_while(&mut txn, ttl_expired)? {
+            for deploy_hash in block
+                .body()
+                .deploy_hashes()
+                .iter()
+                .chain(block.body().transfer_hashes())
+            {
                 let deploy_header = self
                     .get_deploy_header(&mut txn, &deploy_hash)?
                     .expect("deploy to exist in storage");
+                // If block's deploy has already expired, ignore it.
+                // It may happen that deploy was not expired at the time of proposing a block but it is now.
+                if deploy_header.timestamp().elapsed() > ttl {
+                    continue;
+                }
                 deploys.push((*deploy_hash, deploy_header));
-            }
-            for transfer_hash in block.body().transfer_hashes() {
-                let deploy_header = self
-                    .get_deploy_header(&mut txn, &transfer_hash)?
-                    .expect("deploy to exist in storage");
-                deploys.push((*transfer_hash, deploy_header));
             }
         }
         Ok(deploys)

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -75,7 +75,7 @@ use crate::{
     reactor::ReactorEvent,
     types::{
         Block, BlockBody, BlockHash, BlockHeader, BlockSignatures, Deploy, DeployHash,
-        DeployMetadata,
+        DeployHeader, DeployMetadata, TimeDiff,
     },
     utils::WithDir,
     NodeRng,
@@ -449,15 +449,7 @@ impl Storage {
             StorageRequest::GetHighestBlock { responder } => {
                 let mut txn = self.env.begin_ro_txn()?;
                 responder
-                    .respond(
-                        self.block_height_index
-                            .keys()
-                            .last()
-                            .and_then(|&height| {
-                                self.get_block_by_height(&mut txn, height).transpose()
-                            })
-                            .transpose()?,
-                    )
+                    .respond(self.get_highest_block(&mut txn)?)
                     .ignore()
             }
             StorageRequest::GetSwitchBlockAtEraId { era_id, responder } => responder
@@ -695,6 +687,9 @@ impl Storage {
                     self.get_finality_signatures(&mut self.env.begin_ro_txn()?, &block_hash)?;
                 responder.respond(result).ignore()
             }
+            StorageRequest::GetFinalizedDeploys { ttl, responder } => {
+                responder.respond(self.get_finalized_deploys(ttl)?).ignore()
+            }
         })
     }
 
@@ -708,6 +703,73 @@ impl Storage {
             .get(&height)
             .and_then(|block_hash| self.get_single_block(tx, block_hash).transpose())
             .transpose()
+    }
+
+    /// Retrieves the highest block from the storage, if one exists.
+    /// May return an LMDB error.
+    fn get_highest_block<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+    ) -> Result<Option<Block>, LmdbExtError> {
+        self.block_height_index
+            .keys()
+            .last()
+            .and_then(|&height| self.get_block_by_height(txn, height).transpose())
+            .transpose()
+    }
+
+    /// Returns vector blocks that satisfy the predicate, starting from the latest one and following
+    /// the ancestry chain.
+    fn get_blocks_until<F, Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        predicate: F,
+    ) -> Result<Vec<Block>, LmdbExtError>
+    where
+        F: Fn(&Block) -> bool,
+    {
+        let mut next_block = self.get_highest_block(txn)?;
+        let mut blocks = Vec::new();
+        loop {
+            match next_block {
+                None => break,
+                Some(block) if !predicate(&block) => break,
+                Some(block) => {
+                    next_block = match block.parent() {
+                        None => None,
+                        Some(parent_hash) => self.get_single_block(txn, &parent_hash)?,
+                    };
+                    blocks.push(block);
+                }
+            }
+        }
+        Ok(blocks)
+    }
+
+    /// Returns the vector of deploys whose TTL hasn't expired yet.
+    fn get_finalized_deploys(
+        &self,
+        ttl: TimeDiff,
+    ) -> Result<Vec<(DeployHash, DeployHeader)>, LmdbExtError> {
+        let mut txn = self.env.begin_ro_txn()?;
+        // We're interested in deploys whose TTL hasn't expired yet.
+        let ttl_expired = |block: &Block| block.timestamp().elapsed() < ttl;
+        let mut deploys = Vec::new();
+        for block in self.get_blocks_until(&mut txn, ttl_expired)? {
+            for deploy_hash in block.body().deploy_hashes() {
+                let deploy_header = self
+                    .get_deploy_header(&mut txn, &deploy_hash)?
+                    .expect("deploy to exist in storage");
+                deploys.push((*deploy_hash, deploy_header));
+            }
+            for transfer_hash in block.body().transfer_hashes() {
+                let deploy_header = self
+                    .get_deploy_header(&mut txn, &transfer_hash)?
+                    .expect("deploy to exist in storage");
+                deploys.push((*transfer_hash, deploy_header));
+            }
+        }
+        Ok(deploys)
     }
 
     /// Retrieves single switch block by era ID by looking it up in the index and returning it.
@@ -788,6 +850,16 @@ impl Storage {
             .iter()
             .map(|deploy_hash| tx.get_value(self.deploy_db, deploy_hash))
             .collect()
+    }
+
+    /// Returns the deploy's header.
+    fn get_deploy_header<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        deploy_hash: &DeployHash,
+    ) -> Result<Option<DeployHeader>, LmdbExtError> {
+        let maybe_deploy: Option<Deploy> = txn.get_value(self.deploy_db, deploy_hash)?;
+        Ok(maybe_deploy.map(|deploy| deploy.header().clone()))
     }
 
     /// Retrieves deploy metadata associated with deploy.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -75,7 +75,9 @@ use datasize::DataSize;
 use futures::{channel::oneshot, future::BoxFuture, FutureExt};
 use serde::{de::DeserializeOwned, Serialize};
 use smallvec::{smallvec, SmallVec};
-use tracing::{error, warn};
+use tracing::error;
+#[cfg(not(feature = "fast-sync"))]
+use tracing::warn;
 
 use casper_execution_engine::{
     core::engine_state::{
@@ -1242,6 +1244,7 @@ impl<REv> EffectBuilder<REv> {
     /// Key must be a unique key across the the application, as all keys share a common namespace.
     ///
     /// If an error occurs during state loading or no data is found, returns `None`.
+    #[allow(unused)]
     pub(crate) async fn load_state<T>(self, key: Cow<'static, [u8]>) -> Option<T>
     where
         REv: From<StateStoreRequest>,
@@ -1268,12 +1271,28 @@ impl<REv> EffectBuilder<REv> {
         })
     }
 
+    /// Retrieves finalized deploys from blocks that were created more recently than the TTL.
+    pub(crate) async fn get_finalized_deploys(
+        self,
+        ttl: TimeDiff,
+    ) -> Vec<(DeployHash, DeployHeader)>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            move |responder| StorageRequest::GetFinalizedDeploys { ttl, responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Save state to storage.
     ///
     /// Key must be a unique key across the the application, as all keys share a common namespace.
     ///
     /// Returns whether or not storing the state was successful. A component that requires state to
     /// be successfully stored should check the return value and act accordingly.
+    #[cfg(not(feature = "fast-sync"))]
     pub(crate) async fn save_state<T>(self, key: Cow<'static, [u8]>, value: T) -> bool
     where
         REv: From<StateStoreRequest>,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -283,6 +283,14 @@ pub enum StorageRequest {
         /// Responder to call with the results.
         responder: Responder<Vec<Option<DeployHeader>>>,
     },
+    /// Retrieve deploys that are finalized and whose TTL hasn't expired yet.
+    GetFinalizedDeploys {
+        /// Maximum TTL of block we're interested in.
+        /// I.e. we don't want deploys from blocks that are older than this.
+        ttl: TimeDiff,
+        /// Responder to call with the results.
+        responder: Responder<Vec<(DeployHash, DeployHeader)>>,
+    },
     /// Store execution results for a set of deploys of a single block.
     ///
     /// Will return a fatal error if there are already execution results known for a specific
@@ -403,6 +411,9 @@ impl Display for StorageRequest {
             }
             StorageRequest::PutBlockSignatures { .. } => {
                 write!(formatter, "put finality signatures")
+            }
+            StorageRequest::GetFinalizedDeploys { ttl, .. } => {
+                write!(formatter, "get finalized deploys, ttl: {:?}", ttl)
             }
         }
     }

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1133,6 +1133,21 @@ impl Block {
         self.header.protocol_version
     }
 
+    /// Returns the hash of the parent block.
+    /// If the block is the first block in the linear chain returns `None`.
+    pub fn parent(&self) -> Option<&BlockHash> {
+        if self.header.is_genesis_child() {
+            None
+        } else {
+            Some(self.header.parent_hash())
+        }
+    }
+
+    /// Returns the timestamp of the block.
+    pub fn timestamp(&self) -> Timestamp {
+        self.header.timestamp()
+    }
+
     /// Check the integrity of a block by hashing its body and header
     pub fn verify(&self) -> Result<(), BlockValidationError> {
         let actual_body_hash = self.body.hash();


### PR DESCRIPTION
Instead of persisting the `BlockProposerDeploySets` to LMDB and loading in on startup, we recreate that state from the collection of finalized deploys.

This fixes a bug where that set would be incorrectly initialized for joining/restarting/upgrading nodes.