### PR TITLE
NDRS-1061: Remove ProtoBlock from FinalizedBlock and rename wasm_deploys.

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -268,7 +268,7 @@ impl BlockProposerReady {
                 Effects::new()
             }
             Event::FinalizedBlock(block) => {
-                let deploys = block.deploys_transfers_iter().copied().collect_vec();
+                let deploys = block.deploys_and_transfers_iter().copied().collect_vec();
                 let mut height = block.height();
 
                 if height > self.sets.next_finalized {

--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -17,6 +17,7 @@ use std::{
 };
 
 use datasize::DataSize;
+use itertools::Itertools;
 use prometheus::{self, Registry};
 use tracing::{debug, error, info, trace, warn};
 
@@ -266,9 +267,9 @@ impl BlockProposerReady {
                 error!("got loaded event for block proposer state during ready state");
                 Effects::new()
             }
-            Event::FinalizedProtoBlock { block, mut height } => {
-                let (_, mut deploys, transfers, _) = block.destructure();
-                deploys.extend(transfers);
+            Event::FinalizedBlock(block) => {
+                let deploys = block.deploys_transfers_iter().copied().collect_vec();
+                let mut height = block.height();
 
                 if height > self.sets.next_finalized {
                     debug!(

--- a/node/src/components/block_proposer/event.rs
+++ b/node/src/components/block_proposer/event.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::BlockHeight;
 use crate::{
     effect::requests::BlockProposerRequest,
-    types::{DeployHash, DeployHeader, ProtoBlock},
+    types::{DeployHash, DeployHeader, FinalizedBlock},
 };
 use casper_execution_engine::shared::motes::Motes;
 
@@ -93,11 +93,8 @@ pub enum Event {
     },
     /// The block proposer has been asked to prune stale deploys
     Prune,
-    /// A proto block has been finalized. We should never propose its deploys again.
-    FinalizedProtoBlock {
-        block: ProtoBlock,
-        height: BlockHeight,
-    },
+    /// A block has been finalized. We should never propose its deploys again.
+    FinalizedBlock(Box<FinalizedBlock>),
 }
 
 impl Display for Event {
@@ -114,12 +111,8 @@ impl Display for Event {
             ),
             Event::BufferDeploy { hash, .. } => write!(f, "block-proposer add {}", hash),
             Event::Prune => write!(f, "block-proposer prune"),
-            Event::FinalizedProtoBlock { block, height } => {
-                write!(
-                    f,
-                    "deploy-buffer finalized proto block {} at height {}",
-                    block, height
-                )
+            Event::FinalizedBlock(block) => {
+                write!(f, "block-proposer finalized block {}", block)
             }
         }
     }

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -215,11 +215,11 @@ fn should_add_and_take_deploys() {
     assert_eq!(block.deploy_hashes().len(), 2);
 
     // but they shouldn't be returned if we include it in the past deploys
-    let deploy_hashes = block.deploys_transfers_iter().copied().collect_vec();
+    let deploy_hashes = block.deploys_and_transfers_iter().copied().collect_vec();
     let block = proposer.propose_proto_block(
         DeployConfig::default(),
         block_time2,
-        block.deploys_transfers_iter().copied().collect(),
+        block.deploys_and_transfers_iter().copied().collect(),
         true,
     );
     assert!(block.deploy_hashes().is_empty());
@@ -576,7 +576,7 @@ fn test_proposer_with(
     }
 
     let block = proposer.propose_proto_block(config, test_time, past_deploys, true);
-    let all_deploys = block.deploys_transfers_iter().collect_vec();
+    let all_deploys = block.deploys_and_transfers_iter().collect_vec();
     proposer.finalized_deploys(all_deploys.iter().map(|hash| **hash));
     println!("proposed deploys {}", block.deploy_hashes().len());
     println!("proposed transfers {}", block.transfer_hashes().len());
@@ -647,7 +647,7 @@ fn should_return_deploy_dependencies() {
         no_deploys.clone(),
         true,
     );
-    let deploys: Vec<DeployHash> = block.deploys_transfers_iter().cloned().collect();
+    let deploys: Vec<DeployHash> = block.deploys_and_transfers_iter().cloned().collect();
     // only deploy1 should be returned, as it has no dependencies
     assert_eq!(deploys.len(), 1);
     assert!(deploys.contains(deploy1.id()));

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -163,8 +163,8 @@ fn should_add_and_take_deploys() {
         no_deploys.clone(),
         true,
     );
-    assert!(block.wasm_deploys().is_empty());
-    assert!(block.transfers().is_empty());
+    assert!(block.deploy_hashes().is_empty());
+    assert!(block.transfer_hashes().is_empty());
 
     // add two deploys
     proposer.add_deploy_or_transfer(block_time2, *deploy1.id(), deploy1.deploy_type().unwrap());
@@ -178,8 +178,8 @@ fn should_add_and_take_deploys() {
         no_deploys.clone(),
         true,
     );
-    assert!(block.wasm_deploys().is_empty());
-    assert!(block.transfers().is_empty());
+    assert!(block.deploy_hashes().is_empty());
+    assert!(block.transfer_hashes().is_empty());
 
     // if we try to create a block with a timestamp that is too late, we shouldn't get any
     // deploys, either
@@ -189,8 +189,8 @@ fn should_add_and_take_deploys() {
         no_deploys.clone(),
         true,
     );
-    assert!(block.wasm_deploys().is_empty());
-    assert!(block.transfers().is_empty());
+    assert!(block.deploy_hashes().is_empty());
+    assert!(block.transfer_hashes().is_empty());
 
     // take the deploys out
     let block = proposer.propose_proto_block(
@@ -199,10 +199,10 @@ fn should_add_and_take_deploys() {
         no_deploys.clone(),
         true,
     );
-    assert!(block.transfers().is_empty());
-    assert_eq!(block.wasm_deploys().len(), 2);
-    assert!(block.wasm_deploys().contains(&deploy1.id()));
-    assert!(block.wasm_deploys().contains(&deploy2.id()));
+    assert!(block.transfer_hashes().is_empty());
+    assert_eq!(block.deploy_hashes().len(), 2);
+    assert!(block.deploy_hashes().contains(&deploy1.id()));
+    assert!(block.deploy_hashes().contains(&deploy2.id()));
 
     // take the deploys out
     let block = proposer.propose_proto_block(
@@ -211,22 +211,22 @@ fn should_add_and_take_deploys() {
         no_deploys.clone(),
         true,
     );
-    assert!(block.transfers().is_empty());
-    assert_eq!(block.wasm_deploys().len(), 2);
+    assert!(block.transfer_hashes().is_empty());
+    assert_eq!(block.deploy_hashes().len(), 2);
 
     // but they shouldn't be returned if we include it in the past deploys
-    let wasm_deploys = block.deploys_iter().copied().collect_vec();
+    let deploy_hashes = block.deploys_transfers_iter().copied().collect_vec();
     let block = proposer.propose_proto_block(
         DeployConfig::default(),
         block_time2,
-        block.deploys_iter().copied().collect(),
+        block.deploys_transfers_iter().copied().collect(),
         true,
     );
-    assert!(block.wasm_deploys().is_empty());
-    assert!(block.transfers().is_empty());
+    assert!(block.deploy_hashes().is_empty());
+    assert!(block.transfer_hashes().is_empty());
 
     // finalize the block
-    proposer.finalized_deploys(wasm_deploys.iter().copied());
+    proposer.finalized_deploys(deploy_hashes.iter().copied());
 
     // add more deploys
     proposer.add_deploy_or_transfer(block_time2, *deploy3.id(), deploy3.deploy_type().unwrap());
@@ -236,10 +236,10 @@ fn should_add_and_take_deploys() {
         proposer.propose_proto_block(DeployConfig::default(), block_time2, no_deploys, true);
 
     // since block 1 is now finalized, neither deploy1 nor deploy2 should be among the returned
-    assert!(block.transfers().is_empty());
-    assert_eq!(block.wasm_deploys().len(), 2);
-    assert!(block.wasm_deploys().contains(&deploy3.id()));
-    assert!(block.wasm_deploys().contains(&deploy4.id()));
+    assert!(block.transfer_hashes().is_empty());
+    assert_eq!(block.deploy_hashes().len(), 2);
+    assert!(block.deploy_hashes().contains(&deploy3.id()));
+    assert!(block.deploy_hashes().contains(&deploy4.id()));
 }
 
 #[test]
@@ -379,7 +379,7 @@ fn should_keep_track_of_unhandled_deploys() {
 }
 
 #[test]
-fn should_respect_limits_for_wasmless_transfers() {
+fn should_respect_limits_for_wasmless_transfer_hashes() {
     test_proposer_with(TestArgs {
         transfer_count: 30,
         max_transfer_count: 20,
@@ -390,7 +390,7 @@ fn should_respect_limits_for_wasmless_transfers() {
 }
 
 #[test]
-fn should_respect_limits_for_wasm_deploys() {
+fn should_respect_limits_for_deploy_hashes() {
     test_proposer_with(TestArgs {
         deploy_count: 30,
         max_deploy_count: 20,
@@ -401,7 +401,7 @@ fn should_respect_limits_for_wasm_deploys() {
 }
 
 #[test]
-fn should_respect_limits_for_wasm_deploys_and_transfers_together() {
+fn should_respect_limits_for_deploys_and_transfers_together() {
     test_proposer_with(TestArgs {
         transfer_count: 30,
         max_transfer_count: 20,
@@ -576,10 +576,10 @@ fn test_proposer_with(
     }
 
     let block = proposer.propose_proto_block(config, test_time, past_deploys, true);
-    let all_deploys = block.deploys_iter().collect_vec();
+    let all_deploys = block.deploys_transfers_iter().collect_vec();
     proposer.finalized_deploys(all_deploys.iter().map(|hash| **hash));
-    println!("proposed deploys {}", block.wasm_deploys().len());
-    println!("proposed transfers {}", block.transfers().len());
+    println!("proposed deploys {}", block.deploy_hashes().len());
+    println!("proposed transfers {}", block.transfer_hashes().len());
     assert_eq!(
         all_deploys.len(),
         proposed_count,
@@ -635,8 +635,8 @@ fn should_return_deploy_dependencies() {
         no_deploys.clone(),
         true,
     );
-    assert!(block.wasm_deploys().is_empty());
-    assert!(block.transfers().is_empty());
+    assert!(block.deploy_hashes().is_empty());
+    assert!(block.transfer_hashes().is_empty());
 
     // add deploy1
     proposer.add_deploy_or_transfer(creation_time, *deploy1.id(), deploy1.deploy_type().unwrap());
@@ -647,7 +647,7 @@ fn should_return_deploy_dependencies() {
         no_deploys.clone(),
         true,
     );
-    let deploys: Vec<DeployHash> = block.deploys_iter().cloned().collect();
+    let deploys: Vec<DeployHash> = block.deploys_transfers_iter().cloned().collect();
     // only deploy1 should be returned, as it has no dependencies
     assert_eq!(deploys.len(), 1);
     assert!(deploys.contains(deploy1.id()));
@@ -657,7 +657,7 @@ fn should_return_deploy_dependencies() {
 
     let block = proposer.propose_proto_block(DeployConfig::default(), block_time, no_deploys, true);
     // `blocks` contains a block that contains deploy1 now, so we should get deploy2
-    let deploys2 = block.wasm_deploys();
+    let deploys2 = block.deploy_hashes();
     assert_eq!(deploys2.len(), 1);
     assert!(deploys2.contains(deploy2.id()));
 }

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -53,7 +53,7 @@ impl BlockLike for Block {
 
 impl BlockLike for ProtoBlock {
     fn deploys(&self) -> Vec<&DeployHash> {
-        self.deploys_iter().collect()
+        self.deploys_transfers_iter().collect()
     }
 }
 

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -53,7 +53,7 @@ impl BlockLike for Block {
 
 impl BlockLike for ProtoBlock {
     fn deploys(&self) -> Vec<&DeployHash> {
-        self.deploys_transfers_iter().collect()
+        self.deploys_and_transfers_iter().collect()
     }
 }
 

--- a/node/src/components/consensus/candidate_block.rs
+++ b/node/src/components/consensus/candidate_block.rs
@@ -76,7 +76,8 @@ impl ConsensusValueT for CandidateBlock {
     }
 
     fn needs_validation(&self) -> bool {
-        !self.proto_block.wasm_deploys().is_empty() || !self.proto_block.transfers().is_empty()
+        !self.proto_block.deploy_hashes().is_empty()
+            || !self.proto_block.transfer_hashes().is_empty()
     }
 
     fn timestamp(&self) -> Timestamp {

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -981,7 +981,7 @@ where
             } => {
                 let past_deploys = past_values
                     .iter()
-                    .flat_map(|candidate| candidate.proto_block().deploys_iter())
+                    .flat_map(|candidate| candidate.proto_block().deploys_transfers_iter())
                     .cloned()
                     .collect();
                 let parent = parent_value.as_ref().map(CandidateBlock::hash);
@@ -1076,10 +1076,10 @@ where
                 self.era_mut(era_id)
                     .add_candidate(candidate_block, missing_evidence.clone());
                 let proto_block_deploys_set: BTreeSet<DeployHash> =
-                    proto_block.deploys_iter().cloned().collect();
+                    proto_block.deploys_transfers_iter().cloned().collect();
                 for ancestor_block in ancestor_blocks {
                     let ancestor_proto_block = ancestor_block.proto_block();
-                    for deploy in ancestor_proto_block.deploys_iter() {
+                    for deploy in ancestor_proto_block.deploys_transfers_iter() {
                         if proto_block_deploys_set.contains(deploy) {
                             return self.resolve_validity(
                                 era_id,
@@ -1269,7 +1269,7 @@ where
     REv: From<BlockValidationRequest<ProtoBlock, I>> + From<StorageRequest>,
     I: Clone + Send + 'static,
 {
-    for deploy_hash in proto_block.deploys_iter() {
+    for deploy_hash in proto_block.deploys_transfers_iter() {
         let execution_results = match effect_builder
             .get_deploy_and_metadata_from_storage(*deploy_hash)
             .await

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -981,7 +981,7 @@ where
             } => {
                 let past_deploys = past_values
                     .iter()
-                    .flat_map(|candidate| candidate.proto_block().deploys_transfers_iter())
+                    .flat_map(|candidate| candidate.proto_block().deploys_and_transfers_iter())
                     .cloned()
                     .collect();
                 let parent = parent_value.as_ref().map(CandidateBlock::hash);
@@ -1076,10 +1076,10 @@ where
                 self.era_mut(era_id)
                     .add_candidate(candidate_block, missing_evidence.clone());
                 let proto_block_deploys_set: BTreeSet<DeployHash> =
-                    proto_block.deploys_transfers_iter().cloned().collect();
+                    proto_block.deploys_and_transfers_iter().cloned().collect();
                 for ancestor_block in ancestor_blocks {
                     let ancestor_proto_block = ancestor_block.proto_block();
-                    for deploy in ancestor_proto_block.deploys_transfers_iter() {
+                    for deploy in ancestor_proto_block.deploys_and_transfers_iter() {
                         if proto_block_deploys_set.contains(deploy) {
                             return self.resolve_validity(
                                 era_id,
@@ -1269,7 +1269,7 @@ where
     REv: From<BlockValidationRequest<ProtoBlock, I>> + From<StorageRequest>,
     I: Clone + Send + 'static,
 {
-    for deploy_hash in proto_block.deploys_transfers_iter() {
+    for deploy_hash in proto_block.deploys_and_transfers_iter() {
         let execution_results = match effect_builder
             .get_deploy_and_metadata_from_storage(*deploy_hash)
             .await

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -759,8 +759,7 @@ impl ContractRuntime {
         finalized_block: FinalizedBlock,
     ) -> Effects<Event> {
         let deploy_hashes = finalized_block
-            .proto_block()
-            .deploys_iter()
+            .deploys_transfers_iter()
             .copied()
             .collect::<SmallVec<_>>();
         if deploy_hashes.is_empty() {

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -759,7 +759,7 @@ impl ContractRuntime {
         finalized_block: FinalizedBlock,
     ) -> Effects<Event> {
         let deploy_hashes = finalized_block
-            .deploys_transfers_iter()
+            .deploys_and_transfers_iter()
             .copied()
             .collect::<SmallVec<_>>();
         if deploy_hashes.is_empty() {

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -957,10 +957,7 @@ impl reactor::Reactor for Reactor {
             Event::ConsensusAnnouncement(consensus_announcement) => match consensus_announcement {
                 ConsensusAnnouncement::Finalized(block) => {
                     let reactor_event =
-                        Event::BlockProposer(block_proposer::Event::FinalizedProtoBlock {
-                            block: block.proto_block().clone(),
-                            height: block.height(),
-                        });
+                        Event::BlockProposer(block_proposer::Event::FinalizedBlock(block));
                     self.dispatch_event(effect_builder, rng, reactor_event)
                 }
                 ConsensusAnnouncement::CreatedFinalitySignature(fs) => self.dispatch_event(

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -18,7 +18,7 @@ use blake2::{
 
 use datasize::DataSize;
 use hex::FromHexError;
-use hex_fmt::{HexFmt, HexList};
+use hex_fmt::HexList;
 use once_cell::sync::Lazy;
 #[cfg(test)]
 use rand::Rng;
@@ -271,15 +271,6 @@ impl ProtoBlock {
     pub(crate) fn random_bit(&self) -> bool {
         self.random_bit
     }
-
-    pub(crate) fn destructure(self) -> (ProtoBlockHash, Vec<DeployHash>, Vec<DeployHash>, bool) {
-        (
-            self.hash,
-            self.wasm_deploys,
-            self.transfers,
-            self.random_bit,
-        )
-    }
 }
 
 impl Display for ProtoBlock {
@@ -351,7 +342,10 @@ impl DocExample for EraReport {
 /// and before execution happened yet.
 #[derive(Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FinalizedBlock {
-    proto_block: ProtoBlock,
+    deploy_hashes: Vec<DeployHash>,
+    transfer_hashes: Vec<DeployHash>,
+    timestamp: Timestamp,
+    random_bit: bool,
     era_report: Option<EraReport>,
     era_id: EraId,
     height: u64,
@@ -367,7 +361,10 @@ impl FinalizedBlock {
         proposer: PublicKey,
     ) -> Self {
         FinalizedBlock {
-            proto_block,
+            deploy_hashes: proto_block.wasm_deploys,
+            transfer_hashes: proto_block.transfers,
+            timestamp: proto_block.timestamp,
+            random_bit: proto_block.random_bit,
             era_report,
             era_id,
             height,
@@ -375,14 +372,9 @@ impl FinalizedBlock {
         }
     }
 
-    /// The finalized proto block.
-    pub(crate) fn proto_block(&self) -> &ProtoBlock {
-        &self.proto_block
-    }
-
     /// The timestamp from when the proto block was proposed.
     pub(crate) fn timestamp(&self) -> Timestamp {
-        self.proto_block.timestamp
+        self.timestamp
     }
 
     /// Returns slashing and reward information if this is a switch block, i.e. the last block of
@@ -403,6 +395,11 @@ impl FinalizedBlock {
 
     pub(crate) fn proposer(&self) -> PublicKey {
         self.proposer
+    }
+
+    /// Returns an iterator over all deploy and transfer hashes.
+    pub(crate) fn deploys_transfers_iter(&self) -> impl Iterator<Item = &DeployHash> {
+        self.deploy_hashes.iter().chain(&self.transfer_hashes)
     }
 
     /// Generates a random instance using a `TestRng`.
@@ -471,21 +468,12 @@ impl DocExample for FinalizedBlock {
 
 impl From<Block> for FinalizedBlock {
     fn from(block: Block) -> Self {
-        let proto_block = ProtoBlock::new(
-            block.body.deploy_hashes().clone(),
-            block.body.transfer_hashes().clone(),
-            block.header.timestamp,
-            block.header.random_bit,
-        );
-
-        let era_report = match block.header.era_end {
-            Some(data) => Some(data.era_report),
-            None => None,
-        };
-
         FinalizedBlock {
-            proto_block,
-            era_report,
+            deploy_hashes: block.body.deploy_hashes,
+            transfer_hashes: block.body.transfer_hashes,
+            timestamp: block.header.timestamp,
+            random_bit: block.header.random_bit,
+            era_report: block.header.era_end.map(|era_end| era_end.era_report),
             era_id: block.header.era_id,
             height: block.header.height,
             proposer: block.body.proposer,
@@ -497,14 +485,14 @@ impl Display for FinalizedBlock {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
-            "finalized block {:10} in era {:?}, height {}, deploys {:10}, random bit {}, \
-            timestamp {}",
-            HexFmt(self.proto_block.hash().inner()),
+            "finalized block in era {:?}, height {}, deploys {:10}, transfers {:10}, \
+            random bit {}, timestamp {}",
             self.era_id,
             self.height,
-            HexList(&self.proto_block.wasm_deploys),
-            self.proto_block.random_bit,
-            self.timestamp(),
+            HexList(&self.deploy_hashes),
+            HexList(&self.transfer_hashes),
+            self.random_bit,
+            self.timestamp,
         )?;
         if let Some(ee) = &self.era_report {
             write!(formatter, ", era_end: {}", ee)?;
@@ -1051,14 +1039,10 @@ impl Block {
     ) -> Self {
         let body = BlockBody::new(
             finalized_block.proposer,
-            finalized_block.proto_block.wasm_deploys().clone(),
-            finalized_block.proto_block.transfers().clone(),
+            finalized_block.deploy_hashes,
+            finalized_block.transfer_hashes,
         );
         let body_hash = body.hash();
-
-        let era_id = finalized_block.era_id();
-        let height = finalized_block.height();
-        let timestamp = finalized_block.timestamp();
 
         let era_end = match finalized_block.era_report {
             Some(era_report) => Some(EraEnd::new(era_report, next_era_validator_weights.unwrap())),
@@ -1069,7 +1053,7 @@ impl Block {
 
         let mut hasher = VarBlake2b::new(Digest::LENGTH).expect("should create hasher");
         hasher.update(parent_seed);
-        hasher.update([finalized_block.proto_block.random_bit as u8]);
+        hasher.update([finalized_block.random_bit as u8]);
         hasher.finalize_variable(|slice| {
             accumulated_seed.copy_from_slice(slice);
         });
@@ -1078,12 +1062,12 @@ impl Block {
             parent_hash,
             state_root_hash,
             body_hash,
-            random_bit: finalized_block.proto_block.random_bit,
+            random_bit: finalized_block.random_bit,
             accumulated_seed: accumulated_seed.into(),
             era_end,
-            timestamp,
-            era_id,
-            height,
+            timestamp: finalized_block.timestamp,
+            era_id: finalized_block.era_id,
+            height: finalized_block.height,
             protocol_version,
         };
 

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -263,7 +263,7 @@ impl ProtoBlock {
         &self.transfer_hashes
     }
 
-    pub(crate) fn deploys_transfers_iter(&self) -> impl Iterator<Item = &DeployHash> {
+    pub(crate) fn deploys_and_transfers_iter(&self) -> impl Iterator<Item = &DeployHash> {
         self.deploy_hashes()
             .iter()
             .chain(self.transfer_hashes().iter())
@@ -401,7 +401,7 @@ impl FinalizedBlock {
     }
 
     /// Returns an iterator over all deploy and transfer hashes.
-    pub(crate) fn deploys_transfers_iter(&self) -> impl Iterator<Item = &DeployHash> {
+    pub(crate) fn deploys_and_transfers_iter(&self) -> impl Iterator<Item = &DeployHash> {
         self.deploy_hashes.iter().chain(&self.transfer_hashes)
     }
 


### PR DESCRIPTION
This is a refactoring, and a preparation for simplifying the block types, specifically for replacing `ProtoBlock` and `CandidateBlock` with a single type.

This PR removes `ProtoBlock` from `FinalizedBlock`, because the new type will contain fields (`accusations`) that would be redundant as a part of `FinalizedBlock`. It also renames `ProtoBlock::wasm_deploys` to `deploy_hashes`, and `transfers` to `transfer_hashes`, so that it is in line with `BlockBody`.

https://casperlabs.atlassian.net/browse/NDRS-1061