### PR TITLE
HWY-282: Do not request dependency that is already in the synchronizer queue.

### DIFF
--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -504,7 +504,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(bound(
     serialize = "C::Hash: Serialize",
     deserialize = "C::Hash: Deserialize<'de>",

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -378,10 +378,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     /// Drops all vertices that (directly or indirectly) have the specified dependencies, and
     /// returns the set of their senders. If the specified dependencies are known to be invalid,
     /// those senders must be faulty.
-    pub(crate) fn drop_dependent_vertices(
-        &mut self,
-        mut vertices: Vec<Dependency<C>>,
-    ) -> HashSet<I> {
+    pub(crate) fn invalid_vertices(&mut self, mut vertices: Vec<Dependency<C>>) -> HashSet<I> {
         let mut senders = HashSet::new();
         while !vertices.is_empty() {
             let (new_vertices, new_senders) = self.do_drop_dependent_vertices(vertices);

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -214,7 +214,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     }
 
     // Returns number of elements in `vertex_deps` queue.
-    fn vertex_deps_len(&self) -> u64 {
+    fn vertices_awaiting_deps_len(&self) -> u64 {
         self.vertices_awaiting_deps
             .iter()
             .map(|(_, pv)| pv.len())
@@ -222,7 +222,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
     }
 
     // Returns number of elements in `vertices_to_be_added` queue.
-    fn vertices_to_be_added_len(&self) -> u64 {
+    fn vertices_no_deps_len(&self) -> u64 {
         self.vertices_no_deps.len()
     }
 
@@ -230,8 +230,8 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
         debug!(
             era_id = ?self.instance_id,
             vertices_to_be_added_later = self.vertices_to_be_added_later_len(),
-            vertex_deps = self.vertex_deps_len(),
-            vertices_to_be_added = self.vertices_to_be_added_len(),
+            vertices_no_deps = self.vertices_no_deps_len(),
+            vertices_awaiting_deps = self.vertices_awaiting_deps_len(),
             "synchronizer queue lengths"
         );
         // All units seen have seq_number == 0.

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -67,10 +67,7 @@ fn purge_vertices() {
     assert!(maybe_pv.is_none());
     assert!(matches!(
         *outcomes,
-        [
-            ProtocolOutcome::CreatedTargetedMessage(_, NodeId(0)),
-            ProtocolOutcome::CreatedTargetedMessage(_, NodeId(0)),
-        ]
+        [ProtocolOutcome::CreatedTargetedMessage(_, NodeId(0))]
     ));
 
     // At 0x23, c0 gets enqueued and added.
@@ -197,7 +194,8 @@ fn do_not_download_synchronized_dependencies() {
             !outcomes
                 .iter()
                 .any(|outcome| matches!(outcome, ProtocolOutcome::CreatedTargetedMessage(_, _))),
-            "unexpected dependency request {:?}", outcomes
+            "unexpected dependency request {:?}",
+            outcomes
         );
         let vv = highway
             .validate_vertex(pvv(*unit))

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -9,6 +9,8 @@ use crate::components::consensus::{
     protocols::highway::tests::NodeId,
 };
 
+use std::collections::BTreeSet;
+
 #[test]
 fn purge_vertices() {
     let params = test_params(0);
@@ -200,7 +202,7 @@ fn do_not_download_synchronized_dependencies() {
     // "Download" the last dependency.
     let _ = sync.schedule_add_vertex(peer0, pvv(c0), now);
     // Now, the whole chain can be added to the protocol state.
-    let units: std::collections::BTreeSet<Dependency<TestContext>> = vec![c0, c1, b0, c2]
+    let mut units: BTreeSet<Dependency<TestContext>> = vec![c0, c1, b0, c2]
         .into_iter()
         .map(Dependency::Unit)
         .collect();
@@ -214,7 +216,7 @@ fn do_not_download_synchronized_dependencies() {
             outcomes
         );
         let pv_dep = pv.vertex().id();
-        assert!(units.contains(&pv_dep), "unexpected dependency");
+        assert!(units.remove(&pv_dep), "unexpected dependency");
         match pv_dep {
             Dependency::Unit(hash) => {
                 let vv = highway

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -68,7 +68,7 @@ fn purge_vertices() {
     assert_targeted_message(
         &unwrap_single(outcomes),
         &peer0,
-        HighwayMessage::RequestDependency(Dependency::Unit(c0))
+        HighwayMessage::RequestDependency(Dependency::Unit(c0)),
     );
 
     // At 0x23, c0 gets enqueued and added.

--- a/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer/tests.rs
@@ -206,7 +206,6 @@ fn do_not_download_synchronized_dependencies() {
     assert!(sync.is_empty());
 }
 
-#[cfg(test)]
 fn unwrap_single<T: Debug>(vec: Vec<T>) -> T {
     assert_eq!(
         vec.len(),
@@ -217,7 +216,6 @@ fn unwrap_single<T: Debug>(vec: Vec<T>) -> T {
     vec.into_iter().next().unwrap()
 }
 
-#[cfg(test)]
 fn assert_targeted_message(
     outcome: &ProtocolOutcome<NodeId, TestContext>,
     peer: &NodeId,


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/HWY-282

Prior to the addition of [new logic](https://github.com/goral09/casper-node-1/blob/hwy-282/node/src/components/consensus/protocols/highway/synchronizer.rs#L373) we would try downloading a dependency (`c1`) that is already in the synchronizer's state. Now, instead, we will follow the vertices we already have and what those depend on and request the "lowest" one. 