### PR TITLE
NDRS-1122: reduce default deploy TTL to 30 minutes

### DIFF
--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -211,7 +211,7 @@ pub(super) mod ttl {
 
     const ARG_NAME: &str = "ttl";
     const ARG_VALUE_NAME: &str = "DURATION";
-    const ARG_DEFAULT: &str = "1hour";
+    const ARG_DEFAULT: &str = "30min";
     const ARG_HELP: &str =
         "Time that the deploy will remain valid for. A deploy can only be included in a block \
         between `timestamp` and `timestamp + ttl`. Input examples: '1hr 12min', '30min 50sec', \


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1122

This PR updates the client by making the default time-to-live for a deploy 30 minutes.