### PR TITLE
NDRS-1130: Remove BlockLike; verify deploy type in block validator.

### DIFF
--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -65,12 +65,24 @@ impl DeployOrTransferHash {
     }
 }
 
-#[derive(DataSize, Debug, Display, From, Clone, Hash, Eq, PartialEq)]
+#[derive(DataSize, Debug, Display, Clone, Hash, Eq, PartialEq)]
 pub enum ValidatingBlock {
     #[display(fmt = "{}", _0.display())]
     Block(Box<Block>),
     #[display(fmt = "{}", _0.display())]
     ProposedBlock(Box<ProposedBlock<ClContext>>),
+}
+
+impl From<Block> for ValidatingBlock {
+    fn from(block: Block) -> ValidatingBlock {
+        ValidatingBlock::Block(Box::new(block))
+    }
+}
+
+impl From<ProposedBlock<ClContext>> for ValidatingBlock {
+    fn from(proposed_block: ProposedBlock<ClContext>) -> ValidatingBlock {
+        ValidatingBlock::ProposedBlock(Box::new(proposed_block))
+    }
 }
 
 impl ValidatingBlock {

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -8,6 +8,8 @@
 //! calling for validation of the same protoblock multiple times at the same time.
 
 mod keyed_counter;
+#[cfg(test)]
+mod tests;
 
 use std::{
     collections::{hash_map::Entry, BTreeMap, HashMap, HashSet, VecDeque},
@@ -234,6 +236,7 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         let mut effects = Effects::new();
+        println!("event: {:?}", event);
         match event {
             Event::Request(BlockValidationRequest {
                 block,

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -236,7 +236,6 @@ where
         event: Self::Event,
     ) -> Effects<Self::Event> {
         let mut effects = Effects::new();
-        println!("event: {:?}", event);
         match event {
             Event::Request(BlockValidationRequest {
                 block,

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -166,7 +166,7 @@ async fn validate_block(
     // Pass the block to the component. This future will eventually resolve to the result, i.e.
     // whether the block is valid or not.
     let validation_result =
-        tokio::spawn(effect_builder.validate_proposed_block("Bob", proposed_block.clone()));
+        tokio::spawn(effect_builder.validate_block("Bob", proposed_block.clone()));
     let event = reactor.expect_block_validator_event().await;
     let effects = block_validator.handle_event(effect_builder, rng, event);
 

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -1,0 +1,282 @@
+use std::sync::Arc;
+
+use casper_execution_engine::core::engine_state::executable_deploy_item::ExecutableDeployItem;
+use casper_types::{
+    bytesrepr::Bytes, runtime_args, system::standard_payment::ARG_AMOUNT, RuntimeArgs, SecretKey,
+    U512,
+};
+use derive_more::From;
+use itertools::Itertools;
+
+use crate::{
+    components::{consensus::BlockContext, fetcher::FetchResult},
+    crypto::AsymmetricKeyExt,
+    reactor::{EventQueueHandle, QueueKind, Scheduler},
+    testing::TestRng,
+    types::{BlockPayload, TimeDiff},
+    utils::{self, Loadable},
+};
+
+use super::*;
+
+type NodeId = &'static str;
+
+#[derive(Debug, From)]
+enum ReactorEvent {
+    #[from]
+    BlockValidator(Event<NodeId>),
+    #[from]
+    Fetcher(FetcherRequest<NodeId, Deploy>),
+    #[from]
+    Storage(StorageRequest),
+}
+
+impl From<BlockValidationRequest<NodeId>> for ReactorEvent {
+    fn from(req: BlockValidationRequest<NodeId>) -> ReactorEvent {
+        ReactorEvent::BlockValidator(req.into())
+    }
+}
+
+struct MockReactor {
+    scheduler: &'static Scheduler<ReactorEvent>,
+}
+
+impl MockReactor {
+    fn new() -> Self {
+        MockReactor {
+            scheduler: utils::leak(Scheduler::new(QueueKind::weights())),
+        }
+    }
+
+    async fn expect_block_validator_event(&self) -> Event<NodeId> {
+        let (reactor_event, _) = self.scheduler.pop().await;
+        if let ReactorEvent::BlockValidator(event) = reactor_event {
+            return event;
+        } else {
+            panic!("unexpected event: {:?}", reactor_event);
+        }
+    }
+
+    async fn expect_fetch_deploy<T>(&self, deploy: T)
+    where
+        T: Into<Option<Deploy>>,
+    {
+        let (reactor_event, _) = self.scheduler.pop().await;
+        if let ReactorEvent::Fetcher(FetcherRequest::Fetch {
+            id,
+            peer,
+            responder,
+        }) = reactor_event
+        {
+            match deploy.into() {
+                None => responder.respond(None).await,
+                Some(deploy) => {
+                    assert_eq!(id, *deploy.id());
+                    let response = FetchResult::FromPeer(Box::new(deploy), peer);
+                    responder.respond(Some(response)).await;
+                }
+            }
+        } else {
+            panic!("unexpected event: {:?}", reactor_event);
+        }
+    }
+}
+
+fn new_proposed_block(
+    timestamp: Timestamp,
+    deploy_hashes: Vec<DeployHash>,
+    transfer_hashes: Vec<DeployHash>,
+) -> ProposedBlock<ClContext> {
+    // Accusations and ancestors are empty, and the random bit is always true:
+    // These values are not checked by the block validator.
+    let block_context = BlockContext::new(timestamp, vec![]);
+    let block_payload = BlockPayload::new(deploy_hashes, transfer_hashes, vec![], true);
+    ProposedBlock::new(block_payload, block_context)
+}
+
+fn new_deploy(rng: &mut TestRng, timestamp: Timestamp, ttl: TimeDiff) -> Deploy {
+    let secret_key = SecretKey::random(rng);
+    let chain_name = "chain".to_string();
+    let payment = ExecutableDeployItem::ModuleBytes {
+        module_bytes: Bytes::new(),
+        args: runtime_args! { ARG_AMOUNT => U512::from(1) },
+    };
+    let session = ExecutableDeployItem::ModuleBytes {
+        module_bytes: Bytes::new(),
+        args: RuntimeArgs::new(),
+    };
+    let dependencies = vec![];
+    let gas_price = 1;
+
+    Deploy::new(
+        timestamp,
+        ttl,
+        gas_price,
+        dependencies,
+        chain_name,
+        payment,
+        session,
+        &secret_key,
+    )
+}
+
+fn new_transfer(rng: &mut TestRng, timestamp: Timestamp, ttl: TimeDiff) -> Deploy {
+    let secret_key = SecretKey::random(rng);
+    let chain_name = "chain".to_string();
+    let payment = ExecutableDeployItem::ModuleBytes {
+        module_bytes: Bytes::new(),
+        args: runtime_args! { ARG_AMOUNT => 1 },
+    };
+    let session = ExecutableDeployItem::Transfer {
+        args: RuntimeArgs::new(),
+    };
+    let dependencies = vec![];
+    let gas_price = 1;
+
+    Deploy::new(
+        timestamp,
+        ttl,
+        gas_price,
+        dependencies,
+        chain_name,
+        payment,
+        session,
+        &secret_key,
+    )
+}
+
+/// Validates a block using a `BlockValidator` component, and returns the result.
+async fn validate_block(
+    rng: &mut TestRng,
+    timestamp: Timestamp,
+    deploys: Vec<Deploy>,
+    transfers: Vec<Deploy>,
+) -> bool {
+    // Assemble the block to be validated.
+    let deploy_hashes = deploys.iter().map(|deploy| *deploy.id()).collect_vec();
+    let transfer_hashes = transfers.iter().map(|deploy| *deploy.id()).collect_vec();
+    let proposed_block = new_proposed_block(timestamp, deploy_hashes, transfer_hashes);
+
+    // Create the reactor and component.
+    let reactor = MockReactor::new();
+    let effect_builder = EffectBuilder::new(EventQueueHandle::new(reactor.scheduler));
+    let chainspec = Arc::new(Chainspec::from_resources("local"));
+    let mut block_validator = BlockValidator::<NodeId>::new(chainspec);
+
+    // Pass the block to the component. This future will eventually resolve to the result, i.e.
+    // whether the block is valid or not.
+    let validation_result =
+        tokio::spawn(effect_builder.validate_proposed_block("Bob", proposed_block.clone()));
+    let event = reactor.expect_block_validator_event().await;
+    let effects = block_validator.handle_event(effect_builder, rng, event);
+
+    // If validity could already be determined, the effect will be the validation response.
+    if block_validator.validation_states.is_empty() {
+        assert_eq!(1, effects.len());
+        for effect in effects {
+            tokio::spawn(effect).await.unwrap(); // Response.
+        }
+        return validation_result.await.unwrap();
+    }
+
+    // Otherwise the effects must be requests to fetch the block's deploys.
+    let fetch_results: Vec<_> = effects.into_iter().map(tokio::spawn).collect();
+
+    // We make our mock reactor answer with the expected deploys and transfers:
+    for deploy in deploys.into_iter().chain(transfers) {
+        reactor.expect_fetch_deploy(deploy).await;
+    }
+
+    // The resulting `FetchResult`s are passed back into the component. When any deploy turns out
+    // to be invalid, or once all of them have been validated, the component will respond.
+    let mut effects = Effects::new();
+    for fetch_result in fetch_results {
+        let events = fetch_result.await.unwrap();
+        assert_eq!(1, events.len());
+        effects.extend(events.into_iter().flat_map(|found_deploy| {
+            block_validator.handle_event(effect_builder, rng, found_deploy)
+        }));
+    }
+
+    // We expect exactly one effect: the validation response. This will resolve the result.
+    assert_eq!(1, effects.len());
+    for effect in effects {
+        tokio::spawn(effect).await.unwrap(); // Response.
+    }
+    validation_result.await.unwrap()
+}
+
+/// Verifies that a block without any deploys or transfers is valid.
+#[tokio::test]
+async fn empty_block() {
+    assert!(validate_block(&mut TestRng::new(), 1000.into(), vec![], vec![]).await);
+}
+
+/// Verifies that the block validator checks deploy and transfer timestamps and ttl.
+#[tokio::test]
+async fn ttl() {
+    // The ttl is 200, and our deploys and transfers have timestamps 900 and 1000. So the block
+    // timestamp must be at least 1000 and at most 1100.
+    let mut rng = TestRng::new();
+    let ttl = TimeDiff::from(200);
+    let deploys = vec![
+        new_deploy(&mut rng, 1000.into(), ttl),
+        new_deploy(&mut rng, 900.into(), ttl),
+    ];
+    let transfers = vec![
+        new_transfer(&mut rng, 1000.into(), ttl),
+        new_transfer(&mut rng, 900.into(), ttl),
+    ];
+
+    // Both 1000 and 1100 are timestamps compatible with the deploys and transfers.
+    assert!(validate_block(&mut rng, 1000.into(), deploys.clone(), transfers.clone()).await);
+    assert!(validate_block(&mut rng, 1100.into(), deploys.clone(), transfers.clone()).await);
+
+    // A block with timestamp 999 can't contain a transfer or deploy with timestamp 1000.
+    assert!(!validate_block(&mut rng, 999.into(), deploys.clone(), vec![]).await);
+    assert!(!validate_block(&mut rng, 999.into(), vec![], transfers.clone()).await);
+    assert!(!validate_block(&mut rng, 999.into(), deploys.clone(), transfers.clone()).await);
+
+    // At time 1101, the deploy and transfer from time 900 have expired.
+    assert!(!validate_block(&mut rng, 1101.into(), deploys.clone(), vec![]).await);
+    assert!(!validate_block(&mut rng, 1101.into(), vec![], transfers.clone()).await);
+    assert!(!validate_block(&mut rng, 1101.into(), deploys, transfers).await);
+}
+
+/// Verifies that a block is invalid if it contains a transfer in the `deploy_hashes` or a
+/// non-transfer deploy in the `transfer_hashes`, or if it contains a replay.
+#[tokio::test]
+async fn transfer_deploy_mixup_and_replay() {
+    let mut rng = TestRng::new();
+    let ttl = TimeDiff::from(200);
+    let timestamp = Timestamp::from(1000);
+    let deploy1 = new_deploy(&mut rng, timestamp, ttl);
+    let deploy2 = new_deploy(&mut rng, timestamp, ttl);
+    let transfer1 = new_transfer(&mut rng, timestamp, ttl);
+    let transfer2 = new_transfer(&mut rng, timestamp, ttl);
+
+    // First we make sure that our transfers and deploys would normally be valid.
+    let deploys = vec![deploy1.clone(), deploy2.clone()];
+    let transfers = vec![transfer1.clone(), transfer2.clone()];
+    assert!(validate_block(&mut rng, timestamp, deploys, transfers).await);
+
+    // Now we hide a transfer in the deploys section. This should be invalid.
+    let deploys = vec![deploy1.clone(), deploy2.clone(), transfer2.clone()];
+    let transfers = vec![transfer1.clone()];
+    assert!(!validate_block(&mut rng, timestamp, deploys, transfers).await);
+
+    // A regular deploy in the transfers section is also invalid.
+    let deploys = vec![deploy2.clone()];
+    let transfers = vec![transfer1.clone(), deploy1.clone(), transfer2.clone()];
+    assert!(!validate_block(&mut rng, timestamp, deploys, transfers).await);
+
+    // Each deploy must be unique
+    let deploys = vec![deploy1.clone(), deploy2.clone(), deploy1.clone()];
+    let transfers = vec![transfer1.clone(), transfer2.clone()];
+    assert!(!validate_block(&mut rng, timestamp, deploys, transfers).await);
+
+    // And each transfer must be unique, too.
+    let deploys = vec![deploy1.clone(), deploy2.clone()];
+    let transfers = vec![transfer1.clone(), transfer2.clone(), transfer2.clone()];
+    assert!(!validate_block(&mut rng, timestamp, deploys, transfers).await);
+}

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -46,7 +46,7 @@ use crate::{
     NodeRng,
 };
 
-use cl_context::ClContext;
+pub(crate) use cl_context::ClContext;
 pub use config::Config;
 pub(crate) use consensus_protocol::{BlockContext, EraReport, ProposedBlock};
 pub(crate) use era_supervisor::EraSupervisor;
@@ -247,7 +247,7 @@ pub trait ReactorEventT<I>:
     + From<NetworkRequest<I, Message>>
     + From<BlockProposerRequest>
     + From<ConsensusAnnouncement>
-    + From<BlockValidationRequest<BlockPayload, I>>
+    + From<BlockValidationRequest<I>>
     + From<StorageRequest>
     + From<ContractRuntimeRequest>
     + From<ChainspecLoaderRequest>
@@ -263,7 +263,7 @@ impl<REv, I> ReactorEventT<I> for REv where
         + From<NetworkRequest<I, Message>>
         + From<BlockProposerRequest>
         + From<ConsensusAnnouncement>
-        + From<BlockValidationRequest<BlockPayload, I>>
+        + From<BlockValidationRequest<I>>
         + From<StorageRequest>
         + From<ContractRuntimeRequest>
         + From<ChainspecLoaderRequest>

--- a/node/src/components/consensus/cl_context.rs
+++ b/node/src/components/consensus/cl_context.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[derive(DataSize)]
-pub(crate) struct Keypair {
+pub struct Keypair {
     secret_key: Arc<SecretKey>,
     public_key: PublicKey,
 }
@@ -53,7 +53,7 @@ impl ConsensusValueT for BlockPayload {
 
 /// The collection of types used for cryptography, IDs and blocks in the CasperLabs node.
 #[derive(Clone, DataSize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct ClContext;
+pub struct ClContext;
 
 impl Context for ClContext {
     type ConsensusValue = BlockPayload;

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -1,4 +1,9 @@
-use std::{any::Any, collections::BTreeMap, fmt::Debug, path::PathBuf};
+use std::{
+    any::Any,
+    collections::BTreeMap,
+    fmt::{self, Debug, Display, Formatter},
+    path::PathBuf,
+};
 
 use anyhow::Error;
 use datasize::DataSize;
@@ -11,7 +16,7 @@ use crate::{
 
 /// Information about the context in which a new block is created.
 #[derive(Clone, DataSize, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
-pub(crate) struct BlockContext<C>
+pub struct BlockContext<C>
 where
     C: Context,
 {
@@ -47,7 +52,7 @@ impl<C: Context> BlockContext<C> {
 
 /// A proposed block, with context.
 #[derive(Clone, DataSize, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
-pub(crate) struct ProposedBlock<C>
+pub struct ProposedBlock<C>
 where
     C: Context,
 {
@@ -70,6 +75,20 @@ impl<C: Context> ProposedBlock<C> {
 
     pub(crate) fn destructure(self) -> (C::ConsensusValue, BlockContext<C>) {
         (self.value, self.context)
+    }
+}
+
+impl<C: Context> Display for ProposedBlock<C>
+where
+    C::ConsensusValue: Display,
+{
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "proposed block at {}: {}",
+            self.context.timestamp(),
+            self.value
+        )
     }
 }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -50,8 +50,8 @@ use crate::{
     },
     fatal,
     types::{
-        ActivationPoint, Block, BlockHash, BlockHeader, BlockPayload, DeployHash,
-        FinalitySignature, FinalizedBlock, TimeDiff, Timestamp,
+        ActivationPoint, Block, BlockHash, BlockHeader, DeployHash, FinalitySignature,
+        FinalizedBlock, TimeDiff, Timestamp,
     },
     utils::WithDir,
     NodeRng,
@@ -1242,7 +1242,7 @@ async fn check_deploys_for_replay_in_previous_eras_and_validate_block<REv, I>(
     proposed_block: ProposedBlock<ClContext>,
 ) -> Event<I>
 where
-    REv: From<BlockValidationRequest<BlockPayload, I>> + From<StorageRequest>,
+    REv: From<BlockValidationRequest<I>> + From<StorageRequest>,
     I: Clone + Send + 'static,
 {
     for deploy_hash in proposed_block.value().deploys_and_transfers_iter() {
@@ -1271,12 +1271,8 @@ where
     }
 
     let sender_for_validate_block: I = sender.clone();
-    let (valid, _) = effect_builder
-        .validate_block_payload(
-            sender_for_validate_block,
-            proposed_block.value().clone(),
-            proposed_block.context().timestamp(),
-        )
+    let valid = effect_builder
+        .validate_proposed_block(sender_for_validate_block, proposed_block.clone())
         .await;
 
     Event::ResolveValidity(ResolveValidity {

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1272,7 +1272,7 @@ where
 
     let sender_for_validate_block: I = sender.clone();
     let valid = effect_builder
-        .validate_proposed_block(sender_for_validate_block, proposed_block.clone())
+        .validate_block(sender_for_validate_block, proposed_block.clone())
         .await;
 
     Event::ResolveValidity(ResolveValidity {

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -10,11 +10,11 @@ pub trait NodeIdT: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'stat
 impl<I> NodeIdT for I where I: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'static {}
 
 /// A validator identifier.
-pub(crate) trait ValidatorIdT: Eq + Ord + Clone + Debug + Hash + Send + DataSize {}
+pub trait ValidatorIdT: Eq + Ord + Clone + Debug + Hash + Send + DataSize {}
 impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash + Send + DataSize {}
 
 /// The consensus value type, e.g. a list of transactions.
-pub(crate) trait ConsensusValueT:
+pub trait ConsensusValueT:
     Eq + Clone + Debug + Hash + Serialize + DeserializeOwned + Send + DataSize
 {
     /// Returns whether the consensus value needs validation.
@@ -22,7 +22,7 @@ pub(crate) trait ConsensusValueT:
 }
 
 /// A hash, as an identifier for a block or unit.
-pub(crate) trait HashT:
+pub trait HashT:
     Eq + Ord + Copy + Clone + DataSize + Debug + Display + Hash + Serialize + DeserializeOwned + Send
 {
 }
@@ -42,7 +42,7 @@ impl<H> HashT for H where
 }
 
 /// A validator's secret signing key.
-pub(crate) trait ValidatorSecret: Send + DataSize {
+pub trait ValidatorSecret: Send + DataSize {
     type Hash: DataSize;
 
     type Signature: Eq + PartialEq + Clone + Debug + Hash + Serialize + DeserializeOwned + DataSize;
@@ -53,7 +53,7 @@ pub(crate) trait ValidatorSecret: Send + DataSize {
 /// The collection of types the user can choose for cryptography, IDs, transactions, etc.
 // TODO: These trait bounds make `#[derive(...)]` work for types with a `C: Context` type
 // parameter. Split this up or replace the derives with explicit implementations.
-pub(crate) trait Context: Clone + DataSize + Debug + Eq + Ord + Hash + Send {
+pub trait Context: Clone + DataSize + Debug + Eq + Ord + Hash + Send {
     /// The consensus value type, e.g. a list of transactions.
     type ConsensusValue: ConsensusValueT;
     /// Unique identifiers for validators.

--- a/node/src/components/linear_chain_fast_sync.rs
+++ b/node/src/components/linear_chain_fast_sync.rs
@@ -540,10 +540,9 @@ fn fetch_block_deploys<I: Clone + Send + 'static, REv>(
 where
     REv: ReactorEventT<I>,
 {
-    let block_timestamp = block.header().timestamp();
     effect_builder
-        .validate_block(peer.clone(), block, block_timestamp)
-        .event(move |(found, block)| {
+        .validate_block(peer.clone(), block.clone())
+        .event(move |found| {
             if found {
                 Event::GetDeploysResult(DeploysResult::Found(Box::new(block)))
             } else {

--- a/node/src/components/linear_chain_fast_sync/traits.rs
+++ b/node/src/components/linear_chain_fast_sync/traits.rs
@@ -8,7 +8,7 @@ pub trait ReactorEventT<I>:
     From<StorageRequest>
     + From<FetcherRequest<I, Block>>
     + From<FetcherRequest<I, BlockByHeight>>
-    + From<BlockValidationRequest<Block, I>>
+    + From<BlockValidationRequest<I>>
     + From<ContractRuntimeRequest>
     + Send
 {
@@ -18,7 +18,7 @@ impl<I, REv> ReactorEventT<I> for REv where
     REv: From<StorageRequest>
         + From<FetcherRequest<I, Block>>
         + From<FetcherRequest<I, BlockByHeight>>
-        + From<BlockValidationRequest<Block, I>>
+        + From<BlockValidationRequest<I>>
         + From<ContractRuntimeRequest>
         + Send
 {

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -826,11 +826,10 @@ fn fetch_block_deploys<I: Clone + Send + 'static, REv>(
 where
     REv: ReactorEventT<I>,
 {
-    let block_timestamp = block.header().timestamp();
     effect_builder
-        .validate_block(peer.clone(), block, block_timestamp)
-        .event(move |(found, block)| {
-            if found {
+        .validate_block(peer.clone(), block.clone())
+        .event(move |valid| {
+            if valid {
                 Event::GetDeploysResult(DeploysResult::Found(Box::new(block)))
             } else {
                 Event::GetDeploysResult(DeploysResult::NotFound(Box::new(block), peer))

--- a/node/src/components/linear_chain_sync/traits.rs
+++ b/node/src/components/linear_chain_sync/traits.rs
@@ -12,7 +12,7 @@ pub trait ReactorEventT<I>:
     From<StorageRequest>
     + From<FetcherRequest<I, Block>>
     + From<FetcherRequest<I, BlockByHeight>>
-    + From<BlockValidationRequest<Block, I>>
+    + From<BlockValidationRequest<I>>
     + From<ContractRuntimeRequest>
     + From<StateStoreRequest>
     + From<ControlAnnouncement>
@@ -24,7 +24,7 @@ impl<I, REv> ReactorEventT<I> for REv where
     REv: From<StorageRequest>
         + From<FetcherRequest<I, Block>>
         + From<FetcherRequest<I, BlockByHeight>>
-        + From<BlockValidationRequest<Block, I>>
+        + From<BlockValidationRequest<I>>
         + From<ContractRuntimeRequest>
         + From<StateStoreRequest>
         + From<ControlAnnouncement>

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -101,8 +101,8 @@ use casper_types::{
 
 use crate::{
     components::{
+        block_validator::ValidatingBlock,
         chainspec_loader::{CurrentRunInfo, NextUpgrade},
-        consensus::{ClContext, ProposedBlock},
         contract_runtime::EraValidatorsRequest,
         deploy_acceptor,
         fetcher::FetchResult,
@@ -1186,34 +1186,14 @@ impl<REv> EffectBuilder<REv> {
 
     /// Checks whether the deploys included in the block exist on the network and the block is
     /// valid.
-    pub(crate) async fn validate_block<I>(self, sender: I, block: Block) -> bool
+    pub(crate) async fn validate_block<I, T>(self, sender: I, block: T) -> bool
     where
         REv: From<BlockValidationRequest<I>>,
+        T: Into<ValidatingBlock>,
     {
         self.make_request(
             |responder| BlockValidationRequest {
-                block: Box::new(block).into(),
-                sender,
-                responder,
-            },
-            QueueKind::Regular,
-        )
-        .await
-    }
-
-    /// Checks whether the deploys included in the proposed block exist on the network and the
-    /// block is valid.
-    pub(crate) async fn validate_proposed_block<I>(
-        self,
-        sender: I,
-        proposed_block: ProposedBlock<ClContext>,
-    ) -> bool
-    where
-        REv: From<BlockValidationRequest<I>>,
-    {
-        self.make_request(
-            |responder| BlockValidationRequest {
-                block: Box::new(proposed_block).into(),
+                block: block.into(),
                 sender,
                 responder,
             },

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -37,6 +37,7 @@ use casper_types::{
 use super::Responder;
 use crate::{
     components::{
+        block_validator::ValidatingBlock,
         chainspec_loader::CurrentRunInfo,
         contract_runtime::{EraValidatorsRequest, ValidatorWeightsByEraIdRequest},
         deploy_acceptor::Error,
@@ -917,21 +918,18 @@ impl<I, T: Item> Display for FetcherRequest<I, T> {
 /// A block validator request.
 #[derive(Debug)]
 #[must_use]
-pub struct BlockValidationRequest<T, I> {
+pub struct BlockValidationRequest<I> {
     /// The block to be validated.
-    pub(crate) block: T,
+    pub(crate) block: ValidatingBlock,
     /// The sender of the block, which will be asked to provide all missing deploys.
     pub(crate) sender: I,
     /// Responder to call with the result.
     ///
-    /// Indicates whether or not validation was successful and returns `block` unchanged.
-    pub(crate) responder: Responder<(bool, T)>,
-    /// A check will be performed against the deploys to ensure their timestamp is
-    /// older than or equal to the block itself.
-    pub(crate) block_timestamp: Timestamp,
+    /// Indicates whether or not validation was successful.
+    pub(crate) responder: Responder<bool>,
 }
 
-impl<T: Display, I: Display> Display for BlockValidationRequest<T, I> {
+impl<I: Display> Display for BlockValidationRequest<I> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let BlockValidationRequest { block, sender, .. } = self;
         write!(f, "validate block {} from {}", block, sender)

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -62,7 +62,7 @@ use crate::{
     },
     protocol::Message,
     reactor::{self, event_queue_metrics::EventQueueMetrics, EventQueueHandle, ReactorExit},
-    types::{Block, BlockHash, BlockPayload, Deploy, ExitCode, NodeId, Tag},
+    types::{Block, BlockHash, Deploy, ExitCode, NodeId, Tag},
     utils::{Source, WithDir},
     NodeRng,
 };
@@ -119,7 +119,7 @@ pub enum Event {
     ContractRuntime(#[serde(skip_serializing)] contract_runtime::Event),
     /// Block validator event.
     #[from]
-    BlockPayloadValidator(#[serde(skip_serializing)] block_validator::Event<BlockPayload, NodeId>),
+    BlockValidator(#[serde(skip_serializing)] block_validator::Event<NodeId>),
     /// Linear chain event.
     #[from]
     LinearChain(#[serde(skip_serializing)] linear_chain::Event<NodeId>),
@@ -139,9 +139,7 @@ pub enum Event {
     BlockProposerRequest(#[serde(skip_serializing)] BlockProposerRequest),
     /// Block validator request.
     #[from]
-    BlockPayloadValidatorRequest(
-        #[serde(skip_serializing)] BlockValidationRequest<BlockPayload, NodeId>,
-    ),
+    BlockValidatorRequest(#[serde(skip_serializing)] BlockValidationRequest<NodeId>),
     /// Metrics request.
     #[from]
     MetricsRequest(#[serde(skip_serializing)] MetricsRequest),
@@ -267,7 +265,7 @@ impl Display for Event {
             Event::AddressGossiper(event) => write!(f, "address gossiper: {}", event),
             Event::ContractRuntime(event) => write!(f, "contract runtime: {:?}", event),
             Event::LinearChain(event) => write!(f, "linear-chain event {}", event),
-            Event::BlockPayloadValidator(event) => write!(f, "block validator: {}", event),
+            Event::BlockValidator(event) => write!(f, "block validator: {}", event),
             Event::NetworkRequest(req) => write!(f, "network request: {}", req),
             Event::NetworkInfoRequest(req) => write!(f, "network info request: {}", req),
             Event::ChainspecLoaderRequest(req) => write!(f, "chainspec loader request: {}", req),
@@ -275,7 +273,7 @@ impl Display for Event {
             Event::StateStoreRequest(req) => write!(f, "state store request: {}", req),
             Event::DeployFetcherRequest(req) => write!(f, "deploy fetcher request: {}", req),
             Event::BlockProposerRequest(req) => write!(f, "block proposer request: {}", req),
-            Event::BlockPayloadValidatorRequest(req) => {
+            Event::BlockValidatorRequest(req) => {
                 write!(f, "block validator request: {}", req)
             }
             Event::MetricsRequest(req) => write!(f, "metrics request: {}", req),
@@ -352,7 +350,7 @@ pub struct Reactor {
     deploy_fetcher: Fetcher<Deploy>,
     deploy_gossiper: Gossiper<Deploy, Event>,
     block_proposer: BlockProposer,
-    block_payload_validator: BlockValidator<BlockPayload, NodeId>,
+    block_validator: BlockValidator<NodeId>,
     linear_chain: LinearChainComponent<NodeId>,
 
     // Non-components.
@@ -487,8 +485,7 @@ impl reactor::Reactor for Reactor {
         );
         contract_runtime.set_parent_map_from_block(latest_block);
 
-        let block_payload_validator =
-            BlockValidator::new(Arc::clone(&chainspec_loader.chainspec()));
+        let block_validator = BlockValidator::new(Arc::clone(&chainspec_loader.chainspec()));
         let linear_chain = linear_chain::LinearChainComponent::new(
             &registry,
             *protocol_version,
@@ -523,7 +520,7 @@ impl reactor::Reactor for Reactor {
                 deploy_fetcher,
                 deploy_gossiper,
                 block_proposer,
-                block_payload_validator,
+                block_validator,
                 linear_chain,
                 memory_metrics,
                 event_queue_metrics,
@@ -601,9 +598,9 @@ impl reactor::Reactor for Reactor {
                 self.contract_runtime
                     .handle_event(effect_builder, rng, event),
             ),
-            Event::BlockPayloadValidator(event) => reactor::wrap_effects(
-                Event::BlockPayloadValidator,
-                self.block_payload_validator
+            Event::BlockValidator(event) => reactor::wrap_effects(
+                Event::BlockValidator,
+                self.block_validator
                     .handle_event(effect_builder, rng, event),
             ),
             Event::LinearChain(event) => reactor::wrap_effects(
@@ -634,10 +631,10 @@ impl reactor::Reactor for Reactor {
             Event::BlockProposerRequest(req) => {
                 self.dispatch_event(effect_builder, rng, Event::BlockProposer(req.into()))
             }
-            Event::BlockPayloadValidatorRequest(req) => self.dispatch_event(
+            Event::BlockValidatorRequest(req) => self.dispatch_event(
                 effect_builder,
                 rng,
-                Event::BlockPayloadValidator(block_validator::Event::from(req)),
+                Event::BlockValidator(block_validator::Event::from(req)),
             ),
             Event::MetricsRequest(req) => reactor::wrap_effects(
                 Event::MetricsRequest,

--- a/node/src/reactor/validator/memory_metrics.rs
+++ b/node/src/reactor/validator/memory_metrics.rs
@@ -40,7 +40,7 @@ pub(super) struct MemoryMetrics {
     /// Estimated heap memory usage of block_proposer component.
     mem_block_proposer: IntGauge,
     /// Estimated heap memory usage of block validator component.
-    mem_block_payload_validator: IntGauge,
+    mem_block_validator: IntGauge,
     /// Estimated heap memory usage of linear chain component.
     mem_linear_chain: IntGauge,
 
@@ -86,9 +86,9 @@ impl MemoryMetrics {
         )?;
         let mem_block_proposer =
             IntGauge::new("mem_block_proposer", "block_proposer memory usage in bytes")?;
-        let mem_block_payload_validator = IntGauge::new(
-            "mem_block_payload_validator",
-            "block_payload_validator memory usage in bytes",
+        let mem_block_validator = IntGauge::new(
+            "mem_block_validator",
+            "block_validator memory usage in bytes",
         )?;
         let mem_linear_chain =
             IntGauge::new("mem_linear_chain", "linear_chain memory usage in bytes")?;
@@ -116,7 +116,7 @@ impl MemoryMetrics {
         registry.register(Box::new(mem_deploy_fetcher.clone()))?;
         registry.register(Box::new(mem_deploy_gossiper.clone()))?;
         registry.register(Box::new(mem_block_proposer.clone()))?;
-        registry.register(Box::new(mem_block_payload_validator.clone()))?;
+        registry.register(Box::new(mem_block_validator.clone()))?;
         registry.register(Box::new(mem_linear_chain.clone()))?;
         registry.register(Box::new(mem_estimator_runtime_s.clone()))?;
 
@@ -135,7 +135,7 @@ impl MemoryMetrics {
             mem_deploy_fetcher,
             mem_deploy_gossiper,
             mem_block_proposer,
-            mem_block_payload_validator,
+            mem_block_validator,
             mem_linear_chain,
             mem_estimator_runtime_s,
             registry,
@@ -163,7 +163,7 @@ impl MemoryMetrics {
         let deploy_fetcher = reactor.deploy_fetcher.estimate_heap_size() as i64;
         let deploy_gossiper = reactor.deploy_gossiper.estimate_heap_size() as i64;
         let block_proposer = reactor.block_proposer.estimate_heap_size() as i64;
-        let block_payload_validator = reactor.block_payload_validator.estimate_heap_size() as i64;
+        let block_validator = reactor.block_validator.estimate_heap_size() as i64;
 
         let linear_chain = reactor.linear_chain.estimate_heap_size() as i64;
 
@@ -180,7 +180,7 @@ impl MemoryMetrics {
             + deploy_fetcher
             + deploy_gossiper
             + block_proposer
-            + block_payload_validator
+            + block_validator
             + linear_chain;
 
         self.mem_total.set(total);
@@ -197,8 +197,7 @@ impl MemoryMetrics {
         self.mem_deploy_fetcher.set(deploy_fetcher);
         self.mem_deploy_gossiper.set(deploy_gossiper);
         self.mem_block_proposer.set(block_proposer);
-        self.mem_block_payload_validator
-            .set(block_payload_validator);
+        self.mem_block_validator.set(block_validator);
         self.mem_linear_chain.set(linear_chain);
 
         // Stop the timer explicitly, don't count logging.
@@ -219,7 +218,7 @@ impl MemoryMetrics {
                %deploy_fetcher,
                %deploy_gossiper,
                %block_proposer,
-               %block_payload_validator,
+               %block_validator,
                %linear_chain,
                "Collected new set of memory metrics.");
     }
@@ -241,7 +240,7 @@ impl Drop for MemoryMetrics {
         unregister_metric!(self.registry, self.mem_deploy_fetcher);
         unregister_metric!(self.registry, self.mem_deploy_gossiper);
         unregister_metric!(self.registry, self.mem_block_proposer);
-        unregister_metric!(self.registry, self.mem_block_payload_validator);
+        unregister_metric!(self.registry, self.mem_block_validator);
         unregister_metric!(self.registry, self.mem_linear_chain);
         unregister_metric!(self.registry, self.mem_estimator_runtime_s);
     }


### PR DESCRIPTION
This replaces the `BlockLike` trait with an enum that is used only within the block validator, and adds checks that the `transfer_hashes` contain only transfers, and the `deploy_hashes` contain none.

**Renames the metric `mem_block_payload_validator` to `mem_block_validator`!**

https://casperlabs.atlassian.net/browse/NDRS-1130