### PR TITLE
OP-1951: NCTL - new bonds test hanging Fix

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -59,7 +59,7 @@ start_run_teardown "itst13.sh" "itst13.chainspec.toml.in"
 start_run_teardown "itst14.sh" "itst14.chainspec.toml.in" "itst14.accounts.toml"
 start_run_teardown "sync_test.sh node=6 timeout=500"
 start_run_teardown "sync_upgrade_test.sh node=6 era=4 timeout=500"
-#start_run_teardown "bond_its.sh" "bond_its.chainspec.toml.in" "bond_its.accounts.toml"
+start_run_teardown "bond_its.sh" "bond_its.chainspec.toml.in" "bond_its.accounts.toml"
 
 # Clean up cloned repo
 popd

--- a/utils/nctl/sh/scenarios/accounts_toml/bond_its.accounts.toml
+++ b/utils/nctl/sh/scenarios/accounts_toml/bond_its.accounts.toml
@@ -53,10 +53,6 @@ delegation_rate = 5
 public_key = "PBK_V6"
 balance = "1000000000000000000000000000000000"
 
-[accounts.validator]
-bonded_amount = "1000"
-delegation_rate = 6
-
 # VALIDATOR 7.
 [[accounts]]
 public_key = "PBK_V7"
@@ -82,42 +78,40 @@ balance = "1000000000000000000000000000000000"
 validator_public_key = "PBK_V1"
 delegator_public_key = "PBK_U1"
 balance = "1000000000000000000000000000000000"
-delegated_amount = "1000000000000001"
+delegated_amount = "1"
 
 # USER 2.
 [[delegators]]
 validator_public_key = "PBK_V2"
 delegator_public_key = "PBK_U2"
 balance = "1000000000000000000000000000000000"
-delegated_amount = "1000000000000002"
+delegated_amount = "1"
 
 # USER 3.
 [[delegators]]
 validator_public_key = "PBK_V3"
 delegator_public_key = "PBK_U3"
 balance = "1000000000000000000000000000000000"
-delegated_amount = "1000000000000003"
+delegated_amount = "1"
 
 # USER 4.
 [[delegators]]
 validator_public_key = "PBK_V4"
 delegator_public_key = "PBK_U4"
 balance = "1000000000000000000000000000000000"
-delegated_amount = "1000000000000004"
+delegated_amount = "1"
 
 # USER 5.
 [[delegators]]
 validator_public_key = "PBK_V5"
 delegator_public_key = "PBK_U5"
 balance = "1000000000000000000000000000000000"
-delegated_amount = "1000000000000005"
+delegated_amount = "1"
 
 # USER 6.
-[[delegators]]
-validator_public_key = "PBK_V6"
-delegator_public_key = "PBK_U6"
+[[accounts]]
+public_key = "PBK_U6"
 balance = "1000000000000000000000000000000000"
-delegated_amount = "1000000000000006"
 
 # USER 7.
 [[accounts]]

--- a/utils/nctl/sh/scenarios/bond_its.sh
+++ b/utils/nctl/sh/scenarios/bond_its.sh
@@ -30,7 +30,7 @@ function main() {
     assert_new_bonded_validator "6"
     log "The new node has bonded in."
     # 6. Assert that the new bonded validator is producing blocks.
-    assert_node_proposed "6"
+    assert_node_proposed "6" "180"
 
 
     log "------------------------------------------------------------"

--- a/utils/nctl/sh/scenarios/bond_its.sh
+++ b/utils/nctl/sh/scenarios/bond_its.sh
@@ -13,7 +13,6 @@ function main() {
     log "Starting Scenario: Bonding test"
     log "------------------------------------------------------------"
 
-
     # 0. Wait for network to start up
     do_await_genesis_era_to_complete
     # 1. Allow the chain to progress
@@ -25,7 +24,7 @@ function main() {
     do_read_lfb_hash "5"
     do_start_node "6" "$LFB_HASH"
     # 4. wait auction_delay + 1
-    do_await_era_change "3"
+    do_await_era_change "4"
     # 5. Assert that the validator is bonded in.
     assert_new_bonded_validator "6"
     log "The new node has bonded in."
@@ -44,7 +43,7 @@ function do_submit_auction_bids()
     local NODE_ID=${1}
     log_step "submitting POS auction bids:"
     log "----- ----- ----- ----- ----- -----"
-    BID_AMOUNT=$(get_node_staking_weight "$NODE_ID")
+    BID_AMOUNT="1000000000000000000000000000000"
     BID_DELEGATION_RATE=6
 
     source "$NCTL"/sh/contracts-auction/do_bid.sh \
@@ -69,6 +68,21 @@ function assert_new_bonded_validator() {
     fi
 }
 
+function assert_node_proposed() {
+    local NODE_ID=${1}
+    local NODE_PATH=$(get_path_to_node "$NODE_ID")
+    local PUBLIC_KEY_HEX=$(get_node_public_key_hex "$NODE_ID")
+    local TIMEOUT=${2:-300}
+    log_step "Waiting for a node-$NODE_ID to produce a block..."
+    local OUTPUT=$(timeout "$TIMEOUT" tail -n 1 -f "$NODE_PATH/logs/stdout.log" | grep -o -m 1 "proposer: PublicKey::Ed25519($PUBLIC_KEY_HEX)")
+    if ( echo "$OUTPUT" | grep -q "proposer: PublicKey::Ed25519($PUBLIC_KEY_HEX)" ); then
+        log "Node-$NODE_ID created a block!"
+        log "$OUTPUT"
+    else
+        log "ERROR: Node-$NODE_ID didn't create a block within timeout=$TIMEOUT"
+        exit 1
+    fi
+}
 
 # ----------------------------------------------------------------
 # ENTRY POINT


### PR DESCRIPTION
CHANGELOG:

- Updated the `bond_its.accounts.toml` file to help improve the consistency of the test 
- Added a timeout inside the scenario to timeout incase of failure