### PR TITLE
NDRS-833: `LinearChain` cleanup part 3.

### DIFF
--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -187,7 +187,7 @@ where
                     // correct – block was created in a specific era so the IDs have to match.
                     if known_signatures.era_id != fs.era_id {
                         warn!(public_key=%fs.public_key,
-                            expected=%known_signatures.era_id, 
+                            expected=%known_signatures.era_id,
                             got=%fs.era_id,
                             "finality signature with invalid era id.");
                         self.linear_chain_state.remove_from_pending_fs(&*fs);
@@ -199,7 +199,8 @@ where
                         return Effects::new();
                     }
                     // Populate cache so that next incoming signatures don't trigger read from the
-                    // storage. If `known_signatures` are already from cache then this will be a noop.
+                    // storage. If `known_signatures` are already from cache then this will be a
+                    // noop.
                     self.linear_chain_state
                         .cache_signatures(*known_signatures.clone());
                 }

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -124,20 +124,8 @@ where
                 block,
                 execution_results,
             } => {
-                // New linear chain block received. Collect any pending finality signatures that
-                // were waiting for that block.
-                // TODO: Replace with `self.linear_chain_state.new_block(block)`
-                // and have that method do what `collect_ending_finality_signatures` +
-                // `cache_signatures` do.
                 let (signatures, mut effects) =
-                    self.linear_chain_state.collect_pending_finality_signatures(
-                        block.hash(),
-                        block.header().era_id(),
-                        effect_builder,
-                    );
-                // Cache the signature as we expect more finality signatures for the new block to
-                // arrive soon.
-                self.linear_chain_state.cache_signatures(signatures.clone());
+                    self.linear_chain_state.new_block(effect_builder, &*block);
                 let block_to_store = block.clone();
                 effects.extend(
                     async move {

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -233,19 +233,14 @@ where
             Event::IsBonded(Some(mut signatures), fs, true) => {
                 // Known block and signature from a bonded validator.
                 // Check if we had already seen this signature before.
-                let signature_known = signatures
-                    .proofs
-                    .get(&fs.public_key)
-                    .iter()
-                    .any(|sig| *sig == &fs.signature);
-                // If new, gossip and store.
-                if signature_known {
+                if signatures.has_proof(&fs.public_key, &fs.signature) {
                     self.linear_chain_state.remove_from_pending_fs(&*fs);
                     Effects::new()
                 } else {
                     let mut effects = effect_builder
                         .announce_finality_signature(fs.clone())
                         .ignore();
+                    // If new, gossip and store.
                     if let Some(signature) = self.linear_chain_state.remove_from_pending_fs(&*fs) {
                         if signature.is_local() {
                             let message = Message::FinalitySignature(fs.clone());

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -209,9 +209,9 @@ where
                     // validated signatures reject it as they can't both be
                     // correct – block was created in a specific era so the IDs have to match.
                     if known_signatures.era_id != fs.era_id {
-                        warn!(public_key=%fs.public_key,
-                            expected=%known_signatures.era_id,
-                            got=%fs.era_id,
+                        warn!(public_key = %fs.public_key,
+                            expected = %known_signatures.era_id,
+                            got = %fs.era_id,
                             "finality signature with invalid era id.");
                         self.linear_chain_state.remove_from_pending_fs(&*fs);
                         // TODO: Disconnect from the sender.
@@ -257,7 +257,7 @@ where
                 // manage to store it in the database.
                 self.linear_chain_state
                     .cache_signatures(*known_signatures.clone());
-                debug!(hash=%known_signatures.block_hash, "storing finality signatures");
+                debug!(hash = %known_signatures.block_hash, "storing finality signatures");
                 // Announce new finality signatures for other components to pick up.
                 let mut effects = effect_builder
                     .announce_finality_signature(fs.clone())

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -217,7 +217,7 @@ where
                         // TODO: Disconnect from the sender.
                         return Effects::new();
                     }
-                    if known_signatures.has_proof(&fs.public_key, &fs.signature) {
+                    if known_signatures.has_proof(&fs.public_key) {
                         self.linear_chain_state.remove_from_pending_fs(&fs);
                         return Effects::new();
                     }

--- a/node/src/components/linear_chain/pending_signatures.rs
+++ b/node/src/components/linear_chain/pending_signatures.rs
@@ -47,7 +47,9 @@ impl PendingSignatures {
         pending_sigs
     }
 
-    pub(super) fn add(&mut self, signature: Signature) {
+    /// Adds finality signature to the pending collection.
+    /// Returns `true` if it was added.
+    pub(super) fn add(&mut self, signature: Signature) -> bool {
         let public_key = signature.public_key();
         let block_hash = signature.block_hash();
         let sigs = self
@@ -60,10 +62,10 @@ impl PendingSignatures {
                 %block_hash, %public_key,
                 "received too many finality signatures for unknown blocks"
             );
-            return;
+            return false;
         }
         // Add the pending signature.
-        let _ = sigs.insert(block_hash, signature);
+        sigs.insert(block_hash, signature).is_some()
     }
 
     pub(super) fn remove(

--- a/node/src/components/linear_chain/pending_signatures.rs
+++ b/node/src/components/linear_chain/pending_signatures.rs
@@ -65,7 +65,8 @@ impl PendingSignatures {
             return false;
         }
         // Add the pending signature.
-        sigs.insert(block_hash, signature).is_some()
+        sigs.insert(block_hash, signature);
+        true
     }
 
     pub(super) fn remove(

--- a/node/src/components/linear_chain/pending_signatures.rs
+++ b/node/src/components/linear_chain/pending_signatures.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use tracing::warn;
 
 use super::signature::Signature;
-use crate::types::{BlockHash, BlockSignatures};
+use crate::types::BlockHash;
 use casper_types::PublicKey;
 
 /// The maximum number of finality signatures from a single validator we keep in memory while
@@ -36,20 +36,12 @@ impl PendingSignatures {
             .map_or(false, |sigs| sigs.contains_key(block_hash))
     }
 
-    pub(super) fn collect_pending(
-        &mut self,
-        block_hash: &BlockHash,
-        known_signatures: &BlockSignatures,
-    ) -> Vec<Signature> {
+    /// Returns signatures for `block_hash` that are still pending.
+    pub(super) fn collect_pending(&mut self, block_hash: &BlockHash) -> Vec<Signature> {
         let pending_sigs = self
             .pending_finality_signatures
             .values_mut()
             .filter_map(|sigs| sigs.remove(&block_hash))
-            .filter(|signature| {
-                !known_signatures
-                    .proofs
-                    .contains_key(&signature.to_inner().public_key)
-            })
             .collect_vec();
         self.remove_empty_entries();
         pending_sigs

--- a/node/src/components/linear_chain/signature.rs
+++ b/node/src/components/linear_chain/signature.rs
@@ -25,10 +25,6 @@ impl Signature {
         self.to_inner().block_hash
     }
 
-    pub(super) fn signature(&self) -> casper_types::Signature {
-        self.to_inner().signature
-    }
-
     pub(super) fn take(self) -> Box<FinalitySignature> {
         match self {
             Signature::Local(fs) | Signature::External(fs) => fs,

--- a/node/src/components/linear_chain/signature.rs
+++ b/node/src/components/linear_chain/signature.rs
@@ -25,6 +25,10 @@ impl Signature {
         self.to_inner().block_hash
     }
 
+    pub(super) fn signature(&self) -> casper_types::Signature {
+        self.to_inner().signature
+    }
+
     pub(super) fn take(self) -> Box<FinalitySignature> {
         match self {
             Signature::Local(fs) | Signature::External(fs) => fs,

--- a/node/src/components/linear_chain/signature_cache.rs
+++ b/node/src/components/linear_chain/signature_cache.rs
@@ -58,10 +58,11 @@ impl SignatureCache {
         let FinalitySignature {
             block_hash,
             public_key,
+            signature,
             ..
         } = fs;
         self.signatures
             .get(block_hash)
-            .map_or(false, |bs| bs.has_proof(public_key))
+            .map_or(false, |bs| bs.has_proof(public_key, signature))
     }
 }

--- a/node/src/components/linear_chain/signature_cache.rs
+++ b/node/src/components/linear_chain/signature_cache.rs
@@ -40,19 +40,6 @@ impl SignatureCache {
         }
     }
 
-    /// Get signatures from the cache to be updated.
-    /// If there are no signatures, create an empty signature to be updated.
-    pub(super) fn get_known_signatures(
-        &self,
-        block_hash: &BlockHash,
-        block_era: EraId,
-    ) -> BlockSignatures {
-        match self.signatures.get(block_hash) {
-            Some(signatures) => signatures.clone(),
-            None => BlockSignatures::new(*block_hash, block_era),
-        }
-    }
-
     /// Returns whether finality signature is known already.
     pub(super) fn known_signature(&self, fs: &FinalitySignature) -> bool {
         let FinalitySignature {

--- a/node/src/components/linear_chain/signature_cache.rs
+++ b/node/src/components/linear_chain/signature_cache.rs
@@ -45,11 +45,10 @@ impl SignatureCache {
         let FinalitySignature {
             block_hash,
             public_key,
-            signature,
             ..
         } = fs;
         self.signatures
             .get(block_hash)
-            .map_or(false, |bs| bs.has_proof(public_key, signature))
+            .map_or(false, |bs| bs.has_proof(public_key))
     }
 }

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -144,8 +144,7 @@ impl LinearChain {
         } else {
             Signature::Local(Box::new(fs))
         };
-        self.pending_finality_signatures.add(signature);
-        true
+        self.pending_finality_signatures.add(signature)
     }
 
     /// Removes finality signature from the pending collection.

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -161,8 +161,16 @@ impl LinearChain {
             .remove(&public_key, &block_hash)
     }
 
-    // Caches the signature.
-    pub(super) fn cache_signatures(&mut self, signatures: BlockSignatures) {
+    /// Caches the signature.
+    pub(super) fn cache_signatures(&mut self, mut signatures: BlockSignatures) {
+        // Merge already-known signatures and the new ones.
+        self.get_signatures(&signatures.block_hash)
+            .iter()
+            .for_each(|bs| {
+                for (pk, sig) in bs.proofs.iter() {
+                    signatures.insert_proof(*pk, *sig);
+                }
+            });
         self.signature_cache.insert(signatures);
     }
 
@@ -182,7 +190,6 @@ impl LinearChain {
     pub(super) fn latest_block(&self) -> &Option<Block> {
         &self.latest_block
     }
-
 
     /// Adds pending finality signatures to the block; returns events to announce and broadcast
     /// them, and the updated block signatures.
@@ -229,5 +236,4 @@ impl LinearChain {
         }
         (known_signatures, effects)
     }
-
 }

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, marker::PhantomData};
+use std::fmt::Display;
 
 use casper_types::{EraId, ProtocolVersion};
 use datasize::DataSize;
@@ -19,7 +19,7 @@ use super::{
     Event,
 };
 #[derive(DataSize, Debug)]
-pub(crate) struct LinearChain<I> {
+pub(crate) struct LinearChain {
     /// The most recently added block.
     latest_block: Option<Block>,
     /// Finality signatures to be inserted in a block once it is available.
@@ -30,11 +30,9 @@ pub(crate) struct LinearChain<I> {
     protocol_version: ProtocolVersion,
     auction_delay: u64,
     unbonding_delay: u64,
-
-    _marker: PhantomData<I>,
 }
 
-impl<I> LinearChain<I> {
+impl LinearChain {
     pub(crate) fn new(
         protocol_version: ProtocolVersion,
         auction_delay: u64,
@@ -49,7 +47,6 @@ impl<I> LinearChain<I> {
             protocol_version,
             auction_delay,
             unbonding_delay,
-            _marker: PhantomData,
         }
     }
 
@@ -68,7 +65,7 @@ impl<I> LinearChain<I> {
 
     /// Adds pending finality signatures to the block; returns events to announce and broadcast
     /// them, and the updated block signatures.
-    pub(super) fn collect_pending_finality_signatures<REv>(
+    pub(super) fn collect_pending_finality_signatures<I, REv>(
         &mut self,
         block_hash: &BlockHash,
         block_era: EraId,

--- a/node/src/components/linear_chain/state.rs
+++ b/node/src/components/linear_chain/state.rs
@@ -2,7 +2,6 @@ use std::{fmt::Display, marker::PhantomData};
 
 use casper_types::{EraId, ProtocolVersion};
 use datasize::DataSize;
-use prometheus::Registry;
 use tracing::{debug, warn};
 
 use crate::{
@@ -16,8 +15,8 @@ use crate::{
 };
 
 use super::{
-    metrics::LinearChainMetrics, pending_signatures::PendingSignatures, signature::Signature,
-    signature_cache::SignatureCache, Event,
+    pending_signatures::PendingSignatures, signature::Signature, signature_cache::SignatureCache,
+    Event,
 };
 #[derive(DataSize, Debug)]
 pub(crate) struct LinearChain<I> {
@@ -31,22 +30,18 @@ pub(crate) struct LinearChain<I> {
     protocol_version: ProtocolVersion,
     auction_delay: u64,
     unbonding_delay: u64,
-    #[data_size(skip)]
-    pub(super) metrics: LinearChainMetrics,
 
     _marker: PhantomData<I>,
 }
 
 impl<I> LinearChain<I> {
-    pub fn new(
-        registry: &Registry,
+    pub(crate) fn new(
         protocol_version: ProtocolVersion,
         auction_delay: u64,
         unbonding_delay: u64,
         activation_era_id: EraId,
-    ) -> Result<Self, prometheus::Error> {
-        let metrics = LinearChainMetrics::new(registry)?;
-        Ok(LinearChain {
+    ) -> Self {
+        LinearChain {
             latest_block: None,
             pending_finality_signatures: PendingSignatures::new(),
             signature_cache: SignatureCache::new(),
@@ -54,9 +49,8 @@ impl<I> LinearChain<I> {
             protocol_version,
             auction_delay,
             unbonding_delay,
-            metrics,
             _marker: PhantomData,
-        })
+        }
     }
 
     /// Returns whether we have already enqueued that finality signature.

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -342,7 +342,7 @@ pub struct Reactor {
     linear_chain_sync: LinearChainSync<NodeId>,
     block_validator: BlockValidator<Block, NodeId>,
     deploy_fetcher: Fetcher<Deploy>,
-    linear_chain: linear_chain::LinearChain<NodeId>,
+    linear_chain: linear_chain::LinearChainComponent<NodeId>,
     // Handles request for linear chain block by height.
     block_by_height_fetcher: Fetcher<BlockByHeight>,
     pub(super) block_header_by_hash_fetcher: Fetcher<BlockHeader>,
@@ -491,7 +491,7 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.initial_block_header(),
         );
 
-        let linear_chain = linear_chain::LinearChain::new(
+        let linear_chain = linear_chain::LinearChainComponent::new(
             &registry,
             *protocol_version,
             chainspec_loader.chainspec().core_config.auction_delay,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -68,7 +68,7 @@ use crate::{
 };
 pub use config::Config;
 pub use error::Error;
-use linear_chain::LinearChain;
+use linear_chain::LinearChainComponent;
 use memory_metrics::MemoryMetrics;
 
 /// Top-level event for the reactor.
@@ -351,7 +351,7 @@ pub struct Reactor {
     deploy_gossiper: Gossiper<Deploy, Event>,
     block_proposer: BlockProposer,
     proto_block_validator: BlockValidator<ProtoBlock, NodeId>,
-    linear_chain: LinearChain<NodeId>,
+    linear_chain: LinearChainComponent<NodeId>,
 
     // Non-components.
     #[data_size(skip)] // Never allocates heap data.
@@ -486,7 +486,7 @@ impl reactor::Reactor for Reactor {
         contract_runtime.set_parent_map_from_block(latest_block);
 
         let proto_block_validator = BlockValidator::new(Arc::clone(&chainspec_loader.chainspec()));
-        let linear_chain = linear_chain::LinearChain::new(
+        let linear_chain = linear_chain::LinearChainComponent::new(
             &registry,
             *protocol_version,
             chainspec_loader.chainspec().core_config.auction_delay,

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1000,11 +1000,8 @@ impl BlockSignatures {
         self.proofs.insert(public_key, signature)
     }
 
-    pub(crate) fn has_proof(&self, public_key: &PublicKey, signature: &Signature) -> bool {
-        self.proofs
-            .get(public_key)
-            .iter()
-            .any(|sig| *sig == signature)
+    pub(crate) fn has_proof(&self, public_key: &PublicKey) -> bool {
+        self.proofs.contains_key(public_key)
     }
 
     /// Verify the signatures contained within.

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1000,8 +1000,11 @@ impl BlockSignatures {
         self.proofs.insert(public_key, signature)
     }
 
-    pub(crate) fn has_proof(&self, public_key: &PublicKey) -> bool {
-        self.proofs.contains_key(public_key)
+    pub(crate) fn has_proof(&self, public_key: &PublicKey, signature: &Signature) -> bool {
+        self.proofs
+            .get(public_key)
+            .iter()
+            .any(|sig| *sig == signature)
     }
 
     /// Verify the signatures contained within.


### PR DESCRIPTION
Cleanup of the `LinearChain` component (in preparation for unit tests) continued. The main thing that changed in this PR is the addition of `LinearChainComponent` struct that wraps `LinearChain` and `LinearChainMetrics`. All component-level logic is now moved to the `LinearChainComponent` struct, rather than `LinearChain`. The latter does not deal with `Effect`, `REv`, `EffectBuilder`, `I` (peer id type), or any other code related to the reactor or networking. The functionality should be mostly unchanged. I tried working iteratively so reviewing commit-by-commit should be simpler than trying to do it all at once (although not necessarily take less time). I've found a couple of inconsistencies and potential sources of bugs around the handling of pending/cached finality signatures. Those should be now resolved.