### PR TITLE
NDRS-1053: Add a parent to CandidateBlock.

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -474,7 +474,7 @@ impl BlockProposerReady {
             }
         }
 
-        ProtoBlock::new(wasm_deploys, transfers, random_bit)
+        ProtoBlock::new(wasm_deploys, transfers, block_timestamp, random_bit)
     }
 
     /// Prunes expired deploy information from the BlockProposer, returns the total deploys pruned.

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -31,6 +31,7 @@ use casper_types::{PublicKey, U512};
 
 use crate::{
     components::Component,
+    crypto::hash::Digest,
     effect::{
         announcements::ConsensusAnnouncement,
         requests::{
@@ -96,6 +97,7 @@ pub enum Event<I> {
         era_id: EraId,
         proto_block: ProtoBlock,
         block_context: BlockContext,
+        parent: Option<Digest>,
     },
     #[from]
     ConsensusRequest(ConsensusRequest),
@@ -189,10 +191,11 @@ impl<I: Debug> Display for Event<I> {
                 era_id,
                 proto_block,
                 block_context,
+                parent,
             } => write!(
                 f,
-                "New proto-block for era {:?}: {:?}, {:?}",
-                era_id, proto_block, block_context
+                "New proto-block for era {:?}: {:?}, {:?}, parent: {:?}",
+                era_id, proto_block, block_context, parent
             ),
             Event::ConsensusRequest(request) => write!(
                 f,
@@ -303,7 +306,8 @@ where
                 era_id,
                 proto_block,
                 block_context,
-            } => handling_es.handle_new_proto_block(era_id, proto_block, block_context),
+                parent,
+            } => handling_es.handle_new_proto_block(era_id, proto_block, block_context, parent),
             Event::ConsensusRequest(ConsensusRequest::HandleLinearBlock(block, responder)) => {
                 handling_es.handle_linear_chain_block(*block, responder)
             }

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -106,7 +106,6 @@ pub enum Event<I> {
         era_id: EraId,
         sender: I,
         proto_block: ProtoBlock,
-        timestamp: Timestamp,
         parent: Option<Digest>,
         valid: bool,
     },
@@ -207,14 +206,12 @@ impl<I: Debug> Display for Event<I> {
                 era_id,
                 sender,
                 proto_block,
-                timestamp,
                 parent,
                 valid,
             } => write!(
                 f,
-                "Candidate block received from {:?} at {} for {} with parent {:?} is {}: {:?}",
+                "Candidate block received from {:?} for {} with parent {:?} is {}: {:?}",
                 sender,
-                timestamp,
                 era_id,
                 parent,
                 if *valid { "valid" } else { "invalid" },
@@ -318,12 +315,9 @@ where
                 era_id,
                 sender,
                 proto_block,
-                timestamp,
                 parent,
                 valid,
-            } => {
-                handling_es.resolve_validity(era_id, sender, proto_block, timestamp, parent, valid)
-            }
+            } => handling_es.resolve_validity(era_id, sender, proto_block, parent, valid),
             Event::DeactivateEra {
                 era_id,
                 faulty_num,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -210,7 +210,7 @@ impl<I: Debug> Display for Event<I> {
                 valid,
             } => write!(
                 f,
-                "Candidate block received from {:?} for {} with parent {:?} is {}: {:?}",
+                "Proto-block received from {:?} for {} with parent {:?} is {}: {:?}",
                 sender,
                 era_id,
                 parent,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -107,6 +107,7 @@ pub enum Event<I> {
         sender: I,
         proto_block: ProtoBlock,
         timestamp: Timestamp,
+        parent: Option<Digest>,
         valid: bool,
     },
     /// Deactivate the era with the given ID, unless the number of faulty validators increases.
@@ -207,15 +208,17 @@ impl<I: Debug> Display for Event<I> {
                 sender,
                 proto_block,
                 timestamp,
+                parent,
                 valid,
             } => write!(
                 f,
-                "Proto-block received from {:?} at {} for {} is {}: {:?}",
+                "Candidate block received from {:?} at {} for {} with parent {:?} is {}: {:?}",
                 sender,
                 timestamp,
                 era_id,
+                parent,
                 if *valid { "valid" } else { "invalid" },
-                proto_block
+                proto_block,
             ),
             Event::DeactivateEra {
                 era_id, faulty_num, ..
@@ -316,8 +319,11 @@ where
                 sender,
                 proto_block,
                 timestamp,
+                parent,
                 valid,
-            } => handling_es.resolve_validity(era_id, sender, proto_block, timestamp, valid),
+            } => {
+                handling_es.resolve_validity(era_id, sender, proto_block, timestamp, parent, valid)
+            }
             Event::DeactivateEra {
                 era_id,
                 faulty_num,

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -45,22 +45,9 @@ impl CandidateBlock {
         &self.proto_block
     }
 
-    /// Returns the candidate block's timestamp, i.e. when the block was proposed.
-    ///
-    /// This is identical to the timestamp of the Highway unit, and the timestamp of the `Block`,
-    /// if it gets finalized.
-    pub(crate) fn timestamp(&self) -> Timestamp {
-        self.timestamp
-    }
-
     /// Returns the validators accused by this block.
     pub(crate) fn accusations(&self) -> &Vec<PublicKey> {
         &self.accusations
-    }
-
-    /// Returns the parent candidate block, or `Non` if this is the first in this era.
-    pub(crate) fn parent(&self) -> Option<&Digest> {
-        self.parent.as_ref()
     }
 }
 
@@ -94,5 +81,13 @@ impl ConsensusValueT for CandidateBlock {
 
     fn needs_validation(&self) -> bool {
         !self.proto_block.wasm_deploys().is_empty() || !self.proto_block.transfers().is_empty()
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.timestamp
+    }
+
+    fn parent(&self) -> Option<&Self::Hash> {
+        self.parent.as_ref()
     }
 }

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -20,6 +20,8 @@ pub(crate) struct CandidateBlock {
     proto_block: ProtoBlock,
     timestamp: Timestamp,
     accusations: Vec<PublicKey>,
+    /// The parent candidate block in this era, or `None` if this is the first block in this era.
+    parent: Option<Digest>,
 }
 
 impl CandidateBlock {
@@ -28,11 +30,13 @@ impl CandidateBlock {
         proto_block: ProtoBlock,
         timestamp: Timestamp,
         accusations: Vec<PublicKey>,
+        parent: Option<Digest>,
     ) -> Self {
         CandidateBlock {
             proto_block,
             timestamp,
             accusations,
+            parent,
         }
     }
 
@@ -69,12 +73,13 @@ impl ConsensusValueT for CandidateBlock {
             proto_block,
             timestamp,
             accusations,
+            parent,
         } = self;
         let mut result = [0; Digest::LENGTH];
 
         let mut hasher = VarBlake2b::new(Digest::LENGTH).expect("should create hasher");
         hasher.update(proto_block.hash().inner());
-        let data = (timestamp, accusations);
+        let data = (timestamp, accusations, parent);
         hasher.update(bincode::serialize(&data).expect("should serialize candidate block data"));
         hasher.finalize_variable(|slice| {
             result.copy_from_slice(slice);

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -57,6 +57,11 @@ impl CandidateBlock {
     pub(crate) fn accusations(&self) -> &Vec<PublicKey> {
         &self.accusations
     }
+
+    /// Returns the parent candidate block, or `Non` if this is the first in this era.
+    pub(crate) fn parent(&self) -> Option<&Digest> {
+        self.parent.as_ref()
+    }
 }
 
 impl From<CandidateBlock> for ProtoBlock {

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -93,6 +93,7 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     CreateNewBlock {
         block_context: BlockContext,
         past_values: Vec<C::ConsensusValue>,
+        parent_value: Option<C::ConsensusValue>,
     },
     /// A block was finalized.
     FinalizedBlock(FinalizedBlock<C>),

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -106,7 +106,6 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     ValidateConsensusValue {
         sender: I,
         consensus_value: C::ConsensusValue,
-        timestamp: Timestamp,
         ancestor_values: Vec<C::ConsensusValue>,
     },
     /// New direct evidence was added against the given validator.

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1165,33 +1165,36 @@ where
                     .filter(|pub_key| !self.has_evidence(era_id, **pub_key))
                     .cloned()
                     .collect();
-                let mut effects = Effects::new();
-                for pub_key in missing_evidence.iter().cloned() {
-                    let msg = ConsensusMessage::EvidenceRequest { era_id, pub_key };
-                    effects.extend(
-                        self.effect_builder
-                            .send_message(sender.clone(), msg.into())
-                            .ignore(),
-                    );
-                }
+                let cb_parent = candidate_block.parent().cloned();
                 self.era_mut(era_id)
-                    .add_candidate(candidate_block, missing_evidence);
+                    .add_candidate(candidate_block, missing_evidence.clone());
+                if cb_parent != ancestor_blocks.first().map(CandidateBlock::hash) {
+                    return self.resolve_validity(era_id, sender, proto_block, timestamp, false);
+                }
                 let proto_block_deploys_set: BTreeSet<DeployHash> =
                     proto_block.deploys_iter().cloned().collect();
                 for ancestor_block in ancestor_blocks {
                     let ancestor_proto_block = ancestor_block.proto_block();
                     for deploy in ancestor_proto_block.deploys_iter() {
                         if proto_block_deploys_set.contains(deploy) {
-                            effects.extend(self.resolve_validity(
+                            return self.resolve_validity(
                                 era_id,
                                 sender,
                                 proto_block,
                                 timestamp,
                                 false,
-                            ));
-                            return effects;
+                            );
                         }
                     }
+                }
+                let mut effects = Effects::new();
+                for pub_key in missing_evidence {
+                    let msg = ConsensusMessage::EvidenceRequest { era_id, pub_key };
+                    effects.extend(
+                        self.effect_builder
+                            .send_message(sender.clone(), msg.into())
+                            .ignore(),
+                    );
                 }
                 let effect_builder = self.effect_builder;
                 effects.extend(

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -789,8 +789,7 @@ where
             .filter(|pub_key| !self.era(era_id).slashed.contains(pub_key))
             .cloned()
             .collect();
-        let candidate_block =
-            CandidateBlock::new(proto_block, block_context.timestamp(), accusations, parent);
+        let candidate_block = CandidateBlock::new(proto_block, accusations, parent);
         self.delegate_to_era(era_id, move |consensus| {
             consensus.propose(candidate_block, block_context)
         })
@@ -1119,7 +1118,6 @@ where
                 });
                 let finalized_block = FinalizedBlock::new(
                     value.into(),
-                    timestamp,
                     era_end,
                     era_id,
                     era.start_height + height,

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -966,7 +966,6 @@ where
         era_id: EraId,
         sender: I,
         proto_block: ProtoBlock,
-        timestamp: Timestamp,
         parent: Option<Digest>,
         valid: bool,
     ) -> Effects<Event<I>> {
@@ -981,7 +980,7 @@ where
             effects.extend(self.disconnect(sender));
         }
         let candidate_blocks = if let Some(era) = self.era_supervisor.active_eras.get_mut(&era_id) {
-            era.resolve_validity(&proto_block, timestamp, parent, valid)
+            era.resolve_validity(&proto_block, parent, valid)
         } else {
             return effects;
         };
@@ -1177,7 +1176,6 @@ where
                                 era_id,
                                 sender,
                                 proto_block,
-                                timestamp,
                                 parent,
                                 false,
                             );
@@ -1425,7 +1423,6 @@ where
                             era_id: proto_block_era_id,
                             sender: sender.clone(),
                             proto_block: proto_block.clone(),
-                            timestamp,
                             parent,
                             valid: false,
                         });
@@ -1444,7 +1441,6 @@ where
         era_id: proto_block_era_id,
         sender,
         proto_block,
-        timestamp,
         parent,
         valid,
     })

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -14,7 +14,9 @@ use crate::{
     components::consensus::{
         candidate_block::CandidateBlock, cl_context::ClContext,
         consensus_protocol::ConsensusProtocol, protocols::highway::HighwayProtocol,
+        traits::ConsensusValueT,
     },
+    crypto::hash::Digest,
     types::{ProtoBlock, Timestamp},
 };
 
@@ -118,12 +120,13 @@ impl<I> Era<I> {
         &mut self,
         proto_block: &ProtoBlock,
         timestamp: Timestamp,
+        parent: Option<Digest>,
         valid: bool,
     ) -> Vec<CandidateBlock> {
         if valid {
-            self.accept_proto_block(proto_block, timestamp)
+            self.accept_proto_block(proto_block, timestamp, parent)
         } else {
-            self.reject_proto_block(proto_block, timestamp)
+            self.reject_proto_block(proto_block, timestamp, parent)
         }
     }
 
@@ -133,9 +136,13 @@ impl<I> Era<I> {
         &mut self,
         proto_block: &ProtoBlock,
         timestamp: Timestamp,
+        parent: Option<Digest>,
     ) -> Vec<CandidateBlock> {
         for pc in &mut self.candidates {
-            if pc.candidate.proto_block() == proto_block && pc.candidate.timestamp() == timestamp {
+            if pc.candidate.proto_block() == proto_block
+                && pc.candidate.timestamp() == timestamp
+                && pc.candidate.parent() == parent.as_ref()
+            {
                 pc.validated = true;
             }
         }
@@ -148,9 +155,12 @@ impl<I> Era<I> {
         &mut self,
         proto_block: &ProtoBlock,
         timestamp: Timestamp,
+        parent: Option<Digest>,
     ) -> Vec<CandidateBlock> {
         let (invalid, candidates): (Vec<_>, Vec<_>) = self.candidates.drain(..).partition(|pc| {
-            pc.candidate.proto_block() == proto_block && pc.candidate.timestamp() == timestamp
+            pc.candidate.proto_block() == proto_block
+                && pc.candidate.timestamp() == timestamp
+                && pc.candidate.parent() == parent.as_ref()
         });
         self.candidates = candidates;
         invalid.into_iter().map(|pc| pc.candidate).collect()

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -119,14 +119,13 @@ impl<I> Era<I> {
     pub(crate) fn resolve_validity(
         &mut self,
         proto_block: &ProtoBlock,
-        timestamp: Timestamp,
         parent: Option<Digest>,
         valid: bool,
     ) -> Vec<CandidateBlock> {
         if valid {
-            self.accept_proto_block(proto_block, timestamp, parent)
+            self.accept_proto_block(proto_block, parent)
         } else {
-            self.reject_proto_block(proto_block, timestamp, parent)
+            self.reject_proto_block(proto_block, parent)
         }
     }
 
@@ -135,13 +134,10 @@ impl<I> Era<I> {
     pub(crate) fn accept_proto_block(
         &mut self,
         proto_block: &ProtoBlock,
-        timestamp: Timestamp,
         parent: Option<Digest>,
     ) -> Vec<CandidateBlock> {
         for pc in &mut self.candidates {
-            if pc.candidate.proto_block() == proto_block
-                && pc.candidate.timestamp() == timestamp
-                && pc.candidate.parent() == parent.as_ref()
+            if pc.candidate.proto_block() == proto_block && pc.candidate.parent() == parent.as_ref()
             {
                 pc.validated = true;
             }
@@ -154,13 +150,10 @@ impl<I> Era<I> {
     pub(crate) fn reject_proto_block(
         &mut self,
         proto_block: &ProtoBlock,
-        timestamp: Timestamp,
         parent: Option<Digest>,
     ) -> Vec<CandidateBlock> {
         let (invalid, candidates): (Vec<_>, Vec<_>) = self.candidates.drain(..).partition(|pc| {
-            pc.candidate.proto_block() == proto_block
-                && pc.candidate.timestamp() == timestamp
-                && pc.candidate.parent() == parent.as_ref()
+            pc.candidate.proto_block() == proto_block && pc.candidate.parent() == parent.as_ref()
         });
         self.candidates = candidates;
         invalid.into_iter().map(|pc| pc.candidate).collect()

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -54,6 +54,14 @@ impl ConsensusValueT for ConsensusValue {
         std::hash::Hash::hash(&self, &mut hasher);
         hasher.finish()
     }
+
+    fn timestamp(&self) -> Timestamp {
+        0.into() // Not relevant for highway_core tests.
+    }
+
+    fn parent(&self) -> Option<&Self::Hash> {
+        None // Not relevant for highway_core tests.
+    }
 }
 
 const TEST_MIN_ROUND_EXP: u8 = 12;

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -66,6 +66,14 @@ impl ConsensusValueT for u32 {
     fn hash(&self) -> Self::Hash {
         *self
     }
+
+    fn timestamp(&self) -> Timestamp {
+        0.into() // Not relevant for highway_core tests.
+    }
+
+    fn parent(&self) -> Option<&Self::Hash> {
+        None // Not relevant for highway_core tests.
+    }
 }
 
 impl Context for TestContext {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -315,10 +315,23 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
         if let (Some(value), Some(timestamp), Some(swunit)) =
             (vertex.value(), vertex.timestamp(), vertex.unit())
         {
+            let panorama = &swunit.wire_unit().panorama;
+            let fork_choice = self.highway.state().fork_choice(panorama);
+            let parent_value =
+                fork_choice.map(|hash| self.highway.state().block(hash).value.hash());
+            if timestamp != value.timestamp() || parent_value.as_ref() != value.parent() {
+                info!(
+                    timestamp = %value.timestamp(), consensus_timestamp = %timestamp,
+                    parent = ?value.parent(), consensus_parent = ?parent_value,
+                    "consensus value does not match vertex"
+                );
+                let vertices = vec![vv.inner().id()];
+                let faulty_senders = self.synchronizer.drop_dependent_vertices(vertices);
+                outcomes.extend(faulty_senders.into_iter().map(ProtocolOutcome::Disconnect));
+                return outcomes;
+            }
             if value.needs_validation() {
                 self.log_proposal(vertex, "requesting proposal validation");
-                let panorama = &swunit.wire_unit().panorama;
-                let fork_choice = self.highway.state().fork_choice(panorama).cloned();
                 let ancestor_values = self.ancestors(fork_choice).cloned().collect();
                 let consensus_value = value.clone();
                 self.pending_values
@@ -328,7 +341,6 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                 outcomes.push(ProtocolOutcome::ValidateConsensusValue {
                     sender,
                     consensus_value,
-                    timestamp,
                     ancestor_values,
                 });
                 return outcomes;
@@ -418,15 +430,15 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     }
 
     /// Returns an iterator over all the values that are in parents of the given block.
-    fn ancestors(
-        &self,
-        mut maybe_hash: Option<C::Hash>,
-    ) -> impl Iterator<Item = &C::ConsensusValue> {
+    fn ancestors<'a>(
+        &'a self,
+        mut maybe_hash: Option<&'a C::Hash>,
+    ) -> impl Iterator<Item = &'a C::ConsensusValue> {
         iter::from_fn(move || {
             let hash = maybe_hash.take()?;
-            let block = self.highway.state().block(&hash);
+            let block = self.highway.state().block(hash);
             let value = Some(&block.value);
-            maybe_hash = block.parent().cloned();
+            maybe_hash = block.parent();
             value
         })
     }

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -226,10 +226,14 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                 block_context,
                 fork_choice,
             } => {
+                let parent_value = fork_choice
+                    .as_ref()
+                    .map(|hash| self.highway.state().block(hash).value.clone());
                 let past_values = self.non_finalized_values(fork_choice).cloned().collect();
                 vec![ProtocolOutcome::CreateNewBlock {
                     block_context,
                     past_values,
+                    parent_value,
                 }]
             }
             AvEffect::WeAreFaulty(fault) => {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -310,7 +310,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             }
         };
 
-        // If the vertex contains a consensus value, request validation.
+        // If the vertex contains a consensus value, i.e. it is a proposal, request validation.
         let vertex = vv.inner();
         if let (Some(value), Some(timestamp), Some(swunit)) =
             (vertex.value(), vertex.timestamp(), vertex.unit())
@@ -319,6 +319,8 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             let fork_choice = self.highway.state().fork_choice(panorama);
             let parent_value =
                 fork_choice.map(|hash| self.highway.state().block(hash).value.hash());
+            // The timestamp and parent are currently duplicated: The information in the consensus
+            // value must match the information in the Highway DAG.
             if timestamp != value.timestamp() || parent_value.as_ref() != value.parent() {
                 info!(
                     timestamp = %value.timestamp(), consensus_timestamp = %timestamp,

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -191,6 +191,7 @@ fn send_a_valid_wire_unit() {
             ProtoBlock::new(vec![], vec![], false),
             timestamp,
             vec![],
+            None,
         )),
         seq_number,
         timestamp,
@@ -227,7 +228,8 @@ fn detect_doppelganger() {
     let instance_id = ClContext::hash(INSTANCE_ID_DATA);
     let round_exp = 14;
     let timestamp = 0.into();
-    let value = CandidateBlock::new(ProtoBlock::new(vec![], vec![], false), timestamp, vec![]);
+    let proto_block = ProtoBlock::new(vec![], vec![], false);
+    let value = CandidateBlock::new(proto_block, timestamp, vec![], None);
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
         creator,

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -188,8 +188,7 @@ fn send_a_valid_wire_unit() {
         creator,
         instance_id: ClContext::hash(INSTANCE_ID_DATA),
         value: Some(CandidateBlock::new(
-            ProtoBlock::new(vec![], vec![], false),
-            timestamp,
+            ProtoBlock::new(vec![], vec![], timestamp, false),
             vec![],
             None,
         )),
@@ -228,8 +227,8 @@ fn detect_doppelganger() {
     let instance_id = ClContext::hash(INSTANCE_ID_DATA);
     let round_exp = 14;
     let timestamp = 0.into();
-    let proto_block = ProtoBlock::new(vec![], vec![], false);
-    let value = CandidateBlock::new(proto_block, timestamp, vec![], None);
+    let proto_block = ProtoBlock::new(vec![], vec![], timestamp, false);
+    let value = CandidateBlock::new(proto_block, vec![], None);
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
         creator,

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -6,6 +6,8 @@ use std::{
 use datasize::DataSize;
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::types::Timestamp;
+
 pub trait NodeIdT: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'static {}
 impl<I> NodeIdT for I where I: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'static {}
 
@@ -24,6 +26,12 @@ pub(crate) trait ConsensusValueT:
 
     /// Returns whether the consensus value needs validation.
     fn needs_validation(&self) -> bool;
+
+    /// Returns the value's timestamp.
+    fn timestamp(&self) -> Timestamp;
+
+    /// Returns the parent value, or `None` if this is the first block in this era.
+    fn parent(&self) -> Option<&Self::Hash>;
 }
 
 /// A hash, as an identifier for a block or unit.

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -91,21 +91,14 @@ static ERA_END: Lazy<EraEnd> = Lazy::new(|| {
 static FINALIZED_BLOCK: Lazy<FinalizedBlock> = Lazy::new(|| {
     let deploy_hashes = vec![*Deploy::doc_example().id()];
     let random_bit = true;
-    let proto_block = ProtoBlock::new(deploy_hashes, vec![], random_bit);
     let timestamp = *Timestamp::doc_example();
+    let proto_block = ProtoBlock::new(deploy_hashes, vec![], timestamp, random_bit);
     let era_report = Some(EraReport::doc_example().clone());
     let era: u64 = 1;
     let secret_key = SecretKey::doc_example();
     let public_key = PublicKey::from(secret_key);
 
-    FinalizedBlock::new(
-        proto_block,
-        timestamp,
-        era_report,
-        EraId(era),
-        era * 10,
-        public_key,
-    )
+    FinalizedBlock::new(proto_block, era_report, EraId(era), era * 10, public_key)
 });
 static BLOCK: Lazy<Block> = Lazy::new(|| {
     let parent_hash = BlockHash::new(Digest::from([7u8; Digest::LENGTH]));
@@ -230,6 +223,7 @@ pub struct ProtoBlock {
     hash: ProtoBlockHash,
     wasm_deploys: Vec<DeployHash>,
     transfers: Vec<DeployHash>,
+    timestamp: Timestamp,
     random_bit: bool,
 }
 
@@ -237,19 +231,18 @@ impl ProtoBlock {
     pub(crate) fn new(
         wasm_deploys: Vec<DeployHash>,
         transfers: Vec<DeployHash>,
+        timestamp: Timestamp,
         random_bit: bool,
     ) -> Self {
-        let deploys = wasm_deploys
-            .iter()
-            .chain(transfers.iter())
-            .collect::<Vec<_>>();
         let hash = ProtoBlockHash::new(hash::hash(
-            &bincode::serialize(&(&deploys, random_bit)).expect("serialize ProtoBlock"),
+            &bincode::serialize(&(&wasm_deploys, &transfers, timestamp, random_bit))
+                .expect("serialize ProtoBlock"),
         ));
 
         ProtoBlock {
             hash,
             wasm_deploys,
+            timestamp,
             transfers,
             random_bit,
         }
@@ -257,6 +250,11 @@ impl ProtoBlock {
 
     pub(crate) fn hash(&self) -> &ProtoBlockHash {
         &self.hash
+    }
+
+    /// Returns the time when this proto block was proposed.
+    pub(crate) fn timestamp(&self) -> Timestamp {
+        self.timestamp
     }
 
     /// The list of deploy hashes included in the block.
@@ -292,10 +290,11 @@ impl Display for ProtoBlock {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
-            "proto block {}, deploys [{}], random bit {}",
+            "proto block {}, deploys [{}], random bit {}, timestamp {}",
             self.hash.inner(),
             DisplayIter::new(self.wasm_deploys.iter().chain(self.transfers.iter())),
             self.random_bit(),
+            self.timestamp,
         )
     }
 }
@@ -366,7 +365,6 @@ impl DocExample for EraReport {
 #[derive(Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FinalizedBlock {
     proto_block: ProtoBlock,
-    timestamp: Timestamp,
     era_report: Option<EraReport>,
     era_id: EraId,
     height: u64,
@@ -376,7 +374,6 @@ pub struct FinalizedBlock {
 impl FinalizedBlock {
     pub(crate) fn new(
         proto_block: ProtoBlock,
-        timestamp: Timestamp,
         era_report: Option<EraReport>,
         era_id: EraId,
         height: u64,
@@ -384,7 +381,6 @@ impl FinalizedBlock {
     ) -> Self {
         FinalizedBlock {
             proto_block,
-            timestamp,
             era_report,
             era_id,
             height,
@@ -399,7 +395,7 @@ impl FinalizedBlock {
 
     /// The timestamp from when the proto block was proposed.
     pub(crate) fn timestamp(&self) -> Timestamp {
-        self.timestamp
+        self.proto_block.timestamp
     }
 
     /// Returns slashing and reward information if this is a switch block, i.e. the last block of
@@ -445,10 +441,10 @@ impl FinalizedBlock {
             .take(deploy_count)
             .collect();
         let random_bit = rng.gen();
-        let proto_block = ProtoBlock::new(deploy_hashes, vec![], random_bit);
-
         // TODO - make Timestamp deterministic.
         let timestamp = Timestamp::now();
+        let proto_block = ProtoBlock::new(deploy_hashes, vec![], timestamp, random_bit);
+
         let era_report = if is_switch {
             let equivocators_count = rng.gen_range(0..5);
             let rewards_count = rng.gen_range(0..5);
@@ -476,14 +472,7 @@ impl FinalizedBlock {
         let secret_key: SecretKey = SecretKey::ed25519(rng.gen());
         let public_key = PublicKey::from(&secret_key);
 
-        FinalizedBlock::new(
-            proto_block,
-            timestamp,
-            era_report,
-            era_id,
-            height,
-            public_key,
-        )
+        FinalizedBlock::new(proto_block, era_report, era_id, height, public_key)
     }
 }
 
@@ -498,6 +487,7 @@ impl From<Block> for FinalizedBlock {
         let proto_block = ProtoBlock::new(
             block.body.deploy_hashes().clone(),
             block.body.transfer_hashes().clone(),
+            block.timestamp(),
             block.header.random_bit,
         );
 
@@ -508,7 +498,6 @@ impl From<Block> for FinalizedBlock {
 
         FinalizedBlock {
             proto_block,
-            timestamp: block.header.timestamp,
             era_report,
             era_id: block.header.era_id,
             height: block.header.height,
@@ -528,7 +517,7 @@ impl Display for FinalizedBlock {
             self.height,
             HexList(&self.proto_block.wasm_deploys),
             self.proto_block.random_bit,
-            self.timestamp,
+            self.timestamp(),
         )?;
         if let Some(ee) = &self.era_report {
             write!(formatter, ", era_end: {}", ee)?;
@@ -1060,6 +1049,7 @@ impl Block {
 
         let era_id = finalized_block.era_id();
         let height = finalized_block.height();
+        let timestamp = finalized_block.timestamp();
 
         let era_end = match finalized_block.era_report {
             Some(era_report) => Some(EraEnd::new(era_report, next_era_validator_weights.unwrap())),
@@ -1082,7 +1072,7 @@ impl Block {
             random_bit: finalized_block.proto_block.random_bit,
             accumulated_seed: accumulated_seed.into(),
             era_end,
-            timestamp: finalized_block.timestamp,
+            timestamp,
             era_id,
             height,
             protocol_version,


### PR DESCRIPTION
With deploy replay protection the validity of a candidate block depends not only on its contents and its timestamp, but also on its ancestors. So if there are two different vertices with identical consensus values, i.e. candidate blocks, one of them could be valid and one invalid. Whether a node would consider them valid would depend on which one was received first, because that would determine the set of ancestors we check against.

Adding the parent hash makes candidate block ancestors explicit so that consensus can rely on the validity result again: If a candidate block is deemed valid, we know that all vertices that carry it are valid.

https://casperlabs.atlassian.net/browse/NDRS-1053