### PR TITLE
EE-1220: Add Read check in Mint::transfer

### DIFF
--- a/types/src/system/mint/mod.rs
+++ b/types/src/system/mint/mod.rs
@@ -96,6 +96,9 @@ pub trait Mint: RuntimeProvider + StorageProvider + SystemProvider {
         amount: U512,
         id: Option<u64>,
     ) -> Result<(), Error> {
+        if !source.is_readable() {
+            return Err(Error::InvalidAccessRights);
+        }
         if !source.is_writeable() || !target.is_addable() {
             return Err(Error::InvalidAccessRights);
         }


### PR DESCRIPTION
CHANGELOG:

- Added a checked in `Mint::transfer` that checks the `Read` access for the source of the transfer and returns an `InvalidAccessRights` error should the check fail