### PR TITLE
HWY-278: Add an instance ID to Pings.

### DIFF
--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -50,6 +50,8 @@ pub(crate) enum PingError {
     Creator,
     #[error("The signature is invalid.")]
     Signature,
+    #[error("The ping is for a different consensus protocol instance.")]
+    InstanceId,
 }
 
 /// A vertex that has passed initial validation.
@@ -554,7 +556,7 @@ impl<C: Context> Highway<C> {
                 }
                 Ok(())
             }
-            Vertex::Ping(ping) => ping.validate(&self.validators),
+            Vertex::Ping(ping) => ping.validate(&self.validators, &self.instance_id),
         }
     }
 

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -210,6 +210,7 @@ impl<C: Context> Highway<C> {
             &self.state,
             unit_hash_file,
             target_ftt,
+            self.instance_id,
         );
         self.active_validator = Some(av);
         effects
@@ -920,7 +921,8 @@ pub(crate) mod tests {
 
         // Ping by validator that is not bonded, with an index that is outside of boundaries of the
         // state.
-        let ping: Vertex<TestContext> = Vertex::Ping(Ping::new(DAN, now, &DAN_SEC));
+        let ping: Vertex<TestContext> =
+            Vertex::Ping(Ping::new(DAN, now, TEST_INSTANCE_ID, &DAN_SEC));
         assert!(
             DAN.0 >= WEIGHTS.len() as u32,
             "should use validator that is not bonded"

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -326,6 +326,7 @@ where
 {
     creator: ValidatorIndex,
     timestamp: Timestamp,
+    instance_id: C::InstanceId,
     signature: C::Signature,
 }
 
@@ -334,12 +335,15 @@ impl<C: Context> Ping<C> {
     pub(crate) fn new(
         creator: ValidatorIndex,
         timestamp: Timestamp,
+        instance_id: C::InstanceId,
         sk: &C::ValidatorSecret,
     ) -> Self {
+        let signature = sk.sign(&Self::hash(creator, timestamp, instance_id));
         Ping {
             creator,
             timestamp,
-            signature: sk.sign(&Self::hash(creator, timestamp)),
+            instance_id,
+            signature,
         }
     }
 
@@ -358,17 +362,23 @@ impl<C: Context> Ping<C> {
         &self,
         validators: &Validators<C::ValidatorId>,
     ) -> Result<(), VertexError> {
+        let Ping {
+            creator,
+            timestamp,
+            instance_id,
+            signature,
+        } = self;
         let v_id = validators.id(self.creator).ok_or(PingError::Creator)?;
-        let hash = Self::hash(self.creator, self.timestamp);
-        if !C::verify_signature(&hash, v_id, &self.signature) {
+        let hash = Self::hash(*creator, *timestamp, *instance_id);
+        if !C::verify_signature(&hash, v_id, signature) {
             return Err(PingError::Signature.into());
         }
         Ok(())
     }
 
     /// Computes the hash of a ping, i.e. of the creator and timestamp.
-    fn hash(creator: ValidatorIndex, timestamp: Timestamp) -> C::Hash {
-        let bytes = bincode::serialize(&(creator, timestamp)).expect("serialize Ping");
+    fn hash(creator: ValidatorIndex, timestamp: Timestamp, instance_id: C::InstanceId) -> C::Hash {
+        let bytes = bincode::serialize(&(creator, timestamp, instance_id)).expect("serialize Ping");
         <C as Context>::hash(&bytes)
     }
 }

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -361,6 +361,7 @@ impl<C: Context> Ping<C> {
     pub(crate) fn validate(
         &self,
         validators: &Validators<C::ValidatorId>,
+        our_instance_id: &C::InstanceId,
     ) -> Result<(), VertexError> {
         let Ping {
             creator,
@@ -368,6 +369,9 @@ impl<C: Context> Ping<C> {
             instance_id,
             signature,
         } = self;
+        if instance_id != our_instance_id {
+            return Err(PingError::InstanceId.into());
+        }
         let v_id = validators.id(self.creator).ok_or(PingError::Creator)?;
         let hash = Self::hash(*creator, *timestamp, *instance_id);
         if !C::verify_signature(&hash, v_id, signature) {


### PR DESCRIPTION
While not as important as for other vertex types, it's still better to distinguish pings by instance ID, so that they are only handled in the era and the network they were meant for.

https://casperlabs.atlassian.net/browse/HWY-278