### PR TITLE
NDRS-1116: display full cause chain when logging errors

### DIFF
--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -86,7 +86,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use self::error::Result;
 pub(crate) use self::{
-    error::cl_error, event::Event, gossiped_address::GossipedAddress, message::Message,
+    error::display_error, event::Event, gossiped_address::GossipedAddress, message::Message,
 };
 use crate::{
     components::{
@@ -214,7 +214,7 @@ where
                     };
                 }
                 Err(ref err) => {
-                    warn!(%address, err=cl_error(err), "failed to resolve known address");
+                    warn!(%address, err=display_error(err), "failed to resolve known address");
                 }
             }
         }
@@ -501,7 +501,7 @@ where
                         our_id=%self.our_id,
                         %peer_address,
                         local_address=?transport.get_ref().local_addr(),
-                        err=cl_error(err),
+                        err=display_error(err),
                         "incoming connection dropped",
                     );
                     return Effects::new();
@@ -549,7 +549,7 @@ where
                 effects
             }
             Err(ref err) => {
-                warn!(our_id=%self.our_id, %peer_address, err=cl_error(err), "TLS handshake failed");
+                warn!(our_id=%self.our_id, %peer_address, err=display_error(err), "TLS handshake failed");
                 Effects::new()
             }
         }
@@ -568,7 +568,7 @@ where
             Err(ref err) => {
                 // The peer address disappeared, likely because the connection was closed while
                 // we are setting up.
-                warn!(%peer_id, err=cl_error(err), "peer connection terminated while setting up outgoing connection, dropping");
+                warn!(%peer_id, err=display_error(err), "peer connection terminated while setting up outgoing connection, dropping");
 
                 // We still need to clean up any trace of the connection.
                 return self.remove(effect_builder, &peer_id, false);
@@ -648,7 +648,7 @@ where
                     our_id=%self.our_id,
                     %peer_id,
                     %peer_address,
-                    err=cl_error(err),
+                    err=display_error(err),
                     "outgoing connection failed"
                 );
             } else {
@@ -663,7 +663,7 @@ where
             warn!(
                 our_id=%self.our_id,
                 %peer_address,
-                err=cl_error(err),
+                err=display_error(err),
                 "outgoing connection to known address failed"
             );
         } else {
@@ -930,7 +930,7 @@ where
                 match join_handle.await {
                     Ok(_) => debug!(our_id=%self.our_id, "server exited cleanly"),
                     Err(ref err) => {
-                        error!(%self.our_id, err=cl_error(err), "could not join server task cleanly")
+                        error!(%self.our_id, err=display_error(err), "could not join server task cleanly")
                     }
                 }
             } else if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
@@ -997,7 +997,7 @@ where
                         info!(our_id=%self.our_id, %peer_id, %peer_address, "connection closed",)
                     }
                     Err(ref err) => {
-                        warn!(our_id=%self.our_id, %peer_id, %peer_address, err=cl_error(err), "connection dropped")
+                        warn!(our_id=%self.our_id, %peer_id, %peer_address, err=display_error(err), "connection dropped")
                     }
                 }
                 self.remove(effect_builder, &peer_id, false)
@@ -1103,7 +1103,7 @@ async fn server_task<P, REv>(
                 //       The code in its current state will consume 100% CPU if local resource
                 //       exhaustion happens, as no distinction is made and no delay introduced.
                 Err(ref err) => {
-                    warn!(%our_id, err=cl_error(err), "dropping incoming connection during accept")
+                    warn!(%our_id, err=display_error(err), "dropping incoming connection during accept")
                 }
             }
         }
@@ -1264,7 +1264,7 @@ where
                         .await;
                 }
                 Err(err) => {
-                    warn!(%our_id, err=cl_error(&err), %peer_id, "receiving message failed, closing connection");
+                    warn!(%our_id, err=display_error(&err), %peer_id, "receiving message failed, closing connection");
                     return Err(err);
                 }
             }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -90,6 +90,7 @@ use crate::{
     components::{
         network::ENABLE_LIBP2P_NET_ENV_VAR, networking_metrics::NetworkingMetrics, Component,
     },
+    e,
     effect::{
         announcements::{BlocklistAnnouncement, NetworkAnnouncement},
         requests::{NetworkInfoRequest, NetworkRequest},
@@ -211,8 +212,8 @@ where
                         warn!(%address, resolved=%known_address, "ignoring duplicated known address");
                     };
                 }
-                Err(err) => {
-                    warn!(%address, %err, "failed to resolve known address");
+                Err(ref err) => {
+                    warn!(%address, err=e!(err), "failed to resolve known address");
                 }
             }
         }
@@ -494,12 +495,12 @@ where
                 }
 
                 // If the peer has already disconnected, allow the connection to drop.
-                if let Err(error) = transport.get_ref().peer_addr() {
+                if let Err(ref err) = transport.get_ref().peer_addr() {
                     debug!(
                         our_id=%self.our_id,
                         %peer_address,
                         local_address=?transport.get_ref().local_addr(),
-                        %error,
+                        err=e!(err),
                         "incoming connection dropped",
                     );
                     return Effects::new();
@@ -546,8 +547,8 @@ where
 
                 effects
             }
-            Err(err) => {
-                warn!(our_id=%self.our_id, %peer_address, %err, "TLS handshake failed");
+            Err(ref err) => {
+                warn!(our_id=%self.our_id, %peer_address, err=e!(err), "TLS handshake failed");
                 Effects::new()
             }
         }
@@ -563,10 +564,10 @@ where
         // This connection is send-only, we only use the sink.
         let peer_address = match transport.get_ref().peer_addr() {
             Ok(peer_addr) => peer_addr,
-            Err(err) => {
+            Err(ref err) => {
                 // The peer address disappeared, likely because the connection was closed while
                 // we are setting up.
-                warn!(%peer_id, %err, "peer connection terminated while setting up outgoing connection, dropping");
+                warn!(%peer_id, err=e!(err), "peer connection terminated while setting up outgoing connection, dropping");
 
                 // We still need to clean up any trace of the connection.
                 return self.remove(effect_builder, &peer_id, false);
@@ -646,7 +647,7 @@ where
                     our_id=%self.our_id,
                     %peer_id,
                     %peer_address,
-                    %err,
+                    err=e!(err),
                     "outgoing connection failed"
                 );
             } else {
@@ -661,7 +662,7 @@ where
             warn!(
                 our_id=%self.our_id,
                 %peer_address,
-                %err,
+                err=e!(err),
                 "outgoing connection to known address failed"
             );
         } else {
@@ -927,7 +928,9 @@ where
             if let Some(join_handle) = self.server_join_handle.take() {
                 match join_handle.await {
                     Ok(_) => debug!(our_id=%self.our_id, "server exited cleanly"),
-                    Err(err) => error!(%self.our_id,%err, "could not join server task cleanly"),
+                    Err(ref err) => {
+                        error!(%self.our_id, err=e!(err), "could not join server task cleanly")
+                    }
                 }
             } else if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
                 warn!(our_id=%self.our_id, "server shutdown while already shut down")
@@ -992,8 +995,8 @@ where
                     Ok(()) => {
                         info!(our_id=%self.our_id, %peer_id, %peer_address, "connection closed",)
                     }
-                    Err(err) => {
-                        warn!(our_id=%self.our_id, %peer_id, %peer_address, %err, "connection dropped")
+                    Err(ref err) => {
+                        warn!(our_id=%self.our_id, %peer_id, %peer_address, err=e!(err), "connection dropped")
                     }
                 }
                 self.remove(effect_builder, &peer_id, false)
@@ -1098,8 +1101,8 @@ async fn server_task<P, REv>(
                 //
                 //       The code in its current state will consume 100% CPU if local resource
                 //       exhaustion happens, as no distinction is made and no delay introduced.
-                Err(err) => {
-                    warn!(%our_id, %err, "dropping incoming connection during accept")
+                Err(ref err) => {
+                    warn!(%our_id, err=e!(err), "dropping incoming connection during accept")
                 }
             }
         }
@@ -1260,7 +1263,7 @@ where
                         .await;
                 }
                 Err(err) => {
-                    warn!(%our_id, %err, %peer_id, "receiving message failed, closing connection");
+                    warn!(%our_id, err=e!(&err), %peer_id, "receiving message failed, closing connection");
                     return Err(err);
                 }
             }

--- a/node/src/components/small_network.rs
+++ b/node/src/components/small_network.rs
@@ -85,9 +85,10 @@ use tokio_util::codec::{Framed, LengthDelimitedCodec};
 use tracing::{debug, error, info, trace, warn};
 
 use self::error::Result;
-pub(crate) use self::{event::Event, gossiped_address::GossipedAddress, message::Message};
+pub(crate) use self::{
+    error::cl_error, event::Event, gossiped_address::GossipedAddress, message::Message,
+};
 use crate::{
-    cl_error,
     components::{
         network::ENABLE_LIBP2P_NET_ENV_VAR, networking_metrics::NetworkingMetrics, Component,
     },
@@ -213,7 +214,7 @@ where
                     };
                 }
                 Err(ref err) => {
-                    warn!(%address, err=cl_error!(err), "failed to resolve known address");
+                    warn!(%address, err=cl_error(err), "failed to resolve known address");
                 }
             }
         }
@@ -500,7 +501,7 @@ where
                         our_id=%self.our_id,
                         %peer_address,
                         local_address=?transport.get_ref().local_addr(),
-                        err=cl_error!(err),
+                        err=cl_error(err),
                         "incoming connection dropped",
                     );
                     return Effects::new();
@@ -548,7 +549,7 @@ where
                 effects
             }
             Err(ref err) => {
-                warn!(our_id=%self.our_id, %peer_address, err=cl_error!(err), "TLS handshake failed");
+                warn!(our_id=%self.our_id, %peer_address, err=cl_error(err), "TLS handshake failed");
                 Effects::new()
             }
         }
@@ -567,7 +568,7 @@ where
             Err(ref err) => {
                 // The peer address disappeared, likely because the connection was closed while
                 // we are setting up.
-                warn!(%peer_id, err=cl_error!(err), "peer connection terminated while setting up outgoing connection, dropping");
+                warn!(%peer_id, err=cl_error(err), "peer connection terminated while setting up outgoing connection, dropping");
 
                 // We still need to clean up any trace of the connection.
                 return self.remove(effect_builder, &peer_id, false);
@@ -647,7 +648,7 @@ where
                     our_id=%self.our_id,
                     %peer_id,
                     %peer_address,
-                    err=cl_error!(err),
+                    err=cl_error(err),
                     "outgoing connection failed"
                 );
             } else {
@@ -662,7 +663,7 @@ where
             warn!(
                 our_id=%self.our_id,
                 %peer_address,
-                err=cl_error!(err),
+                err=cl_error(err),
                 "outgoing connection to known address failed"
             );
         } else {
@@ -929,7 +930,7 @@ where
                 match join_handle.await {
                     Ok(_) => debug!(our_id=%self.our_id, "server exited cleanly"),
                     Err(ref err) => {
-                        error!(%self.our_id, err=cl_error!(err), "could not join server task cleanly")
+                        error!(%self.our_id, err=cl_error(err), "could not join server task cleanly")
                     }
                 }
             } else if env::var(ENABLE_LIBP2P_NET_ENV_VAR).is_err() {
@@ -996,7 +997,7 @@ where
                         info!(our_id=%self.our_id, %peer_id, %peer_address, "connection closed",)
                     }
                     Err(ref err) => {
-                        warn!(our_id=%self.our_id, %peer_id, %peer_address, err=cl_error!(err), "connection dropped")
+                        warn!(our_id=%self.our_id, %peer_id, %peer_address, err=cl_error(err), "connection dropped")
                     }
                 }
                 self.remove(effect_builder, &peer_id, false)
@@ -1102,7 +1103,7 @@ async fn server_task<P, REv>(
                 //       The code in its current state will consume 100% CPU if local resource
                 //       exhaustion happens, as no distinction is made and no delay introduced.
                 Err(ref err) => {
-                    warn!(%our_id, err=cl_error!(err), "dropping incoming connection during accept")
+                    warn!(%our_id, err=cl_error(err), "dropping incoming connection during accept")
                 }
             }
         }
@@ -1263,7 +1264,7 @@ where
                         .await;
                 }
                 Err(err) => {
-                    warn!(%our_id, err=cl_error!(&err), %peer_id, "receiving message failed, closing connection");
+                    warn!(%our_id, err=cl_error(&err), %peer_id, "receiving message failed, closing connection");
                     return Err(err);
                 }
             }

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -142,7 +142,7 @@ pub enum Error {
 
 /// An error formatter.
 #[derive(Clone, Copy, Debug)]
-pub struct ErrFormatter<'a, T>(pub &'a T);
+pub(crate) struct ErrFormatter<'a, T>(pub &'a T);
 
 impl<'a, T> Display for ErrFormatter<'a, T>
 where

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -1,4 +1,11 @@
-use std::{io, net::SocketAddr, result, time::SystemTimeError};
+use std::{
+    error,
+    fmt::{self, Display, Formatter},
+    io,
+    net::SocketAddr,
+    result,
+    time::SystemTimeError,
+};
 
 use openssl::{error::ErrorStack, ssl};
 use serde::Serialize;
@@ -131,4 +138,96 @@ pub enum Error {
         #[from]
         prometheus::Error,
     ),
+}
+
+/// An error formatter.
+#[derive(Clone, Copy, Debug)]
+pub struct ErrFormatter<'a, T>(pub &'a T);
+
+impl<'a, T> Display for ErrFormatter<'a, T>
+where
+    T: error::Error,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut opt_source: Option<&(dyn error::Error)> = Some(self.0);
+
+        while let Some(source) = opt_source {
+            write!(f, "{}", source)?;
+            opt_source = source.source();
+
+            if opt_source.is_some() {
+                f.write_str(": ")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Wraps an error to ensure it gets properly captured by tracing.
+///
+/// Ensures that errors are properly captured.
+///
+/// This macro should be removed once/if the tracing
+/// issue https://github.com/tokio-rs/tracing/issues/1308 has been resolved, which adds a special
+/// syntax for this case and the known issue https://github.com/tokio-rs/tracing/issues/1308 has
+/// been fixed, which cuts traces short after the first cause.
+#[macro_export]
+macro_rules! cl_error {
+    ($orig_err:expr) => {
+        ::tracing::field::display($crate::components::small_network::error::ErrFormatter(
+            $orig_err,
+        ))
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use thiserror::Error;
+    use tracing::Value;
+
+    use super::ErrFormatter;
+    use crate::cl_error;
+
+    #[derive(Debug, Error)]
+    #[error("this is baz")]
+    struct Baz;
+
+    #[derive(Debug, Error)]
+    #[error("this is bar")]
+    struct Bar(#[source] Baz);
+
+    #[derive(Debug, Error)]
+    enum MyError {
+        #[error("this is foo")]
+        Foo {
+            #[source]
+            bar: Bar,
+        },
+    }
+
+    #[test]
+    fn test_formatter_formats_single() {
+        let single = Baz;
+
+        assert_eq!(ErrFormatter(&single).to_string().as_str(), "this is baz");
+    }
+
+    #[test]
+    fn test_formatter_formats_nested() {
+        let nested = MyError::Foo { bar: Bar(Baz) };
+
+        assert_eq!(
+            ErrFormatter(&nested).to_string().as_str(),
+            "this is foo: this is bar: this is baz"
+        );
+    }
+
+    #[test]
+    #[allow(trivial_casts)]
+    fn test_cl_error_produces_value() {
+        let err = Baz;
+        let wrapped = cl_error!(&err);
+        let _value_ref: &dyn Value = &wrapped as &dyn Value;
+    }
 }

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -66,9 +66,7 @@ pub enum Error {
         ResolveAddressError,
     ),
     /// Failed to send message.
-    // TODO: Inclusion of the cause is a workaround, we should actually be printing cause-traces
-    //       when logging errors.
-    #[error("failed to send message: {0}")]
+    #[error("failed to send message")]
     MessageNotSent(
         #[serde(skip_serializing)]
         #[source]

--- a/node/src/components/small_network/error.rs
+++ b/node/src/components/small_network/error.rs
@@ -173,7 +173,7 @@ where
 /// https://github.com/tokio-rs/tracing/issues/1308 has been resolved, which adds a special syntax
 /// for this case and the known issue https://github.com/tokio-rs/tracing/issues/1308 has been
 /// fixed, which cuts traces short after the first cause.
-pub(crate) fn cl_error<'a, T>(err: &'a T) -> field::DisplayValue<ErrFormatter<'a, T>>
+pub(crate) fn display_error<'a, T>(err: &'a T) -> field::DisplayValue<ErrFormatter<'a, T>>
 where
     T: error::Error + 'a,
 {
@@ -183,9 +183,8 @@ where
 #[cfg(test)]
 mod tests {
     use thiserror::Error;
-    use tracing::Value;
 
-    use super::{cl_error, ErrFormatter};
+    use super::ErrFormatter;
 
     #[derive(Debug, Error)]
     #[error("this is baz")]

--- a/node/src/logging.rs
+++ b/node/src/logging.rs
@@ -1,6 +1,10 @@
 //! Logging via the tracing crate.
 
-use std::{env, fmt, io};
+use std::{
+    env, error,
+    fmt::{self, Display, Formatter},
+    io,
+};
 
 use ansi_term::{Color, Style};
 use anyhow::anyhow;
@@ -295,25 +299,94 @@ pub fn init_with_config(config: &LoggingConfig) -> anyhow::Result<()> {
     .map_err(|error| anyhow!(error))
 }
 
+/// An error formatter.
+///
+/// Stores a pointer to a trait object internally instead of using a generic `T` to avoid an
+/// explosion of monomorphized instances.
+#[derive(Clone, Copy, Debug)]
+pub struct ErrFormatter<'a>(pub &'a dyn std::error::Error);
+
+impl<'a> Display for ErrFormatter<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut opt_source: Option<&(dyn error::Error)> = Some(self.0);
+
+        while let Some(source) = opt_source {
+            write!(f, "{}", source)?;
+            opt_source = source.source();
+
+            if opt_source.is_some() {
+                f.write_str(": ")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Wraps an error to ensure it gets properly captured by tracing.
 ///
-/// Ensures that errors are properly captured as errors, not strings, by performing the necessary
-/// cast to a trait object. As a result, the `cause` of errors is shown.
+/// Ensures that errors are properly captured.
 ///
-/// This macro should be removed once/if the tracing issue
-/// https://github.com/tokio-rs/tracing/issues/1308 has been resolved, which adds a special syntax
-/// for this case.
-///
-/// # Known issues
-///
-/// There is a known bugs in tracing where only the first source in a chain of errors is logged, see
-/// https://github.com/tokio-rs/tracing/issues/1308 for details. If this becomes an issue, this
-/// macro can be replaced with a custom `Fn(&std::error::Error) -> &str` and
-/// `($orig_err:expr) => { custom_fn($orig_err) };` to show the whole chain. At the time of this
-/// writing, most of our errors are pretty shallow though.
+/// This macro should be removed once/if the tracing
+/// issue https://github.com/tokio-rs/tracing/issues/1308 has been resolved, which adds a special
+/// syntax for this case and the known issue https://github.com/tokio-rs/tracing/issues/1308 has
+/// been fixed, which cuts traces short after the first cause.
 #[macro_export]
 macro_rules! e {
     ($orig_err:expr) => {
-        $orig_err.borrow() as &dyn std::error::Error
+        ::tracing::field::display($crate::logging::ErrFormatter(
+            ::std::borrow::Borrow::borrow(&$orig_err),
+        ))
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use thiserror::Error;
+    use tracing::Value;
+
+    use super::ErrFormatter;
+    use crate::e;
+
+    #[derive(Debug, Error)]
+    #[error("this is baz")]
+    struct Baz;
+
+    #[derive(Debug, Error)]
+    #[error("this is bar")]
+    struct Bar(#[source] Baz);
+
+    #[derive(Debug, Error)]
+    enum MyError {
+        #[error("this is foo")]
+        Foo {
+            #[source]
+            bar: Bar,
+        },
+    }
+
+    #[test]
+    fn test_formatter_formats_single() {
+        let single = Baz;
+
+        assert_eq!(ErrFormatter(&single).to_string().as_str(), "this is baz");
+    }
+
+    #[test]
+    fn test_formatter_formats_nested() {
+        let nested = MyError::Foo { bar: Bar(Baz) };
+
+        assert_eq!(
+            ErrFormatter(&nested).to_string().as_str(),
+            "this is foo: this is bar: this is baz"
+        );
+    }
+
+    #[test]
+    #[allow(trivial_casts)]
+    fn test_e_produces_value() {
+        let err = Baz;
+        let wrapped = e!(err);
+        let _value_ref: &dyn Value = &wrapped as &dyn Value;
+    }
 }


### PR DESCRIPTION
This PR introduces the `display_error` function, which causes errors to be properly **lazily** formatted when logging errors.

Currently, in our codebase, we often log errors like this:

```rust
match result {
    Error(err) {
        warn!(%err, "something happened');
    }
    // ...
}
```

This has the drawback of swallowing the errors causes, which are often more interesting than the potentially wrapping error itself.

This can now be addressed by using the `display_error` function:

```rust
match result {
    Error(ref err) {
        warn!(err=display_error(err), "something happened');
    }
    // ...
}
```

Which will cause the error to be output as "error: cause1: cause 2" instead.

Ideally this would be handled using `tracing`'s built-in functionality, but the implementation is lagging behind/buggy; the `display_error` functions documentation has details on how this should be replaced once `tracing` upstream has addressed the issue.

The whole codebase will need to be ultimately updated, this PR addresses `small_network` as a first proving grounds for the change.