### PR TITLE
NDRS-833: Wrap pending signatures in a struct and extract to a file.

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -1,5 +1,6 @@
 mod event;
 mod metrics;
+mod pending_signatures;
 mod signature;
 mod signature_cache;
 mod state;

--- a/node/src/components/linear_chain/pending_signatures.rs
+++ b/node/src/components/linear_chain/pending_signatures.rs
@@ -1,0 +1,95 @@
+use datasize::DataSize;
+use itertools::Itertools;
+use std::collections::HashMap;
+use tracing::warn;
+
+use super::signature::Signature;
+use crate::types::{BlockHash, BlockSignatures};
+use casper_types::PublicKey;
+
+/// The maximum number of finality signatures from a single validator we keep in memory while
+/// waiting for their block.
+const MAX_PENDING_FINALITY_SIGNATURES_PER_VALIDATOR: usize = 1000;
+
+/// Finality signatures to be inserted in a block once it is available.
+/// Keyed by public key of the creator to limit the maximum amount of pending signatures.
+#[derive(DataSize, Debug, Default)]
+pub(super) struct PendingSignatures {
+    pending_finality_signatures: HashMap<PublicKey, HashMap<BlockHash, Signature>>,
+}
+
+impl PendingSignatures {
+    pub(super) fn new() -> Self {
+        PendingSignatures {
+            pending_finality_signatures: HashMap::new(),
+        }
+    }
+    // Checks if we have already enqueued that finality signature.
+    pub(super) fn has_finality_signature(
+        &self,
+        creator: &PublicKey,
+        block_hash: &BlockHash,
+    ) -> bool {
+        self.pending_finality_signatures
+            .get(creator)
+            .map_or(false, |sigs| sigs.contains_key(block_hash))
+    }
+
+    pub(super) fn collect_pending(
+        &mut self,
+        block_hash: &BlockHash,
+        known_signatures: &BlockSignatures,
+    ) -> Vec<Signature> {
+        let pending_sigs = self
+            .pending_finality_signatures
+            .values_mut()
+            .filter_map(|sigs| sigs.remove(&block_hash))
+            .filter(|signature| {
+                !known_signatures
+                    .proofs
+                    .contains_key(&signature.to_inner().public_key)
+            })
+            .collect_vec();
+        self.remove_empty_entries();
+        pending_sigs
+    }
+
+    pub(super) fn add(&mut self, signature: Signature) {
+        let public_key = signature.public_key();
+        let block_hash = signature.block_hash();
+        let sigs = self
+            .pending_finality_signatures
+            .entry(public_key)
+            .or_default();
+        // Limit the memory we use for storing unknown signatures from each validator.
+        if sigs.len() >= MAX_PENDING_FINALITY_SIGNATURES_PER_VALIDATOR {
+            warn!(
+                %block_hash, %public_key,
+                "received too many finality signatures for unknown blocks"
+            );
+            return;
+        }
+        // Add the pending signature.
+        let _ = sigs.insert(block_hash, signature);
+    }
+
+    pub(super) fn remove(
+        &mut self,
+        public_key: &PublicKey,
+        block_hash: &BlockHash,
+    ) -> Option<Signature> {
+        if let Some(validator_sigs) = self.pending_finality_signatures.get_mut(public_key) {
+            let sig = validator_sigs.remove(&block_hash);
+            self.remove_empty_entries();
+            sig
+        } else {
+            None
+        }
+    }
+
+    /// Removes all entries for which there are no finality signatures.
+    fn remove_empty_entries(&mut self) {
+        self.pending_finality_signatures
+            .retain(|_, sigs| !sigs.is_empty());
+    }
+}

--- a/node/src/components/linear_chain/signature.rs
+++ b/node/src/components/linear_chain/signature.rs
@@ -1,6 +1,7 @@
+use casper_types::PublicKey;
 use datasize::DataSize;
 
-use crate::types::FinalitySignature;
+use crate::types::{BlockHash, FinalitySignature};
 
 #[derive(DataSize, Debug)]
 pub(super) enum Signature {
@@ -14,6 +15,14 @@ impl Signature {
             Signature::Local(fs) => fs,
             Signature::External(fs) => fs,
         }
+    }
+
+    pub(super) fn public_key(&self) -> PublicKey {
+        self.to_inner().public_key
+    }
+
+    pub(super) fn block_hash(&self) -> BlockHash {
+        self.to_inner().block_hash
     }
 
     pub(super) fn take(self) -> Box<FinalitySignature> {

--- a/node/src/components/linear_chain/signature_cache.rs
+++ b/node/src/components/linear_chain/signature_cache.rs
@@ -19,7 +19,7 @@ impl SignatureCache {
         }
     }
 
-    pub(super) fn get(&mut self, hash: &BlockHash, _era_id: EraId) -> Option<BlockSignatures> {
+    pub(super) fn get(&self, hash: &BlockHash) -> Option<BlockSignatures> {
         self.signatures.get(hash).cloned()
     }
 

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -25,7 +25,7 @@ pub(crate) struct LinearChain<I> {
     pub(super) latest_block: Option<Block>,
     /// Finality signatures to be inserted in a block once it is available.
     pending_finality_signatures: PendingSignatures,
-    pub(super) signature_cache: SignatureCache,
+    signature_cache: SignatureCache,
     pub(super) activation_era_id: EraId,
     /// Current protocol version of the network.
     pub(super) protocol_version: ProtocolVersion,
@@ -194,5 +194,10 @@ impl<I> LinearChain<I> {
     // Caches the signature.
     pub(super) fn cache_signatures(&mut self, signatures: BlockSignatures) {
         self.signature_cache.insert(signatures);
+    }
+
+    /// Returns cached finality signatures that we have already validated and stored.
+    pub(super) fn get_signatures(&self, block_hash: &BlockHash) -> Option<BlockSignatures> {
+        self.signature_cache.get(block_hash)
     }
 }

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -59,12 +59,17 @@ impl<I> LinearChain<I> {
         })
     }
 
-    // Checks if we have already enqueued that finality signature.
-    pub(super) fn has_finality_signature(&self, fs: &FinalitySignature) -> bool {
+    /// Returns whether we have already enqueued that finality signature.
+    pub(super) fn is_pending(&self, fs: &FinalitySignature) -> bool {
         let creator = fs.public_key;
         let block_hash = fs.block_hash;
         self.pending_finality_signatures
             .has_finality_signature(&creator, &block_hash)
+    }
+
+    /// Returns whether we have already seen and stored the finality signature.
+    pub(super) fn is_new(&self, fs: &FinalitySignature) -> bool {
+        !self.signature_cache.known_signature(fs)
     }
 
     /// Adds pending finality signatures to the block; returns events to announce and broadcast
@@ -141,5 +146,10 @@ impl<I> LinearChain<I> {
         debug!(%block_hash, %public_key, "removing finality signature from pending collection");
         self.pending_finality_signatures
             .remove(&public_key, &block_hash)
+    }
+
+    // Caches the signature.
+    pub(super) fn cache_signatures(&mut self, signatures: BlockSignatures) {
+        self.signature_cache.insert(signatures);
     }
 }


### PR DESCRIPTION
Another clean-up PR that will make writing unit tests easier. In this PR:
* we wrap pending finality signatures with a struct (and extract it to a file) that guards the invariants of the pending collection,
* add methods on the signature cache to mutate the state, rather than mutating it directly from the `LinearChain` component,
* move validation of the incoming signature out of the component-level logic (so that we can test it without involving the component)
* remove the direct access to the signature cache from the component-level logic (it's now accessed only via methods on the `State` struct).