### PR TITLE
NDRS-1120: Add a delay before proposing dependencies. (1.0.2 backport)

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -3,6 +3,7 @@
 //! The block proposer stores deploy hashes in memory, tracking their suitability for inclusion into
 //! a new block. Upon request, it returns a list of candidates that can be included.
 
+mod config;
 mod deploy_sets;
 mod event;
 mod metrics;
@@ -16,6 +17,7 @@ use std::{
     time::Duration,
 };
 
+pub use config::Config;
 use datasize::DataSize;
 use prometheus::{self, Registry};
 use tracing::{debug, error, info, trace, warn};
@@ -78,6 +80,8 @@ enum BlockProposerState {
         state_key: Vec<u8>,
         /// The deploy config from the current chainspec.
         deploy_config: DeployConfig,
+        /// The configuration, containing local settings for deploy selection
+        local_config: Config,
     },
     /// Normal operation.
     Ready(BlockProposerReady),
@@ -90,6 +94,7 @@ impl BlockProposer {
         effect_builder: EffectBuilder<REv>,
         next_finalized_block: BlockHeight,
         chainspec: &Chainspec,
+        local_config: Config,
     ) -> Result<(Self, Effects<Event>), prometheus::Error>
     where
         REv: From<Event> + From<StorageRequest> + From<StateStoreRequest> + Send + 'static,
@@ -109,6 +114,7 @@ impl BlockProposer {
                 pending: Vec::new(),
                 state_key,
                 deploy_config: chainspec.deploy_config,
+                local_config,
             },
             metrics: BlockProposerMetrics::new(registry)?,
         };
@@ -141,6 +147,7 @@ where
                     ref mut pending,
                     state_key,
                     deploy_config,
+                    local_config,
                 },
                 Event::Loaded {
                     finalized_deploys,
@@ -156,6 +163,7 @@ where
                     deploy_config: *deploy_config,
                     state_key: state_key.clone(),
                     request_queue: Default::default(),
+                    local_config: local_config.clone(),
                 };
 
                 // Replay postponed events onto new state.
@@ -211,6 +219,8 @@ struct BlockProposerReady {
     state_key: Vec<u8>,
     /// The queue of requests awaiting being handled.
     request_queue: RequestQueue,
+    /// The block proposer configuration, containing local settings for selecting deploys.
+    local_config: Config,
 }
 
 impl BlockProposerReady {

--- a/node/src/components/block_proposer/config.rs
+++ b/node/src/components/block_proposer/config.rs
@@ -1,0 +1,28 @@
+use datasize::DataSize;
+use serde::{Deserialize, Serialize};
+
+use crate::types::TimeDiff;
+
+/// Block proposer configuration.
+#[derive(DataSize, Debug, Deserialize, Serialize, Clone)]
+// Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// Deploys are only proposed in a new block if the have been received at least this long ago.
+    /// A longer delay makes it more likely that many proposed deploys are already known by the
+    /// other nodes, and don't have to be requested from the proposer afterwards.
+    #[serde(default = "default_deploy_delay")]
+    pub deploy_delay: TimeDiff,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            deploy_delay: default_deploy_delay(),
+        }
+    }
+}
+
+fn default_deploy_delay() -> TimeDiff {
+    "1min".parse().unwrap()
+}

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -12,8 +12,9 @@ use crate::types::{Chainspec, DeployHash, DeployHeader, Timestamp};
 /// Stores the internal state of the BlockProposer.
 #[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
 pub struct BlockProposerDeploySets {
-    /// The collection of deploys pending for inclusion in a block.
-    pub(super) pending: HashMap<DeployHash, DeployType>,
+    /// The collection of deploys pending for inclusion in a block, with a timestamp of when we
+    /// received them.
+    pub(super) pending: HashMap<DeployHash, (DeployType, Timestamp)>,
     /// The deploys that have already been included in a finalized block.
     pub(super) finalized_deploys: HashMap<DeployHash, DeployHeader>,
     /// The next block height we expect to be finalized.
@@ -103,10 +104,10 @@ pub(super) fn prune_deploys(
 /// Prunes expired deploy information from an individual pending deploy collection, returns the
 /// total deploys pruned
 pub(super) fn prune_pending_deploys(
-    deploys: &mut HashMap<DeployHash, DeployType>,
+    deploys: &mut HashMap<DeployHash, (DeployType, Timestamp)>,
     current_instant: Timestamp,
 ) -> usize {
     let initial_len = deploys.len();
-    deploys.retain(|_hash, wrapper| !wrapper.header().expired(current_instant));
+    deploys.retain(|_hash, (deploy_type, _)| !deploy_type.header().expired(current_instant));
     initial_len - deploys.len()
 }

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 const DEFAULT_TEST_GAS_PRICE: u64 = 1;
+const TEST_DEPLOY_DELAY_MILLIS: TimeDiff = TimeDiff::from_millis(10);
 
 fn default_gas_payment() -> Gas {
     Gas::from(1u32)
@@ -95,6 +96,9 @@ fn create_test_proposer() -> BlockProposerReady {
         state_key: b"block-proposer-test".to_vec(),
         request_queue: Default::default(),
         unhandled_finalized: Default::default(),
+        local_config: Config {
+            deploy_delay: TEST_DEPLOY_DELAY_MILLIS,
+        },
     }
 }
 

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 
 const DEFAULT_TEST_GAS_PRICE: u64 = 1;
-const TEST_DEPLOY_DELAY_MILLIS: TimeDiff = TimeDiff::from_millis(10);
 
 fn default_gas_payment() -> Gas {
     Gas::from(1u32)
@@ -89,16 +88,14 @@ fn generate_deploy(
     )
 }
 
-fn create_test_proposer() -> BlockProposerReady {
+fn create_test_proposer(deploy_delay: TimeDiff) -> BlockProposerReady {
     BlockProposerReady {
         sets: Default::default(),
         deploy_config: Default::default(),
         state_key: b"block-proposer-test".to_vec(),
         request_queue: Default::default(),
         unhandled_finalized: Default::default(),
-        local_config: Config {
-            deploy_delay: TEST_DEPLOY_DELAY_MILLIS,
-        },
+        local_config: Config { deploy_delay },
     }
 }
 
@@ -125,7 +122,7 @@ fn should_add_and_take_deploys() {
     let block_time3 = Timestamp::from(220);
 
     let no_deploys = HashSet::new();
-    let mut proposer = create_test_proposer();
+    let mut proposer = create_test_proposer(0.into());
     let mut rng = crate::new_rng();
     let deploy1 = generate_deploy(
         &mut rng,
@@ -288,7 +285,7 @@ fn should_successfully_prune() {
         default_gas_payment(),
         DEFAULT_TEST_GAS_PRICE,
     );
-    let mut proposer = create_test_proposer();
+    let mut proposer = create_test_proposer(0.into());
 
     // pending
     proposer.add_deploy_or_transfer(creation_time, *deploy1.id(), deploy1.deploy_type().unwrap());
@@ -341,7 +338,7 @@ fn should_keep_track_of_unhandled_deploys() {
         default_gas_payment(),
         DEFAULT_TEST_GAS_PRICE,
     );
-    let mut proposer = create_test_proposer();
+    let mut proposer = create_test_proposer(0.into());
 
     // We do NOT add deploy2...
     proposer.add_deploy_or_transfer(creation_time, *deploy1.id(), deploy1.deploy_type().unwrap());
@@ -550,7 +547,7 @@ fn test_proposer_with(
     let past_deploys = HashSet::new();
 
     let mut rng = crate::new_rng();
-    let mut proposer = create_test_proposer();
+    let mut proposer = create_test_proposer(0.into());
     let mut config = proposer.deploy_config;
     // defaults are 10, 1000 respectively
     config.block_max_deploy_count = max_deploy_count;
@@ -629,7 +626,7 @@ fn should_return_deploy_dependencies() {
     );
 
     let no_deploys = HashSet::new();
-    let mut proposer = create_test_proposer();
+    let mut proposer = create_test_proposer(0.into());
 
     // add deploy2
     proposer.add_deploy_or_transfer(creation_time, *deploy2.id(), deploy2.deploy_type().unwrap());
@@ -671,4 +668,29 @@ fn should_return_deploy_dependencies() {
     let deploys2 = block.wasm_deploys();
     assert_eq!(deploys2.len(), 1);
     assert!(deploys2.contains(deploy2.id()));
+}
+
+#[test]
+fn should_respect_deploy_delay() {
+    let mut rng = crate::new_rng();
+    let creation_time = Timestamp::from(0);
+    let ttl = TimeDiff::from(10000);
+    let no_deploys = HashSet::new();
+    let deploy_config = DeployConfig::default();
+    let deploy = generate_deploy(
+        &mut rng,
+        creation_time,
+        ttl,
+        vec![],
+        default_gas_payment(),
+        DEFAULT_TEST_GAS_PRICE,
+    );
+    let mut proposer = create_test_proposer(10.into()); // Deploy delay: 10 milliseconds
+
+    // Add the deploy at time 100. So at 109 it cannot be proposed yet, but at time 110 it can.
+    proposer.add_deploy_or_transfer(100.into(), *deploy.id(), deploy.deploy_type().unwrap());
+    let block = proposer.propose_proto_block(deploy_config, 109.into(), no_deploys.clone(), true);
+    assert!(block.wasm_deploys().is_empty());
+    let block = proposer.propose_proto_block(deploy_config, 110.into(), no_deploys, true);
+    assert_eq!(&vec![*deploy.id()], block.wasm_deploys());
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -53,6 +53,7 @@ use signal_hook::{
 };
 
 pub use components::{
+    block_proposer::Config as BlockProposerConfig,
     consensus::Config as ConsensusConfig,
     contract_runtime::Config as ContractRuntimeConfig,
     deploy_acceptor::Config as DeployAcceptorConfig,

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -462,6 +462,7 @@ impl reactor::Reactor for Reactor {
                 .map(|block| block.height() + 1)
                 .unwrap_or(0),
             chainspec_loader.chainspec().as_ref(),
+            config.block_proposer,
         )?;
         let mut effects = reactor::wrap_effects(Event::BlockProposer, block_proposer_effects);
         let block_executor = BlockExecutor::new(

--- a/node/src/reactor/validator/config.rs
+++ b/node/src/reactor/validator/config.rs
@@ -2,9 +2,9 @@ use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    logging::LoggingConfig, types::NodeConfig, ConsensusConfig, ContractRuntimeConfig,
-    DeployAcceptorConfig, EventStreamServerConfig, FetcherConfig, GossipConfig, RestServerConfig,
-    RpcServerConfig, SmallNetworkConfig, StorageConfig,
+    logging::LoggingConfig, types::NodeConfig, BlockProposerConfig, ConsensusConfig,
+    ContractRuntimeConfig, DeployAcceptorConfig, EventStreamServerConfig, FetcherConfig,
+    GossipConfig, RestServerConfig, RpcServerConfig, SmallNetworkConfig, StorageConfig,
 };
 
 /// Root configuration.
@@ -36,4 +36,7 @@ pub struct Config {
     pub contract_runtime: ContractRuntimeConfig,
     /// Deploy acceptor configuration.
     pub deploy_acceptor: DeployAcceptorConfig,
+    /// Block proposer configuration.
+    #[serde(default)]
+    pub block_proposer: BlockProposerConfig,
 }

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -247,11 +247,6 @@ impl TimeDiff {
     pub const fn from_seconds(seconds: u32) -> Self {
         TimeDiff(seconds as u64 * 1_000)
     }
-
-    /// Returns the product, or `TimeDiff(u64::MAX)` if it would overflow.
-    pub fn saturating_mul(self, rhs: u64) -> Self {
-        TimeDiff(self.0.saturating_mul(rhs))
-    }
 }
 
 impl Mul<u64> for TimeDiff {

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -248,11 +248,6 @@ impl TimeDiff {
         TimeDiff(seconds as u64 * 1_000)
     }
 
-    /// Creates a new time difference from milliseconds.
-    pub const fn from_millis(millis: u64) -> Self {
-        TimeDiff(millis)
-    }
-
     /// Returns the product, or `TimeDiff(u64::MAX)` if it would overflow.
     pub fn saturating_mul(self, rhs: u64) -> Self {
         TimeDiff(self.0.saturating_mul(rhs))

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -247,6 +247,16 @@ impl TimeDiff {
     pub const fn from_seconds(seconds: u32) -> Self {
         TimeDiff(seconds as u64 * 1_000)
     }
+
+    /// Creates a new time difference from milliseconds.
+    pub const fn from_millis(millis: u64) -> Self {
+        TimeDiff(millis)
+    }
+
+    /// Returns the product, or `TimeDiff(u64::MAX)` if it would overflow.
+    pub fn saturating_mul(self, rhs: u64) -> Self {
+        TimeDiff(self.0.saturating_mul(rhs))
+    }
 }
 
 impl Mul<u64> for TimeDiff {

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -254,3 +254,14 @@ verify_accounts = true
 #
 # If unset, defaults to 5.
 #max_query_depth = 5
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if the have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -41,7 +41,6 @@ pending_vertex_timeout = '30min'
 max_execution_delay = 3
 
 
-
 # ====================================
 # Configuration options for networking
 # ====================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -41,6 +41,7 @@ pending_vertex_timeout = '30min'
 max_execution_delay = 3
 
 
+
 # ====================================
 # Configuration options for networking
 # ====================================
@@ -86,6 +87,7 @@ initial_gossip_delay = '5s'
 
 # How long a connection is allowed to be stuck as pending before it is abandoned.
 max_addr_pending_time = '1min'
+
 
 # ==================================================
 # Configuration options for the JSON-RPC HTTP server
@@ -259,3 +261,14 @@ verify_accounts = true
 #
 # If unset, defaults to 5.
 #max_query_depth = 5
+
+
+# ====================================================================
+# Configuration options for selecting deploys to propose in new blocks
+# ====================================================================
+[block_proposer]
+
+# Deploys are only proposed in a new block if the have been received at least this long ago.
+# A longer delay makes it more likely that many proposed deploys are already known by the
+# other nodes, and don't have to be requested from the proposer afterwards.
+#deploy_delay = '1min'


### PR DESCRIPTION
This adds a configurable delay between the time we receive a deploy (from a client or another full node) and the time we propose it in a block. The intention is to give deploys time to spread across the network via gossip, so that when we include them in a new block, the other nodes won't all have to ask us for the deploy.

Backport of https://github.com/CasperLabs/casper-node/pull/1283.