### PR TITLE
NDRS-1073: add last_emergency_restart field to chainspec

### DIFF
--- a/node/src/types/chainspec.rs
+++ b/node/src/types/chainspec.rs
@@ -329,6 +329,7 @@ mod tests {
                     Motes::new(U512::from((index as u64 + 1) * 10))
                 );
             }
+            assert!(spec.protocol_config.last_emergency_restart.is_none());
         } else {
             assert_eq!(
                 spec.protocol_config.version,
@@ -343,6 +344,10 @@ mod tests {
             for value in spec.protocol_config.global_state_update.unwrap().0.values() {
                 assert!(StoredValue::from_bytes(value).is_ok());
             }
+            assert_eq!(
+                spec.protocol_config.last_emergency_restart,
+                Some(EraId::new(99))
+            );
         }
 
         assert_eq!(spec.network_config.name, "test-chain");

--- a/node/src/types/chainspec/activation_point.rs
+++ b/node/src/types/chainspec/activation_point.rs
@@ -122,7 +122,7 @@ impl ActivationPoint {
     /// Generates a random instance using a `TestRng`.
     pub fn random(rng: &mut TestRng) -> Self {
         if rng.gen() {
-            ActivationPoint::EraId(EraId::from(rng.gen::<u8>() as u64))
+            ActivationPoint::EraId(rng.gen())
         } else {
             ActivationPoint::Genesis(Timestamp::random(rng))
         }

--- a/node/src/types/chainspec/parse_toml.rs
+++ b/node/src/types/chainspec/parse_toml.rs
@@ -11,7 +11,7 @@ use std::{convert::TryFrom, path::Path};
 use serde::{Deserialize, Serialize};
 
 use casper_execution_engine::shared::{system_config::SystemConfig, wasm_config::WasmConfig};
-use casper_types::ProtocolVersion;
+use casper_types::{EraId, ProtocolVersion};
 
 use super::{
     accounts_config::AccountsConfig, global_state_update::GlobalStateUpdateConfig, ActivationPoint,
@@ -35,6 +35,7 @@ struct TomlProtocol {
     version: ProtocolVersion,
     hard_reset: bool,
     activation_point: ActivationPoint,
+    last_emergency_restart: Option<EraId>,
 }
 
 /// A chainspec configuration as laid out in the TOML-encoded configuration file.
@@ -57,6 +58,7 @@ impl From<&Chainspec> for TomlChainspec {
             version: chainspec.protocol_config.version,
             hard_reset: chainspec.protocol_config.hard_reset,
             activation_point: chainspec.protocol_config.activation_point,
+            last_emergency_restart: chainspec.protocol_config.last_emergency_restart,
         };
         let network = TomlNetwork {
             name: chainspec.network_config.name.clone(),
@@ -107,6 +109,7 @@ pub(super) fn parse_toml<P: AsRef<Path>>(chainspec_path: P) -> Result<Chainspec,
         hard_reset: toml_chainspec.protocol.hard_reset,
         activation_point: toml_chainspec.protocol.activation_point,
         global_state_update,
+        last_emergency_restart: toml_chainspec.protocol.last_emergency_restart,
     };
 
     Ok(Chainspec {

--- a/node/src/types/chainspec/protocol_config.rs
+++ b/node/src/types/chainspec/protocol_config.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    ProtocolVersion,
+    EraId, ProtocolVersion,
 };
 
 use super::{ActivationPoint, GlobalStateUpdate};
@@ -29,6 +29,8 @@ pub struct ProtocolConfig {
     /// Any arbitrary updates we might want to make to the global state at the start of the era
     /// specified in the activation point.
     pub(crate) global_state_update: Option<GlobalStateUpdate>,
+    /// The era ID in which the last emergency restart happened.
+    pub(crate) last_emergency_restart: Option<EraId>,
 }
 
 #[cfg(test)]
@@ -41,12 +43,14 @@ impl ProtocolConfig {
             rng.gen::<u8>() as u32,
         );
         let activation_point = ActivationPoint::random(rng);
+        let last_emergency_restart = rng.gen::<bool>().then(|| rng.gen());
 
         ProtocolConfig {
             version: protocol_version,
             hard_reset: rng.gen(),
             activation_point,
             global_state_update: None,
+            last_emergency_restart,
         }
     }
 }
@@ -58,6 +62,7 @@ impl ToBytes for ProtocolConfig {
         buffer.extend(self.hard_reset.to_bytes()?);
         buffer.extend(self.activation_point.to_bytes()?);
         buffer.extend(self.global_state_update.to_bytes()?);
+        buffer.extend(self.last_emergency_restart.to_bytes()?);
         Ok(buffer)
     }
 
@@ -66,22 +71,25 @@ impl ToBytes for ProtocolConfig {
             + self.hard_reset.serialized_length()
             + self.activation_point.serialized_length()
             + self.global_state_update.serialized_length()
+            + self.last_emergency_restart.serialized_length()
     }
 }
 
 impl FromBytes for ProtocolConfig {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (protocol_version_string, remainder) = String::from_bytes(bytes)?;
-        let protocol_version = ProtocolVersion::from_str(&protocol_version_string)
+        let version = ProtocolVersion::from_str(&protocol_version_string)
             .map_err(|_| bytesrepr::Error::Formatting)?;
         let (hard_reset, remainder) = bool::from_bytes(remainder)?;
         let (activation_point, remainder) = ActivationPoint::from_bytes(remainder)?;
         let (global_state_update, remainder) = Option::<GlobalStateUpdate>::from_bytes(remainder)?;
+        let (last_emergency_restart, remainder) = Option::<EraId>::from_bytes(remainder)?;
         let protocol_config = ProtocolConfig {
-            version: protocol_version,
+            version,
+            hard_reset,
             activation_point,
             global_state_update,
-            hard_reset,
+            last_emergency_restart,
         };
         Ok((protocol_config, remainder))
     }

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -12,6 +12,8 @@ hard_reset = false
 #
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '${TIMESTAMP}'
+# Optional era ID in which the last emergency restart happened.
+#last_emergency_restart = 0
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -12,6 +12,8 @@ hard_reset = false
 #
 # If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era.
 activation_point = '2021-03-31T15:00:00Z'
+# Optional era ID in which the last emergency restart happened.
+#last_emergency_restart = 0
 
 [network]
 # Human readable name for convenience; the genesis_hash is the true identifier.  The name influences the genesis hash by

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -2,6 +2,7 @@
 version = '1.0.0'
 hard_reset = false
 activation_point = 1
+last_emergency_restart = 99
 
 [network]
 name = 'test-chain'

--- a/types/src/era_id.rs
+++ b/types/src/era_id.rs
@@ -183,7 +183,7 @@ impl CLTyped for EraId {
 
 impl Distribution<EraId> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> EraId {
-        EraId(rng.gen())
+        EraId(rng.gen_range(0..1_000_000))
     }
 }
 


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1073.

This PR introduces a field `last_emergency_restart` to the chainspec for use by fast sync.

Fast sync needs to ensure it doesn't traverse an emergency restart.  Since this information is not recorded anywhere on-chain, we need to provide it via the chainspec.