### PR TITLE
NDSR-1048: Fix fetcher metrics.

### DIFF
--- a/node/src/components/fetcher/event.rs
+++ b/node/src/components/fetcher/event.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Display, Formatter};
+use std::{
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+};
 
 use datasize::DataSize;
 use serde::Serialize;
@@ -16,7 +19,19 @@ pub enum FetchResult<T, I> {
     FromPeer(Box<T>, I),
 }
 
+impl<T, I> FetchResult<T, I> {
+    pub fn is_from_storage(&self) -> bool {
+        matches!(self, FetchResult::FromStorage(_))
+    }
+
+    pub fn is_from_peer(&self) -> bool {
+        matches!(self, FetchResult::FromPeer(_, _))
+    }
+}
+
 pub(crate) type FetchResponder<T> = Responder<Option<FetchResult<T, NodeId>>>;
+
+pub(crate) type ItemResponders<T> = HashMap<NodeId, Vec<FetchResponder<T>>>;
 
 /// `Fetcher` events.
 #[derive(Debug, Serialize)]

--- a/node/src/components/fetcher/metrics.rs
+++ b/node/src/components/fetcher/metrics.rs
@@ -3,13 +3,13 @@ use prometheus::{IntCounter, Registry};
 use crate::unregister_metric;
 
 #[derive(Debug)]
-pub(super) struct FetcherMetrics {
+pub struct FetcherMetrics {
     /// Number of fetch requests that found an item in the storage.
-    pub(super) found_in_storage: IntCounter,
+    pub found_in_storage: IntCounter,
     /// Number of fetch requests that fetched an item from peer.
-    pub(super) found_on_peer: IntCounter,
+    pub found_on_peer: IntCounter,
     /// Number of fetch requests that timed out.
-    pub(super) timeouts: IntCounter,
+    pub timeouts: IntCounter,
     /// Reference to the registry for unregistering.
     registry: Registry,
 }


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-1048

This PR fixes a bug where `Fetcher` would incorrectly count the number of requests that time out. Previously, we would consider every request made as timed out as `TimeoutPeer` events are not canceled if the original fetch request had completed successfully. 

### Note: ###
I am not happy with the fact that I had to put `metrics` method into the `ItemFetcher` trait but b/c of how the abstractions are written and the fact that the whole logic/information about whether the request really timed-out or not is hidden inside the `signal` method (that is implemented on the `ItemFetcher` trait), there was no easy way to extract this information without a major rewrite. I've spent a lot of time on this already so I went for a correct solution right now.