### PR TITLE
EE-1207: make definition of system account AccountHash consistent

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -47,7 +47,6 @@ use casper_types::{
     SecretKey, URef, U512,
 };
 
-use super::SYSTEM_ACCOUNT_ADDR;
 use crate::{
     core::{
         engine_state::{execution_effect::ExecutionEffect, EngineConfig},
@@ -248,7 +247,7 @@ impl GenesisAccount {
     /// The account hash for the account.
     pub fn account_hash(&self) -> AccountHash {
         match self {
-            GenesisAccount::System => SYSTEM_ACCOUNT_ADDR,
+            GenesisAccount::System => PublicKey::System.to_account_hash(),
             GenesisAccount::Account { public_key, .. } => public_key.to_account_hash(),
             GenesisAccount::Delegator {
                 delegator_public_key,
@@ -750,13 +749,15 @@ where
 
         let protocol_data = ProtocolData::default();
 
+        let system_account_addr = PublicKey::System.to_account_hash();
+
         let virtual_system_account = {
             let named_keys = NamedKeys::new();
             let purse = URef::new(Default::default(), AccessRights::READ_ADD_WRITE);
-            Account::create(SYSTEM_ACCOUNT_ADDR, named_keys, purse)
+            Account::create(system_account_addr, named_keys, purse)
         };
 
-        let key = Key::Account(SYSTEM_ACCOUNT_ADDR);
+        let key = Key::Account(system_account_addr);
         let value = { StoredValue::Account(virtual_system_account.clone()) };
 
         tracking_copy.borrow_mut().write(key, value);

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -91,8 +91,6 @@ use crate::{
 pub const MAX_PAYMENT_AMOUNT: u64 = 2_500_000_000;
 pub static MAX_PAYMENT: Lazy<U512> = Lazy::new(|| U512::from(MAX_PAYMENT_AMOUNT));
 
-pub const SYSTEM_ACCOUNT_ADDR: AccountHash = AccountHash::new([0u8; 32]);
-
 /// Gas/motes conversion rate of wasmless transfer cost is always 1 regardless of what user wants to
 /// pay.
 pub const WASMLESS_TRANSFER_FIXED_GAS_PRICE: u64 = 1;
@@ -977,7 +975,7 @@ where
             };
 
             let system_account = Account::new(
-                SYSTEM_ACCOUNT_ADDR,
+                PublicKey::System.to_account_hash(),
                 Default::default(),
                 URef::new(Default::default(), AccessRights::READ_ADD_WRITE),
                 Default::default(),
@@ -1186,7 +1184,7 @@ where
         // Finalization is executed by system account (currently genesis account)
         // payment_code_spec_5: system executes finalization
         let system_account = Account::new(
-            SYSTEM_ACCOUNT_ADDR,
+            PublicKey::System.to_account_hash(),
             Default::default(),
             URef::new(Default::default(), AccessRights::READ_ADD_WRITE),
             Default::default(),
@@ -1738,9 +1736,9 @@ where
         let virtual_system_account = {
             let named_keys = NamedKeys::new();
             let purse = URef::new(Default::default(), AccessRights::READ_ADD_WRITE);
-            Account::create(SYSTEM_ACCOUNT_ADDR, named_keys, purse)
+            Account::create(PublicKey::System.to_account_hash(), named_keys, purse)
         };
-        let authorization_keys = BTreeSet::from_iter(vec![SYSTEM_ACCOUNT_ADDR]);
+        let authorization_keys = BTreeSet::from_iter(vec![PublicKey::System.to_account_hash()]);
         let blocktime = BlockTime::default();
         let deploy_hash = {
             // seeds address generator w/ protocol version
@@ -1861,14 +1859,16 @@ where
         self.system_contract_cache
             .initialize_with_protocol_data(&protocol_data, &system_module);
 
+        let system_account_addr = PublicKey::System.to_account_hash();
+
         let virtual_system_account = {
             let named_keys = NamedKeys::new();
             let purse = URef::new(Default::default(), AccessRights::READ_ADD_WRITE);
-            Account::create(SYSTEM_ACCOUNT_ADDR, named_keys, purse)
+            Account::create(system_account_addr, named_keys, purse)
         };
         let authorization_keys = {
             let mut ret = BTreeSet::new();
-            ret.insert(SYSTEM_ACCOUNT_ADDR);
+            ret.insert(system_account_addr);
             ret
         };
         let mut named_keys = auction_contract.named_keys().to_owned();

--- a/execution_engine/src/core/runtime_context/mod.rs
+++ b/execution_engine/src/core/runtime_context/mod.rs
@@ -17,12 +17,12 @@ use casper_types::{
     system::auction::EraInfo,
     AccessRights, BlockTime, CLType, CLValue, Contract, ContractPackage, ContractPackageHash,
     DeployHash, DeployInfo, EntryPointAccess, EntryPointType, Key, KeyTag, Phase, ProtocolVersion,
-    RuntimeArgs, Transfer, TransferAddr, URef, KEY_HASH_LENGTH,
+    PublicKey, RuntimeArgs, Transfer, TransferAddr, URef, KEY_HASH_LENGTH,
 };
 
 use crate::{
     core::{
-        engine_state::{execution_effect::ExecutionEffect, SYSTEM_ACCOUNT_ADDR},
+        engine_state::execution_effect::ExecutionEffect,
         execution::{AddressGenerator, Error},
         tracking_copy::{AddResult, TrackingCopy},
         Address,
@@ -759,7 +759,7 @@ where
     where
         T: Into<Gas>,
     {
-        if self.account.account_hash() == SYSTEM_ACCOUNT_ADDR {
+        if self.account.account_hash() == PublicKey::System.to_account_hash() {
             // Don't try to charge a system account for calling a system contract's entry point.
             // This will make sure that (for example) calling a mint's transfer from within auction
             // wouldn't try to incur cost to system account.

--- a/execution_engine_testing/test_support/src/internal/mod.rs
+++ b/execution_engine_testing/test_support/src/internal/mod.rs
@@ -120,3 +120,4 @@ pub static DEFAULT_RUN_GENESIS_REQUEST: Lazy<RunGenesisRequest> = Lazy::new(|| {
         DEFAULT_EXEC_CONFIG.clone(),
     )
 });
+pub static SYSTEM_ADDR: Lazy<AccountHash> = Lazy::new(|| PublicKey::System.to_account_hash());

--- a/execution_engine_testing/test_support/src/internal/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/internal/wasm_test_builder.rs
@@ -23,7 +23,7 @@ use casper_execution_engine::{
             run_genesis_request::RunGenesisRequest,
             step::{StepRequest, StepResult},
             BalanceResult, EngineConfig, EngineState, GenesisResult, GetBidsRequest, QueryRequest,
-            QueryResult, UpgradeConfig, UpgradeResult, SYSTEM_ACCOUNT_ADDR,
+            QueryResult, UpgradeConfig, UpgradeResult,
         },
         execution,
     },
@@ -66,7 +66,7 @@ use casper_types::{
 };
 
 use crate::internal::{
-    utils, ExecuteRequestBuilder, DEFAULT_PROPOSER_ADDR, DEFAULT_PROTOCOL_VERSION,
+    utils, ExecuteRequestBuilder, DEFAULT_PROPOSER_ADDR, DEFAULT_PROTOCOL_VERSION, SYSTEM_ADDR,
 };
 
 /// LMDB initial map size is calculated based on DEFAULT_LMDB_PAGES and systems page size.
@@ -336,7 +336,7 @@ where
     }
 
     pub fn run_genesis(&mut self, run_genesis_request: &RunGenesisRequest) -> &mut Self {
-        let system_account = Key::Account(SYSTEM_ACCOUNT_ADDR);
+        let system_account = Key::Account(PublicKey::System.to_account_hash());
 
         let genesis_result = self
             .engine_state
@@ -547,10 +547,9 @@ where
         era_end_timestamp_millis: u64,
         evicted_validators: Vec<PublicKey>,
     ) -> &mut Self {
-        const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
         let auction = self.get_auction_contract_hash();
         let run_request = ExecuteRequestBuilder::contract_call_by_hash(
-            SYSTEM_ADDR,
+            *SYSTEM_ADDR,
             auction,
             METHOD_RUN_AUCTION,
             runtime_args! {

--- a/execution_engine_testing/tests/src/test/contract_api/mint_purse.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/mint_purse.rs
@@ -1,12 +1,11 @@
 use casper_engine_test_support::{
-    internal::{ExecuteRequestBuilder, WasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
+    internal::{ExecuteRequestBuilder, WasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST, SYSTEM_ADDR},
     DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_types::{account::AccountHash, runtime_args, RuntimeArgs, U512};
+use casper_types::{runtime_args, RuntimeArgs, U512};
 
 const CONTRACT_MINT_PURSE: &str = "mint_purse.wasm";
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
-const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 const TRANSFER_AMOUNT: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 
 #[ignore]
@@ -15,11 +14,11 @@ fn should_run_mint_purse_contract() {
     let exec_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
-        runtime_args! { "target" =>SYSTEM_ADDR, "amount" => U512::from(TRANSFER_AMOUNT) },
+        runtime_args! { "target" => *SYSTEM_ADDR, "amount" => U512::from(TRANSFER_AMOUNT) },
     )
     .build();
     let exec_request_2 =
-        ExecuteRequestBuilder::standard(SYSTEM_ADDR, CONTRACT_MINT_PURSE, RuntimeArgs::default())
+        ExecuteRequestBuilder::standard(*SYSTEM_ADDR, CONTRACT_MINT_PURSE, RuntimeArgs::default())
             .build();
 
     let mut builder = WasmTestBuilder::default();

--- a/execution_engine_testing/tests/src/test/regression/ee_1045.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1045.rs
@@ -5,7 +5,7 @@ use casper_engine_test_support::{
     internal::{
         utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS,
         DEFAULT_AUCTION_DELAY, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
-        DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, TIMESTAMP_MILLIS_INCREMENT,
+        DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, SYSTEM_ADDR, TIMESTAMP_MILLIS_INCREMENT,
     },
     DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
@@ -14,7 +14,6 @@ use casper_execution_engine::{
     shared::motes::Motes,
 };
 use casper_types::{
-    account::AccountHash,
     runtime_args,
     system::auction::{DelegationRate, ARG_VALIDATOR_PUBLIC_KEYS, INITIAL_ERA_ID, METHOD_SLASH},
     PublicKey, RuntimeArgs, SecretKey, U512,
@@ -46,8 +45,6 @@ static ACCOUNT_4_PK: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([206; SecretKey::ED25519_LENGTH]).into());
 const ACCOUNT_4_BALANCE: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 const ACCOUNT_4_BOND: u64 = 200_000;
-
-const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 
 #[ignore]
 #[test]
@@ -105,7 +102,7 @@ fn should_run_ee_1045_squash_validators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -132,7 +129,7 @@ fn should_run_ee_1045_squash_validators() {
             ARG_VALIDATOR_PUBLIC_KEYS => round_1_validator_squash.clone(),
         };
         ExecuteRequestBuilder::contract_call_by_hash(
-            SYSTEM_ADDR,
+            *SYSTEM_ADDR,
             auction_contract,
             METHOD_SLASH,
             args,
@@ -145,7 +142,7 @@ fn should_run_ee_1045_squash_validators() {
             ARG_VALIDATOR_PUBLIC_KEYS => round_2_validator_squash.clone(),
         };
         ExecuteRequestBuilder::contract_call_by_hash(
-            SYSTEM_ADDR,
+            *SYSTEM_ADDR,
             auction_contract,
             METHOD_SLASH,
             args,

--- a/execution_engine_testing/tests/src/test/regression/ee_1103.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1103.rs
@@ -4,7 +4,7 @@ use once_cell::sync::Lazy;
 use casper_engine_test_support::{
     internal::{
         utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS,
-        DEFAULT_GENESIS_TIMESTAMP_MILLIS, DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
+        DEFAULT_GENESIS_TIMESTAMP_MILLIS, DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, SYSTEM_ADDR,
         TIMESTAMP_MILLIS_INCREMENT,
     },
     MINIMUM_ACCOUNT_CREATION_BALANCE,
@@ -26,7 +26,6 @@ const ARG_AMOUNT: &str = "amount";
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
 const CONTRACT_DELEGATE: &str = "delegate.wasm";
 const TRANSFER_AMOUNT: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
-const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 
 static FAUCET: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([1; SecretKey::ED25519_LENGTH]).into());
@@ -105,7 +104,7 @@ fn validator_scores_should_reflect_delegates() {
         *FAUCET_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )

--- a/execution_engine_testing/tests/src/test/regression/ee_1119.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1119.rs
@@ -5,7 +5,7 @@ use casper_engine_test_support::{
     internal::{
         utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS,
         DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
-        DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
+        DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, SYSTEM_ADDR,
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
@@ -39,7 +39,6 @@ const TRANSFER_AMOUNT: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
 const ARG_AMOUNT: &str = "amount";
 const ARG_PUBLIC_KEY: &str = "public_key";
 
-const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 static VALIDATOR_1: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([3; SecretKey::ED25519_LENGTH]).into());
 static VALIDATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_1));
@@ -73,7 +72,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" => *SYSTEM_ADDR,
             "amount" => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -195,7 +194,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
     );
 
     let slash_request_1 = ExecuteRequestBuilder::contract_call_by_hash(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         auction,
         METHOD_SLASH,
         runtime_args! {
@@ -223,7 +222,7 @@ fn should_run_ee_1119_dont_slash_delegated_validators() {
         builder.get_value(builder.get_mint_contract_hash(), TOTAL_SUPPLY_KEY);
 
     let slash_request_2 = ExecuteRequestBuilder::contract_call_by_hash(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         auction,
         METHOD_SLASH,
         runtime_args! {

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -4,7 +4,9 @@ use num_traits::Zero;
 use once_cell::sync::Lazy;
 
 use casper_engine_test_support::{
-    internal::{utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS},
+    internal::{
+        utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS, SYSTEM_ADDR,
+    },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
 use casper_execution_engine::{
@@ -12,7 +14,7 @@ use casper_execution_engine::{
     shared::motes::Motes,
 };
 use casper_types::{
-    account::{AccountHash, ACCOUNT_HASH_LENGTH},
+    account::AccountHash,
     runtime_args,
     system::auction::{
         Bids, DelegationRate, UnbondingPurses, ARG_DELEGATOR, ARG_VALIDATOR,
@@ -43,7 +45,6 @@ static VALIDATOR_2: Lazy<PublicKey> =
 static DELEGATOR_1: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([5; SecretKey::ED25519_LENGTH]).into());
 
-static SYSTEM_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::new([0u8; ACCOUNT_HASH_LENGTH]));
 static VALIDATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_1));
 static VALIDATOR_2_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*VALIDATOR_2));
 static DELEGATOR_1_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*DELEGATOR_1));

--- a/execution_engine_testing/tests/src/test/regression/ee_1152.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1152.rs
@@ -11,9 +11,7 @@ use casper_engine_test_support::{
     MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
 use casper_execution_engine::{
-    core::engine_state::{
-        genesis::GenesisValidator, GenesisAccount, RewardItem, SYSTEM_ACCOUNT_ADDR,
-    },
+    core::engine_state::{genesis::GenesisValidator, GenesisAccount, RewardItem},
     shared::motes::Motes,
 };
 use casper_types::{
@@ -69,7 +67,10 @@ fn should_run_ee_1152_regression_test() {
     let fund_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
-        runtime_args! { ARG_TARGET => SYSTEM_ACCOUNT_ADDR, ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE) },
+        runtime_args! {
+            ARG_TARGET => PublicKey::System.to_account_hash(),
+            ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE)
+        },
     )
     .build();
 

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -9,7 +9,7 @@ use casper_engine_test_support::{
         utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS,
         DEFAULT_AUCTION_DELAY, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
         DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_RUN_GENESIS_REQUEST, DEFAULT_UNBONDING_DELAY,
-        TIMESTAMP_MILLIS_INCREMENT,
+        SYSTEM_ADDR, TIMESTAMP_MILLIS_INCREMENT,
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
@@ -49,7 +49,6 @@ const CONTRACT_DELEGATE: &str = "delegate.wasm";
 const CONTRACT_UNDELEGATE: &str = "undelegate.wasm";
 
 const TRANSFER_AMOUNT: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE + 1000;
-const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 
 const ADD_BID_AMOUNT_1: u64 = 95_000;
 const ADD_BID_AMOUNT_2: u64 = 47_500;
@@ -264,7 +263,7 @@ fn should_run_delegate_and_undelegate() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -444,7 +443,7 @@ fn should_calculate_era_validators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -597,7 +596,7 @@ fn should_get_first_seigniorage_recipients() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -745,7 +744,7 @@ fn should_release_founder_stake() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE / 10)
         },
     )
@@ -982,7 +981,7 @@ fn should_calculate_era_validators_multiple_new_bids() {
 
     // Fund additional accounts
     for target in &[
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         *NON_FOUNDER_VALIDATOR_1_ADDR,
         *NON_FOUNDER_VALIDATOR_2_ADDR,
     ] {
@@ -1066,7 +1065,7 @@ fn undelegated_funds_should_be_released() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(SYSTEM_TRANSFER_AMOUNT)
         },
     )
@@ -1190,7 +1189,7 @@ fn fully_undelegated_funds_should_be_released() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(SYSTEM_TRANSFER_AMOUNT)
         },
     )
@@ -1315,7 +1314,7 @@ fn should_undelegate_delegators_when_validator_unbonds() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1563,7 +1562,7 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1820,7 +1819,7 @@ fn should_handle_evictions() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(SYSTEM_TRANSFER_AMOUNT)
         },
     )
@@ -2332,7 +2331,7 @@ fn should_not_undelegate_vfta_holder_stake() {
             *DEFAULT_ACCOUNT_ADDR,
             CONTRACT_TRANSFER_TO_ACCOUNT,
             runtime_args! {
-                ARG_TARGET => SYSTEM_ADDR,
+                ARG_TARGET => *SYSTEM_ADDR,
                 ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE)
             },
         )
@@ -2515,7 +2514,7 @@ fn should_release_vfta_holder_stake() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE)
         },
     )
@@ -2638,7 +2637,7 @@ fn should_reset_delegators_stake_after_slashing() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(SYSTEM_TRANSFER_AMOUNT)
         },
     )
@@ -2797,7 +2796,7 @@ fn should_reset_delegators_stake_after_slashing() {
     assert!(validator_2_delegator_stakes_1 > U512::zero());
 
     let slash_request_1 = ExecuteRequestBuilder::contract_call_by_hash(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         auction_hash,
         auction::METHOD_SLASH,
         runtime_args! {
@@ -2844,7 +2843,7 @@ fn should_reset_delegators_stake_after_slashing() {
     );
 
     let slash_request_2 = ExecuteRequestBuilder::contract_call_by_hash(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         auction_hash,
         auction::METHOD_SLASH,
         runtime_args! {

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -8,7 +8,7 @@ use casper_engine_test_support::{
         ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
         DEFAULT_GENESIS_TIMESTAMP_MILLIS, DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS,
         DEFAULT_PROTOCOL_VERSION, DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_RUN_GENESIS_REQUEST,
-        TIMESTAMP_MILLIS_INCREMENT,
+        SYSTEM_ADDR, TIMESTAMP_MILLIS_INCREMENT,
     },
     DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
@@ -32,7 +32,6 @@ const CONTRACT_AUCTION_BIDS: &str = "auction_bids.wasm";
 const CONTRACT_ADD_BID: &str = "add_bid.wasm";
 const CONTRACT_DELEGATE: &str = "delegate.wasm";
 const TRANSFER_AMOUNT: u64 = MINIMUM_ACCOUNT_CREATION_BALANCE;
-const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 
 static VALIDATOR_1: Lazy<PublicKey> =
     Lazy::new(|| SecretKey::ed25519([3; SecretKey::ED25519_LENGTH]).into());
@@ -154,7 +153,7 @@ fn should_distribute_delegation_rate_zero() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -261,7 +260,7 @@ fn should_distribute_delegation_rate_zero() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -392,7 +391,7 @@ fn should_withdraw_bids_after_distribute() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -499,7 +498,7 @@ fn should_withdraw_bids_after_distribute() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -666,7 +665,7 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -773,7 +772,7 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
     };
 
     let distribute_request_1 = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -872,7 +871,7 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
     assert!(total_supply_2 > initial_supply);
 
     let distribute_request_2 = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -1042,7 +1041,7 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1151,7 +1150,7 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
     };
 
     let distribute_request_1 = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -1260,7 +1259,7 @@ fn should_distribute_reinvested_rewards_by_different_factor() {
     };
 
     let distribute_request_2 = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -1433,7 +1432,7 @@ fn should_distribute_delegation_rate_half() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1540,7 +1539,7 @@ fn should_distribute_delegation_rate_half() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -1629,7 +1628,7 @@ fn should_distribute_delegation_rate_full() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1736,7 +1735,7 @@ fn should_distribute_delegation_rate_full() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -1830,7 +1829,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -1937,7 +1936,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -2032,7 +2031,7 @@ fn should_distribute_by_factor() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -2141,7 +2140,7 @@ fn should_distribute_by_factor() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -2243,7 +2242,7 @@ fn should_distribute_by_factor_regardless_of_stake() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -2352,7 +2351,7 @@ fn should_distribute_by_factor_regardless_of_stake() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -2455,7 +2454,7 @@ fn should_distribute_by_factor_uneven() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -2564,7 +2563,7 @@ fn should_distribute_by_factor_uneven() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -2667,7 +2666,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -2845,7 +2844,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -2993,7 +2992,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -3171,7 +3170,7 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -3351,7 +3350,7 @@ fn should_increase_total_supply_after_distribute() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -3541,7 +3540,7 @@ fn should_increase_total_supply_after_distribute() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -3574,7 +3573,7 @@ fn should_distribute_delegation_rate_full_after_upgrading() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            ARG_TARGET => SYSTEM_ADDR,
+            ARG_TARGET => *SYSTEM_ADDR,
             ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -3681,7 +3680,7 @@ fn should_distribute_delegation_rate_full_after_upgrading() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,
@@ -3763,7 +3762,7 @@ fn should_distribute_delegation_rate_full_after_upgrading() {
     };
 
     let distribute_request = ExecuteRequestBuilder::standard(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         CONTRACT_AUCTION_BIDS,
         runtime_args! {
             ARG_ENTRY_POINT => METHOD_DISTRIBUTE,

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -6,7 +6,8 @@ use casper_engine_test_support::{
         utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
         DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_PUBLIC_KEY, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
         DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS, DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION,
-        DEFAULT_RUN_GENESIS_REQUEST, DEFAULT_UNBONDING_DELAY, TIMESTAMP_MILLIS_INCREMENT,
+        DEFAULT_RUN_GENESIS_REQUEST, DEFAULT_UNBONDING_DELAY, SYSTEM_ADDR,
+        TIMESTAMP_MILLIS_INCREMENT,
     },
     DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
@@ -48,7 +49,6 @@ const ARG_ENTRY_POINT: &str = "entry_point";
 const ARG_ACCOUNT_HASH: &str = "account_hash";
 const ARG_DELEGATION_RATE: &str = "delegation_rate";
 
-const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 const DELEGATION_RATE: DelegationRate = 42;
 
 #[ignore]
@@ -62,7 +62,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" => *SYSTEM_ADDR,
             "amount" => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -170,7 +170,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
     assert_eq!(unbond_era_2, unbond_era_1);
 
     let exec_request_5 = ExecuteRequestBuilder::contract_call_by_hash(
-        SYSTEM_ADDR,
+        *SYSTEM_ADDR,
         auction,
         METHOD_SLASH,
         runtime_args! {
@@ -361,7 +361,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" => *SYSTEM_ADDR,
             "amount" => U512::from(TRANSFER_AMOUNT)
         },
     )
@@ -535,7 +535,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_TO_ACCOUNT,
         runtime_args! {
-            "target" => SYSTEM_ADDR,
+            "target" => *SYSTEM_ADDR,
             "amount" => U512::from(TRANSFER_AMOUNT)
         },
     )

--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -13,7 +13,6 @@ use casper_execution_engine::{
     core::engine_state::{
         genesis::{ExecConfig, GenesisAccount, GenesisValidator},
         run_genesis_request::RunGenesisRequest,
-        SYSTEM_ACCOUNT_ADDR,
     },
     shared::{motes::Motes, stored_value::StoredValue},
 };
@@ -92,7 +91,7 @@ fn should_run_genesis() {
     builder.run_genesis(&run_genesis_request);
 
     let system_account = builder
-        .get_account(SYSTEM_ACCOUNT_ADDR)
+        .get_account(PublicKey::System.to_account_hash())
         .expect("system account should exist");
 
     let account_1 = builder

--- a/execution_engine_testing/tests/src/test/system_contracts/handle_payment/finalize_payment.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/handle_payment/finalize_payment.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use casper_engine_test_support::{
     internal::{
         DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_PAYMENT,
-        DEFAULT_RUN_GENESIS_REQUEST,
+        DEFAULT_RUN_GENESIS_REQUEST, SYSTEM_ADDR,
     },
     DEFAULT_ACCOUNT_ADDR, MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
@@ -17,7 +17,6 @@ const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm
 const FINALIZE_PAYMENT: &str = "finalize_payment.wasm";
 const LOCAL_REFUND_PURSE: &str = "local_refund_purse";
 
-const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 const ACCOUNT_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 pub const ARG_AMOUNT: &str = "amount";
 pub const ARG_AMOUNT_SPENT: &str = "amount_spent";
@@ -31,7 +30,10 @@ fn initialize() -> InMemoryWasmTestBuilder {
     let exec_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_PURSE_TO_ACCOUNT,
-        runtime_args! { ARG_TARGET => SYSTEM_ADDR, ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE) },
+        runtime_args! {
+            ARG_TARGET => *SYSTEM_ADDR,
+            ARG_AMOUNT => U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE)
+        },
     )
     .build();
 

--- a/types/src/system/auction/constants.rs
+++ b/types/src/system/auction/constants.rs
@@ -1,9 +1,6 @@
-use crate::{account::AccountHash, system::auction::EraId};
+use crate::system::auction::EraId;
 
 use super::DelegationRate;
-
-/// System account hash.
-pub const SYSTEM_ACCOUNT: AccountHash = AccountHash::new([0; 32]);
 
 /// Initial value of era id we start at genesis.
 pub const INITIAL_ERA_ID: EraId = 0;

--- a/types/src/system/auction/detail.rs
+++ b/types/src/system/auction/detail.rs
@@ -187,7 +187,7 @@ where
 ///
 /// This function can be called by the system only.
 pub(crate) fn process_unbond_requests<P: Auction + ?Sized>(provider: &mut P) -> Result<(), Error> {
-    if provider.get_caller() != SYSTEM_ACCOUNT {
+    if provider.get_caller() != PublicKey::System.to_account_hash() {
         return Err(Error::InvalidCaller);
     }
 

--- a/types/src/system/auction/mod.rs
+++ b/types/src/system/auction/mod.rs
@@ -310,7 +310,7 @@ pub trait Auction:
     ///
     /// This can be only invoked through a system call.
     fn slash(&mut self, validator_public_keys: Vec<PublicKey>) -> Result<(), Error> {
-        if self.get_caller() != SYSTEM_ACCOUNT {
+        if self.get_caller() != PublicKey::System.to_account_hash() {
             return Err(Error::InvalidCaller);
         }
 
@@ -357,7 +357,7 @@ pub trait Auction:
         era_end_timestamp_millis: u64,
         evicted_validators: Vec<PublicKey>,
     ) -> Result<(), Error> {
-        if self.get_caller() != SYSTEM_ACCOUNT {
+        if self.get_caller() != PublicKey::System.to_account_hash() {
             return Err(Error::InvalidCaller);
         }
 
@@ -456,7 +456,7 @@ pub trait Auction:
     /// Mint and distribute seigniorage rewards to validators and their delegators,
     /// according to `reward_factors` returned by the consensus component.
     fn distribute(&mut self, reward_factors: BTreeMap<PublicKey, u64>) -> Result<(), Error> {
-        if self.get_caller() != SYSTEM_ACCOUNT {
+        if self.get_caller() != PublicKey::System.to_account_hash() {
             return Err(Error::InvalidCaller);
         }
 

--- a/types/src/system/handle_payment/mod.rs
+++ b/types/src/system/handle_payment/mod.rs
@@ -53,13 +53,10 @@ mod internal {
     use crate::{
         account::AccountHash,
         system::handle_payment::{Error, MintProvider, RuntimeProvider},
-        Key, Phase, URef, U512,
+        Key, Phase, PublicKey, URef, U512,
     };
 
     use super::{PAYMENT_PURSE_KEY, REFUND_PERCENTAGE, REFUND_PURSE_KEY};
-
-    /// Account used to run system functions (in particular `finalize_payment`).
-    const SYSTEM_ACCOUNT: AccountHash = AccountHash::new([0u8; 32]);
 
     /// Returns the purse for accepting payment for transactions.
     pub fn get_payment_purse<R: RuntimeProvider>(runtime_provider: &R) -> Result<URef, Error> {
@@ -106,7 +103,7 @@ mod internal {
         target: URef,
     ) -> Result<(), Error> {
         let caller = provider.get_caller();
-        if caller != SYSTEM_ACCOUNT {
+        if caller != PublicKey::System.to_account_hash() {
             return Err(Error::SystemFunctionCalledByUserAccount);
         }
 

--- a/types/src/system/mint/mod.rs
+++ b/types/src/system/mint/mod.rs
@@ -7,14 +7,12 @@ mod system_provider;
 
 use num_rational::Ratio;
 
-use crate::{account::AccountHash, Key, URef, U512};
+use crate::{account::AccountHash, Key, PublicKey, URef, U512};
 
 pub use crate::system::mint::{
     constants::*, error::Error, runtime_provider::RuntimeProvider,
     storage_provider::StorageProvider, system_provider::SystemProvider,
 };
-
-const SYSTEM_ACCOUNT: AccountHash = AccountHash::new([0; 32]);
 
 /// Mint trait.
 pub trait Mint: RuntimeProvider + StorageProvider + SystemProvider {
@@ -23,7 +21,7 @@ pub trait Mint: RuntimeProvider + StorageProvider + SystemProvider {
     fn mint(&mut self, initial_balance: U512) -> Result<URef, Error> {
         let caller = self.get_caller();
         let is_empty_purse = initial_balance.is_zero();
-        if !is_empty_purse && caller != SYSTEM_ACCOUNT {
+        if !is_empty_purse && caller != PublicKey::System.to_account_hash() {
             return Err(Error::InvalidNonEmptyPurseCreation);
         }
 
@@ -54,7 +52,7 @@ pub trait Mint: RuntimeProvider + StorageProvider + SystemProvider {
     fn reduce_total_supply(&mut self, amount: U512) -> Result<(), Error> {
         // only system may reduce total supply
         let caller = self.get_caller();
-        if caller != SYSTEM_ACCOUNT {
+        if caller != PublicKey::System.to_account_hash() {
             return Err(Error::InvalidTotalSupplyReductionAttempt);
         }
 


### PR DESCRIPTION
This change will change the `AccountHash` bytes of the system account to:
```
blake2b(b"system0")
```
(as defined by `AccountHash::from_public_key`)