### PR TITLE
EE-1213: Added get_balance using PublicKey

### DIFF
--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -2074,7 +2074,7 @@ where
         state_hash: Blake2bHash,
         public_key: PublicKey,
     ) -> Result<BalanceResult, Error> {
-        //look up the account, get the main purse, and then do the existing balance check
+        // Look up the account, get the main purse, and then do the existing balance check
         let tracking_copy = match self.tracking_copy(state_hash) {
             Ok(Some(tracking_copy)) => Rc::new(RefCell::new(tracking_copy)),
             Ok(None) => return Ok(BalanceResult::RootNotFound),

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -2067,4 +2067,51 @@ where
             next_era_validators,
         })
     }
+
+    pub fn get_balance(
+        &self,
+        correlation_id: CorrelationId,
+        state_hash: Blake2bHash,
+        public_key: PublicKey,
+    ) -> Result<BalanceResult, Error> {
+        //look up the account, get the main purse, and then do the existing balance check
+        let tracking_copy = match self.tracking_copy(state_hash) {
+            Ok(Some(tracking_copy)) => Rc::new(RefCell::new(tracking_copy)),
+            Ok(None) => return Ok(BalanceResult::RootNotFound),
+            Err(error) => return Err(error),
+        };
+
+        let account_addr = public_key.to_account_hash();
+
+        let account = match tracking_copy
+            .borrow_mut()
+            .get_account(correlation_id, account_addr)
+        {
+            Ok(account) => account,
+            Err(error) => return Err(error.into()),
+        };
+
+        let main_purse_balance_key = {
+            let main_purse = account.main_purse();
+            match tracking_copy
+                .borrow_mut()
+                .get_purse_balance_key(correlation_id, main_purse.into())
+            {
+                Ok(balance_key) => balance_key,
+                Err(error) => return Err(error.into()),
+            }
+        };
+
+        let (account_balance, proof) = match tracking_copy
+            .borrow_mut()
+            .get_purse_balance_with_proof(correlation_id, main_purse_balance_key)
+        {
+            Ok((balance, proof)) => (balance, proof),
+            Err(error) => return Err(error.into()),
+        };
+
+        let proof = Box::new(proof);
+        let motes = account_balance.value();
+        Ok(BalanceResult::Success { motes, proof })
+    }
 }

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -2094,7 +2094,7 @@ where
         let main_purse_balance_key = {
             let main_purse = account.main_purse();
             match tracking_copy
-                .borrow_mut()
+                .borrow()
                 .get_purse_balance_key(correlation_id, main_purse.into())
             {
                 Ok(balance_key) => balance_key,
@@ -2103,7 +2103,7 @@ where
         };
 
         let (account_balance, proof) = match tracking_copy
-            .borrow_mut()
+            .borrow()
             .get_purse_balance_with_proof(correlation_id, main_purse_balance_key)
         {
             Ok((balance, proof)) => (balance, proof),

--- a/execution_engine_testing/test_support/src/internal/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/internal/wasm_test_builder.rs
@@ -730,6 +730,15 @@ where
             .expect("should get purse balance")
     }
 
+    pub fn get_public_key_balance_result(&self, public_key: PublicKey) -> BalanceResult {
+        let correlation_id = CorrelationId::new();
+        let state_root_hash: Blake2bHash =
+            self.post_state_hash.expect("should have post_state_hash");
+        self.engine_state
+            .get_balance(correlation_id, state_root_hash, public_key)
+            .expect("should get purse balance using public key")
+    }
+
     pub fn get_proposer_purse_balance(&self) -> U512 {
         let proposer_account = self
             .get_account(*DEFAULT_PROPOSER_ADDR)

--- a/execution_engine_testing/tests/src/test/get_balance.rs
+++ b/execution_engine_testing/tests/src/test/get_balance.rs
@@ -104,3 +104,88 @@ fn get_balance_should_work() {
         Err(ValidationError::UnexpectedValue)
     );
 }
+
+#[ignore]
+#[test]
+fn get_balance_using_public_key_should_work() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    let transfer_request = ExecuteRequestBuilder::transfer(
+        *DEFAULT_ACCOUNT_ADDR,
+        runtime_args! {
+            TRANSFER_ARG_TARGET => *ALICE_ADDR,
+            TRANSFER_ARG_AMOUNT => *TRANSFER_AMOUNT_1,
+            TRANSFER_ARG_ID => <Option<u64>>::None,
+        },
+    )
+    .build();
+
+    builder.exec(transfer_request).commit().expect_success();
+
+    let alice_account = builder
+        .get_account(*ALICE_ADDR)
+        .expect("should have Alice's account");
+
+    let alice_main_purse = alice_account.main_purse();
+
+    let alice_balance_result = builder.get_public_key_balance_result(*ALICE_KEY);
+
+    let alice_balance = alice_balance_result
+        .motes()
+        .cloned()
+        .expect("should have motes");
+
+    assert_eq!(alice_balance, *TRANSFER_AMOUNT_1);
+
+    let state_root_hash = builder.get_post_state_hash();
+
+    let balance_proof = alice_balance_result.proof().expect("should have proofs");
+
+    assert!(core::validate_balance_proof(
+        &state_root_hash,
+        &balance_proof,
+        alice_main_purse.into(),
+        &alice_balance,
+    )
+    .is_ok());
+
+    let bogus_key = Key::Hash([1u8; 32]);
+    assert_eq!(
+        core::validate_balance_proof(
+            &state_root_hash,
+            &balance_proof,
+            bogus_key.to_owned(),
+            &alice_balance,
+        ),
+        Err(ValidationError::KeyIsNotAURef(bogus_key))
+    );
+
+    let bogus_uref: Key = Key::URef(URef::new([3u8; 32], AccessRights::READ_ADD_WRITE));
+    assert_eq!(
+        core::validate_balance_proof(&state_root_hash, &balance_proof, bogus_uref, &alice_balance,),
+        Err(ValidationError::UnexpectedKey)
+    );
+
+    let bogus_hash = Blake2bHash::new(&[5u8; 32]);
+    assert_eq!(
+        core::validate_balance_proof(
+            &bogus_hash,
+            &balance_proof,
+            alice_main_purse.into(),
+            &alice_balance,
+        ),
+        Err(ValidationError::InvalidProofHash)
+    );
+
+    let bogus_motes = U512::from(1337);
+    assert_eq!(
+        core::validate_balance_proof(
+            &state_root_hash,
+            &balance_proof,
+            alice_main_purse.into(),
+            &bogus_motes,
+        ),
+        Err(ValidationError::UnexpectedValue)
+    );
+}


### PR DESCRIPTION
REF: https://casperlabs.atlassian.net/browse/EE-1213

CHANGELOG:

- Added a new function `EngineState::get_balance` which uses a `PublicKey` and returns a `BalanceResult`
- Added a new function `get_public_key_balance_result` to the WASM test builder to help with testing
- Added `get_balance_using_public_key_should_work` unit test