### PR TITLE
NO-TICKET: Fix nightly build

### DIFF
--- a/utils/nctl/sh/assets/compile_client.sh
+++ b/utils/nctl/sh/assets/compile_client.sh
@@ -25,7 +25,6 @@ make build-contract-rs/activate-bid
 make build-contract-rs/add-bid
 make build-contract-rs/delegate
 make build-contract-rs/transfer-to-account-u512
-make build-contract-rs/transfer-to-account-u512-stored
 make build-contract-rs/undelegate
 make build-contract-rs/withdraw-bid
 

--- a/utils/nctl/sh/utils/constants.sh
+++ b/utils/nctl/sh/utils/constants.sh
@@ -33,7 +33,6 @@ export NCTL_CONTRACTS_CLIENT_AUCTION=(
 # Set of client side transfer contracts.
 export NCTL_CONTRACTS_CLIENT_TRANSFERS=(
     "transfer_to_account_u512.wasm"
-    "transfer_to_account_u512_stored.wasm"
 )
 
 # Default amount used when delegating.


### PR DESCRIPTION
After #1282 got merged in bypassing bors CI, it introduced a regression in nightly builds. This PR fixes the references to absent contracts in nctl scripts.