### PR TITLE
NDRS-{1052,1053}: Prevent deploy replays. (Ports #1216, #1218, #1219, #1223 to dev.)

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -488,7 +488,7 @@ impl BlockProposerReady {
             }
         }
 
-        ProtoBlock::new(wasm_deploys, transfers, random_bit)
+        ProtoBlock::new(wasm_deploys, transfers, block_timestamp, random_bit)
     }
 
     /// Prunes expired deploy information from the BlockProposer, returns the total deploys pruned.

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -42,10 +42,20 @@ impl Default for BlockProposerDeploySets {
 }
 
 impl BlockProposerDeploySets {
-    pub(super) fn with_next_finalized(self, next_finalized: BlockHeight) -> Self {
+    /// Constructs the instance of `BlockProposerDeploySets` from the list of finalized deploys.
+    pub(super) fn from_finalized(
+        stored_deploys: Vec<(DeployHash, DeployHeader)>,
+        next_finalized_height: u64,
+    ) -> BlockProposerDeploySets {
+        let mut finalized_deploys: HashMap<DeployHash, DeployHeader> = HashMap::new();
+        for (hash, header) in stored_deploys.into_iter() {
+            finalized_deploys.insert(hash, header);
+        }
         BlockProposerDeploySets {
-            next_finalized,
-            ..self
+            pending: HashMap::new(),
+            finalized_deploys,
+            next_finalized: next_finalized_height,
+            finalization_queue: Default::default(),
         }
     }
 }

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -42,7 +42,6 @@ impl Default for BlockProposerDeploySets {
 }
 
 impl BlockProposerDeploySets {
-    
     /// Constructs the instance of `BlockProposerDeploySets` from the list of finalized deploys.
     pub(super) fn from_finalized(
         finalized_deploys: Vec<(DeployHash, DeployHeader)>,

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -42,18 +42,15 @@ impl Default for BlockProposerDeploySets {
 }
 
 impl BlockProposerDeploySets {
+    
     /// Constructs the instance of `BlockProposerDeploySets` from the list of finalized deploys.
     pub(super) fn from_finalized(
-        stored_deploys: Vec<(DeployHash, DeployHeader)>,
+        finalized_deploys: Vec<(DeployHash, DeployHeader)>,
         next_finalized_height: u64,
     ) -> BlockProposerDeploySets {
-        let mut finalized_deploys: HashMap<DeployHash, DeployHeader> = HashMap::new();
-        for (hash, header) in stored_deploys.into_iter() {
-            finalized_deploys.insert(hash, header);
-        }
         BlockProposerDeploySets {
             pending: HashMap::new(),
-            finalized_deploys,
+            finalized_deploys: finalized_deploys.into_iter().collect(),
             next_finalized: next_finalized_height,
             finalization_queue: Default::default(),
         }

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -5,7 +5,7 @@ use derive_more::From;
 use fmt::Display;
 use serde::{Deserialize, Serialize};
 
-use super::{BlockHeight, BlockProposerDeploySets};
+use super::BlockHeight;
 use crate::{
     effect::requests::BlockProposerRequest,
     types::{DeployHash, DeployHeader, ProtoBlock},
@@ -81,8 +81,8 @@ pub enum Event {
     Request(BlockProposerRequest),
     /// The chainspec and previous sets have been successfully loaded from storage.
     Loaded {
-        /// Loaded previously stored block proposer sets.
-        sets: Option<BlockProposerDeploySets>,
+        /// Previously finalized deploys.
+        finalized_deploys: Vec<(DeployHash, DeployHeader)>,
         /// The height of the next expected finalized block.
         next_finalized_block: BlockHeight,
     },
@@ -105,20 +105,11 @@ impl Display for Event {
         match self {
             Event::Request(req) => write!(f, "block-proposer request: {}", req),
             Event::Loaded {
-                sets: Some(sets),
                 next_finalized_block,
+                ..
             } => write!(
                 f,
-                "loaded block-proposer deploy sets: {}; expected next finalized block: {}",
-                sets, next_finalized_block
-            ),
-            Event::Loaded {
-                sets: None,
-                next_finalized_block,
-            } => write!(
-                f,
-                "loaded block-proposer deploy sets, none found in storage; \
-                expected next finalized block: {}",
+                "loaded block-proposer finalized deploys; expected next finalized block: {}",
                 next_finalized_block
             ),
             Event::BufferDeploy { hash, .. } => write!(f, "block-proposer add {}", hash),

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -149,11 +149,20 @@ where
                 responder,
                 block_timestamp,
             }) => {
-                let block_deploys = block
-                    .deploys()
+                let block_deploys = block.deploys();
+                let deploy_count = block_deploys.len();
+                // Collect the deploys in a set; this also deduplicates them.
+                let block_deploys: HashSet<_> = block_deploys
                     .iter()
                     .map(|deploy_hash| **deploy_hash)
-                    .collect::<HashSet<_>>();
+                    .collect();
+                if block_deploys.len() != deploy_count {
+                    info!(
+                        deploys = ?block.deploys(), ?sender,
+                        "received invalid block containing duplicated deploys"
+                    );
+                    return responder.respond((false, block)).ignore();
+                }
                 if block_deploys.is_empty() {
                     // If there are no deploys, return early.
                     return responder.respond((true, block)).ignore();

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -106,7 +106,6 @@ pub enum Event<I> {
         era_id: EraId,
         sender: I,
         proto_block: ProtoBlock,
-        timestamp: Timestamp,
         parent: Option<Digest>,
         valid: bool,
     },
@@ -206,14 +205,12 @@ impl<I: Debug> Display for Event<I> {
                 era_id,
                 sender,
                 proto_block,
-                timestamp,
                 parent,
                 valid,
             } => write!(
                 f,
-                "Candidate block received from {:?} at {} for {} with parent {:?} is {}: {:?}",
+                "Candidate block received from {:?} for {} with parent {:?} is {}: {:?}",
                 sender,
-                timestamp,
                 era_id,
                 parent,
                 if *valid { "valid" } else { "invalid" },
@@ -308,12 +305,9 @@ where
                 era_id,
                 sender,
                 proto_block,
-                timestamp,
                 parent,
                 valid,
-            } => {
-                handling_es.resolve_validity(era_id, sender, proto_block, timestamp, parent, valid)
-            }
+            } => handling_es.resolve_validity(era_id, sender, proto_block, parent, valid),
             Event::DeactivateEra {
                 era_id,
                 faulty_num,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -209,7 +209,7 @@ impl<I: Debug> Display for Event<I> {
                 valid,
             } => write!(
                 f,
-                "Candidate block received from {:?} for {} with parent {:?} is {}: {:?}",
+                "Proto-block received from {:?} for {} with parent {:?} is {}: {:?}",
                 sender,
                 era_id,
                 parent,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -107,6 +107,7 @@ pub enum Event<I> {
         sender: I,
         proto_block: ProtoBlock,
         timestamp: Timestamp,
+        parent: Option<Digest>,
         valid: bool,
     },
     /// Deactivate the era with the given ID, unless the number of faulty validators increases.
@@ -206,15 +207,17 @@ impl<I: Debug> Display for Event<I> {
                 sender,
                 proto_block,
                 timestamp,
+                parent,
                 valid,
             } => write!(
                 f,
-                "Proto-block received from {:?} at {} for {} is {}: {:?}",
+                "Candidate block received from {:?} at {} for {} with parent {:?} is {}: {:?}",
                 sender,
                 timestamp,
                 era_id,
+                parent,
                 if *valid { "valid" } else { "invalid" },
-                proto_block
+                proto_block,
             ),
             Event::DeactivateEra {
                 era_id, faulty_num, ..
@@ -306,8 +309,11 @@ where
                 sender,
                 proto_block,
                 timestamp,
+                parent,
                 valid,
-            } => handling_es.resolve_validity(era_id, sender, proto_block, timestamp, valid),
+            } => {
+                handling_es.resolve_validity(era_id, sender, proto_block, timestamp, parent, valid)
+            }
             Event::DeactivateEra {
                 era_id,
                 faulty_num,

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -32,6 +32,7 @@ use casper_types::{EraId, PublicKey, U512};
 
 use crate::{
     components::Component,
+    crypto::hash::Digest,
     effect::{
         announcements::ConsensusAnnouncement,
         requests::{
@@ -94,6 +95,7 @@ pub enum Event<I> {
         era_id: EraId,
         proto_block: ProtoBlock,
         block_context: BlockContext,
+        parent: Option<Digest>,
     },
     #[from]
     ConsensusRequest(ConsensusRequest),
@@ -183,10 +185,11 @@ impl<I: Debug> Display for Event<I> {
                 era_id,
                 proto_block,
                 block_context,
+                parent,
             } => write!(
                 f,
-                "New proto-block for era {:?}: {:?}, {:?}",
-                era_id, proto_block, block_context
+                "New proto-block for era {:?}: {:?}, {:?}, parent: {:?}",
+                era_id, proto_block, block_context, parent
             ),
             Event::ConsensusRequest(request) => write!(
                 f,
@@ -295,7 +298,8 @@ where
                 era_id,
                 proto_block,
                 block_context,
-            } => handling_es.handle_new_proto_block(era_id, proto_block, block_context),
+                parent,
+            } => handling_es.handle_new_proto_block(era_id, proto_block, block_context, parent),
             Event::BlockAdded(block) => handling_es.handle_block_added(*block),
             Event::ResolveValidity {
                 era_id,

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -45,22 +45,9 @@ impl CandidateBlock {
         &self.proto_block
     }
 
-    /// Returns the candidate block's timestamp, i.e. when the block was proposed.
-    ///
-    /// This is identical to the timestamp of the Highway unit, and the timestamp of the `Block`,
-    /// if it gets finalized.
-    pub(crate) fn timestamp(&self) -> Timestamp {
-        self.timestamp
-    }
-
     /// Returns the validators accused by this block.
     pub(crate) fn accusations(&self) -> &Vec<PublicKey> {
         &self.accusations
-    }
-
-    /// Returns the parent candidate block, or `Non` if this is the first in this era.
-    pub(crate) fn parent(&self) -> Option<&Digest> {
-        self.parent.as_ref()
     }
 }
 
@@ -94,5 +81,13 @@ impl ConsensusValueT for CandidateBlock {
 
     fn needs_validation(&self) -> bool {
         !self.proto_block.wasm_deploys().is_empty() || !self.proto_block.transfers().is_empty()
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.timestamp
+    }
+
+    fn parent(&self) -> Option<&Self::Hash> {
+        self.parent.as_ref()
     }
 }

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -20,6 +20,8 @@ pub(crate) struct CandidateBlock {
     proto_block: ProtoBlock,
     timestamp: Timestamp,
     accusations: Vec<PublicKey>,
+    /// The parent candidate block in this era, or `None` if this is the first block in this era.
+    parent: Option<Digest>,
 }
 
 impl CandidateBlock {
@@ -28,11 +30,13 @@ impl CandidateBlock {
         proto_block: ProtoBlock,
         timestamp: Timestamp,
         accusations: Vec<PublicKey>,
+        parent: Option<Digest>,
     ) -> Self {
         CandidateBlock {
             proto_block,
             timestamp,
             accusations,
+            parent,
         }
     }
 
@@ -69,12 +73,13 @@ impl ConsensusValueT for CandidateBlock {
             proto_block,
             timestamp,
             accusations,
+            parent,
         } = self;
         let mut result = [0; Digest::LENGTH];
 
         let mut hasher = VarBlake2b::new(Digest::LENGTH).expect("should create hasher");
         hasher.update(proto_block.hash().inner());
-        let data = (timestamp, accusations);
+        let data = (timestamp, accusations, parent);
         hasher.update(bincode::serialize(&data).expect("should serialize candidate block data"));
         hasher.finalize_variable(|slice| {
             result.copy_from_slice(slice);

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -57,6 +57,11 @@ impl CandidateBlock {
     pub(crate) fn accusations(&self) -> &Vec<PublicKey> {
         &self.accusations
     }
+
+    /// Returns the parent candidate block, or `Non` if this is the first in this era.
+    pub(crate) fn parent(&self) -> Option<&Digest> {
+        self.parent.as_ref()
+    }
 }
 
 impl From<CandidateBlock> for ProtoBlock {

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -102,7 +102,12 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     /// The domain logic should verify any intrinsic validity conditions of consensus values, e.g.
     /// that it has the expected structure, or that deploys that are mentioned by hash actually
     /// exist, and then call `ConsensusProtocol::resolve_validity`.
-    ValidateConsensusValue(I, C::ConsensusValue, Timestamp),
+    ValidateConsensusValue {
+        sender: I,
+        consensus_value: C::ConsensusValue,
+        timestamp: Timestamp,
+        ancestor_values: Vec<C::ConsensusValue>,
+    },
     /// New direct evidence was added against the given validator.
     NewEvidence(C::ValidatorId),
     /// Send evidence about the validator from an earlier era to the peer.

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -93,6 +93,7 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     CreateNewBlock {
         block_context: BlockContext,
         past_values: Vec<C::ConsensusValue>,
+        parent_value: Option<C::ConsensusValue>,
     },
     /// A block was finalized.
     FinalizedBlock(FinalizedBlock<C>),

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -106,7 +106,6 @@ pub(crate) enum ProtocolOutcome<I, C: Context> {
     ValidateConsensusValue {
         sender: I,
         consensus_value: C::ConsensusValue,
-        timestamp: Timestamp,
         ancestor_values: Vec<C::ConsensusValue>,
     },
     /// New direct evidence was added against the given validator.

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -721,8 +721,7 @@ where
             .filter(|pub_key| !self.era(era_id).slashed.contains(pub_key))
             .cloned()
             .collect();
-        let candidate_block =
-            CandidateBlock::new(proto_block, block_context.timestamp(), accusations, parent);
+        let candidate_block = CandidateBlock::new(proto_block, accusations, parent);
         self.delegate_to_era(era_id, move |consensus| {
             consensus.propose(candidate_block, block_context, Timestamp::now())
         })
@@ -1039,7 +1038,6 @@ where
                 });
                 let finalized_block = FinalizedBlock::new(
                     value.into(),
-                    timestamp,
                     era_end,
                     era_id,
                     era.start_height + height,

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -882,7 +882,6 @@ where
         era_id: EraId,
         sender: I,
         proto_block: ProtoBlock,
-        timestamp: Timestamp,
         parent: Option<Digest>,
         valid: bool,
     ) -> Effects<Event<I>> {
@@ -897,7 +896,7 @@ where
             effects.extend(self.disconnect(sender));
         }
         let candidate_blocks = if let Some(era) = self.era_supervisor.active_eras.get_mut(&era_id) {
-            era.resolve_validity(&proto_block, timestamp, parent, valid)
+            era.resolve_validity(&proto_block, parent, valid)
         } else {
             return effects;
         };
@@ -1097,7 +1096,6 @@ where
                                 era_id,
                                 sender,
                                 proto_block,
-                                timestamp,
                                 parent,
                                 false,
                             );
@@ -1318,7 +1316,6 @@ where
                             era_id: proto_block_era_id,
                             sender: sender.clone(),
                             proto_block: proto_block.clone(),
-                            timestamp,
                             parent,
                             valid: false,
                         });
@@ -1337,7 +1334,6 @@ where
         era_id: proto_block_era_id,
         sender,
         proto_block,
-        timestamp,
         parent,
         valid,
     })

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1062,7 +1062,12 @@ where
                 self.era_supervisor.update_consensus_pause();
                 effects
             }
-            ProtocolOutcome::ValidateConsensusValue(sender, candidate_block, timestamp) => {
+            ProtocolOutcome::ValidateConsensusValue {
+                sender,
+                consensus_value: candidate_block,
+                timestamp,
+                ancestor_values: _ancestor_blocks,
+            } => {
                 if !self.era_supervisor.is_bonded(era_id) {
                     return Effects::new();
                 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -55,6 +55,11 @@ use crate::{
 };
 
 pub use self::era::Era;
+use crate::{
+    effect::requests::BlockValidationRequest,
+    types::{DeployHash, DeployMetadata},
+};
+use std::collections::BTreeSet;
 
 /// The delay in milliseconds before we shutdown after the number of faulty validators exceeded the
 /// fault tolerance threshold.
@@ -1066,7 +1071,7 @@ where
                 sender,
                 consensus_value: candidate_block,
                 timestamp,
-                ancestor_values: _ancestor_blocks,
+                ancestor_values: ancestor_blocks,
             } => {
                 if !self.era_supervisor.is_bonded(era_id) {
                     return Effects::new();
@@ -1089,16 +1094,36 @@ where
                 }
                 self.era_mut(era_id)
                     .add_candidate(candidate_block, missing_evidence);
+                let proto_block_deploys_set: BTreeSet<DeployHash> =
+                    proto_block.deploys_iter().cloned().collect();
+                for ancestor_block in ancestor_blocks {
+                    let ancestor_proto_block = ancestor_block.proto_block();
+                    for deploy in ancestor_proto_block.deploys_iter() {
+                        if proto_block_deploys_set.contains(deploy) {
+                            effects.extend(self.resolve_validity(
+                                era_id,
+                                sender,
+                                proto_block,
+                                timestamp,
+                                false,
+                            ));
+                            return effects;
+                        }
+                    }
+                }
+                let effect_builder = self.effect_builder;
                 effects.extend(
-                    self.effect_builder
-                        .validate_block(sender.clone(), proto_block, timestamp)
-                        .event(move |(valid, proto_block)| Event::ResolveValidity {
+                    async move {
+                        check_deploys_for_replay_and_validate_block(
+                            effect_builder,
                             era_id,
                             sender,
                             proto_block,
                             timestamp,
-                            valid,
-                        }),
+                        )
+                        .await
+                    }
+                    .event(std::convert::identity),
                 );
                 effects
             }
@@ -1222,4 +1247,59 @@ pub(crate) fn oldest_bonded_era(protocol_config: &ProtocolConfig, current_era: E
     current_era
         .saturating_sub(bonded_eras(protocol_config))
         .max(protocol_config.last_activation_point)
+}
+
+async fn check_deploys_for_replay_and_validate_block<REv, I>(
+    effect_builder: EffectBuilder<REv>,
+    proto_block_era_id: EraId,
+    sender: I,
+    proto_block: ProtoBlock,
+    timestamp: Timestamp,
+) -> Event<I>
+where
+    REv: From<BlockValidationRequest<ProtoBlock, I>> + From<StorageRequest>,
+    I: Clone + Send + 'static,
+{
+    for deploy_hash in proto_block.deploys_iter() {
+        let execution_results = match effect_builder
+            .get_deploy_and_metadata_from_storage(*deploy_hash)
+            .await
+        {
+            None => continue,
+            Some((_, DeployMetadata { execution_results })) => execution_results,
+        };
+        for (block_hash, _) in execution_results {
+            match effect_builder
+                .get_block_header_from_storage(block_hash)
+                .await
+            {
+                // TODO: Throw an error here and use fatal! elsewhere
+                None => continue,
+                Some(block_header) => {
+                    if block_header.era_id() < proto_block_era_id {
+                        return Event::ResolveValidity {
+                            era_id: proto_block_era_id,
+                            sender: sender.clone(),
+                            proto_block: proto_block.clone(),
+                            timestamp,
+                            valid: false,
+                        };
+                    }
+                }
+            }
+        }
+    }
+
+    let sender_for_validate_block: I = sender.clone();
+    let (valid, proto_block) = effect_builder
+        .validate_block(sender_for_validate_block, proto_block, timestamp)
+        .await;
+
+    Event::ResolveValidity {
+        era_id: proto_block_era_id,
+        sender,
+        proto_block,
+        timestamp,
+        valid,
+    }
 }

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -14,7 +14,9 @@ use crate::{
     components::consensus::{
         candidate_block::CandidateBlock, cl_context::ClContext,
         consensus_protocol::ConsensusProtocol, protocols::highway::HighwayProtocol,
+        traits::ConsensusValueT,
     },
+    crypto::hash::Digest,
     types::{ProtoBlock, Timestamp},
 };
 
@@ -118,12 +120,13 @@ impl<I> Era<I> {
         &mut self,
         proto_block: &ProtoBlock,
         timestamp: Timestamp,
+        parent: Option<Digest>,
         valid: bool,
     ) -> Vec<CandidateBlock> {
         if valid {
-            self.accept_proto_block(proto_block, timestamp)
+            self.accept_proto_block(proto_block, timestamp, parent)
         } else {
-            self.reject_proto_block(proto_block, timestamp)
+            self.reject_proto_block(proto_block, timestamp, parent)
         }
     }
 
@@ -133,9 +136,13 @@ impl<I> Era<I> {
         &mut self,
         proto_block: &ProtoBlock,
         timestamp: Timestamp,
+        parent: Option<Digest>,
     ) -> Vec<CandidateBlock> {
         for pc in &mut self.candidates {
-            if pc.candidate.proto_block() == proto_block && pc.candidate.timestamp() == timestamp {
+            if pc.candidate.proto_block() == proto_block
+                && pc.candidate.timestamp() == timestamp
+                && pc.candidate.parent() == parent.as_ref()
+            {
                 pc.validated = true;
             }
         }
@@ -148,9 +155,12 @@ impl<I> Era<I> {
         &mut self,
         proto_block: &ProtoBlock,
         timestamp: Timestamp,
+        parent: Option<Digest>,
     ) -> Vec<CandidateBlock> {
         let (invalid, candidates): (Vec<_>, Vec<_>) = self.candidates.drain(..).partition(|pc| {
-            pc.candidate.proto_block() == proto_block && pc.candidate.timestamp() == timestamp
+            pc.candidate.proto_block() == proto_block
+                && pc.candidate.timestamp() == timestamp
+                && pc.candidate.parent() == parent.as_ref()
         });
         self.candidates = candidates;
         invalid.into_iter().map(|pc| pc.candidate).collect()

--- a/node/src/components/consensus/era_supervisor/era.rs
+++ b/node/src/components/consensus/era_supervisor/era.rs
@@ -119,14 +119,13 @@ impl<I> Era<I> {
     pub(crate) fn resolve_validity(
         &mut self,
         proto_block: &ProtoBlock,
-        timestamp: Timestamp,
         parent: Option<Digest>,
         valid: bool,
     ) -> Vec<CandidateBlock> {
         if valid {
-            self.accept_proto_block(proto_block, timestamp, parent)
+            self.accept_proto_block(proto_block, parent)
         } else {
-            self.reject_proto_block(proto_block, timestamp, parent)
+            self.reject_proto_block(proto_block, parent)
         }
     }
 
@@ -135,13 +134,10 @@ impl<I> Era<I> {
     pub(crate) fn accept_proto_block(
         &mut self,
         proto_block: &ProtoBlock,
-        timestamp: Timestamp,
         parent: Option<Digest>,
     ) -> Vec<CandidateBlock> {
         for pc in &mut self.candidates {
-            if pc.candidate.proto_block() == proto_block
-                && pc.candidate.timestamp() == timestamp
-                && pc.candidate.parent() == parent.as_ref()
+            if pc.candidate.proto_block() == proto_block && pc.candidate.parent() == parent.as_ref()
             {
                 pc.validated = true;
             }
@@ -154,13 +150,10 @@ impl<I> Era<I> {
     pub(crate) fn reject_proto_block(
         &mut self,
         proto_block: &ProtoBlock,
-        timestamp: Timestamp,
         parent: Option<Digest>,
     ) -> Vec<CandidateBlock> {
         let (invalid, candidates): (Vec<_>, Vec<_>) = self.candidates.drain(..).partition(|pc| {
-            pc.candidate.proto_block() == proto_block
-                && pc.candidate.timestamp() == timestamp
-                && pc.candidate.parent() == parent.as_ref()
+            pc.candidate.proto_block() == proto_block && pc.candidate.parent() == parent.as_ref()
         });
         self.candidates = candidates;
         invalid.into_iter().map(|pc| pc.candidate).collect()

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -56,6 +56,14 @@ impl ConsensusValueT for ConsensusValue {
         std::hash::Hash::hash(&self, &mut hasher);
         hasher.finish()
     }
+
+    fn timestamp(&self) -> Timestamp {
+        0.into() // Not relevant for highway_core tests.
+    }
+
+    fn parent(&self) -> Option<&Self::Hash> {
+        None // Not relevant for highway_core tests.
+    }
 }
 
 const TEST_MIN_ROUND_EXP: u8 = 12;

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -67,6 +67,14 @@ impl ConsensusValueT for u32 {
     fn hash(&self) -> Self::Hash {
         *self
     }
+
+    fn timestamp(&self) -> Timestamp {
+        0.into() // Not relevant for highway_core tests.
+    }
+
+    fn parent(&self) -> Option<&Self::Hash> {
+        None // Not relevant for highway_core tests.
+    }
 }
 
 impl Context for TestContext {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -339,7 +339,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             }
         };
 
-        // If the vertex contains a consensus value, request validation.
+        // If the vertex contains a consensus value, i.e. it is a proposal, request validation.
         let vertex = vv.inner();
         if let (Some(value), Some(timestamp), Some(swunit)) =
             (vertex.value(), vertex.timestamp(), vertex.unit())
@@ -348,6 +348,8 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             let fork_choice = self.highway.state().fork_choice(panorama);
             let parent_value =
                 fork_choice.map(|hash| self.highway.state().block(hash).value.hash());
+            // The timestamp and parent are currently duplicated: The information in the consensus
+            // value must match the information in the Highway DAG.
             if timestamp != value.timestamp() || parent_value.as_ref() != value.parent() {
                 info!(
                     timestamp = %value.timestamp(), consensus_timestamp = %timestamp,

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -255,10 +255,14 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                 block_context,
                 fork_choice,
             } => {
+                let parent_value = fork_choice
+                    .as_ref()
+                    .map(|hash| self.highway.state().block(hash).value.clone());
                 let past_values = self.non_finalized_values(fork_choice).cloned().collect();
                 vec![ProtocolOutcome::CreateNewBlock {
                     block_context,
                     past_values,
+                    parent_value,
                 }]
             }
             AvEffect::WeAreFaulty(fault) => {

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -337,17 +337,25 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
 
         // If the vertex contains a consensus value, request validation.
         let vertex = vv.inner();
-        if let (Some(value), Some(timestamp)) = (vertex.value(), vertex.timestamp()) {
+        if let (Some(value), Some(timestamp), Some(swunit)) =
+            (vertex.value(), vertex.timestamp(), vertex.unit())
+        {
             if value.needs_validation() {
                 self.log_proposal(vertex, "requesting proposal validation");
-                let cv = value.clone();
+                let panorama = &swunit.wire_unit().panorama;
+                let fork_choice = self.highway.state().fork_choice(panorama).cloned();
+                let ancestor_values = self.ancestors(fork_choice).cloned().collect();
+                let consensus_value = value.clone();
                 self.pending_values
                     .entry(value.hash())
                     .or_default()
                     .push(vv);
-                outcomes.push(ProtocolOutcome::ValidateConsensusValue(
-                    sender, cv, timestamp,
-                ));
+                outcomes.push(ProtocolOutcome::ValidateConsensusValue {
+                    sender,
+                    consensus_value,
+                    timestamp,
+                    ancestor_values,
+                });
                 return outcomes;
             } else {
                 self.log_proposal(vertex, "proposal does not need validation");
@@ -423,6 +431,20 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
             let maybe_block = fork_choice.map(|bhash| self.highway.state().block(&bhash));
             let value = maybe_block.map(|block| &block.value);
             fork_choice = maybe_block.and_then(|block| block.parent().cloned());
+            value
+        })
+    }
+
+    /// Returns an iterator over all the values that are in parents of the given block.
+    fn ancestors(
+        &self,
+        mut maybe_hash: Option<C::Hash>,
+    ) -> impl Iterator<Item = &C::ConsensusValue> {
+        iter::from_fn(move || {
+            let hash = maybe_hash.take()?;
+            let block = self.highway.state().block(&hash);
+            let value = Some(&block.value);
+            maybe_hash = block.parent().cloned();
             value
         })
     }

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -205,6 +205,7 @@ fn send_a_valid_wire_unit() {
             ProtoBlock::new(vec![], vec![], false),
             now,
             vec![],
+            None,
         )),
         seq_number,
         timestamp: now,
@@ -262,7 +263,8 @@ fn detect_doppelganger() {
     let instance_id = ClContext::hash(INSTANCE_ID_DATA);
     let round_exp = 14;
     let now = Timestamp::zero();
-    let value = CandidateBlock::new(ProtoBlock::new(vec![], vec![], false), now, vec![]);
+    let proto_block = ProtoBlock::new(vec![], vec![], false);
+    let value = CandidateBlock::new(proto_block, now, vec![], None);
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
         creator,

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -202,8 +202,7 @@ fn send_a_valid_wire_unit() {
         creator,
         instance_id: ClContext::hash(INSTANCE_ID_DATA),
         value: Some(CandidateBlock::new(
-            ProtoBlock::new(vec![], vec![], false),
-            now,
+            ProtoBlock::new(vec![], vec![], now, false),
             vec![],
             None,
         )),
@@ -263,8 +262,8 @@ fn detect_doppelganger() {
     let instance_id = ClContext::hash(INSTANCE_ID_DATA);
     let round_exp = 14;
     let now = Timestamp::zero();
-    let proto_block = ProtoBlock::new(vec![], vec![], false);
-    let value = CandidateBlock::new(proto_block, now, vec![], None);
+    let proto_block = ProtoBlock::new(vec![], vec![], now, false);
+    let value = CandidateBlock::new(proto_block, vec![], None);
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,
         creator,

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -6,6 +6,8 @@ use std::{
 use datasize::DataSize;
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::types::Timestamp;
+
 pub trait NodeIdT: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'static {}
 impl<I> NodeIdT for I where I: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'static {}
 
@@ -24,6 +26,12 @@ pub(crate) trait ConsensusValueT:
 
     /// Returns whether the consensus value needs validation.
     fn needs_validation(&self) -> bool;
+
+    /// Returns the value's timestamp.
+    fn timestamp(&self) -> Timestamp;
+
+    /// Returns the parent value, or `None` if this is the first block in this era.
+    fn parent(&self) -> Option<&Self::Hash>;
 }
 
 /// A hash, as an identifier for a block or unit.

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -77,7 +77,7 @@ use crate::{
     reactor::ReactorEvent,
     types::{
         Block, BlockBody, BlockHash, BlockHeader, BlockHeaderWithMetadata, BlockSignatures, Deploy,
-        DeployHash, DeployMetadata,
+        DeployHash, DeployHeader, DeployMetadata, TimeDiff,
     },
     utils::WithDir,
     NodeRng,
@@ -458,15 +458,7 @@ impl Storage {
             StorageRequest::GetHighestBlock { responder } => {
                 let mut txn = self.env.begin_ro_txn()?;
                 responder
-                    .respond(
-                        self.block_height_index
-                            .keys()
-                            .last()
-                            .and_then(|&height| {
-                                self.get_block_by_height(&mut txn, height).transpose()
-                            })
-                            .transpose()?,
-                    )
+                    .respond(self.get_highest_block(&mut txn)?)
                     .ignore()
             }
             StorageRequest::GetSwitchBlockAtEraId { era_id, responder } => responder
@@ -710,6 +702,9 @@ impl Storage {
                     self.get_finality_signatures(&mut self.env.begin_ro_txn()?, &block_hash)?;
                 responder.respond(result).ignore()
             }
+            StorageRequest::GetFinalizedDeploys { ttl, responder } => {
+                responder.respond(self.get_finalized_deploys(ttl)?).ignore()
+            }
         })
     }
 
@@ -759,6 +754,73 @@ impl Storage {
             .get(&height)
             .and_then(|block_hash| self.get_single_block(tx, block_hash).transpose())
             .transpose()
+    }
+
+    /// Retrieves the highest block from the storage, if one exists.
+    /// May return an LMDB error.
+    fn get_highest_block<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+    ) -> Result<Option<Block>, LmdbExtError> {
+        self.block_height_index
+            .keys()
+            .last()
+            .and_then(|&height| self.get_block_by_height(txn, height).transpose())
+            .transpose()
+    }
+
+    /// Returns vector blocks that satisfy the predicate, starting from the latest one and following
+    /// the ancestry chain.
+    fn get_blocks_until<F, Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        predicate: F,
+    ) -> Result<Vec<Block>, LmdbExtError>
+    where
+        F: Fn(&Block) -> bool,
+    {
+        let mut next_block = self.get_highest_block(txn)?;
+        let mut blocks = Vec::new();
+        loop {
+            match next_block {
+                None => break,
+                Some(block) if !predicate(&block) => break,
+                Some(block) => {
+                    next_block = match block.parent() {
+                        None => None,
+                        Some(parent_hash) => self.get_single_block(txn, &parent_hash)?,
+                    };
+                    blocks.push(block);
+                }
+            }
+        }
+        Ok(blocks)
+    }
+
+    /// Returns the vector of deploys whose TTL hasn't expired yet.
+    fn get_finalized_deploys(
+        &self,
+        ttl: TimeDiff,
+    ) -> Result<Vec<(DeployHash, DeployHeader)>, LmdbExtError> {
+        let mut txn = self.env.begin_ro_txn()?;
+        // We're interested in deploys whose TTL hasn't expired yet.
+        let ttl_expired = |block: &Block| block.timestamp().elapsed() < ttl;
+        let mut deploys = Vec::new();
+        for block in self.get_blocks_until(&mut txn, ttl_expired)? {
+            for deploy_hash in block.body().deploy_hashes() {
+                let deploy_header = self
+                    .get_deploy_header(&mut txn, &deploy_hash)?
+                    .expect("deploy to exist in storage");
+                deploys.push((*deploy_hash, deploy_header));
+            }
+            for transfer_hash in block.body().transfer_hashes() {
+                let deploy_header = self
+                    .get_deploy_header(&mut txn, &transfer_hash)?
+                    .expect("deploy to exist in storage");
+                deploys.push((*transfer_hash, deploy_header));
+            }
+        }
+        Ok(deploys)
     }
 
     /// Retrieves single switch block by era ID by looking it up in the index and returning it.
@@ -863,6 +925,16 @@ impl Storage {
             .iter()
             .map(|deploy_hash| tx.get_value(self.deploy_db, deploy_hash))
             .collect()
+    }
+
+    /// Returns the deploy's header.
+    fn get_deploy_header<Tx: Transaction>(
+        &self,
+        txn: &mut Tx,
+        deploy_hash: &DeployHash,
+    ) -> Result<Option<DeployHeader>, LmdbExtError> {
+        let maybe_deploy: Option<Deploy> = txn.get_value(self.deploy_db, deploy_hash)?;
+        Ok(maybe_deploy.map(|deploy| deploy.header().clone()))
     }
 
     /// Retrieves deploy metadata associated with deploy.

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -817,7 +817,8 @@ impl Storage {
                     .get_deploy_header(&mut txn, &deploy_hash)?
                     .expect("deploy to exist in storage");
                 // If block's deploy has already expired, ignore it.
-                // It may happen that deploy was not expired at the time of proposing a block but it is now.
+                // It may happen that deploy was not expired at the time of proposing a block but it
+                // is now.
                 if deploy_header.timestamp().elapsed() > ttl {
                     continue;
                 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -77,7 +77,9 @@ use once_cell::sync::Lazy;
 use serde::{de::DeserializeOwned, Serialize};
 use smallvec::{smallvec, SmallVec};
 use tokio::sync::Semaphore;
-use tracing::{error, warn};
+use tracing::error;
+#[cfg(not(feature = "fast-sync"))]
+use tracing::warn;
 
 use casper_execution_engine::{
     core::engine_state::{
@@ -1277,6 +1279,7 @@ impl<REv> EffectBuilder<REv> {
     /// Key must be a unique key across the the application, as all keys share a common namespace.
     ///
     /// If an error occurs during state loading or no data is found, returns `None`.
+    #[allow(unused)]
     pub(crate) async fn load_state<T>(self, key: Cow<'static, [u8]>) -> Option<T>
     where
         REv: From<StateStoreRequest>,
@@ -1303,12 +1306,28 @@ impl<REv> EffectBuilder<REv> {
         })
     }
 
+    /// Retrieves finalized deploys from blocks that were created more recently than the TTL.
+    pub(crate) async fn get_finalized_deploys(
+        self,
+        ttl: TimeDiff,
+    ) -> Vec<(DeployHash, DeployHeader)>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            move |responder| StorageRequest::GetFinalizedDeploys { ttl, responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Save state to storage.
     ///
     /// Key must be a unique key across the the application, as all keys share a common namespace.
     ///
     /// Returns whether or not storing the state was successful. A component that requires state to
     /// be successfully stored should check the return value and act accordingly.
+    #[cfg(not(feature = "fast-sync"))]
     pub(crate) async fn save_state<T>(self, key: Cow<'static, [u8]>, value: T) -> bool
     where
         REv: From<StateStoreRequest>,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -728,6 +728,24 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    /// Gets the requested block header from the linear block store.
+    pub(crate) async fn get_block_header_from_storage(
+        self,
+        block_hash: BlockHash,
+    ) -> Option<BlockHeader>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetBlockHeader {
+                block_hash,
+                responder,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
     /// Gets the requested signatures for a given block hash.
     pub(crate) async fn get_signatures_from_storage(
         self,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -277,6 +277,14 @@ pub enum StorageRequest {
         /// Responder to call with the results.
         responder: Responder<Vec<Option<DeployHeader>>>,
     },
+    /// Retrieve deploys that are finalized and whose TTL hasn't expired yet.
+    GetFinalizedDeploys {
+        /// Maximum TTL of block we're interested in.
+        /// I.e. we don't want deploys from blocks that are older than this.
+        ttl: TimeDiff,
+        /// Responder to call with the results.
+        responder: Responder<Vec<(DeployHash, DeployHeader)>>,
+    },
     /// Store execution results for a set of deploys of a single block.
     ///
     /// Will return a fatal error if there are already execution results known for a specific
@@ -397,6 +405,9 @@ impl Display for StorageRequest {
             }
             StorageRequest::PutBlockSignatures { .. } => {
                 write!(formatter, "put finality signatures")
+            }
+            StorageRequest::GetFinalizedDeploys { ttl, .. } => {
+                write!(formatter, "get finalized deploys, ttl: {:?}", ttl)
             }
         }
     }

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1149,6 +1149,21 @@ impl Block {
         self.header.protocol_version
     }
 
+    /// Returns the hash of the parent block.
+    /// If the block is the first block in the linear chain returns `None`.
+    pub fn parent(&self) -> Option<&BlockHash> {
+        if self.header.is_genesis_child() {
+            None
+        } else {
+            Some(self.header.parent_hash())
+        }
+    }
+
+    /// Returns the timestamp of the block.
+    pub fn timestamp(&self) -> Timestamp {
+        self.header.timestamp()
+    }
+
     /// Check the integrity of a block by hashing its body and header
     pub fn verify(&self) -> Result<(), BlockValidationError> {
         let actual_body_hash = self.body.hash();

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -91,21 +91,14 @@ static ERA_END: Lazy<EraEnd> = Lazy::new(|| {
 static FINALIZED_BLOCK: Lazy<FinalizedBlock> = Lazy::new(|| {
     let deploy_hashes = vec![*Deploy::doc_example().id()];
     let random_bit = true;
-    let proto_block = ProtoBlock::new(deploy_hashes, vec![], random_bit);
     let timestamp = *Timestamp::doc_example();
+    let proto_block = ProtoBlock::new(deploy_hashes, vec![], timestamp, random_bit);
     let era_report = Some(EraReport::doc_example().clone());
-    let era: u64 = 1;
+    let era_id = EraId::from(1);
+    let height = 10;
     let secret_key = SecretKey::doc_example();
     let public_key = PublicKey::from(secret_key);
-
-    FinalizedBlock::new(
-        proto_block,
-        timestamp,
-        era_report,
-        EraId::from(era),
-        era * 10,
-        public_key,
-    )
+    FinalizedBlock::new(proto_block, era_report, era_id, height, public_key)
 });
 static BLOCK: Lazy<Block> = Lazy::new(|| {
     let parent_hash = BlockHash::new(Digest::from([7u8; Digest::LENGTH]));
@@ -230,6 +223,7 @@ pub struct ProtoBlock {
     hash: ProtoBlockHash,
     wasm_deploys: Vec<DeployHash>,
     transfers: Vec<DeployHash>,
+    timestamp: Timestamp,
     random_bit: bool,
 }
 
@@ -237,19 +231,18 @@ impl ProtoBlock {
     pub(crate) fn new(
         wasm_deploys: Vec<DeployHash>,
         transfers: Vec<DeployHash>,
+        timestamp: Timestamp,
         random_bit: bool,
     ) -> Self {
-        let deploys = wasm_deploys
-            .iter()
-            .chain(transfers.iter())
-            .collect::<Vec<_>>();
         let hash = ProtoBlockHash::new(hash::hash(
-            &bincode::serialize(&(&deploys, random_bit)).expect("serialize ProtoBlock"),
+            &bincode::serialize(&(&wasm_deploys, &transfers, timestamp, random_bit))
+                .expect("serialize ProtoBlock"),
         ));
 
         ProtoBlock {
             hash,
             wasm_deploys,
+            timestamp,
             transfers,
             random_bit,
         }
@@ -257,6 +250,11 @@ impl ProtoBlock {
 
     pub(crate) fn hash(&self) -> &ProtoBlockHash {
         &self.hash
+    }
+
+    /// Returns the time when this proto block was proposed.
+    pub(crate) fn timestamp(&self) -> Timestamp {
+        self.timestamp
     }
 
     /// The list of deploy hashes included in the block.
@@ -292,10 +290,11 @@ impl Display for ProtoBlock {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
-            "proto block {}, deploys [{}], random bit {}",
+            "proto block {}, deploys [{}], random bit {}, timestamp {}",
             self.hash.inner(),
             DisplayIter::new(self.wasm_deploys.iter().chain(self.transfers.iter())),
             self.random_bit(),
+            self.timestamp,
         )
     }
 }
@@ -366,7 +365,6 @@ impl DocExample for EraReport {
 #[derive(Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FinalizedBlock {
     proto_block: ProtoBlock,
-    timestamp: Timestamp,
     era_report: Option<EraReport>,
     era_id: EraId,
     height: u64,
@@ -376,7 +374,6 @@ pub struct FinalizedBlock {
 impl FinalizedBlock {
     pub(crate) fn new(
         proto_block: ProtoBlock,
-        timestamp: Timestamp,
         era_report: Option<EraReport>,
         era_id: EraId,
         height: u64,
@@ -384,7 +381,6 @@ impl FinalizedBlock {
     ) -> Self {
         FinalizedBlock {
             proto_block,
-            timestamp,
             era_report,
             era_id,
             height,
@@ -399,7 +395,7 @@ impl FinalizedBlock {
 
     /// The timestamp from when the proto block was proposed.
     pub(crate) fn timestamp(&self) -> Timestamp {
-        self.timestamp
+        self.proto_block.timestamp
     }
 
     /// Returns slashing and reward information if this is a switch block, i.e. the last block of
@@ -445,10 +441,10 @@ impl FinalizedBlock {
             .take(deploy_count)
             .collect();
         let random_bit = rng.gen();
-        let proto_block = ProtoBlock::new(deploy_hashes, vec![], random_bit);
-
         // TODO - make Timestamp deterministic.
         let timestamp = Timestamp::now();
+        let proto_block = ProtoBlock::new(deploy_hashes, vec![], timestamp, random_bit);
+
         let era_report = if is_switch {
             let equivocators_count = rng.gen_range(0..5);
             let rewards_count = rng.gen_range(0..5);
@@ -476,14 +472,7 @@ impl FinalizedBlock {
         let secret_key: SecretKey = SecretKey::ed25519(rng.gen());
         let public_key = PublicKey::from(&secret_key);
 
-        FinalizedBlock::new(
-            proto_block,
-            timestamp,
-            era_report,
-            era_id,
-            height,
-            public_key,
-        )
+        FinalizedBlock::new(proto_block, era_report, era_id, height, public_key)
     }
 }
 
@@ -498,6 +487,7 @@ impl From<Block> for FinalizedBlock {
         let proto_block = ProtoBlock::new(
             block.body.deploy_hashes().clone(),
             block.body.transfer_hashes().clone(),
+            block.header.timestamp,
             block.header.random_bit,
         );
 
@@ -508,7 +498,6 @@ impl From<Block> for FinalizedBlock {
 
         FinalizedBlock {
             proto_block,
-            timestamp: block.header.timestamp,
             era_report,
             era_id: block.header.era_id,
             height: block.header.height,
@@ -528,7 +517,7 @@ impl Display for FinalizedBlock {
             self.height,
             HexList(&self.proto_block.wasm_deploys),
             self.proto_block.random_bit,
-            self.timestamp,
+            self.timestamp(),
         )?;
         if let Some(ee) = &self.era_report {
             write!(formatter, ", era_end: {}", ee)?;
@@ -1082,6 +1071,7 @@ impl Block {
 
         let era_id = finalized_block.era_id();
         let height = finalized_block.height();
+        let timestamp = finalized_block.timestamp();
 
         let era_end = match finalized_block.era_report {
             Some(era_report) => Some(EraEnd::new(era_report, next_era_validator_weights.unwrap())),
@@ -1104,7 +1094,7 @@ impl Block {
             random_bit: finalized_block.proto_block.random_bit,
             accumulated_seed: accumulated_seed.into(),
             era_end,
-            timestamp: finalized_block.timestamp,
+            timestamp,
             era_id,
             height,
             protocol_version,

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -269,6 +269,10 @@ impl ProtoBlock {
         &self.transfers
     }
 
+    pub(crate) fn deploys_iter(&self) -> impl Iterator<Item = &DeployHash> {
+        self.wasm_deploys().iter().chain(self.transfers().iter())
+    }
+
     /// A random bit needed for initializing a future era.
     pub(crate) fn random_bit(&self) -> bool {
         self.random_bit


### PR DESCRIPTION
This is a port of https://github.com/CasperLabs/casper-node/pull/1216, https://github.com/CasperLabs/casper-node/pull/1218, https://github.com/CasperLabs/casper-node/pull/1219, https://github.com/CasperLabs/casper-node/pull/1223 to the `dev` branch.

* Instead of persisting the `BlockProposerDeploySets` to LMDB and loading in on startup, we recreate that state from the collection of finalized deploys. This fixes a bug where that set would be incorrectly initialized for joining/restarting/upgrading nodes.
* Blocks are considered invalid if they contain the same deploy twice, or if they contain a deploy that was already present in any of their ancestors.

https://casperlabs.atlassian.net/browse/NDRS-1052
https://casperlabs.atlassian.net/browse/NDRS-1053