### PR TITLE
NO-TICK: nctl bug fix

### DIFF
--- a/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/bond_its.chainspec.toml.in
@@ -18,6 +18,9 @@ activation_point = '${TIMESTAMP}'
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper-example'
+# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# be rejected at the networking level.
+maximum_net_message_size = 23_068_672
 
 [core]
 # Era duration.

--- a/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst13.chainspec.toml.in
@@ -18,11 +18,6 @@ activation_point = '${TIMESTAMP}'
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper-example'
-# Timestamp for the genesis block.  This is the beginning of era 0. By this time, a sufficient majority (> 50% + F/2 —
-# see finality_threshold_percent below) of validator nodes must be up and running to start the blockchain.  This
-# timestamp is also used in seeding the pseudo-random number generator used in contract-runtime for computing genesis
-# post-state hash.
-timestamp = '${TIMESTAMP}'
 # The maximum size of an acceptable networking message in bytes.  Any message larger than this will
 # be rejected at the networking level.
 maximum_net_message_size = 23_068_672

--- a/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
+++ b/utils/nctl/sh/scenarios/chainspecs/itst14.chainspec.toml.in
@@ -18,6 +18,9 @@ activation_point = '${TIMESTAMP}'
 # contributing to the seeding of the pseudo-random number generator used in contract-runtime for computing genesis
 # post-state hash.
 name = 'casper-example'
+# The maximum size of an acceptable networking message in bytes.  Any message larger than this will
+# be rejected at the networking level.
+maximum_net_message_size = 23_068_672
 
 [core]
 # Era duration.


### PR DESCRIPTION
Changes:
- Bug: Removes `timestamp` from `[network]` section of itst13 chainspec 
- Syncs other testing chainspecs with new `maximum_net_message_size`

Both introduced here: https://github.com/CasperLabs/casper-node/commit/8572d2946e9c0f40936a6a73920ef5c540da1fa6