### PR TITLE
NDRS-1113: fix reconnecting if isolated

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -582,7 +582,7 @@ where
                 local_address=?transport.get_ref().local_addr(),
                 "connected outgoing to ourself - closing connection",
             );
-            return Effects::new();
+            return self.reconnect_if_not_connected_to_any_known_addresses(effect_builder);
         }
 
         // The stream is only used to receive a single handshake message and then dropped.
@@ -638,29 +638,39 @@ where
     ) -> Effects<Event<P>> {
         let _ = self.pending.remove(&peer_address);
 
-        let mut effects = Effects::new();
-
         if let Some(peer_id) = peer_id {
             if let Some(ref err) = error {
-                warn!(our_id=%self.our_id, %peer_id, %peer_address, %err, "outgoing connection failed");
+                warn!(
+                    our_id=%self.our_id,
+                    %peer_id,
+                    %peer_address,
+                    %err,
+                    "outgoing connection failed"
+                );
             } else {
                 warn!(our_id=%self.our_id, %peer_id, %peer_address, "outgoing connection closed");
             }
-            effects.extend(self.remove(effect_builder, &peer_id, false));
-        } else {
-            // If we are not calling remove, call the reconnection check explicitly.
-            effects.extend(self.reconnect_if_not_connected_to_any_known_addresses(effect_builder));
+            return self.remove(effect_builder, &peer_id, false);
         }
 
         // If we don't have the node ID passed in here, it was never added as an
         // outgoing connection, hence no need to call `self.remove()`.
         if let Some(ref err) = error {
-            warn!(our_id=%self.our_id, %peer_address, %err, "outgoing connection failed");
+            warn!(
+                our_id=%self.our_id,
+                %peer_address,
+                %err,
+                "outgoing connection to known address failed"
+            );
         } else {
-            warn!(our_id=%self.our_id, %peer_address, "outgoing connection closed");
+            warn!(
+                our_id=%self.our_id,
+                %peer_address,
+                "outgoing connection to known address closed"
+            );
         }
-
-        effects
+        // Since we are not calling `self.remove()`, call the reconnection check explicitly.
+        self.reconnect_if_not_connected_to_any_known_addresses(effect_builder)
     }
 
     fn remove(


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1113.

This PR fixes a bug where a node which is a member of the known addresses can become isolated but not retry to connect to other known addresses.

It also improves the logging of an outgoing connection failure in two ways:
1. A lost outgoing connection where the peer ID is known is now only logged once
2. The log messages for peer ID known vs unknown are now even more different to help disambiguate them.