### PR TITLE
NDRS-1117: Backport handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -330,11 +330,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
 ]
 
 [[package]]
@@ -430,9 +430,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
-version = "1.3.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder",
  "serde",
@@ -634,9 +634,15 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
@@ -676,17 +682,17 @@ dependencies = [
  "futures",
  "hex",
  "humantime",
- "hyper",
+ "hyper 0.14.4",
  "jsonrpc-lite",
  "once_cell",
  "rand 0.8.3",
- "reqwest",
+ "reqwest 0.11.2",
  "semver 0.11.0",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 1.4.0",
  "tower",
  "warp",
  "warp-json-rpc",
@@ -820,7 +826,7 @@ dependencies = [
  "hostname",
  "http",
  "humantime",
- "hyper",
+ "hyper 0.14.4",
  "itertools 0.10.0",
  "jemalloc-ctl",
  "jemallocator",
@@ -849,6 +855,8 @@ dependencies = [
  "rand_core 0.6.2",
  "rand_pcg",
  "regex",
+ "reqwest 0.10.10",
+ "rmp-serde",
  "schemars",
  "sd-notify",
  "serde",
@@ -864,11 +872,11 @@ dependencies = [
  "sys-info",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 1.4.0",
  "tokio-openssl",
  "tokio-serde",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.5",
  "toml",
  "tower",
  "tracing",
@@ -1340,7 +1348,7 @@ dependencies = [
  "crossterm_winapi",
  "lazy_static",
  "libc",
- "mio",
+ "mio 0.7.11",
  "parking_lot",
  "signal-hook 0.1.17",
  "winapi 0.3.9",
@@ -2062,6 +2070,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags 1.2.1",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,7 +2151,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "waker-fn",
 ]
 
@@ -2174,7 +2198,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -2334,11 +2358,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.2"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc018e188373e2777d0ef2467ebff62a08e66c3f5857b23c8fbec3018210dc00"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2346,8 +2370,28 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc018e188373e2777d0ef2467ebff62a08e66c3f5857b23c8fbec3018210dc00"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.4.0",
+ "tokio-util 0.6.5",
  "tracing",
 ]
 
@@ -2374,7 +2418,7 @@ checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
 dependencies = [
  "base64",
  "bitflags 1.2.1",
- "bytes",
+ "bytes 1.0.1",
  "headers-core",
  "http",
  "mime",
@@ -2499,9 +2543,19 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes 0.5.6",
+ "http",
 ]
 
 [[package]]
@@ -2510,9 +2564,9 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "http",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
 ]
 
 [[package]]
@@ -2535,26 +2589,63 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.7",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project 1.0.6",
  "socket2 0.3.19",
- "tokio",
+ "tokio 0.2.25",
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.2",
+ "http",
+ "http-body 0.4.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.6",
+ "socket2 0.3.19",
+ "tokio 1.4.0",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes 0.5.6",
+ "hyper 0.13.10",
+ "native-tls",
+ "tokio 0.2.25",
+ "tokio-tls",
 ]
 
 [[package]]
@@ -2563,10 +2654,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes",
- "hyper",
+ "bytes 1.0.1",
+ "hyper 0.14.4",
  "native-tls",
- "tokio",
+ "tokio 1.4.0",
  "tokio-native-tls",
 ]
 
@@ -2635,7 +2726,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
 ]
 
 [[package]]
@@ -2645,6 +2736,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2808,7 +2908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc225a49973cf9ab10d0cdd6a4b8f0cda299df9b760824bbb623f15f8f0c95a"
 dependencies = [
  "atomic",
- "bytes",
+ "bytes 1.0.1",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -2918,7 +3018,7 @@ dependencies = [
  "asynchronous-codec",
  "base64",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "futures",
  "hex_fmt",
@@ -2959,7 +3059,7 @@ checksum = "cf3da6c9acbcc05f93235d201d7d45ef4e8b88a45d8836f98becd8b4d443f066"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
- "bytes",
+ "bytes 1.0.1",
  "either",
  "fnv",
  "futures",
@@ -3005,7 +3105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350ce8b3923594aedabd5d6e3f875d058435052a29c3f32df378bc70d10be464"
 dependencies = [
  "asynchronous-codec",
- "bytes",
+ "bytes 1.0.1",
  "futures",
  "libp2p-core",
  "log 0.4.14",
@@ -3022,7 +3122,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "curve25519-dalek",
  "futures",
  "lazy_static",
@@ -3060,7 +3160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10e5552827c33d8326502682da73a0ba4bfa40c1b55b216af3c303f32169dd89"
 dependencies = [
  "async-trait",
- "bytes",
+ "bytes 1.0.1",
  "futures",
  "libp2p-core",
  "libp2p-swarm",
@@ -3115,7 +3215,7 @@ dependencies = [
  "libp2p-core",
  "log 0.4.14",
  "socket2 0.3.19",
- "tokio",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -3385,15 +3485,46 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log 0.4.14",
+ "miow 0.2.2",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log 0.4.14",
- "miow",
+ "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -3466,7 +3597,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d91ec0a2440aaff5f78ec35631a7027d50386c6163aa975f7caa0d5da4b6ff8"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures",
  "log 0.4.14",
  "pin-project 1.0.6",
@@ -3516,6 +3647,17 @@ checksum = "a19900e7eee95eb2b3c2e26d12a874cc80aaf750e31be6fcbe743ead369fa45d"
 dependencies = [
  "libc",
  "socket2 0.4.0",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3897,6 +4039,12 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
+
+[[package]]
+name = "pin-project-lite"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
@@ -4199,7 +4347,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "prost-derive",
 ]
 
@@ -4209,7 +4357,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "heck",
  "itertools 0.9.0",
  "log 0.4.14",
@@ -4240,7 +4388,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "prost",
 ]
 
@@ -4534,19 +4682,54 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.10.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+dependencies = [
+ "base64",
+ "bytes 0.5.6",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.3.1",
+ "hyper 0.13.10",
+ "hyper-tls 0.4.3",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log 0.4.14",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite 0.2.6",
+ "serde",
+ "serde_urlencoded",
+ "tokio 0.2.25",
+ "tokio-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
 dependencies = [
  "base64",
- "bytes",
+ "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
- "hyper-tls",
+ "http-body 0.4.1",
+ "hyper 0.14.4",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -4554,11 +4737,11 @@ dependencies = [
  "mime",
  "native-tls",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 1.4.0",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -4588,6 +4771,27 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce7d70c926fe472aed493b902010bccc17fa9f7284145cb8772fd22fdb052d8"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -4948,7 +5152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.7.11",
  "signal-hook-registry",
 ]
 
@@ -5337,17 +5541,34 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "memchr",
+ "mio 0.6.23",
+ "pin-project-lite 0.1.12",
+ "slab",
+]
+
+[[package]]
+name = "tokio"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
  "autocfg",
- "bytes",
+ "bytes 1.0.1",
  "libc",
  "memchr",
- "mio",
+ "mio 0.7.11",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "tokio-macros",
 ]
 
@@ -5369,7 +5590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -5381,7 +5602,7 @@ dependencies = [
  "futures",
  "openssl",
  "pin-project 1.0.6",
- "tokio",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -5391,7 +5612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
 dependencies = [
  "bincode",
- "bytes",
+ "bytes 1.0.1",
  "educe",
  "futures-core",
  "futures-sink",
@@ -5406,9 +5627,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
- "tokio-util",
+ "pin-project-lite 0.2.6",
+ "tokio 1.4.0",
+ "tokio-util 0.6.5",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -5420,8 +5651,22 @@ dependencies = [
  "futures-util",
  "log 0.4.14",
  "pin-project 1.0.6",
- "tokio",
+ "tokio 1.4.0",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log 0.4.14",
+ "pin-project-lite 0.1.12",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -5430,12 +5675,12 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log 0.4.14",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.2.6",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -5455,8 +5700,8 @@ checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
 dependencies = [
  "futures-core",
  "pin-project 1.0.6",
- "tokio",
- "tokio-util",
+ "tokio 1.4.0",
+ "tokio-util 0.6.5",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5482,7 +5727,7 @@ checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "log 0.4.14",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -5704,7 +5949,7 @@ checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
 dependencies = [
  "base64",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "http",
  "httparse",
  "input_buffer",
@@ -5830,7 +6075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f8d425fafb8cd76bc3f22aace4af471d3156301d7508f2107e98fbeae10bc7f"
 dependencies = [
  "asynchronous-codec",
- "bytes",
+ "bytes 1.0.1",
  "futures-io",
  "futures-util",
 ]
@@ -5976,11 +6221,11 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures",
  "headers",
  "http",
- "hyper",
+ "hyper 0.14.4",
  "log 0.4.14",
  "mime",
  "mime_guess",
@@ -5991,10 +6236,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 1.4.0",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util",
+ "tokio-util 0.6.5",
  "tower-service",
  "tracing",
 ]
@@ -6009,7 +6254,7 @@ dependencies = [
  "erased-serde",
  "futures",
  "http",
- "hyper",
+ "hyper 0.14.4",
  "lazycell",
  "log 0.4.14",
  "serde",
@@ -6241,6 +6486,16 @@ version = "0.1.0"
 dependencies = [
  "casper-contract",
  "casper-types",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -106,6 +106,8 @@ multihash = "0.13.2"
 pnet = "0.27.2"
 rand_core = "0.6.2"
 rand_pcg = "0.3.0"
+reqwest = "0.10.8"
+rmp-serde = "0.14.4"
 tokio = { version = "1", features = ["test-util"] }
 
 [features]

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -32,6 +32,7 @@
 //! No explicit reconnect is attempted. Instead, if the peer is still online, the normal gossiping
 //! process will cause both peers to connect again.
 
+mod chain_info;
 mod config;
 mod error;
 mod event;
@@ -99,6 +100,7 @@ use crate::{
     types::{NodeId, TimeDiff, Timestamp},
     utils, NodeRng,
 };
+use chain_info::ChainInfo;
 pub use config::Config;
 pub use error::Error;
 
@@ -156,11 +158,10 @@ where
 
     /// Pending outgoing connections: ones for which we are currently trying to make a connection.
     pending: HashMap<SocketAddr, Instant>,
-    /// Name of the network we participate in. We only remain connected to peers with the same
-    /// network name as us.
-    network_name: String,
-    /// The maximum message size for a network message, as supplied from the chainspec.
-    maximum_net_message_size: u32,
+
+    /// Information retained from the chainspec required for operating the networking component.
+    chain_info: Arc<ChainInfo>,
+
     /// Channel signaling a shutdown of the small network.
     // Note: This channel is closed when `SmallNetwork` is dropped, signalling the receivers that
     // they should cease operation.
@@ -194,13 +195,12 @@ where
     /// If `notify` is set to `false`, no systemd notifications will be sent, regardless of
     /// configuration.
     #[allow(clippy::type_complexity)]
-    pub(crate) fn new(
+    pub(crate) fn new<C: Into<ChainInfo>>(
         event_queue: EventQueueHandle<REv>,
         cfg: Config,
         registry: &Registry,
         small_network_identity: SmallNetworkIdentity,
-        network_name: String,
-        maximum_net_message_size: u32,
+        chain_info_source: C,
         notify: bool,
     ) -> Result<(SmallNetwork<REv, P>, Effects<Event<P>>)> {
         let mut known_addresses = HashSet::new();
@@ -230,6 +230,8 @@ where
         let secret_key = small_network_identity.secret_key;
         let certificate = small_network_identity.tls_certificate;
 
+        let chain_info = Arc::new(chain_info_source.into());
+
         // If the env var "CASPER_ENABLE_LIBP2P_NET" is defined, exit without starting the
         // server.
         if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_ok() {
@@ -246,8 +248,7 @@ where
                 outgoing: HashMap::new(),
                 pending: HashMap::new(),
                 blocklist: HashMap::new(),
-                network_name,
-                maximum_net_message_size,
+                chain_info,
                 shutdown_sender: None,
                 shutdown_receiver: watch::channel(()).1,
                 server_join_handle: None,
@@ -315,8 +316,7 @@ where
             outgoing: HashMap::new(),
             pending: HashMap::new(),
             blocklist: HashMap::new(),
-            network_name,
-            maximum_net_message_size,
+            chain_info,
             shutdown_sender: Some(server_shutdown_sender),
             shutdown_receiver,
             server_join_handle: Some(server_join_handle),
@@ -508,11 +508,8 @@ where
                 info!(our_id=%self.our_id, %peer_id, %peer_address, "established incoming connection");
                 // The sink is only used to send a single handshake message, then dropped.
                 let (mut sink, stream) =
-                    framed::<P>(transport, self.maximum_net_message_size).split();
-                let handshake = Message::Handshake {
-                    network_name: self.network_name.clone(),
-                    public_address: self.public_address,
-                };
+                    framed::<P>(transport, self.chain_info.maximum_net_message_size).split();
+                let handshake = self.chain_info.create_handshake(self.public_address);
                 let mut effects = async move {
                     let _ = sink.send(handshake).await;
                 }
@@ -592,7 +589,8 @@ where
         }
 
         // The stream is only used to receive a single handshake message and then dropped.
-        let (sink, stream) = framed::<P>(transport, self.maximum_net_message_size).split();
+        let (sink, stream) =
+            framed::<P>(transport, self.chain_info.maximum_net_message_size).split();
         debug!(our_id=%self.our_id, %peer_id, %peer_address, "established outgoing connection");
 
         let (sender, receiver) = mpsc::unbounded_channel();
@@ -610,10 +608,8 @@ where
 
         let mut effects = self.check_connection_complete(effect_builder, peer_id);
 
-        let handshake = Message::Handshake {
-            network_name: self.network_name.clone(),
-            public_address: self.public_address,
-        };
+        let handshake = self.chain_info.create_handshake(self.public_address);
+
         effects.extend(
             message_sender(
                 receiver,
@@ -759,13 +755,16 @@ where
             Message::Handshake {
                 network_name,
                 public_address,
+                protocol_version,
             } => {
-                if network_name != self.network_name {
+                if network_name != self.chain_info.network_name {
                     info!(
                         our_id=%self.our_id,
                         %peer_id,
-                        our_network=?self.network_name,
+                        our_network=?self.chain_info.network_name,
                         their_network=?network_name,
+                        our_protocol_version=%self.chain_info.protocol_version,
+                        their_protocol_version=%protocol_version,
                         "dropping connection due to network name mismatch"
                     );
                     let remove = self.remove(effect_builder, &peer_id, false);

--- a/node/src/components/small_network/chain_info.rs
+++ b/node/src/components/small_network/chain_info.rs
@@ -1,0 +1,57 @@
+//! Network-related chain identification information.
+
+// TODO: This module and `ChainId` should disappear in its entirety and the actual chainspec be made
+// available.
+
+use std::net::SocketAddr;
+
+use casper_types::ProtocolVersion;
+use datasize::DataSize;
+
+use super::Message;
+use crate::types::Chainspec;
+
+/// Data retained from the chainspec by the small networking component.
+///
+/// Typically this information is used for creating handshakes.
+#[derive(DataSize, Debug)]
+pub(crate) struct ChainInfo {
+    /// Name of the network we participate in. We only remain connected to peers with the same
+    /// network name as us.
+    pub(super) network_name: String,
+    /// The maximum message size for a network message, as supplied from the chainspec.
+    pub(super) maximum_net_message_size: u32,
+    /// The protocol version.
+    pub(super) protocol_version: ProtocolVersion,
+}
+
+impl ChainInfo {
+    /// Create an instance of `ChainInfo` for testing.
+    #[cfg(test)]
+    pub fn create_for_testing() -> Self {
+        ChainInfo {
+            network_name: "rust-tests-network".to_string(),
+            maximum_net_message_size: 22 * 1024 * 1024, // Hardcoded at 22M.
+            protocol_version: ProtocolVersion::V1_0_0,
+        }
+    }
+
+    /// Create a handshake based on chain identification data.
+    pub(super) fn create_handshake<P>(&self, public_address: SocketAddr) -> Message<P> {
+        Message::Handshake {
+            network_name: self.network_name.clone(),
+            public_address,
+            protocol_version: self.protocol_version,
+        }
+    }
+}
+
+impl From<&Chainspec> for ChainInfo {
+    fn from(chainspec: &Chainspec) -> Self {
+        ChainInfo {
+            network_name: chainspec.network_config.name.clone(),
+            maximum_net_message_size: chainspec.network_config.maximum_net_message_size,
+            protocol_version: chainspec.protocol_version(),
+        }
+    }
+}

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -66,7 +66,9 @@ pub enum Error {
         ResolveAddressError,
     ),
     /// Failed to send message.
-    #[error("failed to send message")]
+    // TODO: Inclusion of the cause is a workaround, we should actually be printing cause-traces
+    //       when logging errors.
+    #[error("failed to send message: {0}")]
     MessageNotSent(
         #[serde(skip_serializing)]
         #[source]

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -3,7 +3,14 @@ use std::{
     net::SocketAddr,
 };
 
+use casper_types::ProtocolVersion;
 use serde::{Deserialize, Serialize};
+
+/// The default protocol version to use in absence of one in the protocol version field.
+#[inline]
+fn default_protocol_version() -> ProtocolVersion {
+    ProtocolVersion::V1_0_0
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Message<P> {
@@ -12,6 +19,9 @@ pub enum Message<P> {
         network_name: String,
         /// The public address of the node connecting.
         public_address: SocketAddr,
+        /// Protocol version the node is speaking.
+        #[serde(default = "default_protocol_version")]
+        protocol_version: ProtocolVersion,
     },
     Payload(P),
 }
@@ -22,12 +32,192 @@ impl<P: Display> Display for Message<P> {
             Message::Handshake {
                 network_name,
                 public_address,
+                protocol_version,
             } => write!(
                 f,
-                "handshake: {}, public addr: {}",
-                network_name, public_address
+                "handshake: {}, public addr: {}, protocol_version: {}",
+                network_name, public_address, protocol_version,
             ),
             Message::Payload(payload) => write!(f, "payload: {}", payload),
+        }
+    }
+}
+
+#[cfg(test)]
+// We use a variety of weird names in these tests.
+#[allow(non_camel_case_types)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use casper_types::ProtocolVersion;
+    use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+    use crate::protocol;
+
+    use super::Message;
+
+    /// Version 1.0.0 network level message.
+    ///
+    /// Note that the message itself may go out of sync over time as `protocol::Message` changes.
+    /// The test further below ensures that the handshake is accurate in the meantime.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub enum V1_0_0_Message {
+        Handshake {
+            /// Network we are connected to.
+            network_name: String,
+            /// The public address of the node connecting.
+            public_address: SocketAddr,
+        },
+        Payload(protocol::Message),
+    }
+
+    /// A "conserved" version 1.0.0 handshake.
+    ///
+    /// NEVER CHANGE THIS CONSTANT TO MAKE TESTS PASS, AS IT IS BASED ON MAINNET DATA.
+    const V1_0_0_HANDSHAKE: &[u8] = &[
+        129, 0, 146, 178, 115, 101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, 45, 116,
+        101, 115, 116, 177, 49, 50, 46, 51, 52, 46, 53, 54, 46, 55, 56, 58, 49, 50, 51, 52, 54,
+    ];
+
+    // Note: MessagePacke messages can be visualized using the message pack visualizer at
+    // https://sugendran.github.io/msgpack-visualizer/
+    // Rust arrays can be copy&pasted and converted to base64 using the following one-liner:
+    // `import base64; base64.b64encode(bytes([129, 0, ...]))`
+
+    // It is very important to note that different versions of the message pack codec crate set the
+    // human-readable flag in a different manner. Thus the V1.0.0 handshake can be serialized in two
+    // different ways, with "human readable" enabled and without.
+    //
+    // Our V1.0.0 protocol uses the "human readable" enabled version, they key difference being that
+    // the `SocketAddr` is encoded as a string instead of a two-item array.
+
+    /// A pseudo-1.0.0 handshake, where the serde human readable flag has been changed due to an
+    /// `rmp` version mismatch.
+    const BROKEN_V1_0_0_HANDSHAKE: &[u8] = &[
+        129, 0, 146, 178, 115, 101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, 45, 116,
+        101, 115, 116, 129, 0, 146, 148, 12, 34, 56, 78, 205, 48, 58,
+    ];
+
+    /// Serialize a message using the standard serialization method for handshakes.
+    fn serialize_message<M: Serialize>(msg: &M) -> Vec<u8> {
+        // The actual serialization/deserialization code can be found at
+        // https://github.com/carllerche/tokio-serde/blob/f3c3d69ce049437973468118c9d01b46e0b1ade5/src/lib.rs#L426-L450
+
+        rmp_serde::to_vec(&msg).expect("handshake serialization failed")
+    }
+
+    /// Deserialize a message using the standard deserialization method for handshakes.
+    fn deserialize_message<M: DeserializeOwned>(serialized: &[u8]) -> M {
+        rmp_serde::from_read(std::io::Cursor::new(&serialized))
+            .expect("handshake deserialization failed")
+    }
+
+    /// Given a message `from` of type `F`, serializes it, then deserializes it as `T`.
+    fn roundtrip_message<F, T>(from: &F) -> T
+    where
+        F: Serialize,
+        T: DeserializeOwned,
+    {
+        let serialized = serialize_message(from);
+        deserialize_message(&serialized)
+    }
+
+    // This test ensure that the serialization of the `V_1_0_0_Message` has not changed and that the
+    // serialization/deserialization methods for message in this test are likely accurate.
+    #[test]
+    fn v1_0_0_handshake_is_as_expected() {
+        let handshake = V1_0_0_Message::Handshake {
+            network_name: "serialization-test".to_owned(),
+            public_address: ([12, 34, 56, 78], 12346).into(),
+        };
+
+        let serialized = serialize_message::<V1_0_0_Message>(&handshake);
+
+        assert_eq!(&serialized, V1_0_0_HANDSHAKE);
+        assert_ne!(&serialized, BROKEN_V1_0_0_HANDSHAKE);
+
+        let deserialized: V1_0_0_Message = deserialize_message(&serialized);
+
+        match deserialized {
+            V1_0_0_Message::Handshake {
+                network_name,
+                public_address,
+            } => {
+                assert_eq!(network_name, "serialization-test");
+                assert_eq!(public_address, ([12, 34, 56, 78], 12346).into());
+            }
+            other => {
+                panic!("did not expect {:?} as the deserialized product", other);
+            }
+        }
+    }
+
+    #[test]
+    fn v1_0_0_can_decode_current_handshake() {
+        let modern_handshake = Message::<protocol::Message>::Handshake {
+            network_name: "example-handshake".to_string(),
+            public_address: ([12, 34, 56, 78], 12346).into(),
+            protocol_version: ProtocolVersion::from_parts(5, 6, 7),
+        };
+
+        let legacy_handshake: V1_0_0_Message = roundtrip_message(&modern_handshake);
+
+        match legacy_handshake {
+            V1_0_0_Message::Handshake {
+                network_name,
+                public_address,
+            } => {
+                assert_eq!(network_name, "example-handshake");
+                assert_eq!(public_address, ([12, 34, 56, 78], 12346).into());
+            }
+            V1_0_0_Message::Payload(_) => {
+                panic!("did not expect legacy handshake to deserialize to payload")
+            }
+        }
+    }
+
+    #[test]
+    fn current_handshake_decodes_from_v1_0_0() {
+        let legacy_handshake = V1_0_0_Message::Handshake {
+            network_name: "example-handshake".to_string(),
+            public_address: ([12, 34, 56, 78], 12346).into(),
+        };
+
+        let modern_handshake: Message<protocol::Message> = roundtrip_message(&legacy_handshake);
+
+        match modern_handshake {
+            Message::Handshake {
+                network_name,
+                public_address,
+                protocol_version,
+            } => {
+                assert_eq!(network_name, "example-handshake");
+                assert_eq!(public_address, ([12, 34, 56, 78], 12346).into());
+                assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
+            }
+            Message::Payload(_) => {
+                panic!("did not expect modern handshake to deserialize to payload")
+            }
+        }
+    }
+
+    #[test]
+    fn current_handshake_decodes_from_historic_v1_0_0() {
+        let modern_handshake: Message<protocol::Message> = deserialize_message(&V1_0_0_HANDSHAKE);
+
+        match modern_handshake {
+            Message::Handshake {
+                network_name,
+                public_address,
+                protocol_version,
+            } => {
+                assert_eq!(network_name, "serialization-test");
+                assert_eq!(public_address, ([12, 34, 56, 78], 12346).into());
+                assert_eq!(protocol_version, ProtocolVersion::V1_0_0);
+            }
+            Message::Payload(_) => {
+                panic!("did not expect modern handshake to deserialize to payload")
+            }
         }
     }
 }

--- a/node/src/components/small_network/message.rs
+++ b/node/src/components/small_network/message.rs
@@ -79,10 +79,10 @@ mod tests {
         101, 115, 116, 177, 49, 50, 46, 51, 52, 46, 53, 54, 46, 55, 56, 58, 49, 50, 51, 52, 54,
     ];
 
-    // Note: MessagePacke messages can be visualized using the message pack visualizer at
-    // https://sugendran.github.io/msgpack-visualizer/
-    // Rust arrays can be copy&pasted and converted to base64 using the following one-liner:
-    // `import base64; base64.b64encode(bytes([129, 0, ...]))`
+    // Note: MessagePack messages can be visualized using the message pack visualizer at
+    // https://sugendran.github.io/msgpack-visualizer/. Rust arrays can be copy&pasted and converted
+    // to base64 using the following one-liner: `import base64; base64.b64encode(bytes([129, 0,
+    // ...]))`
 
     // It is very important to note that different versions of the message pack codec crate set the
     // human-readable flag in a different manner. Thus the V1.0.0 handshake can be serialized in two

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -140,6 +140,7 @@ impl Reactor for TestReactor {
             registry,
             small_network_identity,
             "test_network".to_string(),
+            23 * 1024 * 1024, // Hardcoded at 23 megs.
             false,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();

--- a/node/src/components/small_network/tests.rs
+++ b/node/src/components/small_network/tests.rs
@@ -17,7 +17,9 @@ use reactor::ReactorEvent;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
-use super::{Config, Event as SmallNetworkEvent, GossipedAddress, SmallNetwork};
+use super::{
+    chain_info::ChainInfo, Config, Event as SmallNetworkEvent, GossipedAddress, SmallNetwork,
+};
 use crate::{
     components::{
         gossiper::{self, Gossiper},
@@ -139,8 +141,7 @@ impl Reactor for TestReactor {
             cfg,
             registry,
             small_network_identity,
-            "test_network".to_string(),
-            23 * 1024 * 1024, // Hardcoded at 23 megs.
+            ChainInfo::create_for_testing(),
             false,
         )?;
         let gossiper_config = gossiper::Config::new_with_small_timeouts();

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -403,18 +403,12 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             false,
         )?;
-        let network_name = chainspec_loader.chainspec().network_config.name.clone();
-        let maximum_net_message_size = chainspec_loader
-            .chainspec()
-            .network_config
-            .maximum_net_message_size;
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network.clone(),
             registry,
             small_network_identity,
-            network_name,
-            maximum_net_message_size,
+            chainspec_loader.chainspec().as_ref(),
             false,
         )?;
 

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -404,12 +404,17 @@ impl reactor::Reactor for Reactor {
             false,
         )?;
         let network_name = chainspec_loader.chainspec().network_config.name.clone();
+        let maximum_net_message_size = chainspec_loader
+            .chainspec()
+            .network_config
+            .maximum_net_message_size;
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network.clone(),
             registry,
             small_network_identity,
             network_name,
+            maximum_net_message_size,
             false,
         )?;
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -415,18 +415,12 @@ impl reactor::Reactor for Reactor {
             chainspec_loader.chainspec(),
             true,
         )?;
-        let network_name = chainspec_loader.chainspec().network_config.name.clone();
-        let maximum_net_message_size = chainspec_loader
-            .chainspec()
-            .network_config
-            .maximum_net_message_size;
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network,
             registry,
             small_network_identity,
-            network_name,
-            maximum_net_message_size,
+            chainspec_loader.chainspec().as_ref(),
             true,
         )?;
 

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -416,12 +416,17 @@ impl reactor::Reactor for Reactor {
             true,
         )?;
         let network_name = chainspec_loader.chainspec().network_config.name.clone();
+        let maximum_net_message_size = chainspec_loader
+            .chainspec()
+            .network_config
+            .maximum_net_message_size;
         let (small_network, small_network_effects) = SmallNetwork::new(
             event_queue,
             config.network,
             registry,
             small_network_identity,
             network_name,
+            maximum_net_message_size,
             true,
         )?;
 

--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -24,7 +24,10 @@ use casper_execution_engine::{
     core::engine_state::genesis::ExecConfig,
     shared::{system_config::SystemConfig, wasm_config::WasmConfig},
 };
-use casper_types::bytesrepr::{self, FromBytes, ToBytes};
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    ProtocolVersion,
+};
 
 #[cfg(test)]
 pub(crate) use self::accounts_config::{AccountConfig, ValidatorConfig};
@@ -93,6 +96,11 @@ impl Chainspec {
     /// Returns true if this chainspec has an activation_point specifying era ID 0.
     pub(crate) fn is_genesis(&self) -> bool {
         self.protocol_config.activation_point.is_genesis()
+    }
+
+    /// Returns the protocol version of the chainspec.
+    pub(crate) fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_config.version
     }
 }
 

--- a/node/src/types/chainspec/network_config.rs
+++ b/node/src/types/chainspec/network_config.rs
@@ -17,7 +17,11 @@ use crate::testing::TestRng;
 pub struct NetworkConfig {
     /// The network name.
     pub(crate) name: String,
+    /// The maximum size of an accepted network message, in bytes.
+    pub(crate) maximum_net_message_size: u32,
     /// Validator accounts specified in the chainspec.
+    // Note: `accounts_config` must be the last field on this struct due to issues in the TOML
+    // crate - see <https://github.com/alexcrichton/toml-rs/search?q=ValueAfterTable&type=issues>.
     pub(crate) accounts_config: AccountsConfig,
 }
 
@@ -46,10 +50,12 @@ impl NetworkConfig {
         let accounts = vec![rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen()];
         let delegators = vec![rng.gen(), rng.gen(), rng.gen(), rng.gen(), rng.gen()];
         let accounts_config = AccountsConfig::new(accounts, delegators);
+        let maximum_net_message_size = 4 + rng.gen_range(0..4);
 
         NetworkConfig {
             name,
             accounts_config,
+            maximum_net_message_size,
         }
     }
 }
@@ -59,11 +65,14 @@ impl ToBytes for NetworkConfig {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         buffer.extend(self.name.to_bytes()?);
         buffer.extend(self.accounts_config.to_bytes()?);
+        buffer.extend(self.maximum_net_message_size.to_bytes()?);
         Ok(buffer)
     }
 
     fn serialized_length(&self) -> usize {
-        self.name.serialized_length() + self.accounts_config.serialized_length()
+        self.name.serialized_length()
+            + self.accounts_config.serialized_length()
+            + self.maximum_net_message_size.serialized_length()
     }
 }
 
@@ -71,9 +80,11 @@ impl FromBytes for NetworkConfig {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (name, remainder) = String::from_bytes(bytes)?;
         let (accounts_config, remainder) = FromBytes::from_bytes(remainder)?;
+        let (maximum_net_message_size, remainder) = FromBytes::from_bytes(remainder)?;
         let config = NetworkConfig {
             name,
             accounts_config,
+            maximum_net_message_size,
         };
         Ok((config, remainder))
     }

--- a/node/src/types/chainspec/parse_toml.rs
+++ b/node/src/types/chainspec/parse_toml.rs
@@ -25,6 +25,7 @@ use crate::utils::{self, Loadable};
 #[serde(deny_unknown_fields)]
 struct TomlNetwork {
     name: String,
+    maximum_net_message_size: u32,
 }
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
@@ -59,6 +60,7 @@ impl From<&Chainspec> for TomlChainspec {
         };
         let network = TomlNetwork {
             name: chainspec.network_config.name.clone(),
+            maximum_net_message_size: chainspec.network_config.maximum_net_message_size,
         };
         let core = chainspec.core_config;
         let deploys = chainspec.deploy_config;
@@ -93,6 +95,7 @@ pub(super) fn parse_toml<P: AsRef<Path>>(chainspec_path: P) -> Result<Chainspec,
     let network_config = NetworkConfig {
         name: toml_chainspec.network.name,
         accounts_config,
+        maximum_net_message_size: toml_chainspec.network.maximum_net_message_size,
     };
 
     let global_state_update = Option::<GlobalStateUpdateConfig>::from_path(root)?

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -18,6 +18,9 @@ activation_point = '${TIMESTAMP}'
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper-example'
+# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# be rejected at the networking level.
+maximum_net_message_size = 23_068_672
 
 [core]
 # Era duration.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -18,6 +18,9 @@ activation_point = '2021-03-15T17:00:00Z'
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'delta-11'
+# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# be rejected at the networking level.
+maximum_net_message_size = 23_068_672
 
 [core]
 # Era duration.

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -5,6 +5,7 @@ activation_point = '2020-09-18T18:45:00Z'
 
 [network]
 name = 'test-chain'
+maximum_net_message_size = 23_068_672
 
 [core]
 era_duration = '3minutes'

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -5,6 +5,7 @@ activation_point = '2020-09-18T18:45:00Z'
 
 [network]
 name = 'test-chain'
+maximum_net_message_size = 23_068_672
 
 [core]
 era_duration = '3minutes'

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -5,6 +5,7 @@ activation_point = 1
 
 [network]
 name = 'test-chain'
+maximum_net_message_size = 23_068_672
 
 [core]
 era_duration = '3minutes'

--- a/shell.nix
+++ b/shell.nix
@@ -37,7 +37,7 @@ in pkgs.stdenv.mkDerivation {
   name = "rustenv";
   nativeBuildInputs = with pkgs; [ pkg-config perl which protobuf ];
   buildInputs = with pkgs;
-    [ cmake pkg-config openssl.dev zlib.dev rustup ]
+    [ cmake pkg-config openssl.dev zlib.dev rustup envsubst ]
     ++ lists.optionals ops [ kubectl python skopeo git nix ]
     ++ lists.optionals dev [ black docker coreutils run-nctl ];
 

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -18,6 +18,14 @@ activation_point = '${TIMESTAMP}'
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper-example'
+# Timestamp for the genesis block.  This is the beginning of era 0. By this time, a sufficient majority (> 50% + F/2 —
+# see finality_threshold_percent below) of validator nodes must be up and running to start the blockchain.  This
+# timestamp is also used in seeding the pseudo-random number generator used in contract-runtime for computing genesis
+# post-state hash.
+timestamp = '${TIMESTAMP}'
+# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# be rejected at the networking level.
+maximum_net_message_size = 23_068_672
 
 [core]
 # Era duration.


### PR DESCRIPTION
This backports two 1.1.0 changes to `dev`, with the necessary alterations: https://github.com/CasperLabs/casper-node/pull/1256 (making the maximum message size depend on the chainspec instead of being hardcoded) https://github.com/CasperLabs/casper-node/pull/1263 (include the chainspec version in the handshake)

It also introduces the first set of rountrip tests that are ensuring we can serialize/deserialize network messages from 1.0.0 and onwards.