### PR TITLE
NDRS-1086: change SSE broadcast channel size to be a factor of event stream buffer size

### DIFF
--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -46,6 +46,16 @@ pub use config::Config;
 pub(crate) use event::Event;
 pub use sse_server::SseData;
 
+/// This is used to define the number of events to buffer in the tokio broadcast channel to help
+/// slower clients to try to avoid missing events (See
+/// https://docs.rs/tokio/1.4.0/tokio/sync/broadcast/index.html#lagging for further details).  The
+/// resulting broadcast channel size is `ADDITIONAL_PERCENT_FOR_BROADCAST_CHANNEL_SIZE` percent
+/// greater than `config.event_stream_buffer_length`.
+///
+/// We always want the broadcast channel size to be greater than the event stream buffer length so
+/// that a new client can retrieve the entire set of buffered events if desired.
+const ADDITIONAL_PERCENT_FOR_BROADCAST_CHANNEL_SIZE: u32 = 20;
+
 /// A helper trait whose bounds represent the requirements for a reactor event that `run_server` can
 /// work with.
 pub trait ReactorEventT: From<Event> + Send {}
@@ -77,8 +87,10 @@ impl EventStreamServer {
         let (sse_data_sender, sse_data_receiver) = mpsc::unbounded_channel();
 
         // Event stream channels and filter.
+        let broadcast_channel_size = config.event_stream_buffer_length / 100
+            * (100 + ADDITIONAL_PERCENT_FOR_BROADCAST_CHANNEL_SIZE);
         let (broadcaster, new_subscriber_info_receiver, sse_filter) =
-            sse_server::create_channels_and_filter(config.broadcast_channel_size);
+            sse_server::create_channels_and_filter(broadcast_channel_size as usize);
 
         let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
 

--- a/node/src/components/event_stream_server/config.rs
+++ b/node/src/components/event_stream_server/config.rs
@@ -7,10 +7,7 @@ use serde::{Deserialize, Serialize};
 const DEFAULT_ADDRESS: &str = "0.0.0.0:0";
 
 /// Default number of SSEs to buffer.
-const DEFAULT_EVENT_STREAM_BUFFER_LENGTH: u32 = 100;
-
-/// Default broadcast channel size.
-const DEFAULT_BROADCAST_CHANNEL_SIZE: usize = 100;
+const DEFAULT_EVENT_STREAM_BUFFER_LENGTH: u32 = 5000;
 
 /// Default rate limit in qps.
 const DEFAULT_QPS_LIMIT: u64 = 100;
@@ -26,11 +23,6 @@ pub struct Config {
     /// Number of SSEs to buffer.
     pub event_stream_buffer_length: u32,
 
-    /// The number of events to buffer in the tokio broadcast channel to help slower clients to try
-    /// to avoid missing events.  See <https://docs.rs/tokio/0.2.22/tokio/sync/broadcast/index.html#lagging>
-    /// for further details.
-    pub broadcast_channel_size: usize,
-
     /// Rate limit for queries per second.
     pub qps_limit: u64,
 }
@@ -41,7 +33,6 @@ impl Config {
         Config {
             address: DEFAULT_ADDRESS.to_string(),
             event_stream_buffer_length: DEFAULT_EVENT_STREAM_BUFFER_LENGTH,
-            broadcast_channel_size: DEFAULT_BROADCAST_CHANNEL_SIZE,
             qps_limit: DEFAULT_QPS_LIMIT,
         }
     }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -31,16 +31,19 @@ abbreviate_modules = false
 # consensus messages.
 secret_key_path = 'secret_key.pem'
 
+
 # ===========================================
 # Configuration options for Highway consensus
 # ===========================================
 [consensus.highway]
+
 # The folder in which the files with per-era latest unit hashes will be stored.
 unit_hashes_folder = "../node-storage"
 
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '1min'
 
+# The period at which we will ask peers for their latest state.
 request_latest_state_timeout = '30sec'
 
 # If the current era's protocol state has not progressed for this long, shut down.
@@ -74,6 +77,7 @@ acceleration_parameter = 40
 # The required quorum in a summit we will look for to check if a round was successful is
 # determined by this FTT.
 acceleration_ftt = [1, 100]
+
 
 # ====================================
 # Configuration options for networking
@@ -121,9 +125,10 @@ initial_gossip_delay = '5s'
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
 
-# =============================================
+
+# ==================================================
 # Configuration options for the JSON-RPC HTTP server
-# =============================================
+# ==================================================
 [rpc_server]
 
 # Listening address for JSON-RPC HTTP server.  If the port is set to 0, a random port will be used.
@@ -138,9 +143,10 @@ address = '0.0.0.0:7777'
 # Request will be delayed to the next 1 second bucket once limited.
 qps_limit = 100
 
-# =============================================
+
+# ==============================================
 # Configuration options for the REST HTTP server
-# =============================================
+# ==============================================
 [rest_server]
 
 # Listening address for REST HTTP server.  If the port is set to 0, a random port will be used.
@@ -155,9 +161,10 @@ address = '0.0.0.0:8888'
 # Request will be delayed to the next 1 second bucket once limited.
 qps_limit = 100
 
-# =============================================
+
+# ==========================================================
 # Configuration options for the SSE HTTP event stream server
-# =============================================
+# ==========================================================
 [event_stream_server]
 
 # Listening address for SSE HTTP event stream server.  If the port is set to 0, a random port will be used.
@@ -169,14 +176,12 @@ qps_limit = 100
 address = '0.0.0.0:9999'
 
 # The number of event stream events to buffer.
-event_stream_buffer_length = 100
-
-# The capacity of the broadcast channel size.
-broadcast_channel_size = 100
+event_stream_buffer_length = 5000
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
 qps_limit = 100
+
 
 # ===============================================
 # Configuration options for the storage component
@@ -219,6 +224,7 @@ max_deploy_metadata_store_size = 12_884_901_888
 # 10_737_418_240 == 10 GiB.
 max_state_store_size = 10_737_418_240
 
+
 # ===================================
 # Configuration options for gossiping
 # ===================================
@@ -251,15 +257,16 @@ gossip_request_timeout_secs = 10
 get_remainder_timeout_secs = 5
 
 
-# ===================================
+# =================================
 # Configuration options for fetcher
-# ===================================
+# =================================
 [fetcher]
 
 # The timeout duration in seconds for a single fetcher request, i.e. for a single fetcher message
 # sent from this node to another node, it will be considered timed out if the expected response from that peer is
 # not received within this specified duration.
 get_from_peer_timeout = 3
+
 
 # ===================================================
 # Configuration options for deploy acceptor component
@@ -274,6 +281,7 @@ verify_accounts = true
 # Configuration options for the contract runtime component
 # ========================================================
 [contract_runtime]
+
 # Optional setting to enable bonding or not.  If unset, defaults to false.
 #enable_bonding = false
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -26,6 +26,7 @@ abbreviate_modules = false
 # Configuration options for consensus
 # ===================================
 [consensus]
+
 # Path (absolute, or relative to this config.toml) to validator's secret key file used to sign
 # consensus messages.
 secret_key_path = '/etc/casper/validator_keys/secret_key.pem'
@@ -35,12 +36,14 @@ secret_key_path = '/etc/casper/validator_keys/secret_key.pem'
 # Configuration options for Highway consensus
 # ===========================================
 [consensus.highway]
+
 # The folder in which the files with per-era latest unit hashes will be stored.
 unit_hashes_folder = "/var/lib/casper/casper-node"
 
 # The duration for which incoming vertices with missing dependencies should be kept in a queue.
 pending_vertex_timeout = '1min'
 
+# The period at which we will ask peers for their latest state.
 request_latest_state_timeout = '30sec'
 
 # If the current era's protocol state has not progressed for this long, shut down.
@@ -100,8 +103,6 @@ bind_address = '0.0.0.0:35000'
 # Multiple addresses can be given and the node will attempt to connect to each, requiring at least
 # one connection.
 known_addresses = ['139.162.132.144:35000','3.225.191.9:35000','31.7.207.16:35000','178.238.235.196:35000','209.145.60.74:35000','157.90.131.49:35000','18.188.152.102:35000','94.130.107.198:35000','135.181.134.57:35000','47.88.87.63:35000','139.59.247.32:35000','188.40.83.254:35000','135.181.165.110:35000','54.180.220.20:35000','148.251.190.103:35000','54.39.129.79:35000','54.39.129.78:35000','88.99.95.7:35000','101.36.120.117:35000','52.207.122.179:35000','18.144.20.51:35000','168.119.209.31:35000','134.209.16.172:35000','18.219.70.138:35000','3.221.194.62:35000','168.119.69.6:35000','62.171.135.101:35000','46.101.61.107:35000','13.58.71.180:35000','52.51.46.127:35000','157.90.131.121:35000','148.251.135.60:35000','54.215.53.35:35000','18.184.78.232:35000','18.188.103.230:35000','168.119.137.143:35000','54.179.8.192:35000','1.15.171.36:35000','47.57.239.181:35000','47.242.53.164:35000','139.59.247.32:35000','99.81.225.72:35000','82.95.0.200:35000','54.252.66.23:35000','134.209.243.124:35000','3.141.97.53:35000','98.149.220.243:35000','46.4.91.24:35000']
-
-
 
 # The interval (in milliseconds) between each fresh round of gossiping the node's public address.
 gossip_interval = 120_000
@@ -176,9 +177,6 @@ address = '0.0.0.0:9999'
 
 # The number of event stream events to buffer.
 event_stream_buffer_length = 5000
-
-# The capacity of the broadcast channel size.
-broadcast_channel_size = 6500
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
@@ -283,6 +281,7 @@ verify_accounts = true
 # Configuration options for the contract runtime component
 # ========================================================
 [contract_runtime]
+
 # Optional setting to enable bonding or not.  If unset, defaults to false.
 #enable_bonding = false
 


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1086.

This PR removes `broadcast_channel_size` from the SSE config, instead making the value a factor (120%) of the `event_stream_buffer_length`.

We always want the broadcast channel size to be greater than the event stream buffer length so that a new client can retrieve the entire set of buffered events if desired.

@sacherjj @momipsl note that this PR changes the config.toml.