### PR TITLE
EE-1223: Remove get refund purse

### DIFF
--- a/execution_engine/src/core/engine_state/genesis.rs
+++ b/execution_engine/src/core/engine_state/genesis.rs
@@ -31,7 +31,7 @@ use casper_types::{
         },
         handle_payment::{
             self, ARG_ACCOUNT, METHOD_FINALIZE_PAYMENT, METHOD_GET_PAYMENT_PURSE,
-            METHOD_GET_REFUND_PURSE, METHOD_SET_REFUND_PURSE,
+            METHOD_SET_REFUND_PURSE,
         },
         mint::{
             self, ARG_AMOUNT, ARG_ID, ARG_PURSE, ARG_ROUND_SEIGNIORAGE_RATE, ARG_SOURCE,
@@ -1386,15 +1386,6 @@ where
             EntryPointType::Contract,
         );
         entry_points.add_entry_point(set_refund_purse);
-
-        let get_refund_purse = EntryPoint::new(
-            METHOD_GET_REFUND_PURSE,
-            vec![],
-            CLType::Option(Box::new(CLType::URef)),
-            EntryPointAccess::Public,
-            EntryPointType::Contract,
-        );
-        entry_points.add_entry_point(get_refund_purse);
 
         let finalize_payment = EntryPoint::new(
             METHOD_FINALIZE_PAYMENT,

--- a/execution_engine/src/core/runtime/mod.rs
+++ b/execution_engine/src/core/runtime/mod.rs
@@ -1522,12 +1522,6 @@ where
                 runtime.set_refund_purse(purse).map_err(Self::reverter)?;
                 CLValue::from_t(()).map_err(Self::reverter)
             })(),
-            handle_payment::METHOD_GET_REFUND_PURSE => (|| {
-                runtime.charge_system_contract_call(handle_payment_costs.get_refund_purse)?;
-
-                let maybe_purse = runtime.get_refund_purse().map_err(Self::reverter)?;
-                CLValue::from_t(maybe_purse).map_err(Self::reverter)
-            })(),
             handle_payment::METHOD_FINALIZE_PAYMENT => (|| {
                 runtime.charge_system_contract_call(handle_payment_costs.finalize_payment)?;
 

--- a/execution_engine/src/core/runtime/standard_payment_internal.rs
+++ b/execution_engine/src/core/runtime/standard_payment_internal.rs
@@ -12,8 +12,6 @@ use crate::{
     storage::global_state::StateReader,
 };
 
-pub(crate) const METHOD_GET_PAYMENT_PURSE: &str = "get_payment_purse";
-
 impl From<execution::Error> for Option<ApiError> {
     fn from(exec_error: execution::Error) -> Self {
         match exec_error {
@@ -73,7 +71,7 @@ where
         let cl_value = self
             .call_contract(
                 handle_payment_contract_hash,
-                METHOD_GET_PAYMENT_PURSE,
+                handle_payment::METHOD_GET_PAYMENT_PURSE,
                 RuntimeArgs::new(),
             )
             .map_err(|exec_error| {

--- a/execution_engine/src/shared/system_config/handle_payment_costs.rs
+++ b/execution_engine/src/shared/system_config/handle_payment_costs.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_GET_PAYMENT_PURSE_COST: u32 = 10_000;
 pub const DEFAULT_SET_REFUND_PURSE_COST: u32 = 10_000;
-pub const DEFAULT_GET_REFUND_PURSE_COST: u32 = 10_000;
 pub const DEFAULT_FINALIZE_PAYMENT_COST: u32 = 10_000;
 
 /// Description of costs of calling handle payment entrypoints.
@@ -13,7 +12,6 @@ pub const DEFAULT_FINALIZE_PAYMENT_COST: u32 = 10_000;
 pub struct HandlePaymentCosts {
     pub get_payment_purse: u32,
     pub set_refund_purse: u32,
-    pub get_refund_purse: u32,
     pub finalize_payment: u32,
 }
 
@@ -22,7 +20,6 @@ impl Default for HandlePaymentCosts {
         Self {
             get_payment_purse: DEFAULT_GET_PAYMENT_PURSE_COST,
             set_refund_purse: DEFAULT_SET_REFUND_PURSE_COST,
-            get_refund_purse: DEFAULT_GET_REFUND_PURSE_COST,
             finalize_payment: DEFAULT_FINALIZE_PAYMENT_COST,
         }
     }
@@ -34,7 +31,6 @@ impl ToBytes for HandlePaymentCosts {
 
         ret.append(&mut self.get_payment_purse.to_bytes()?);
         ret.append(&mut self.set_refund_purse.to_bytes()?);
-        ret.append(&mut self.get_refund_purse.to_bytes()?);
         ret.append(&mut self.finalize_payment.to_bytes()?);
 
         Ok(ret)
@@ -43,7 +39,6 @@ impl ToBytes for HandlePaymentCosts {
     fn serialized_length(&self) -> usize {
         self.get_payment_purse.serialized_length()
             + self.set_refund_purse.serialized_length()
-            + self.get_refund_purse.serialized_length()
             + self.finalize_payment.serialized_length()
     }
 }
@@ -52,14 +47,12 @@ impl FromBytes for HandlePaymentCosts {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), casper_types::bytesrepr::Error> {
         let (get_payment_purse, rem) = FromBytes::from_bytes(bytes)?;
         let (set_refund_purse, rem) = FromBytes::from_bytes(rem)?;
-        let (get_refund_purse, rem) = FromBytes::from_bytes(rem)?;
         let (finalize_payment, rem) = FromBytes::from_bytes(rem)?;
 
         Ok((
             Self {
                 get_payment_purse,
                 set_refund_purse,
-                get_refund_purse,
                 finalize_payment,
             },
             rem,
@@ -72,7 +65,6 @@ impl Distribution<HandlePaymentCosts> for Standard {
         HandlePaymentCosts {
             get_payment_purse: rng.gen(),
             set_refund_purse: rng.gen(),
-            get_refund_purse: rng.gen(),
             finalize_payment: rng.gen(),
         }
     }
@@ -88,13 +80,11 @@ pub mod gens {
         pub fn handle_payment_costs_arb()(
             get_payment_purse in num::u32::ANY,
             set_refund_purse in num::u32::ANY,
-            get_refund_purse in num::u32::ANY,
             finalize_payment in num::u32::ANY,
         ) -> HandlePaymentCosts {
             HandlePaymentCosts {
                 get_payment_purse,
                 set_refund_purse,
-                get_refund_purse,
                 finalize_payment,
             }
         }

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -205,7 +205,6 @@ read_base_round_reward = 10_000
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000
 set_refund_purse = 10_000
-get_refund_purse = 10_000
 finalize_payment = 10_000
 
 [system_costs.standard_payment_costs]

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -208,7 +208,6 @@ read_base_round_reward = 10_000
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000
 set_refund_purse = 10_000
-get_refund_purse = 10_000
 finalize_payment = 10_000
 
 [system_costs.standard_payment_costs]

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -133,7 +133,6 @@ read_base_round_reward = 10_000
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000
 set_refund_purse = 10_000
-get_refund_purse = 10_000
 finalize_payment = 10_000
 
 [system_costs.standard_payment_costs]

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -133,7 +133,6 @@ read_base_round_reward = 10_000
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000
 set_refund_purse = 10_000
-get_refund_purse = 10_000
 finalize_payment = 10_000
 
 [system_costs.standard_payment_costs]

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -133,7 +133,6 @@ read_base_round_reward = 10_000
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000
 set_refund_purse = 10_000
-get_refund_purse = 10_000
 finalize_payment = 10_000
 
 [system_costs.standard_payment_costs]

--- a/smart_contracts/contracts/client/named-purse-payment/src/main.rs
+++ b/smart_contracts/contracts/client/named-purse-payment/src/main.rs
@@ -9,10 +9,7 @@ use casper_contract::{
     contract_api::{runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use casper_types::{runtime_args, ApiError, RuntimeArgs, URef, U512};
-
-const GET_PAYMENT_PURSE: &str = "get_payment_purse";
-const SET_REFUND_PURSE: &str = "set_refund_purse";
+use casper_types::{runtime_args, system::handle_payment, ApiError, RuntimeArgs, URef, U512};
 
 const ARG_AMOUNT: &str = "amount";
 const ARG_PURSE: &str = "purse";
@@ -45,13 +42,13 @@ pub extern "C" fn call() {
         let args = runtime_args! {
             ARG_PURSE => purse_uref,
         };
-        runtime::call_contract::<()>(contract_hash, SET_REFUND_PURSE, args);
+        runtime::call_contract::<()>(contract_hash, handle_payment::METHOD_SET_REFUND_PURSE, args);
     }
 
     // get payment purse for current execution
     let payment_purse: URef = runtime::call_contract(
         handle_payment_hash,
-        GET_PAYMENT_PURSE,
+        handle_payment::METHOD_GET_PAYMENT_PURSE,
         RuntimeArgs::default(),
     );
 

--- a/smart_contracts/contracts/test/ee-549-regression/src/main.rs
+++ b/smart_contracts/contracts/test/ee-549-regression/src/main.rs
@@ -2,9 +2,8 @@
 #![no_main]
 
 use casper_contract::contract_api::{runtime, system};
-use casper_types::{runtime_args, RuntimeArgs};
+use casper_types::{runtime_args, system::handle_payment, RuntimeArgs};
 
-const SET_REFUND_PURSE: &str = "set_refund_purse";
 const ARG_PURSE: &str = "purse";
 
 fn malicious_revenue_stealing_contract() {
@@ -14,7 +13,7 @@ fn malicious_revenue_stealing_contract() {
         ARG_PURSE => system::create_purse(),
     };
 
-    runtime::call_contract::<()>(contract_hash, SET_REFUND_PURSE, args);
+    runtime::call_contract::<()>(contract_hash, handle_payment::METHOD_SET_REFUND_PURSE, args);
 }
 
 #[no_mangle]

--- a/smart_contracts/contracts/test/ee-601-regression/src/main.rs
+++ b/smart_contracts/contracts/test/ee-601-regression/src/main.rs
@@ -9,9 +9,8 @@ use casper_contract::{
     contract_api::{account, runtime, storage, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use casper_types::{ApiError, Phase, RuntimeArgs, URef, U512};
+use casper_types::{system::handle_payment, ApiError, Phase, RuntimeArgs, URef, U512};
 
-const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 const NEW_UREF_RESULT_UREF_NAME: &str = "new_uref_result";
 const ARG_AMOUNT: &str = "amount";
 
@@ -28,7 +27,7 @@ pub extern "C" fn call() {
 
         let payment_purse: URef = runtime::call_contract(
             system::get_handle_payment(),
-            GET_PAYMENT_PURSE,
+            handle_payment::METHOD_GET_PAYMENT_PURSE,
             RuntimeArgs::default(),
         );
 

--- a/smart_contracts/contracts/test/finalize-payment/src/main.rs
+++ b/smart_contracts/contracts/test/finalize-payment/src/main.rs
@@ -5,7 +5,10 @@ use casper_contract::{
     contract_api::{account, runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use casper_types::{account::AccountHash, runtime_args, ContractHash, RuntimeArgs, URef, U512};
+use casper_types::{
+    account::AccountHash, runtime_args, system::handle_payment, ContractHash, RuntimeArgs, URef,
+    U512,
+};
 
 pub const ARG_AMOUNT: &str = "amount";
 pub const ARG_AMOUNT_SPENT: &str = "amount_spent";
@@ -16,7 +19,7 @@ pub const ARG_ACCOUNT_KEY: &str = "account";
 fn set_refund_purse(contract_hash: ContractHash, purse: URef) {
     runtime::call_contract(
         contract_hash,
-        "set_refund_purse",
+        handle_payment::METHOD_SET_REFUND_PURSE,
         runtime_args! {
             ARG_PURSE => purse,
         },
@@ -24,7 +27,11 @@ fn set_refund_purse(contract_hash: ContractHash, purse: URef) {
 }
 
 fn get_payment_purse(contract_hash: ContractHash) -> URef {
-    runtime::call_contract(contract_hash, "get_payment_purse", runtime_args! {})
+    runtime::call_contract(
+        contract_hash,
+        handle_payment::METHOD_GET_PAYMENT_PURSE,
+        runtime_args! {},
+    )
 }
 
 fn submit_payment(contract_hash: ContractHash, amount: U512) {
@@ -36,7 +43,7 @@ fn submit_payment(contract_hash: ContractHash, amount: U512) {
 fn finalize_payment(contract_hash: ContractHash, amount_spent: U512, account: AccountHash) {
     runtime::call_contract(
         contract_hash,
-        "finalize_payment",
+        handle_payment::METHOD_FINALIZE_PAYMENT,
         runtime_args! {
             ARG_AMOUNT => amount_spent,
             ARG_ACCOUNT_KEY => account,

--- a/smart_contracts/contracts/test/get-payment-purse/src/main.rs
+++ b/smart_contracts/contracts/test/get-payment-purse/src/main.rs
@@ -5,7 +5,7 @@ use casper_contract::{
     contract_api::{account, runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use casper_types::{ApiError, RuntimeArgs, URef, U512};
+use casper_types::{system::handle_payment, ApiError, RuntimeArgs, URef, U512};
 
 #[repr(u16)]
 enum Error {
@@ -16,7 +16,6 @@ enum Error {
 }
 
 const ARG_AMOUNT: &str = "amount";
-const ENTRY_POINT_GET_PAYMENT_PURSE: &str = "get_payment_purse";
 
 #[no_mangle]
 pub extern "C" fn call() {
@@ -28,7 +27,7 @@ pub extern "C" fn call() {
     let payment_amount: U512 = 100.into();
     let payment_purse: URef = runtime::call_contract(
         contract_hash,
-        ENTRY_POINT_GET_PAYMENT_PURSE,
+        handle_payment::METHOD_GET_PAYMENT_PURSE,
         RuntimeArgs::default(),
     );
 

--- a/smart_contracts/contracts/test/get-phase-payment/src/main.rs
+++ b/smart_contracts/contracts/test/get-phase-payment/src/main.rs
@@ -5,9 +5,8 @@ use casper_contract::{
     contract_api::{account, runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use casper_types::{Phase, RuntimeArgs, URef, U512};
+use casper_types::{system::handle_payment, Phase, RuntimeArgs, URef, U512};
 
-const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 const ARG_PHASE: &str = "phase";
 const ARG_AMOUNT: &str = "amount";
 
@@ -18,7 +17,7 @@ fn standard_payment(amount: U512) {
 
     let payment_purse: URef = runtime::call_contract(
         handle_payment_pointer,
-        GET_PAYMENT_PURSE,
+        handle_payment::METHOD_GET_PAYMENT_PURSE,
         RuntimeArgs::default(),
     );
 

--- a/smart_contracts/contracts/test/refund-purse/src/main.rs
+++ b/smart_contracts/contracts/test/refund-purse/src/main.rs
@@ -5,7 +5,9 @@ use casper_contract::{
     contract_api::{account, runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use casper_types::{runtime_args, ApiError, ContractHash, RuntimeArgs, URef, U512};
+use casper_types::{
+    runtime_args, system::handle_payment, ApiError, ContractHash, RuntimeArgs, URef, U512,
+};
 
 #[repr(u16)]
 enum Error {
@@ -17,26 +19,31 @@ enum Error {
 
 pub const ARG_PURSE: &str = "purse";
 const ARG_PAYMENT_AMOUNT: &str = "payment_amount";
-const SET_REFUND_PURSE: &str = "set_refund_purse";
-const GET_REFUND_PURSE: &str = "get_refund_purse";
-const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 
 fn set_refund_purse(contract_hash: ContractHash, p: &URef) {
     runtime::call_contract(
         contract_hash,
-        SET_REFUND_PURSE,
+        handle_payment::METHOD_SET_REFUND_PURSE,
         runtime_args! {
             ARG_PURSE => *p,
         },
     )
 }
 
-fn get_refund_purse(handle_payment: ContractHash) -> Option<URef> {
-    runtime::call_contract(handle_payment, GET_REFUND_PURSE, runtime_args! {})
+fn get_refund_purse(handle_payment_hash: ContractHash) -> Option<URef> {
+    runtime::call_contract(
+        handle_payment_hash,
+        handle_payment::METHOD_GET_REFUND_PURSE,
+        runtime_args! {},
+    )
 }
 
 fn get_payment_purse(handle_payment: ContractHash) -> URef {
-    runtime::call_contract(handle_payment, GET_PAYMENT_PURSE, runtime_args! {})
+    runtime::call_contract(
+        handle_payment,
+        handle_payment::METHOD_GET_PAYMENT_PURSE,
+        runtime_args! {},
+    )
 }
 
 fn submit_payment(handle_payment: ContractHash, amount: U512) {

--- a/smart_contracts/contracts/test/refund-purse/src/main.rs
+++ b/smart_contracts/contracts/test/refund-purse/src/main.rs
@@ -5,17 +5,7 @@ use casper_contract::{
     contract_api::{account, runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use casper_types::{
-    runtime_args, system::handle_payment, ApiError, ContractHash, RuntimeArgs, URef, U512,
-};
-
-#[repr(u16)]
-enum Error {
-    ShouldNotExist = 0,
-    NotFound,
-    Invalid,
-    IncorrectAccessRights,
-}
+use casper_types::{runtime_args, system::handle_payment, ContractHash, RuntimeArgs, URef, U512};
 
 pub const ARG_PURSE: &str = "purse";
 const ARG_PAYMENT_AMOUNT: &str = "payment_amount";
@@ -27,14 +17,6 @@ fn set_refund_purse(contract_hash: ContractHash, p: &URef) {
         runtime_args! {
             ARG_PURSE => *p,
         },
-    )
-}
-
-fn get_refund_purse(handle_payment_hash: ContractHash) -> Option<URef> {
-    runtime::call_contract(
-        handle_payment_hash,
-        handle_payment::METHOD_GET_REFUND_PURSE,
-        runtime_args! {},
     )
 }
 
@@ -58,34 +40,13 @@ pub extern "C" fn call() {
 
     let refund_purse = system::create_purse();
     {
-        // get_refund_purse should return None before setting it
-        let refund_result = get_refund_purse(handle_payment);
-        if refund_result.is_some() {
-            runtime::revert(ApiError::User(Error::ShouldNotExist as u16));
-        }
-
         // it should return Some(x) after calling set_refund_purse(x)
         set_refund_purse(handle_payment, &refund_purse);
-        let refund_purse = match get_refund_purse(handle_payment) {
-            None => runtime::revert(ApiError::User(Error::NotFound as u16)),
-            Some(x) if x.addr() == refund_purse.addr() => x,
-            Some(_) => runtime::revert(ApiError::User(Error::Invalid as u16)),
-        };
-
-        // the returned purse should not have any access rights
-        if refund_purse.is_addable() || refund_purse.is_writeable() || refund_purse.is_readable() {
-            runtime::revert(ApiError::User(Error::IncorrectAccessRights as u16))
-        }
     }
     {
         let refund_purse = system::create_purse();
-        // get_refund_purse should return correct value after setting a second time
+
         set_refund_purse(handle_payment, &refund_purse);
-        match get_refund_purse(handle_payment) {
-            None => runtime::revert(ApiError::User(Error::NotFound as u16)),
-            Some(uref) if uref.addr() == refund_purse.addr() => (),
-            Some(_) => runtime::revert(ApiError::User(Error::Invalid as u16)),
-        }
 
         let payment_amount: U512 = runtime::get_named_arg(ARG_PAYMENT_AMOUNT);
         submit_payment(handle_payment, payment_amount);

--- a/smart_contracts/contracts/test/test-payment-stored/src/main.rs
+++ b/smart_contracts/contracts/test/test-payment-stored/src/main.rs
@@ -11,7 +11,7 @@ use casper_contract::{
 };
 use casper_types::{
     contracts::{EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Parameter},
-    system::mint::ARG_AMOUNT,
+    system::{handle_payment, mint::ARG_AMOUNT},
     CLType, RuntimeArgs, URef, U512,
 };
 
@@ -21,7 +21,6 @@ const PACKAGE_HASH_KEY_NAME: &str = "test_payment_package_hash";
 const ACCESS_KEY_NAME: &str = "test_payment_access";
 const ARG_NAME: &str = "amount";
 const CONTRACT_VERSION: &str = "contract_version";
-const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 
 #[no_mangle]
 pub extern "C" fn pay() {
@@ -36,7 +35,7 @@ pub extern "C" fn pay() {
     // get payment purse for current execution
     let payment_purse: URef = runtime::call_contract(
         handle_payment_contract_hash,
-        GET_PAYMENT_PURSE,
+        handle_payment::METHOD_GET_PAYMENT_PURSE,
         RuntimeArgs::default(),
     );
 

--- a/types/src/system/handle_payment/constants.rs
+++ b/types/src/system/handle_payment/constants.rs
@@ -11,8 +11,6 @@ pub const ARG_TARGET: &str = "target";
 pub const METHOD_GET_PAYMENT_PURSE: &str = "get_payment_purse";
 /// Named constant for method `set_refund_purse`.
 pub const METHOD_SET_REFUND_PURSE: &str = "set_refund_purse";
-/// Named constant for method `get_refund_purse`.
-pub const METHOD_GET_REFUND_PURSE: &str = "get_refund_purse";
 /// Named constant for method `finalize_payment`.
 pub const METHOD_FINALIZE_PAYMENT: &str = "finalize_payment";
 

--- a/types/src/system/handle_payment/mod.rs
+++ b/types/src/system/handle_payment/mod.rs
@@ -29,15 +29,6 @@ pub trait HandlePayment: MintProvider + RuntimeProvider + Sized {
         internal::set_refund(self, purse)
     }
 
-    /// Get refund purse.
-    fn get_refund_purse(&self) -> Result<Option<URef>, Error> {
-        // We purposely choose to remove the access rights so that we do not
-        // accidentally give rights for a purse to some contract that is not
-        // supposed to have it.
-        let maybe_purse = internal::get_refund_purse(self)?;
-        Ok(maybe_purse.map(|p| p.remove_access_rights()))
-    }
-
     /// Finalize payment with `amount_spent` and a given `account`.
     fn finalize_payment(
         &mut self,

--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -202,7 +202,6 @@ read_base_round_reward = 10_000
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000
 set_refund_purse = 10_000
-get_refund_purse = 10_000
 finalize_payment = 10_000
 
 [system_costs.standard_payment_costs]

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -210,7 +210,6 @@ read_base_round_reward = 10_000
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000
 set_refund_purse = 10_000
-get_refund_purse = 10_000
 finalize_payment = 10_000
 
 [system_costs.standard_payment_costs]

--- a/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
@@ -202,7 +202,6 @@ read_base_round_reward = 10_000
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000
 set_refund_purse = 10_000
-get_refund_purse = 10_000
 finalize_payment = 10_000
 
 [system_costs.standard_payment_costs]


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/EE-1223

Removes `get_refund_purse` entry point altogether as we were returning an `URef` there without access rights which could pose a security risk.