### PR TITLE
NDRS-1126: remove impl Sub for Timestamp

### DIFF
--- a/client/tests/integration_test.rs
+++ b/client/tests/integration_test.rs
@@ -830,7 +830,7 @@ mod rate_limit {
             assert_eq!(join_handle.await.unwrap(), Ok(()));
         }
 
-        let diff = Timestamp::now() - now;
+        let diff = now.elapsed();
         assert!(
             diff < Duration::from_millis(4000).into(),
             "Rate limiting of 1 qps for 3 sec took too long at {}ms",

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -93,7 +93,6 @@ pub struct EraSupervisor<I> {
     config: Config,
     #[data_size(skip)] // Negligible for most closures, zero for functions.
     new_consensus: Box<ConsensusConstructor<I>>,
-    node_start_time: Timestamp,
     /// The height of the next block to be finalized.
     /// We keep that in order to be able to signal to the Block Proposer how many blocks have been
     /// finalized when we request a new block. This way the Block Proposer can know whether it's up
@@ -169,9 +168,6 @@ where
             protocol_config,
             config,
             new_consensus,
-            // TODO: Find a better way to decide whether to activate validator, or get the
-            // timestamp from when the process started.
-            node_start_time: Timestamp::now(),
             next_block_height: next_height,
             metrics,
             unit_hashes_folder,

--- a/node/src/components/consensus/protocols/highway/participation.rs
+++ b/node/src/components/consensus/protocols/highway/participation.rs
@@ -39,7 +39,7 @@ impl Status {
             return Some(Status::Inactive);
         }
         if state.last_seen(idx) + state.params().max_round_length() < now {
-            let seconds = (now - state.last_seen(idx)).millis() / 1000;
+            let seconds = now.saturating_diff(state.last_seen(idx)).millis() / 1000;
             return Some(Status::LastSeenSecondsAgo(seconds));
         }
         None

--- a/node/src/components/linear_chain.rs
+++ b/node/src/components/linear_chain.rs
@@ -27,7 +27,7 @@ use crate::{
         EffectBuilder, EffectExt, EffectResultExt, Effects,
     },
     protocol::Message,
-    types::{BlockByHeight, Timestamp},
+    types::BlockByHeight,
     NodeRng,
 };
 use casper_types::{EraId, ProtocolVersion};
@@ -195,8 +195,7 @@ where
                 outcomes_to_effects(effect_builder, outcomes)
             }
             Event::PutBlockResult { block } => {
-                let completion_duration =
-                    Timestamp::now().millis() - block.header().timestamp().millis();
+                let completion_duration = block.header().timestamp().elapsed().millis();
                 self.metrics
                     .block_completion_duration
                     .set(completion_duration as i64);

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -784,8 +784,9 @@ where
     }
 
     fn connect_to_peer_if_required(&mut self, peer_address: SocketAddr) -> Effects<Event<P>> {
+        let now = Timestamp::now();
         self.blocklist
-            .retain(|_, ts| *ts > Timestamp::now() - *BLOCKLIST_RETAIN_DURATION);
+            .retain(|_, ts| *ts > now - *BLOCKLIST_RETAIN_DURATION);
         if self.pending.contains_key(&peer_address)
             || self.blocklist.contains_key(&peer_address)
             || self

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -38,18 +38,18 @@ static TIMESTAMP_EXAMPLE: Lazy<Timestamp> = Lazy::new(|| {
 pub struct Timestamp(u64);
 
 impl Timestamp {
-    /// Returns the timestamp of the current moment
+    /// Returns the timestamp of the current moment.
     pub fn now() -> Self {
         let millis = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64;
         Timestamp(millis)
     }
 
-    /// Returns the time that has elapsed since this timestamp
+    /// Returns the time that has elapsed since this timestamp.
     pub fn elapsed(&self) -> TimeDiff {
-        Timestamp::now() - *self
+        TimeDiff(Timestamp::now().0.saturating_sub(self.0))
     }
 
-    /// Returns a zero timestamp
+    /// Returns a zero timestamp.
     pub fn zero() -> Self {
         Timestamp(0)
     }
@@ -106,14 +106,6 @@ impl FromStr for Timestamp {
             .map_err(|_| TimestampError::OutOfRange)?
             .as_millis() as u64;
         Ok(Timestamp(inner))
-    }
-}
-
-impl Sub<Timestamp> for Timestamp {
-    type Output = TimeDiff;
-
-    fn sub(self, other: Timestamp) -> TimeDiff {
-        TimeDiff(self.0 - other.0)
     }
 }
 


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1126.

This PR removes `impl Sub<Timestamp> for Timestamp` as it made it somewhat easy to create code which could potentially panic in non-obvious edge cases.