### PR TITLE
NDRS-1061: Move BlockLike into block_validator.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -50,7 +50,7 @@ use crate::{
     },
     fatal,
     types::{
-        ActivationPoint, Block, BlockHash, BlockHeader, BlockLike, DeployHash, DeployMetadata,
+        ActivationPoint, Block, BlockHash, BlockHeader, DeployHash, DeployMetadata,
         FinalitySignature, FinalizedBlock, ProtoBlock, TimeDiff, Timestamp,
     },
     utils::WithDir,
@@ -981,7 +981,7 @@ where
             } => {
                 let past_deploys = past_values
                     .iter()
-                    .flat_map(|candidate| BlockLike::deploys(candidate.proto_block()))
+                    .flat_map(|candidate| candidate.proto_block().deploys_iter())
                     .cloned()
                     .collect();
                 let parent = parent_value.as_ref().map(CandidateBlock::hash);
@@ -1316,7 +1316,7 @@ where
 
     let sender_for_validate_block: I = sender.clone();
     let (valid, proto_block) = effect_builder
-        .validate_block(sender_for_validate_block, proto_block.clone(), timestamp)
+        .validate_proto_block(sender_for_validate_block, proto_block.clone(), timestamp)
         .await;
 
     Ok(Event::ResolveValidity {

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -48,8 +48,8 @@ use crate::{
         EffectBuilder, EffectExt, Effects,
     },
     types::{
-        Block, BlockHash, BlockHeader, BlockLike, Chainspec, Deploy, DeployHash, DeployHeader,
-        FinalizedBlock, NodeId,
+        Block, BlockHash, BlockHeader, Chainspec, Deploy, DeployHash, DeployHeader, FinalizedBlock,
+        NodeId,
     },
     utils::WithDir,
     NodeRng, StorageConfig,
@@ -760,9 +760,8 @@ impl ContractRuntime {
     ) -> Effects<Event> {
         let deploy_hashes = finalized_block
             .proto_block()
-            .deploys()
-            .iter()
-            .map(|hash| **hash)
+            .deploys_iter()
+            .copied()
             .collect::<SmallVec<_>>();
         if deploy_hashes.is_empty() {
             let result_event = move |_| {

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -112,9 +112,9 @@ use crate::{
     effect::requests::LinearChainRequest,
     reactor::{EventQueueHandle, QueueKind},
     types::{
-        Block, BlockByHeight, BlockHash, BlockHeader, BlockLike, BlockSignatures, Chainspec,
-        ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature,
-        FinalizedBlock, Item, ProtoBlock, TimeDiff, Timestamp,
+        Block, BlockByHeight, BlockHash, BlockHeader, BlockSignatures, Chainspec, ChainspecInfo,
+        Deploy, DeployHash, DeployHeader, DeployMetadata, FinalitySignature, FinalizedBlock, Item,
+        ProtoBlock, TimeDiff, Timestamp,
     },
     utils::Source,
 };
@@ -1124,15 +1124,38 @@ impl<REv> EffectBuilder<REv> {
     /// Checks whether the deploys included in the block exist on the network. This includes
     /// the block's timestamp, in order that it be checked against the timestamp of the deploys
     /// within the block.
-    pub(crate) async fn validate_block<I, T>(
+    pub(crate) async fn validate_block<I>(
         self,
         sender: I,
-        block: T,
+        block: Block,
         block_timestamp: Timestamp,
-    ) -> (bool, T)
+    ) -> (bool, Block)
     where
-        REv: From<BlockValidationRequest<T, I>>,
-        T: BlockLike + Send + 'static,
+        REv: From<BlockValidationRequest<Block, I>>,
+    {
+        self.make_request(
+            |responder| BlockValidationRequest {
+                block,
+                sender,
+                responder,
+                block_timestamp,
+            },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Checks whether the deploys included in the proto block exist on the network. This includes
+    /// the block's timestamp, in order that it be checked against the timestamp of the deploys
+    /// within the block.
+    pub(crate) async fn validate_proto_block<I>(
+        self,
+        sender: I,
+        block: ProtoBlock,
+        block_timestamp: Timestamp,
+    ) -> (bool, ProtoBlock)
+    where
+        REv: From<BlockValidationRequest<ProtoBlock, I>>,
     {
         self.make_request(
             |responder| BlockValidationRequest {

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -20,9 +20,7 @@ pub use block::{
     json_compatibility::JsonBlock, Block, BlockBody, BlockHash, BlockHeader, BlockSignatures,
     BlockValidationError, FinalitySignature,
 };
-pub(crate) use block::{
-    BlockByHeight, BlockHeaderWithMetadata, BlockLike, FinalizedBlock, ProtoBlock,
-};
+pub(crate) use block::{BlockByHeight, BlockHeaderWithMetadata, FinalizedBlock, ProtoBlock};
 pub(crate) use chainspec::ActivationPoint;
 pub use chainspec::Chainspec;
 pub use deploy::{

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -170,10 +170,6 @@ impl From<TryFromSliceError> for Error {
     }
 }
 
-pub trait BlockLike: Eq + Hash {
-    fn deploys(&self) -> Vec<&DeployHash>;
-}
-
 /// A cryptographic hash identifying a `ProtoBlock`.
 #[derive(
     Copy,
@@ -296,15 +292,6 @@ impl Display for ProtoBlock {
             self.random_bit(),
             self.timestamp,
         )
-    }
-}
-
-impl BlockLike for ProtoBlock {
-    fn deploys(&self) -> Vec<&DeployHash> {
-        self.wasm_deploys()
-            .iter()
-            .chain(self.transfers())
-            .collect::<Vec<_>>()
     }
 }
 
@@ -1281,15 +1268,6 @@ impl FromBytes for Block {
         let (body, remainder) = BlockBody::from_bytes(remainder)?;
         let block = Block { hash, header, body };
         Ok((block, remainder))
-    }
-}
-
-impl BlockLike for Block {
-    fn deploys(&self) -> Vec<&DeployHash> {
-        self.deploy_hashes()
-            .iter()
-            .chain(self.transfer_hashes().iter())
-            .collect()
     }
 }
 


### PR DESCRIPTION
The goal is to remove the `BlockLike` trait; this change limits its use to `block_validator` as a first step.

https://casperlabs.atlassian.net/browse/NDRS-1061