### PR TITLE
NDRS-1025: Make get_era_validators take parameters directly from ChainspecLoader

### DIFF
--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -150,6 +150,7 @@ impl Display for NextUpgrade {
     }
 }
 
+/// Basic information about the current run of the node software.
 #[derive(Clone, Debug)]
 pub struct CurrentRunInfo {
     pub activation_point: ActivationPoint,

--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -94,7 +94,7 @@ impl Display for Event {
             }
             Event::CommitGenesisResult(_) => write!(formatter, "commit genesis result"),
             Event::UpgradeResult(_) => write!(formatter, "contract runtime upgrade result"),
-            Event::Request(_) => write!(formatter, "chainspec_loader request"),
+            Event::Request(req) => write!(formatter, "chainspec_loader request: {}", req),
             Event::CheckForNextUpgrade => {
                 write!(formatter, "check for next upgrade")
             }
@@ -148,6 +148,13 @@ impl Display for NextUpgrade {
             self.activation_point.era_id()
         )
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct CurrentRunInfo {
+    pub activation_point: ActivationPoint,
+    pub protocol_version: ProtocolVersion,
+    pub initial_state_root_hash: Digest,
 }
 
 #[derive(Clone, DataSize, Debug)]
@@ -542,6 +549,20 @@ impl ChainspecLoader {
         )
     }
 
+    fn get_current_run_info(&self) -> CurrentRunInfo {
+        let version = &self.chainspec.protocol_config.version;
+        let protocol_version = ProtocolVersion::from_parts(
+            version.major as u32,
+            version.minor as u32,
+            version.patch as u32,
+        );
+        CurrentRunInfo {
+            activation_point: self.chainspec.protocol_config.activation_point,
+            protocol_version,
+            initial_state_root_hash: self.initial_state_root_hash,
+        }
+    }
+
     fn check_for_next_upgrade<REv>(&self, effect_builder: EffectBuilder<REv>) -> Effects<Event>
     where
         REv: From<ChainspecLoaderAnnouncement> + Send,
@@ -608,6 +629,9 @@ where
             Event::UpgradeResult(result) => self.handle_upgrade_result(result),
             Event::Request(ChainspecLoaderRequest::GetChainspecInfo(responder)) => {
                 responder.respond(self.new_chainspec_info()).ignore()
+            }
+            Event::Request(ChainspecLoaderRequest::GetCurrentRunInfo(responder)) => {
+                responder.respond(self.get_current_run_info()).ignore()
             }
             Event::CheckForNextUpgrade => self.check_for_next_upgrade(effect_builder),
             Event::GotNextUpgrade(next_upgrade) => self.handle_got_next_upgrade(next_upgrade),

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -28,7 +28,7 @@ use prometheus::Registry;
 use rand::Rng;
 use tracing::{debug, error, info, trace, warn};
 
-use casper_types::{AsymmetricType, EraId, ProtocolVersion, PublicKey, SecretKey, U512};
+use casper_types::{AsymmetricType, EraId, PublicKey, SecretKey, U512};
 
 use crate::{
     components::consensus::{
@@ -134,7 +134,6 @@ where
         config: WithDir<Config>,
         effect_builder: EffectBuilder<REv>,
         protocol_config: ProtocolConfig,
-        initial_state_root_hash: Digest,
         maybe_latest_block_header: Option<&BlockHeader>,
         next_upgrade_activation_point: Option<ActivationPoint>,
         registry: &Registry,
@@ -154,11 +153,6 @@ where
         info!(our_id = %public_signing_key, "EraSupervisor pubkey",);
         let metrics = ConsensusMetrics::new(registry)
             .expect("failure to setup and register ConsensusMetrics");
-        let protocol_version = ProtocolVersion::from_parts(
-            protocol_config.protocol_version.major as u32,
-            protocol_config.protocol_version.minor as u32,
-            protocol_config.protocol_version.patch as u32,
-        );
         let activation_era_id = protocol_config.last_activation_point;
         let auction_delay = protocol_config.auction_delay;
         #[allow(clippy::integer_arithmetic)] // Block height should never reach u64::MAX.
@@ -212,12 +206,7 @@ where
                 (key_blocks, booking_blocks, Default::default())
             } else {
                 let activation_era_validators = effect_builder
-                    .get_era_validators(
-                        activation_era_id,
-                        activation_era_id,
-                        initial_state_root_hash,
-                        protocol_version,
-                    )
+                    .get_era_validators(activation_era_id)
                     .await
                     .unwrap_or_default();
                 (key_blocks, booking_blocks, activation_era_validators)

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -19,7 +19,10 @@ use crate::{
     crypto::hash::Digest,
     effect::{
         announcements::LinearChainAnnouncement,
-        requests::{ContractRuntimeRequest, LinearChainRequest, NetworkRequest, StorageRequest},
+        requests::{
+            ChainspecLoaderRequest, ContractRuntimeRequest, LinearChainRequest, NetworkRequest,
+            StorageRequest,
+        },
         EffectBuilder, EffectExt, EffectResultExt, Effects,
     },
     protocol::Message,
@@ -348,6 +351,7 @@ where
         + From<NetworkRequest<I, Message>>
         + From<LinearChainAnnouncement>
         + From<ContractRuntimeRequest>
+        + From<ChainspecLoaderRequest>
         + Send,
     I: Display + Send + 'static,
 {
@@ -519,8 +523,6 @@ where
                 // Check if the validator is bonded in the era in which the block was created.
                 // TODO: Use protocol version that is valid for the block's height.
                 let protocol_version = self.protocol_version;
-                let initial_state_root_hash = self.initial_state_root_hash;
-                let activation_era_id = self.activation_era_id;
                 let latest_state_root_hash = self
                     .latest_block
                     .as_ref()
@@ -529,8 +531,6 @@ where
                     .is_bonded_validator(
                         fs.public_key,
                         fs.era_id,
-                        activation_era_id,
-                        initial_state_root_hash,
                         latest_state_root_hash,
                         protocol_version,
                     )

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -37,6 +37,7 @@ use casper_types::{
 use super::Responder;
 use crate::{
     components::{
+        chainspec_loader::CurrentRunInfo,
         contract_runtime::{EraValidatorsRequest, ValidatorWeightsByEraIdRequest},
         deploy_acceptor::Error,
         fetcher::FetchResult,
@@ -936,12 +937,15 @@ pub enum ConsensusRequest {
 pub enum ChainspecLoaderRequest {
     /// Chainspec info request.
     GetChainspecInfo(Responder<ChainspecInfo>),
+    /// Request for information about the current run.
+    GetCurrentRunInfo(Responder<CurrentRunInfo>),
 }
 
 impl Display for ChainspecLoaderRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ChainspecLoaderRequest::GetChainspecInfo(_) => write!(f, "get chainspec info"),
+            ChainspecLoaderRequest::GetCurrentRunInfo(_) => write!(f, "get current run info"),
         }
     }
 }

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -466,7 +466,6 @@ impl reactor::Reactor for Reactor {
             WithDir::new(root, config.consensus),
             effect_builder,
             chainspec_loader.chainspec().as_ref().into(),
-            chainspec_loader.initial_state_root_hash(),
             latest_block.as_ref().map(Block::header),
             maybe_next_activation_point,
             registry,


### PR DESCRIPTION
`get_era_validators` currently takes `activation_era_id`, `initial_state_root_hash` and `protocol_version` as arguments. All these values could, and should, be taken directly from the Chainspec Loader via a new request (or a set of new requests), so that the components calling `get_era_validators` won't have to store them.

https://casperlabs.atlassian.net/browse/NDRS-1025