### PR TITLE
NDRS-1142: Use only block headers, not bodies, in the consensus component.

### DIFF
--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -108,7 +108,7 @@ pub enum Event<I> {
     #[from]
     ConsensusRequest(ConsensusRequest),
     /// A new block has been added to the linear chain.
-    BlockAdded(BlockHash, Box<BlockHeader>),
+    BlockAdded(Box<BlockHeader>),
     /// The proto-block has been validated.
     ResolveValidity(ResolveValidity<I>),
     /// Deactivate the era with the given ID, unless the number of faulty validators increases.
@@ -197,10 +197,10 @@ impl<I: Debug> Display for Event<I> {
                 "A request for consensus component hash been receieved: {:?}",
                 request
             ),
-            Event::BlockAdded(block_hash, _) => write!(
+            Event::BlockAdded(block_header) => write!(
                 f,
                 "A block has been added to the linear chain: {}",
-                block_hash,
+                block_header.hash(),
             ),
             Event::ResolveValidity(ResolveValidity {
                 era_id,
@@ -298,9 +298,7 @@ where
             Event::NewBlockPayload(new_block_payload) => {
                 handling_es.handle_new_block_payload(new_block_payload)
             }
-            Event::BlockAdded(block_hash, block_header) => {
-                handling_es.handle_block_added(block_hash, *block_header)
-            }
+            Event::BlockAdded(block_header) => handling_es.handle_block_added(*block_header),
             Event::ResolveValidity(resolve_validity) => {
                 handling_es.resolve_validity(resolve_validity)
             }

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -42,7 +42,7 @@ use crate::{
     fatal,
     protocol::Message,
     reactor::ReactorEvent,
-    types::{ActivationPoint, Block, BlockHash, BlockHeader, BlockPayload, Timestamp},
+    types::{ActivationPoint, BlockHash, BlockHeader, BlockPayload, Timestamp},
     NodeRng,
 };
 
@@ -108,7 +108,7 @@ pub enum Event<I> {
     #[from]
     ConsensusRequest(ConsensusRequest),
     /// A new block has been added to the linear chain.
-    BlockAdded(Box<Block>),
+    BlockAdded(BlockHash, Box<BlockHeader>),
     /// The proto-block has been validated.
     ResolveValidity(ResolveValidity<I>),
     /// Deactivate the era with the given ID, unless the number of faulty validators increases.
@@ -197,10 +197,10 @@ impl<I: Debug> Display for Event<I> {
                 "A request for consensus component hash been receieved: {:?}",
                 request
             ),
-            Event::BlockAdded(block) => write!(
+            Event::BlockAdded(block_hash, _) => write!(
                 f,
                 "A block has been added to the linear chain: {}",
-                block.hash()
+                block_hash,
             ),
             Event::ResolveValidity(ResolveValidity {
                 era_id,
@@ -298,7 +298,9 @@ where
             Event::NewBlockPayload(new_block_payload) => {
                 handling_es.handle_new_block_payload(new_block_payload)
             }
-            Event::BlockAdded(block) => handling_es.handle_block_added(*block),
+            Event::BlockAdded(block_hash, block_header) => {
+                handling_es.handle_block_added(block_hash, *block_header)
+            }
             Event::ResolveValidity(resolve_validity) => {
                 handling_es.resolve_validity(resolve_validity)
             }

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -120,8 +120,8 @@ pub enum Event<I> {
     /// Event raised when a new era should be created: once we get the set of validators, the
     /// booking block hash and the seed from the key block.
     CreateNewEra {
-        /// The header of the switch block
-        block: Box<Block>,
+        /// The header of the switch block, i.e. the last block before the new era.
+        switch_block_header: Box<BlockHeader>,
         /// `Ok(block_hash)` if the booking block was found, `Err(era_id)` if not
         booking_block_hash: Result<BlockHash, EraId>,
     },
@@ -224,11 +224,11 @@ impl<I: Debug> Display for Event<I> {
             ),
             Event::CreateNewEra {
                 booking_block_hash,
-                block,
+                switch_block_header,
             } => write!(
                 f,
                 "New era should be created; booking block hash: {:?}, switch block: {:?}",
-                booking_block_hash, block
+                booking_block_hash, switch_block_header
             ),
             Event::InitializeEras { .. } => write!(f, "Starting eras should be initialized"),
             Event::GotUpgradeActivationPoint(activation_point) => {
@@ -308,7 +308,7 @@ where
                 delay,
             } => handling_es.handle_deactivate_era(era_id, faulty_num, delay),
             Event::CreateNewEra {
-                block,
+                switch_block_header,
                 booking_block_hash,
             } => {
                 let booking_block_hash = match booking_block_hash {
@@ -317,7 +317,7 @@ where
                         error!(
                             "could not find the booking block in era {}, for era {}",
                             era_id,
-                            block.header().era_id().successor()
+                            switch_block_header.era_id().successor()
                         );
                         return fatal!(
                             handling_es.effect_builder,
@@ -326,7 +326,7 @@ where
                         .ignore();
                     }
                 };
-                handling_es.handle_create_new_era(*block, booking_block_hash)
+                handling_es.handle_create_new_era(*switch_block_header, booking_block_hash)
             }
             Event::InitializeEras {
                 key_blocks,

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -711,11 +711,7 @@ where
         })
     }
 
-    pub(super) fn handle_block_added(
-        &mut self,
-        block_hash: BlockHash,
-        block_header: BlockHeader,
-    ) -> Effects<Event<I>> {
+    pub(super) fn handle_block_added(&mut self, block_header: BlockHeader) -> Effects<Event<I>> {
         let our_pk = self.era_supervisor.public_signing_key.clone();
         let our_sk = self.era_supervisor.secret_signing_key.clone();
         let era_id = block_header.era_id();
@@ -723,7 +719,10 @@ where
         let mut effects = if self.era_supervisor.is_validator_in(&our_pk, era_id) {
             self.effect_builder
                 .announce_created_finality_signature(FinalitySignature::new(
-                    block_hash, era_id, &our_sk, our_pk,
+                    block_header.hash(),
+                    era_id,
+                    &our_sk,
+                    our_pk,
                 ))
                 .ignore()
         } else {

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -187,7 +187,7 @@ where
             info!(?era_ids, "collecting key blocks and booking blocks");
 
             let key_blocks = effect_builder
-                .collect_key_blocks(era_ids.iter().cloned())
+                .collect_key_block_headers(era_ids.iter().cloned())
                 .await
                 .expect("should have all the key blocks in storage");
 
@@ -563,17 +563,17 @@ where
         valid_booking_block_era_id(era_id, auction_delay, last_activation_point)
     {
         match effect_builder
-            .get_switch_block_at_era_id_from_storage(booking_block_era_id)
+            .get_switch_block_header_at_era_id_from_storage(booking_block_era_id)
             .await
         {
-            Some(block) => *block.hash(),
+            Some(block_header) => block_header.hash(),
             None => {
                 error!(
                     ?era_id,
                     ?booking_block_era_id,
-                    "booking block for era must exist"
+                    "booking block header for era must exist"
                 );
-                panic!("booking block not found in storage");
+                panic!("booking block header not found in storage");
             }
         }
     } else {

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -1026,7 +1026,6 @@ impl reactor::Reactor for Reactor {
             }
             Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded(block)) => {
                 let reactor_event_consensus = Event::Consensus(consensus::Event::BlockAdded(
-                    *block.hash(),
                     Box::new(block.header().clone()),
                 ));
                 let reactor_event_es =

--- a/node/src/reactor/validator.rs
+++ b/node/src/reactor/validator.rs
@@ -1025,11 +1025,14 @@ impl reactor::Reactor for Reactor {
                 self.dispatch_event(effect_builder, rng, reactor_event)
             }
             Event::LinearChainAnnouncement(LinearChainAnnouncement::BlockAdded(block)) => {
-                let reactor_event =
-                    Event::EventStreamServer(event_stream_server::Event::BlockAdded(block.clone()));
-                let mut effects = self.dispatch_event(effect_builder, rng, reactor_event);
-                let reactor_event = Event::Consensus(consensus::Event::BlockAdded(block));
-                effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
+                let reactor_event_consensus = Event::Consensus(consensus::Event::BlockAdded(
+                    *block.hash(),
+                    Box::new(block.header().clone()),
+                ));
+                let reactor_event_es =
+                    Event::EventStreamServer(event_stream_server::Event::BlockAdded(block));
+                let mut effects = self.dispatch_event(effect_builder, rng, reactor_event_es);
+                effects.extend(self.dispatch_event(effect_builder, rng, reactor_event_consensus));
                 effects
             }
             Event::LinearChainAnnouncement(LinearChainAnnouncement::NewFinalitySignature(fs)) => {

--- a/node/src/types/block.rs
+++ b/node/src/types/block.rs
@@ -1065,7 +1065,8 @@ impl Block {
         &self.body
     }
 
-    pub(crate) fn take_header(self) -> BlockHeader {
+    /// Returns the header, consuming the block.
+    pub fn take_header(self) -> BlockHeader {
         self.header
     }
 


### PR DESCRIPTION
Fast sync won't download all block bodies, so in preparation, the consensus component needs to not rely on them.

https://casperlabs.atlassian.net/browse/NDRS-1142