### PR TITLE
NDRS-1088: Change replay detection to not use execution results

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1256,9 +1256,6 @@ where
         // We have found the deploy in the database. If it was from a previous era, it was a
         // replay attack.
         //
-        // If the deploy was included in a block which is from before the current era_id
-        // then this must have been a replay attack.
-        //
         // If not, then it might be this is a deploy for a block we are currently
         // coming to consensus, and we will rely on the immediate ancestors of the
         // block_payload within the current era to determine if we are facing a replay

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -735,6 +735,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Gets the requested block header from the linear block store.
+    #[allow(unused)]
     pub(crate) async fn get_block_header_from_storage(
         self,
         block_hash: BlockHash,
@@ -813,6 +814,24 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(
             |responder| StorageRequest::GetBlockHeaderAtHeight { height, responder },
+            QueueKind::Regular,
+        )
+        .await
+    }
+
+    /// Requests the header of the block containing the given deploy.
+    pub(crate) async fn get_block_header_for_deploy_from_storage(
+        self,
+        deploy_hash: DeployHash,
+    ) -> Option<BlockHeader>
+    where
+        REv: From<StorageRequest>,
+    {
+        self.make_request(
+            |responder| StorageRequest::GetBlockHeaderForDeploy {
+                deploy_hash,
+                responder,
+            },
             QueueKind::Regular,
         )
         .await


### PR DESCRIPTION
Fast sync will not execute all the deploys that were included in the past blocks, so we can't rely on execution results to detect replays.

https://casperlabs.atlassian.net/browse/NDRS-1088