### PR TITLE
NO-TICKET: Include chainspec version in handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,9 +423,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
-version = "1.3.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder",
  "serde",
@@ -618,9 +618,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -839,6 +839,7 @@ dependencies = [
  "rand_pcg 0.3.0",
  "regex",
  "reqwest",
+ "rmp-serde",
  "schemars",
  "sd-notify",
  "semver 0.11.0",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -102,6 +102,7 @@ pnet = "0.27.2"
 rand_core = "0.6.2"
 rand_pcg = "0.3.0"
 reqwest = "0.10.8"
+rmp-serde = "0.14.4"
 tokio = { version = "0.2.20", features = ["test-util"] }
 
 [features]

--- a/node/src/components/small_network/chain_info.rs
+++ b/node/src/components/small_network/chain_info.rs
@@ -1,0 +1,57 @@
+//! Network-related chain identification information.
+
+// TODO: This module and `ChainId` should disappear in its entirety and the actual chainspec be made
+// available.
+
+use std::net::SocketAddr;
+
+use casper_types::ProtocolVersion;
+use datasize::DataSize;
+
+use super::Message;
+use crate::types::Chainspec;
+
+/// Data retained from the chainspec by the small networking component.
+///
+/// Typically this information is used for creating handshakes.
+#[derive(DataSize, Debug)]
+pub(crate) struct ChainInfo {
+    /// Name of the network we participate in. We only remain connected to peers with the same
+    /// network name as us.
+    pub(super) network_name: String,
+    /// The maximum message size for a network message, as supplied from the chainspec.
+    pub(super) maximum_net_message_size: u32,
+    /// The protocol version.
+    pub(super) protocol_version: ProtocolVersion,
+}
+
+impl ChainInfo {
+    /// Create an instance of `ChainInfo` for testing.
+    #[cfg(test)]
+    pub fn create_for_testing() -> Self {
+        ChainInfo {
+            network_name: "rust-tests-network".to_string(),
+            maximum_net_message_size: 22 * 1024 * 1024, // Hardcoded at 22M.
+            protocol_version: ProtocolVersion::V1_0_0,
+        }
+    }
+
+    /// Create a handshake based on chain identification data.
+    pub(super) fn create_handshake<P>(&self, public_address: SocketAddr) -> Message<P> {
+        Message::Handshake {
+            network_name: self.network_name.clone(),
+            public_address,
+            protocol_version: self.protocol_version,
+        }
+    }
+}
+
+impl From<&Chainspec> for ChainInfo {
+    fn from(chainspec: &Chainspec) -> Self {
+        ChainInfo {
+            network_name: chainspec.network_config.name.clone(),
+            maximum_net_message_size: chainspec.network_config.maximum_net_message_size,
+            protocol_version: chainspec.protocol_version(),
+        }
+    }
+}

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -3,7 +3,14 @@ use std::{
     net::SocketAddr,
 };
 
+use casper_types::ProtocolVersion;
 use serde::{Deserialize, Serialize};
+
+/// The default protocol version to use in absence of one in the protocol version field.
+#[inline]
+fn default_protocol_version() -> ProtocolVersion {
+    ProtocolVersion::V1_0_0
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Message<P> {
@@ -12,6 +19,9 @@ pub enum Message<P> {
         network_name: String,
         /// The public address of the node connecting.
         public_address: SocketAddr,
+        /// Protocol version the node is speaking.
+        #[serde(default = "default_protocol_version")]
+        protocol_version: ProtocolVersion,
     },
     Payload(P),
 }
@@ -22,12 +32,192 @@ impl<P: Display> Display for Message<P> {
             Message::Handshake {
                 network_name,
                 public_address,
+                protocol_version,
             } => write!(
                 f,
-                "handshake: {}, public addr: {}",
-                network_name, public_address
+                "handshake: {}, public addr: {}, protocol_version: {}",
+                network_name, public_address, protocol_version,
             ),
             Message::Payload(payload) => write!(f, "payload: {}", payload),
+        }
+    }
+}
+
+#[cfg(test)]
+// We use a variety of weird names in these tests.
+#[allow(non_camel_case_types)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use casper_types::ProtocolVersion;
+    use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+    use crate::protocol;
+
+    use super::Message;
+
+    /// Version 1.0.0 network level message.
+    ///
+    /// Note that the message itself may go out of sync over time as `protocol::Message` changes.
+    /// The test further below ensures that the handshake is accurate in the meantime.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub enum V1_0_0_Message {
+        Handshake {
+            /// Network we are connected to.
+            network_name: String,
+            /// The public address of the node connecting.
+            public_address: SocketAddr,
+        },
+        Payload(protocol::Message),
+    }
+
+    /// A "conserved" version 1.0.0 handshake.
+    ///
+    /// NEVER CHANGE THIS CONSTANT TO MAKE TESTS PASS, AS IT IS BASED ON MAINNET DATA.
+    const V1_0_0_HANDSHAKE: &[u8] = &[
+        129, 0, 146, 178, 115, 101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, 45, 116,
+        101, 115, 116, 177, 49, 50, 46, 51, 52, 46, 53, 54, 46, 55, 56, 58, 49, 50, 51, 52, 54,
+    ];
+
+    // Note: MessagePacke messages can be visualized using the message pack visualizer at
+    // https://sugendran.github.io/msgpack-visualizer/
+    // Rust arrays can be copy&pasted and converted to base64 using the following one-liner:
+    // `import base64; base64.b64encode(bytes([129, 0, ...]))`
+
+    // It is very important to note that different versions of the message pack codec crate set the
+    // human-readable flag in a different manner. Thus the V1.0.0 handshake can be serialized in two
+    // different ways, with "human readable" enabled and without.
+    //
+    // Our V1.0.0 protocol uses the "human readable" enabled version, they key difference being that
+    // the `SocketAddr` is encoded as a string instead of a two-item array.
+
+    /// A pseudo-1.0.0 handshake, where the serde human readable flag has been changed due to an
+    /// `rmp` version mismatch.
+    const BROKEN_V1_0_0_HANDSHAKE: &[u8] = &[
+        129, 0, 146, 178, 115, 101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, 45, 116,
+        101, 115, 116, 129, 0, 146, 148, 12, 34, 56, 78, 205, 48, 58,
+    ];
+
+    /// Serialize a message using the standard serialization method for handshakes.
+    fn serialize_message<M: Serialize>(msg: &M) -> Vec<u8> {
+        // The actual serialization/deserialization code can be found at
+        // https://github.com/carllerche/tokio-serde/blob/f3c3d69ce049437973468118c9d01b46e0b1ade5/src/lib.rs#L426-L450
+
+        rmp_serde::to_vec(&msg).expect("handshake serialization failed")
+    }
+
+    /// Deserialize a message using the standard deserialization method for handshakes.
+    fn deserialize_message<M: DeserializeOwned>(serialized: &[u8]) -> M {
+        rmp_serde::from_read(std::io::Cursor::new(&serialized))
+            .expect("handshake deserialization failed")
+    }
+
+    /// Given a message `from` of type `F`, serializes it, then deserializes it as `T`.
+    fn roundtrip_message<F, T>(from: &F) -> T
+    where
+        F: Serialize,
+        T: DeserializeOwned,
+    {
+        let serialized = serialize_message(from);
+        deserialize_message(&serialized)
+    }
+
+    // This test ensure that the serialization of the `V_1_0_0_Message` has not changed and that the
+    // serialization/deserialization methods for message in this test are likely accurate.
+    #[test]
+    fn v1_0_0_handshake_is_as_expected() {
+        let handshake = V1_0_0_Message::Handshake {
+            network_name: "serialization-test".to_owned(),
+            public_address: ([12, 34, 56, 78], 12346).into(),
+        };
+
+        let serialized = serialize_message::<V1_0_0_Message>(&handshake);
+
+        assert_eq!(&serialized, V1_0_0_HANDSHAKE);
+        assert_ne!(&serialized, BROKEN_V1_0_0_HANDSHAKE);
+
+        let deserialized: V1_0_0_Message = deserialize_message(&serialized);
+
+        match deserialized {
+            V1_0_0_Message::Handshake {
+                network_name,
+                public_address,
+            } => {
+                assert_eq!(network_name, "serialization-test");
+                assert_eq!(public_address, ([12, 34, 56, 78], 12346).into());
+            }
+            other => {
+                panic!("did not expect {:?} as the deserialized product", other);
+            }
+        }
+    }
+
+    #[test]
+    fn v1_0_0_can_decode_current_handshake() {
+        let modern_handshake = Message::<protocol::Message>::Handshake {
+            network_name: "example-handshake".to_string(),
+            public_address: ([12, 34, 56, 78], 12346).into(),
+            protocol_version: ProtocolVersion::from_parts(5, 6, 7),
+        };
+
+        let legacy_handshake: V1_0_0_Message = roundtrip_message(&modern_handshake);
+
+        match legacy_handshake {
+            V1_0_0_Message::Handshake {
+                network_name,
+                public_address,
+            } => {
+                assert_eq!(network_name, "example-handshake");
+                assert_eq!(public_address, ([12, 34, 56, 78], 12346).into());
+            }
+            V1_0_0_Message::Payload(_) => {
+                panic!("did not expect legacy handshake to deserialize to payload")
+            }
+        }
+    }
+
+    #[test]
+    fn current_handshake_decodes_from_v1_0_0() {
+        let legacy_handshake = V1_0_0_Message::Handshake {
+            network_name: "example-handshake".to_string(),
+            public_address: ([12, 34, 56, 78], 12346).into(),
+        };
+
+        let modern_handshake: Message<protocol::Message> = roundtrip_message(&legacy_handshake);
+
+        match modern_handshake {
+            Message::Handshake {
+                network_name,
+                public_address,
+                protocol_version,
+            } => {
+                assert_eq!(network_name, "example-handshake");
+                assert_eq!(public_address, ([12, 34, 56, 78], 12346).into());
+                assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
+            }
+            Message::Payload(_) => {
+                panic!("did not expect modern handshake to deserialize to payload")
+            }
+        }
+    }
+
+    #[test]
+    fn current_handshake_decodes_from_historic_v1_0_0() {
+        let modern_handshake: Message<protocol::Message> = deserialize_message(&V1_0_0_HANDSHAKE);
+
+        match modern_handshake {
+            Message::Handshake {
+                network_name,
+                public_address,
+                protocol_version,
+            } => {
+                assert_eq!(network_name, "serialization-test");
+                assert_eq!(public_address, ([12, 34, 56, 78], 12346).into());
+                assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
+            }
+            Message::Payload(_) => {
+                panic!("did not expect modern handshake to deserialize to payload")
+            }
         }
     }
 }

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -17,7 +17,9 @@ use reactor::ReactorEvent;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
-use super::{Config, Event as SmallNetworkEvent, GossipedAddress, SmallNetwork};
+use super::{
+    chain_info::ChainInfo, Config, Event as SmallNetworkEvent, GossipedAddress, SmallNetwork,
+};
 use crate::{
     components::{
         gossiper::{self, Gossiper},
@@ -139,8 +141,7 @@ impl Reactor for TestReactor {
             cfg,
             registry,
             small_network_identity,
-            "test_network".to_string(),
-            23 * 1024 * 1024, // Hardcoded at 23 megs.
+            ChainInfo::create_for_testing(),
             false,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -423,18 +423,12 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             false,
         )?;
-        let network_name = chainspec_loader.chainspec().network_config.name.clone();
-        let maximum_net_message_size = chainspec_loader
-            .chainspec()
-            .network_config
-            .maximum_net_message_size;
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network.clone(),
             registry,
             small_network_identity,
-            network_name,
-            maximum_net_message_size,
+            chainspec_loader.chainspec().as_ref(),
             false,
         )?;
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -421,18 +421,12 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             true,
         )?;
-        let network_name = chainspec_loader.chainspec().network_config.name.clone();
-        let maximum_net_message_size = chainspec_loader
-            .chainspec()
-            .network_config
-            .maximum_net_message_size;
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network,
             registry,
             small_network_identity,
-            network_name,
-            maximum_net_message_size,
+            chainspec_loader.chainspec().as_ref(),
             true,
         )?;
 

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -24,7 +24,10 @@ use casper_execution_engine::{
     core::engine_state::genesis::ExecConfig,
     shared::{system_config::SystemConfig, wasm_config::WasmConfig},
 };
-use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    ProtocolVersion,
+};
 
 #[cfg(test)]
 pub(crate) use self::accounts_config::{AccountConfig, ValidatorConfig};
@@ -93,6 +96,15 @@ impl Chainspec {
     /// Returns true if this chainspec has an activation_point specifying era ID 0.
     pub(crate) fn is_genesis(&self) -> bool {
         self.protocol_config.activation_point.is_genesis()
+    }
+
+    /// Returns the protocol version of the chainspec.
+    pub(crate) fn protocol_version(&self) -> ProtocolVersion {
+        ProtocolVersion::from_parts(
+            self.protocol_config.version.major as u32,
+            self.protocol_config.version.minor as u32,
+            self.protocol_config.version.patch as u32,
+        )
     }
 }
 


### PR DESCRIPTION
This introduces a protocol version field into the handshake, which is ignored by the V1.0.0 node. At the same time, if absent, V1.0.0 is filled in. As a result, every version of the release node software has a correct protocol version field.

~~**NOTE** This PR is due a rebase & force push once https://github.com/CasperLabs/casper-node/pull/1256 is merged to master.~~