### PR TITLE
NDRS-833: Clean up the `LinearChain` component.

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -1,11 +1,7 @@
 mod event;
+mod signature_cache;
 
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    convert::Infallible,
-    fmt::Display,
-    marker::PhantomData,
-};
+use std::{collections::HashMap, convert::Infallible, fmt::Display, marker::PhantomData};
 
 use datasize::DataSize;
 use itertools::Itertools;
@@ -31,67 +27,11 @@ use crate::{
 };
 
 pub use event::Event;
+use signature_cache::SignatureCache;
 
 /// The maximum number of finality signatures from a single validator we keep in memory while
 /// waiting for their block.
 const MAX_PENDING_FINALITY_SIGNATURES_PER_VALIDATOR: usize = 1000;
-
-#[derive(DataSize, Debug)]
-struct SignatureCache {
-    curr_era: EraId,
-    signatures: HashMap<BlockHash, BlockSignatures>,
-}
-
-impl SignatureCache {
-    fn new() -> Self {
-        SignatureCache {
-            curr_era: EraId::from(0),
-            signatures: Default::default(),
-        }
-    }
-
-    fn get(&mut self, hash: &BlockHash, _era_id: EraId) -> Option<BlockSignatures> {
-        self.signatures.get(hash).cloned()
-    }
-
-    fn insert(&mut self, block_signature: BlockSignatures) {
-        // We optimistically assume that most of the signatures that arrive in close temporal
-        // proximity refer to the same era.
-        if self.curr_era < block_signature.era_id {
-            self.signatures.clear();
-            self.curr_era = block_signature.era_id;
-        }
-        match self.signatures.entry(block_signature.block_hash) {
-            Entry::Occupied(mut entry) => {
-                entry.get_mut().proofs.extend(block_signature.proofs);
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(block_signature);
-            }
-        }
-    }
-
-    /// Get signatures from the cache to be updated.
-    /// If there are no signatures, create an empty signature to be updated.
-    fn get_known_signatures(&self, block_hash: &BlockHash, block_era: EraId) -> BlockSignatures {
-        match self.signatures.get(block_hash) {
-            Some(signatures) => signatures.clone(),
-            None => BlockSignatures::new(*block_hash, block_era),
-        }
-    }
-
-    /// Returns whether finality signature is known already.
-    fn known_signature(&self, fs: &FinalitySignature) -> bool {
-        let FinalitySignature {
-            block_hash,
-            public_key,
-            ..
-        } = fs;
-        self.signatures
-            .get(block_hash)
-            .map_or(false, |bs| bs.has_proof(public_key))
-    }
-}
 
 #[derive(DataSize, Debug)]
 enum Signature {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -1,5 +1,6 @@
 mod event;
 mod metrics;
+mod signature;
 mod signature_cache;
 
 use std::{collections::HashMap, convert::Infallible, fmt::Display, marker::PhantomData};
@@ -27,6 +28,7 @@ use crate::{
     NodeRng,
 };
 
+use self::signature::Signature;
 pub use event::Event;
 use metrics::LinearChainMetrics;
 use signature_cache::SignatureCache;
@@ -34,31 +36,6 @@ use signature_cache::SignatureCache;
 /// The maximum number of finality signatures from a single validator we keep in memory while
 /// waiting for their block.
 const MAX_PENDING_FINALITY_SIGNATURES_PER_VALIDATOR: usize = 1000;
-
-#[derive(DataSize, Debug)]
-enum Signature {
-    Local(Box<FinalitySignature>),
-    External(Box<FinalitySignature>),
-}
-
-impl Signature {
-    fn to_inner(&self) -> &FinalitySignature {
-        match self {
-            Signature::Local(fs) => fs,
-            Signature::External(fs) => fs,
-        }
-    }
-
-    fn take(self) -> Box<FinalitySignature> {
-        match self {
-            Signature::Local(fs) | Signature::External(fs) => fs,
-        }
-    }
-
-    fn is_local(&self) -> bool {
-        matches!(self, Signature::Local(_))
-    }
-}
 
 #[derive(DataSize, Debug)]
 pub(crate) struct LinearChain<I> {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -14,7 +14,6 @@ use casper_types::{EraId, ProtocolVersion, PublicKey};
 
 use super::Component;
 use crate::{
-    crypto::hash::Digest,
     effect::{
         announcements::LinearChainAnnouncement,
         requests::{
@@ -44,7 +43,6 @@ pub(crate) struct LinearChain<I> {
     /// Finality signatures to be inserted in a block once it is available.
     pending_finality_signatures: HashMap<PublicKey, HashMap<BlockHash, Signature>>,
     signature_cache: SignatureCache,
-    initial_state_root_hash: Digest,
     activation_era_id: EraId,
     /// Current protocol version of the network.
     protocol_version: ProtocolVersion,
@@ -60,7 +58,6 @@ impl<I> LinearChain<I> {
     pub fn new(
         registry: &Registry,
         protocol_version: ProtocolVersion,
-        initial_state_root_hash: Digest,
         auction_delay: u64,
         unbonding_delay: u64,
         activation_era_id: EraId,
@@ -70,7 +67,6 @@ impl<I> LinearChain<I> {
             latest_block: None,
             pending_finality_signatures: HashMap::new(),
             signature_cache: SignatureCache::new(),
-            initial_state_root_hash,
             activation_era_id,
             protocol_version,
             auction_delay,

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -2,15 +2,11 @@ mod event;
 mod metrics;
 mod signature;
 mod signature_cache;
+mod state;
 
-use std::{collections::HashMap, convert::Infallible, fmt::Display, marker::PhantomData};
+use std::{convert::Infallible, fmt::Display};
 
-use datasize::DataSize;
-use itertools::Itertools;
-use prometheus::Registry;
 use tracing::{debug, error, info, warn};
-
-use casper_types::{EraId, ProtocolVersion, PublicKey};
 
 use super::Component;
 use crate::{
@@ -23,177 +19,12 @@ use crate::{
         EffectBuilder, EffectExt, EffectResultExt, Effects,
     },
     protocol::Message,
-    types::{Block, BlockByHeight, BlockHash, BlockSignatures, FinalitySignature, Timestamp},
+    types::{BlockByHeight, FinalitySignature, Timestamp},
     NodeRng,
 };
 
-use self::signature::Signature;
 pub use event::Event;
-use metrics::LinearChainMetrics;
-use signature_cache::SignatureCache;
-
-/// The maximum number of finality signatures from a single validator we keep in memory while
-/// waiting for their block.
-const MAX_PENDING_FINALITY_SIGNATURES_PER_VALIDATOR: usize = 1000;
-
-#[derive(DataSize, Debug)]
-pub(crate) struct LinearChain<I> {
-    /// The most recently added block.
-    latest_block: Option<Block>,
-    /// Finality signatures to be inserted in a block once it is available.
-    pending_finality_signatures: HashMap<PublicKey, HashMap<BlockHash, Signature>>,
-    signature_cache: SignatureCache,
-    activation_era_id: EraId,
-    /// Current protocol version of the network.
-    protocol_version: ProtocolVersion,
-    auction_delay: u64,
-    unbonding_delay: u64,
-    #[data_size(skip)]
-    metrics: LinearChainMetrics,
-
-    _marker: PhantomData<I>,
-}
-
-impl<I> LinearChain<I> {
-    pub fn new(
-        registry: &Registry,
-        protocol_version: ProtocolVersion,
-        auction_delay: u64,
-        unbonding_delay: u64,
-        activation_era_id: EraId,
-    ) -> Result<Self, prometheus::Error> {
-        let metrics = LinearChainMetrics::new(registry)?;
-        Ok(LinearChain {
-            latest_block: None,
-            pending_finality_signatures: HashMap::new(),
-            signature_cache: SignatureCache::new(),
-            activation_era_id,
-            protocol_version,
-            auction_delay,
-            unbonding_delay,
-            metrics,
-            _marker: PhantomData,
-        })
-    }
-
-    // Checks if we have already enqueued that finality signature.
-    fn has_finality_signature(&self, fs: &FinalitySignature) -> bool {
-        let creator = fs.public_key;
-        let block_hash = fs.block_hash;
-        self.pending_finality_signatures
-            .get(&creator)
-            .map_or(false, |sigs| sigs.contains_key(&block_hash))
-    }
-
-    /// Removes all entries for which there are no finality signatures.
-    fn remove_empty_entries(&mut self) {
-        self.pending_finality_signatures
-            .retain(|_, sigs| !sigs.is_empty());
-    }
-
-    /// Adds pending finality signatures to the block; returns events to announce and broadcast
-    /// them, and the updated block signatures.
-    fn collect_pending_finality_signatures<REv>(
-        &mut self,
-        block_hash: &BlockHash,
-        block_era: EraId,
-        effect_builder: EffectBuilder<REv>,
-    ) -> (BlockSignatures, Effects<Event<I>>)
-    where
-        REv: From<StorageRequest>
-            + From<NetworkRequest<I, Message>>
-            + From<LinearChainAnnouncement>
-            + Send,
-        I: Display + Send + 'static,
-    {
-        let mut effects = Effects::new();
-        let mut known_signatures = self
-            .signature_cache
-            .get_known_signatures(block_hash, block_era);
-        let pending_sigs = self
-            .pending_finality_signatures
-            .values_mut()
-            .filter_map(|sigs| sigs.remove(&block_hash))
-            .filter(|signature| {
-                !known_signatures
-                    .proofs
-                    .contains_key(&signature.to_inner().public_key)
-            })
-            .collect_vec();
-        self.remove_empty_entries();
-        // Add new signatures and send the updated block to storage.
-        for signature in pending_sigs {
-            if signature.to_inner().era_id != block_era {
-                // finality signature was created with era id that doesn't match block's era.
-                // TODO: disconnect from the sender.
-                continue;
-            }
-            known_signatures.insert_proof(
-                signature.to_inner().public_key,
-                signature.to_inner().signature,
-            );
-            if signature.is_local() {
-                let message = Message::FinalitySignature(Box::new(signature.to_inner().clone()));
-                effects.extend(effect_builder.broadcast_message(message).ignore());
-            }
-            effects.extend(
-                effect_builder
-                    .announce_finality_signature(signature.take())
-                    .ignore(),
-            );
-        }
-        (known_signatures, effects)
-    }
-
-    /// Adds finality signature to the collection of pending finality signatures.
-    fn add_pending_finality_signature(&mut self, fs: FinalitySignature, gossiped: bool) {
-        let FinalitySignature {
-            block_hash,
-            public_key,
-            ..
-        } = fs;
-        debug!(%block_hash, %public_key, "received new finality signature");
-        let sigs = self
-            .pending_finality_signatures
-            .entry(public_key)
-            .or_default();
-        // Limit the memory we use for storing unknown signatures from each validator.
-        if sigs.len() >= MAX_PENDING_FINALITY_SIGNATURES_PER_VALIDATOR {
-            warn!(
-                %block_hash, %public_key,
-                "received too many finality signatures for unknown blocks"
-            );
-            return;
-        }
-
-        let signature = if gossiped {
-            Signature::External(Box::new(fs))
-        } else {
-            Signature::Local(Box::new(fs))
-        };
-        // Add the pending signature.
-        let _ = sigs.insert(block_hash, signature);
-    }
-
-    /// Removes finality signature from the pending collection.
-    fn remove_from_pending_fs(&mut self, fs: &FinalitySignature) -> Option<Signature> {
-        let FinalitySignature {
-            block_hash,
-            era_id: _era_id,
-            signature: _signature,
-            public_key,
-        } = fs;
-        debug!(%block_hash, %public_key, "removing finality signature from pending collection");
-        let maybe_sig =
-            if let Some(validator_sigs) = self.pending_finality_signatures.get_mut(public_key) {
-                validator_sigs.remove(&block_hash)
-            } else {
-                None
-            };
-        self.remove_empty_entries();
-        maybe_sig
-    }
-}
+pub(crate) use state::LinearChain;
 
 impl<I, REv> Component<REv> for LinearChain<I>
 where

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -1,17 +1,18 @@
+mod event;
+
 use std::{
     collections::{hash_map::Entry, HashMap},
     convert::Infallible,
-    fmt::{self, Display, Formatter},
+    fmt::Display,
     marker::PhantomData,
 };
 
 use datasize::DataSize;
-use derive_more::From;
 use itertools::Itertools;
 use prometheus::{IntGauge, Registry};
 use tracing::{debug, error, info, warn};
 
-use casper_types::{EraId, ExecutionResult, ProtocolVersion, PublicKey};
+use casper_types::{EraId, ProtocolVersion, PublicKey};
 
 use super::Component;
 use crate::{
@@ -25,73 +26,15 @@ use crate::{
         EffectBuilder, EffectExt, EffectResultExt, Effects,
     },
     protocol::Message,
-    types::{
-        Block, BlockByHeight, BlockHash, BlockSignatures, DeployHash, FinalitySignature, Timestamp,
-    },
+    types::{Block, BlockByHeight, BlockHash, BlockSignatures, FinalitySignature, Timestamp},
     unregister_metric, NodeRng,
 };
+
+pub use event::Event;
 
 /// The maximum number of finality signatures from a single validator we keep in memory while
 /// waiting for their block.
 const MAX_PENDING_FINALITY_SIGNATURES_PER_VALIDATOR: usize = 1000;
-
-#[derive(Debug, From)]
-pub enum Event<I> {
-    /// A linear chain request issued by another node in the network.
-    #[from]
-    Request(LinearChainRequest<I>),
-    /// New linear chain block has been produced.
-    NewLinearChainBlock {
-        /// The block.
-        block: Box<Block>,
-        /// The deploys' execution results.
-        execution_results: HashMap<DeployHash, ExecutionResult>,
-    },
-    /// Finality signature received.
-    /// Not necessarily _new_ finality signature.
-    FinalitySignatureReceived(Box<FinalitySignature>, bool),
-    /// The result of putting a block to storage.
-    PutBlockResult {
-        /// The block.
-        block: Box<Block>,
-    },
-    /// The result of requesting finality signatures from storage to add pending signatures.
-    GetStoredFinalitySignaturesResult(Box<FinalitySignature>, Option<Box<BlockSignatures>>),
-    /// Result of testing if creator of the finality signature is bonded validator.
-    IsBonded(Option<Box<BlockSignatures>>, Box<FinalitySignature>, bool),
-}
-
-impl<I: Display> Display for Event<I> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Event::Request(req) => write!(f, "linear chain request: {}", req),
-            Event::NewLinearChainBlock { block, .. } => {
-                write!(f, "linear chain new block: {}", block.hash())
-            }
-            Event::FinalitySignatureReceived(fs, gossiped) => write!(
-                f,
-                "linear-chain new finality signature for block: {}, from: {}, external: {}",
-                fs.block_hash, fs.public_key, gossiped
-            ),
-            Event::PutBlockResult { .. } => write!(f, "linear-chain put-block result"),
-            Event::GetStoredFinalitySignaturesResult(finality_signature, maybe_signatures) => {
-                write!(
-                    f,
-                    "linear chain get-stored-finality-signatures result for {} found: {}",
-                    finality_signature.block_hash,
-                    maybe_signatures.is_some(),
-                )
-            }
-            Event::IsBonded(_block, fs, is_bonded) => {
-                write!(
-                    f,
-                    "linear chain is-bonded for era {} validator {}, is_bonded: {}",
-                    fs.era_id, fs.public_key, is_bonded
-                )
-            }
-        }
-    }
-}
 
 #[derive(DataSize, Debug)]
 struct SignatureCache {

--- a/node/src/components/linear_chain/event.rs
+++ b/node/src/components/linear_chain/event.rs
@@ -1,0 +1,70 @@
+use std::{
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+};
+
+use casper_types::ExecutionResult;
+use derive_more::From;
+
+use crate::{
+    effect::requests::LinearChainRequest,
+    types::{Block, BlockSignatures, DeployHash, FinalitySignature},
+};
+
+#[derive(Debug, From)]
+pub enum Event<I> {
+    /// A linear chain request issued by another node in the network.
+    #[from]
+    Request(LinearChainRequest<I>),
+    /// New linear chain block has been produced.
+    NewLinearChainBlock {
+        /// The block.
+        block: Box<Block>,
+        /// The deploys' execution results.
+        execution_results: HashMap<DeployHash, ExecutionResult>,
+    },
+    /// Finality signature received.
+    /// Not necessarily _new_ finality signature.
+    FinalitySignatureReceived(Box<FinalitySignature>, bool),
+    /// The result of putting a block to storage.
+    PutBlockResult {
+        /// The block.
+        block: Box<Block>,
+    },
+    /// The result of requesting finality signatures from storage to add pending signatures.
+    GetStoredFinalitySignaturesResult(Box<FinalitySignature>, Option<Box<BlockSignatures>>),
+    /// Result of testing if creator of the finality signature is bonded validator.
+    IsBonded(Option<Box<BlockSignatures>>, Box<FinalitySignature>, bool),
+}
+
+impl<I: Display> Display for Event<I> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Event::Request(req) => write!(f, "linear chain request: {}", req),
+            Event::NewLinearChainBlock { block, .. } => {
+                write!(f, "linear chain new block: {}", block.hash())
+            }
+            Event::FinalitySignatureReceived(fs, gossiped) => write!(
+                f,
+                "linear-chain new finality signature for block: {}, from: {}, external: {}",
+                fs.block_hash, fs.public_key, gossiped
+            ),
+            Event::PutBlockResult { .. } => write!(f, "linear-chain put-block result"),
+            Event::GetStoredFinalitySignaturesResult(finality_signature, maybe_signatures) => {
+                write!(
+                    f,
+                    "linear chain get-stored-finality-signatures result for {} found: {}",
+                    finality_signature.block_hash,
+                    maybe_signatures.is_some(),
+                )
+            }
+            Event::IsBonded(_block, fs, is_bonded) => {
+                write!(
+                    f,
+                    "linear chain is-bonded for era {} validator {}, is_bonded: {}",
+                    fs.era_id, fs.public_key, is_bonded
+                )
+            }
+        }
+    }
+}

--- a/node/src/components/linear_chain/metrics.rs
+++ b/node/src/components/linear_chain/metrics.rs
@@ -1,0 +1,30 @@
+use prometheus::{IntGauge, Registry};
+
+use crate::unregister_metric;
+
+#[derive(Debug)]
+pub(super) struct LinearChainMetrics {
+    pub(super) block_completion_duration: IntGauge,
+    /// Prometheus registry used to publish metrics.
+    registry: Registry,
+}
+
+impl LinearChainMetrics {
+    pub(super) fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
+        let block_completion_duration = IntGauge::new(
+            "block_completion_duration",
+            "duration of time from consensus through execution for a block",
+        )?;
+        registry.register(Box::new(block_completion_duration.clone()))?;
+        Ok(Self {
+            block_completion_duration,
+            registry: registry.clone(),
+        })
+    }
+}
+
+impl Drop for LinearChainMetrics {
+    fn drop(&mut self) {
+        unregister_metric!(self.registry, self.block_completion_duration);
+    }
+}

--- a/node/src/components/linear_chain/signature.rs
+++ b/node/src/components/linear_chain/signature.rs
@@ -1,0 +1,28 @@
+use datasize::DataSize;
+
+use crate::types::FinalitySignature;
+
+#[derive(DataSize, Debug)]
+pub(super) enum Signature {
+    Local(Box<FinalitySignature>),
+    External(Box<FinalitySignature>),
+}
+
+impl Signature {
+    pub(super) fn to_inner(&self) -> &FinalitySignature {
+        match self {
+            Signature::Local(fs) => fs,
+            Signature::External(fs) => fs,
+        }
+    }
+
+    pub(super) fn take(self) -> Box<FinalitySignature> {
+        match self {
+            Signature::Local(fs) | Signature::External(fs) => fs,
+        }
+    }
+
+    pub(super) fn is_local(&self) -> bool {
+        matches!(self, Signature::Local(_))
+    }
+}

--- a/node/src/components/linear_chain/signature_cache.rs
+++ b/node/src/components/linear_chain/signature_cache.rs
@@ -1,0 +1,67 @@
+use std::collections::{hash_map::Entry, HashMap};
+
+use casper_types::EraId;
+use datasize::DataSize;
+
+use crate::types::{BlockHash, BlockSignatures, FinalitySignature};
+
+#[derive(DataSize, Debug)]
+pub(super) struct SignatureCache {
+    curr_era: EraId,
+    signatures: HashMap<BlockHash, BlockSignatures>,
+}
+
+impl SignatureCache {
+    pub(super) fn new() -> Self {
+        SignatureCache {
+            curr_era: EraId::from(0),
+            signatures: Default::default(),
+        }
+    }
+
+    pub(super) fn get(&mut self, hash: &BlockHash, _era_id: EraId) -> Option<BlockSignatures> {
+        self.signatures.get(hash).cloned()
+    }
+
+    pub(super) fn insert(&mut self, block_signature: BlockSignatures) {
+        // We optimistically assume that most of the signatures that arrive in close temporal
+        // proximity refer to the same era.
+        if self.curr_era < block_signature.era_id {
+            self.signatures.clear();
+            self.curr_era = block_signature.era_id;
+        }
+        match self.signatures.entry(block_signature.block_hash) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().proofs.extend(block_signature.proofs);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(block_signature);
+            }
+        }
+    }
+
+    /// Get signatures from the cache to be updated.
+    /// If there are no signatures, create an empty signature to be updated.
+    pub(super) fn get_known_signatures(
+        &self,
+        block_hash: &BlockHash,
+        block_era: EraId,
+    ) -> BlockSignatures {
+        match self.signatures.get(block_hash) {
+            Some(signatures) => signatures.clone(),
+            None => BlockSignatures::new(*block_hash, block_era),
+        }
+    }
+
+    /// Returns whether finality signature is known already.
+    pub(super) fn known_signature(&self, fs: &FinalitySignature) -> bool {
+        let FinalitySignature {
+            block_hash,
+            public_key,
+            ..
+        } = fs;
+        self.signatures
+            .get(block_hash)
+            .map_or(false, |bs| bs.has_proof(public_key))
+    }
+}

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -1,0 +1,183 @@
+use std::{collections::HashMap, fmt::Display, marker::PhantomData};
+
+use casper_types::{EraId, ProtocolVersion, PublicKey};
+use datasize::DataSize;
+use itertools::Itertools;
+use prometheus::Registry;
+use tracing::{debug, warn};
+
+use crate::{
+    effect::{
+        announcements::LinearChainAnnouncement,
+        requests::{NetworkRequest, StorageRequest},
+        EffectBuilder, EffectExt, Effects,
+    },
+    protocol::Message,
+    types::{Block, BlockHash, BlockSignatures, FinalitySignature},
+};
+
+use super::{
+    metrics::LinearChainMetrics, signature::Signature, signature_cache::SignatureCache, Event,
+};
+
+/// The maximum number of finality signatures from a single validator we keep in memory while
+/// waiting for their block.
+const MAX_PENDING_FINALITY_SIGNATURES_PER_VALIDATOR: usize = 1000;
+#[derive(DataSize, Debug)]
+pub(crate) struct LinearChain<I> {
+    /// The most recently added block.
+    pub(super) latest_block: Option<Block>,
+    /// Finality signatures to be inserted in a block once it is available.
+    pending_finality_signatures: HashMap<PublicKey, HashMap<BlockHash, Signature>>,
+    pub(super) signature_cache: SignatureCache,
+    pub(super) activation_era_id: EraId,
+    /// Current protocol version of the network.
+    pub(super) protocol_version: ProtocolVersion,
+    pub(super) auction_delay: u64,
+    pub(super) unbonding_delay: u64,
+    #[data_size(skip)]
+    pub(super) metrics: LinearChainMetrics,
+
+    _marker: PhantomData<I>,
+}
+
+impl<I> LinearChain<I> {
+    pub fn new(
+        registry: &Registry,
+        protocol_version: ProtocolVersion,
+        auction_delay: u64,
+        unbonding_delay: u64,
+        activation_era_id: EraId,
+    ) -> Result<Self, prometheus::Error> {
+        let metrics = LinearChainMetrics::new(registry)?;
+        Ok(LinearChain {
+            latest_block: None,
+            pending_finality_signatures: HashMap::new(),
+            signature_cache: SignatureCache::new(),
+            activation_era_id,
+            protocol_version,
+            auction_delay,
+            unbonding_delay,
+            metrics,
+            _marker: PhantomData,
+        })
+    }
+
+    // Checks if we have already enqueued that finality signature.
+    pub(super) fn has_finality_signature(&self, fs: &FinalitySignature) -> bool {
+        let creator = fs.public_key;
+        let block_hash = fs.block_hash;
+        self.pending_finality_signatures
+            .get(&creator)
+            .map_or(false, |sigs| sigs.contains_key(&block_hash))
+    }
+
+    /// Removes all entries for which there are no finality signatures.
+    fn remove_empty_entries(&mut self) {
+        self.pending_finality_signatures
+            .retain(|_, sigs| !sigs.is_empty());
+    }
+
+    /// Adds pending finality signatures to the block; returns events to announce and broadcast
+    /// them, and the updated block signatures.
+    pub(super) fn collect_pending_finality_signatures<REv>(
+        &mut self,
+        block_hash: &BlockHash,
+        block_era: EraId,
+        effect_builder: EffectBuilder<REv>,
+    ) -> (BlockSignatures, Effects<Event<I>>)
+    where
+        REv: From<StorageRequest>
+            + From<NetworkRequest<I, Message>>
+            + From<LinearChainAnnouncement>
+            + Send,
+        I: Display + Send + 'static,
+    {
+        let mut effects = Effects::new();
+        let mut known_signatures = self
+            .signature_cache
+            .get_known_signatures(block_hash, block_era);
+        let pending_sigs = self
+            .pending_finality_signatures
+            .values_mut()
+            .filter_map(|sigs| sigs.remove(&block_hash))
+            .filter(|signature| {
+                !known_signatures
+                    .proofs
+                    .contains_key(&signature.to_inner().public_key)
+            })
+            .collect_vec();
+        self.remove_empty_entries();
+        // Add new signatures and send the updated block to storage.
+        for signature in pending_sigs {
+            if signature.to_inner().era_id != block_era {
+                // finality signature was created with era id that doesn't match block's era.
+                // TODO: disconnect from the sender.
+                continue;
+            }
+            known_signatures.insert_proof(
+                signature.to_inner().public_key,
+                signature.to_inner().signature,
+            );
+            if signature.is_local() {
+                let message = Message::FinalitySignature(Box::new(signature.to_inner().clone()));
+                effects.extend(effect_builder.broadcast_message(message).ignore());
+            }
+            effects.extend(
+                effect_builder
+                    .announce_finality_signature(signature.take())
+                    .ignore(),
+            );
+        }
+        (known_signatures, effects)
+    }
+
+    /// Adds finality signature to the collection of pending finality signatures.
+    pub(super) fn add_pending_finality_signature(&mut self, fs: FinalitySignature, gossiped: bool) {
+        let FinalitySignature {
+            block_hash,
+            public_key,
+            ..
+        } = fs;
+        debug!(%block_hash, %public_key, "received new finality signature");
+        let sigs = self
+            .pending_finality_signatures
+            .entry(public_key)
+            .or_default();
+        // Limit the memory we use for storing unknown signatures from each validator.
+        if sigs.len() >= MAX_PENDING_FINALITY_SIGNATURES_PER_VALIDATOR {
+            warn!(
+                %block_hash, %public_key,
+                "received too many finality signatures for unknown blocks"
+            );
+            return;
+        }
+
+        let signature = if gossiped {
+            Signature::External(Box::new(fs))
+        } else {
+            Signature::Local(Box::new(fs))
+        };
+        // Add the pending signature.
+        let _ = sigs.insert(block_hash, signature);
+    }
+
+    /// Removes finality signature from the pending collection.
+    pub(super) fn remove_from_pending_fs(&mut self, fs: &FinalitySignature) -> Option<Signature> {
+        let FinalitySignature {
+            block_hash,
+            era_id: _era_id,
+            signature: _signature,
+            public_key,
+        } = fs;
+        debug!(%block_hash, %public_key, "removing finality signature from pending collection");
+        let maybe_sig =
+            if let Some(validator_sigs) = self.pending_finality_signatures.get_mut(public_key) {
+                validator_sigs.remove(&block_hash)
+            } else {
+                None
+            };
+        self.remove_empty_entries();
+        maybe_sig
+    }
+}

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -494,7 +494,6 @@ impl reactor::Reactor for Reactor {
         let linear_chain = linear_chain::LinearChain::new(
             &registry,
             *protocol_version,
-            chainspec_loader.initial_state_root_hash(),
             chainspec_loader.chainspec().core_config.auction_delay,
             chainspec_loader.chainspec().core_config.unbonding_delay,
             chainspec_loader

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -489,7 +489,6 @@ impl reactor::Reactor for Reactor {
         let linear_chain = linear_chain::LinearChain::new(
             &registry,
             *protocol_version,
-            chainspec_loader.initial_state_root_hash(),
             chainspec_loader.chainspec().core_config.auction_delay,
             chainspec_loader.chainspec().core_config.unbonding_delay,
             chainspec_loader


### PR DESCRIPTION
This PR moves some `struct`s from the `linear_chain.rs` file to separate files. No functional changes.

I recommend reviewing this commit-by-commit.