### PR TITLE
NO-TICKET: Limit message size in chainspec

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -158,6 +158,8 @@ where
     /// Name of the network we participate in. We only remain connected to peers with the same
     /// network name as us.
     network_name: String,
+    /// The maximum message size for a network message, as supplied from the chainspec.
+    maximum_net_message_size: u32,
     /// Channel signaling a shutdown of the small network.
     // Note: This channel is closed when `SmallNetwork` is dropped, signalling the receivers that
     // they should cease operation.
@@ -196,6 +198,7 @@ where
         registry: &Registry,
         small_network_identity: SmallNetworkIdentity,
         network_name: String,
+        maximum_net_message_size: u32,
         notify: bool,
     ) -> Result<(SmallNetwork<REv, P>, Effects<Event<P>>)> {
         let mut known_addresses = HashSet::new();
@@ -242,6 +245,7 @@ where
                 pending: HashMap::new(),
                 blocklist: HashMap::new(),
                 network_name,
+                maximum_net_message_size,
                 shutdown_sender: None,
                 shutdown_receiver: watch::channel(()).1,
                 server_join_handle: None,
@@ -306,6 +310,7 @@ where
             pending: HashMap::new(),
             blocklist: HashMap::new(),
             network_name,
+            maximum_net_message_size,
             shutdown_sender: Some(server_shutdown_sender),
             shutdown_receiver,
             server_join_handle: Some(server_join_handle),
@@ -496,7 +501,8 @@ where
 
                 debug!(our_id=%self.our_id, %peer_id, %peer_address, "established incoming connection");
                 // The sink is only used to send a single handshake message, then dropped.
-                let (mut sink, stream) = framed::<P>(transport).split();
+                let (mut sink, stream) =
+                    framed::<P>(transport, self.maximum_net_message_size).split();
                 let handshake = Message::Handshake {
                     network_name: self.network_name.clone(),
                     public_address: self.public_address,
@@ -580,7 +586,7 @@ where
         }
 
         // The stream is only used to receive a single handshake message and then dropped.
-        let (sink, stream) = framed::<P>(transport).split();
+        let (sink, stream) = framed::<P>(transport, self.maximum_net_message_size).split();
         debug!(our_id=%self.our_id, %peer_id, %peer_address, "established outgoing connection");
 
         let (sender, receiver) = mpsc::unbounded_channel();
@@ -1302,8 +1308,13 @@ type FramedTransport<P> = SymmetricallyFramed<
 >;
 
 /// Constructs a new framed transport on a stream.
-fn framed<P>(stream: Transport) -> FramedTransport<P> {
-    let length_delimited = Framed::new(stream, LengthDelimitedCodec::new());
+fn framed<P>(stream: Transport, maximum_net_message_size: u32) -> FramedTransport<P> {
+    let length_delimited = Framed::new(
+        stream,
+        LengthDelimitedCodec::builder()
+            .max_frame_length(maximum_net_message_size as usize)
+            .new_codec(),
+    );
     SymmetricallyFramed::new(
         length_delimited,
         SymmetricalMessagePack::<Message<P>>::default(),

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -61,7 +61,9 @@ pub enum Error {
         ResolveAddressError,
     ),
     /// Failed to send message.
-    #[error("failed to send message")]
+    // TODO: Inclusion of the cause is a workaround, we should actually be printing cause-traces
+    //       when logging errors.
+    #[error("failed to send message: {0}")]
     MessageNotSent(
         #[serde(skip_serializing)]
         #[source]

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -140,6 +140,7 @@ impl Reactor for TestReactor {
             registry,
             small_network_identity,
             "test_network".to_string(),
+            23 * 1024 * 1024, // Hardcoded at 23 megs.
             false,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -424,12 +424,17 @@ impl reactor::Reactor for Reactor {
             false,
         )?;
         let network_name = chainspec_loader.chainspec().network_config.name.clone();
+        let maximum_net_message_size = chainspec_loader
+            .chainspec()
+            .network_config
+            .maximum_net_message_size;
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network.clone(),
             registry,
             small_network_identity,
             network_name,
+            maximum_net_message_size,
             false,
         )?;
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -422,12 +422,17 @@ impl reactor::Reactor for Reactor {
             true,
         )?;
         let network_name = chainspec_loader.chainspec().network_config.name.clone();
+        let maximum_net_message_size = chainspec_loader
+            .chainspec()
+            .network_config
+            .maximum_net_message_size;
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network,
             registry,
             small_network_identity,
             network_name,
+            maximum_net_message_size,
             true,
         )?;
 

--- a/node/src/types/chainspec/network_config.rs
+++ b/node/src/types/chainspec/network_config.rs
@@ -17,7 +17,11 @@ use crate::testing::TestRng;
 pub struct NetworkConfig {
     /// The network name.
     pub(crate) name: String,
+    /// The maximum size of an accepted network message, in bytes.
+    pub(crate) maximum_net_message_size: u32,
     /// Validator accounts specified in the chainspec.
+    // Note: `accounts_config` must be the last field on this struct due to issues in the TOML
+    // crate - see <https://github.com/alexcrichton/toml-rs/search?q=ValueAfterTable&type=issues>.
     pub(crate) accounts_config: AccountsConfig,
 }
 
@@ -46,10 +50,12 @@ impl NetworkConfig {
         let accounts = vec![rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen()];
         let delegators = vec![rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen()];
         let accounts_config = AccountsConfig::new(accounts, delegators);
+        let maximum_net_message_size = 4 + rng.gen_range(0..4);
 
         NetworkConfig {
             name,
             accounts_config,
+            maximum_net_message_size,
         }
     }
 }
@@ -59,11 +65,14 @@ impl ToBytes for NetworkConfig {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         buffer.extend(self.name.to_bytes()?);
         buffer.extend(self.accounts_config.to_bytes()?);
+        buffer.extend(self.maximum_net_message_size.to_bytes()?);
         Ok(buffer)
     }
 
     fn serialized_length(&self) -> usize {
-        self.name.serialized_length() + self.accounts_config.serialized_length()
+        self.name.serialized_length()
+            + self.accounts_config.serialized_length()
+            + self.maximum_net_message_size.serialized_length()
     }
 }
 
@@ -71,9 +80,11 @@ impl FromBytes for NetworkConfig {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (name, remainder) = String::from_bytes(bytes)?;
         let (accounts_config, remainder) = FromBytes::from_bytes(remainder)?;
+        let (maximum_net_message_size, remainder) = FromBytes::from_bytes(remainder)?;
         let config = NetworkConfig {
             name,
             accounts_config,
+            maximum_net_message_size,
         };
         Ok((config, remainder))
     }

--- a/node/src/types/chainspec/parse_toml.rs
+++ b/node/src/types/chainspec/parse_toml.rs
@@ -25,6 +25,7 @@ use crate::utils::{self, Loadable};
 #[serde(deny_unknown_fields)]
 struct TomlNetwork {
     name: String,
+    maximum_net_message_size: u32,
 }
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
@@ -59,6 +60,7 @@ impl From<&Chainspec> for TomlChainspec {
         };
         let network = TomlNetwork {
             name: chainspec.network_config.name.clone(),
+            maximum_net_message_size: chainspec.network_config.maximum_net_message_size,
         };
         let core = chainspec.core_config;
         let deploys = chainspec.deploy_config;
@@ -93,6 +95,7 @@ pub(super) fn parse_toml<P: AsRef<Path>>(chainspec_path: P) -> Result<Chainspec,
     let network_config = NetworkConfig {
         name: toml_chainspec.network.name,
         accounts_config,
+        maximum_net_message_size: toml_chainspec.network.maximum_net_message_size,
     };
 
     let global_state_update = Option::<GlobalStateUpdateConfig>::from_path(root)?

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -18,6 +18,9 @@ activation_point = '${TIMESTAMP}'
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper-example'
+# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# be rejected at the networking level.
+maximum_net_message_size = 23_068_672
 
 [core]
 # Era duration.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -18,6 +18,9 @@ activation_point = '2021-03-31T15:00:00Z'
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper'
+# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# be rejected at the networking level.
+maximum_net_message_size = 23_068_672
 
 [core]
 # Era duration.

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -5,6 +5,7 @@ activation_point = '2020-09-18T18:45:00Z'
 
 [network]
 name = 'test-chain'
+maximum_net_message_size = 23_068_672
 
 [core]
 era_duration = '3minutes'

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -5,6 +5,7 @@ activation_point = '2020-09-18T18:45:00Z'
 
 [network]
 name = 'test-chain'
+maximum_net_message_size = 23_068_672
 
 [core]
 era_duration = '3minutes'

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -5,6 +5,7 @@ activation_point = 1
 
 [network]
 name = 'test-chain'
+maximum_net_message_size = 23_068_672
 
 [core]
 era_duration = '3minutes'

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -18,6 +18,9 @@ name = 'casper-example'
 # timestamp is also used in seeding the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 timestamp = '${TIMESTAMP}'
+# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# be rejected at the networking level.
+maximum_net_message_size = 23_068_672
 
 [core]
 # Era duration.


### PR DESCRIPTION
This ensures that nodes are in agreement about what the maximum message size is through the chainspec.