### PR TITLE
NDRS-1026: Make get_era_validators use only block headers instead of full blocks

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -446,6 +446,9 @@ impl Storage {
             } => responder
                 .respond(self.get_single_block(&mut self.env.begin_ro_txn()?, &block_hash)?)
                 .ignore(),
+            StorageRequest::GetBlockHeaderAtHeight { height, responder } => responder
+                .respond(self.get_block_header_by_height(&mut self.env.begin_ro_txn()?, height)?)
+                .ignore(),
             StorageRequest::GetBlockAtHeight { height, responder } => responder
                 .respond(self.get_block_by_height(&mut self.env.begin_ro_txn()?, height)?)
                 .ignore(),
@@ -455,6 +458,11 @@ impl Storage {
                     .respond(self.get_highest_block(&mut txn)?)
                     .ignore()
             }
+            StorageRequest::GetSwitchBlockHeaderAtEraId { era_id, responder } => responder
+                .respond(
+                    self.get_switch_block_header_by_era_id(&mut self.env.begin_ro_txn()?, era_id)?,
+                )
+                .ignore(),
             StorageRequest::GetSwitchBlockAtEraId { era_id, responder } => responder
                 .respond(self.get_switch_block_by_era_id(&mut self.env.begin_ro_txn()?, era_id)?)
                 .ignore(),
@@ -738,6 +746,18 @@ impl Storage {
         Ok(maybe_block_header_and_finality_signatures)
     }
 
+    /// Retrieves single block header by height by looking it up in the index and returning it.
+    fn get_block_header_by_height<Tx: Transaction>(
+        &self,
+        tx: &mut Tx,
+        height: u64,
+    ) -> Result<Option<BlockHeader>, LmdbExtError> {
+        self.block_height_index
+            .get(&height)
+            .and_then(|block_hash| self.get_single_block_header(tx, block_hash).transpose())
+            .transpose()
+    }
+
     /// Retrieves single block by height by looking it up in the index and returning it.
     fn get_block_by_height<Tx: Transaction>(
         &self,
@@ -747,6 +767,19 @@ impl Storage {
         self.block_height_index
             .get(&height)
             .and_then(|block_hash| self.get_single_block(tx, block_hash).transpose())
+            .transpose()
+    }
+
+    /// Retrieves single switch block header by era ID by looking it up in the index and returning
+    /// it.
+    fn get_switch_block_header_by_era_id<Tx: Transaction>(
+        &self,
+        tx: &mut Tx,
+        era_id: EraId,
+    ) -> Result<Option<BlockHeader>, LmdbExtError> {
+        self.switch_block_era_id_index
+            .get(&era_id)
+            .and_then(|block_hash| self.get_single_block_header(tx, block_hash).transpose())
             .transpose()
     }
 

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -216,6 +216,13 @@ pub enum StorageRequest {
         /// storage.
         responder: Responder<Option<Block>>,
     },
+    /// Retrieve block header with given height.
+    GetBlockHeaderAtHeight {
+        /// Height of the block.
+        height: BlockHeight,
+        /// Responder.
+        responder: Responder<Option<BlockHeader>>,
+    },
     /// Retrieve block with given height.
     GetBlockAtHeight {
         /// Height of the block.
@@ -227,6 +234,13 @@ pub enum StorageRequest {
     GetHighestBlock {
         /// Responder.
         responder: Responder<Option<Block>>,
+    },
+    /// Retrieve switch block header with given era ID.
+    GetSwitchBlockHeaderAtEraId {
+        /// Era ID of the switch block.
+        era_id: EraId,
+        /// Responder.
+        responder: Responder<Option<BlockHeader>>,
     },
     /// Retrieve switch block with given era ID.
     GetSwitchBlockAtEraId {
@@ -349,10 +363,16 @@ impl Display for StorageRequest {
         match self {
             StorageRequest::PutBlock { block, .. } => write!(formatter, "put {}", block),
             StorageRequest::GetBlock { block_hash, .. } => write!(formatter, "get {}", block_hash),
+            StorageRequest::GetBlockHeaderAtHeight { height, .. } => {
+                write!(formatter, "get block header at height {}", height)
+            }
             StorageRequest::GetBlockAtHeight { height, .. } => {
                 write!(formatter, "get block at height {}", height)
             }
             StorageRequest::GetHighestBlock { .. } => write!(formatter, "get highest block"),
+            StorageRequest::GetSwitchBlockHeaderAtEraId { era_id, .. } => {
+                write!(formatter, "get switch block header at era id {}", era_id)
+            }
             StorageRequest::GetSwitchBlockAtEraId { era_id, .. } => {
                 write!(formatter, "get switch block at era id {}", era_id)
             }


### PR DESCRIPTION
This is the first part of changes for compatibility with Fast Sync.

https://casperlabs.atlassian.net/browse/NDRS-1026