### PR TITLE
Update version to 1.1.0 and chainspec.toml for upgrade.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,7 +658,7 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cargo-casper"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "casper-client"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "casper-contract"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "casper-types",
  "hex_fmt",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "casper-engine-test-support"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "casper-contract",
  "casper-execution-engine",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node-macros"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "Inflector",
  "indexmap",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base16",
  "base64",
@@ -2299,7 +2299,7 @@ checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -5506,11 +5506,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -6270,9 +6271,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-client"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "A client for interacting with the Casper network"
@@ -22,9 +22,9 @@ doc = false
 
 [dependencies]
 base64 = "0.13.0"
-casper-execution-engine = { version = "1.0.0", path = "../execution_engine" }
-casper-node = { version = "1.0.0", path = "../node" }
-casper-types = { version = "1.0.0", path = "../types", features = ["std"] }
+casper-execution-engine = { version = "1.1.0", path = "../execution_engine" }
+casper-node = { version = "1.1.0", path = "../node" }
+casper-types = { version = "1.1.0", path = "../types", features = ["std"] }
 clap = "2"
 futures = "0.3.5"
 hex = { version = "0.4.2", features = ["serde"] }

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-execution-engine"
-version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.1.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "CasperLabs execution engine crates."
@@ -15,7 +15,7 @@ anyhow = "1.0.33"
 base16 = "0.2.1"
 bincode = "1.3.1"
 blake2 = "0.9.0"
-casper-types = { version = "1.0.0", path = "../types", features = ["std", "gens"] }
+casper-types = { version = "1.1.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 datasize = "0.2.4"
 hex = "0.4.2"

--- a/execution_engine/src/lib.rs
+++ b/execution_engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! The engine which executes smart contracts on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-execution-engine/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-execution-engine/1.1.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution_engine_testing/cargo_casper/Cargo.toml
+++ b/execution_engine_testing/cargo_casper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-casper"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Command line tool for creating a Wasm smart contract and tests for use on the Casper network."

--- a/execution_engine_testing/cargo_casper/src/common.rs
+++ b/execution_engine_testing/cargo_casper/src/common.rs
@@ -12,9 +12,9 @@ use once_cell::sync::Lazy;
 use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
 
 pub static CL_CONTRACT: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-contract", "1.0.0", "smart_contracts/contract"));
+    Lazy::new(|| Dependency::new("casper-contract", "1.1.0", "smart_contracts/contract"));
 pub static CL_TYPES: Lazy<Dependency> =
-    Lazy::new(|| Dependency::new("casper-types", "1.0.0", "types"));
+    Lazy::new(|| Dependency::new("casper-types", "1.1.0", "types"));
 
 pub fn print_error_and_exit(msg: &str) -> ! {
     e_red!("error");

--- a/execution_engine_testing/cargo_casper/src/tests_package.rs
+++ b/execution_engine_testing/cargo_casper/src/tests_package.rs
@@ -114,7 +114,7 @@ static INTEGRATION_TESTS_RS: Lazy<PathBuf> = Lazy::new(|| {
 static ENGINE_TEST_SUPPORT: Lazy<Dependency> = Lazy::new(|| {
     Dependency::new(
         "casper-engine-test-support",
-        "1.0.0",
+        "1.1.0",
         "execution_engine_testing/test_support",
     )
 });

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-engine-test-support"
-version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.1.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the Casper network."
@@ -11,9 +11,9 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/execution_en
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-contract = { version = "1.0.0", path = "../../smart_contracts/contract", features = ["std"] }
-casper-execution-engine = { version = "1.0.0", path = "../../execution_engine", features = ["gens"] }
-casper-types = { version = "1.0.0", path = "../../types", features = ["std"] }
+casper-contract = { version = "1.1.0", path = "../../smart_contracts/contract", features = ["std"] }
+casper-execution-engine = { version = "1.1.0", path = "../../execution_engine", features = ["gens"] }
+casper-types = { version = "1.1.0", path = "../../types", features = ["std"] }
 lmdb = "0.8.0"
 log = "0.4.8"
 num-rational = "0.4.0"

--- a/execution_engine_testing/test_support/src/lib.rs
+++ b/execution_engine_testing/test_support/src/lib.rs
@@ -56,7 +56,7 @@
 //! assert_eq!(expected_value, returned_value);
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-engine-test-support/1.1.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.1.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "The Casper blockchain node"
@@ -19,9 +19,9 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 blake2 = { version = "0.9.0", default-features = false }
-casper-execution-engine = { version = "1.0.0", path = "../execution_engine" }
-casper-node-macros = { version = "1.0.0", path = "../node_macros" }
-casper-types = { version = "1.0.0", path = "../types", features = ["std", "gens"] }
+casper-execution-engine = { version = "1.1.0", path = "../execution_engine" }
+casper-node-macros = { version = "1.1.0", path = "../node_macros" }
+casper-types = { version = "1.1.0", path = "../types", features = ["std", "gens"] }
 chrono = "0.4.10"
 datasize = { version = "0.2.9", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -29,7 +29,7 @@ use super::{
 use crate::{effect::EffectBuilder, rpcs::chain::GetEraInfoBySwitchBlock};
 
 pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
-    ProtocolVersion::from_parts(1, 0, 0);
+    ProtocolVersion::from_parts(1, 1, 0);
 
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-node/1.1.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/node_macros/Cargo.toml
+++ b/node_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node-macros"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Marc Brinkmann <marc@casperlabs.io>"]
 edition = "2018"
 description = "A macro to create reactor implementations for the casper-node."

--- a/node_macros/src/lib.rs
+++ b/node_macros/src/lib.rs
@@ -1,6 +1,6 @@
 //! Generates reactors with routing from concise definitions. See `README.md` for details.
 
-#![doc(html_root_url = "https://docs.rs/casper-node-macros/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-node-macros/1.1.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '1.0.0'
+version = '1.1.0'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = false
 # This protocol version becomes active at this point.
@@ -11,7 +11,7 @@ hard_reset = false
 # in contract-runtime for computing genesis post-state hash.
 #
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
-activation_point = '2021-03-31T15:00:00Z'
+activation_point = 359
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-contract"
-version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.1.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Library for developing Casper smart contracts."
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/casper-node/tree/master/smart_contra
 license-file = "../../LICENSE"
 
 [dependencies]
-casper-types = { version = "1.0.0", path = "../../types" }
+casper-types = { version = "1.1.0", path = "../../types" }
 hex_fmt = "0.3.0"
 thiserror = "1.0.18"
 version-sync = { version = "0.9", optional = true }

--- a/smart_contracts/contract/src/lib.rs
+++ b/smart_contracts/contract/src/lib.rs
@@ -53,7 +53,7 @@
     not(feature = "std"),
     feature(alloc_error_handler, core_intrinsics, lang_items)
 )]
-#![doc(html_root_url = "https://docs.rs/casper-contract/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-contract/1.1.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/smart_contracts/contract_as/package-lock.json
+++ b/smart_contracts/contract_as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/smart_contracts/contract_as/package.json
+++ b/smart_contracts/contract_as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-contract",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Library for developing Casper smart contracts.",
   "main": "index.js",
   "ascMain": "assembly/index.ts",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-types"
-version = "1.0.0" # when updating, also update 'html_root_url' in lib.rs
+version = "1.1.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Types used to allow creation of Wasm contracts and tests for use on the Casper network."

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -10,7 +10,7 @@
     not(feature = "no-unstable-features"),
     feature(min_specialization, try_reserve)
 )]
-#![doc(html_root_url = "https://docs.rs/casper-types/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-types/1.1.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
Era 359 is around 2021-04-30T13:00:00Z and expected activation time for casper network.