### PR TITLE
NDRS-1121: Deduplicate block validity criteria. (1.0.2 backport)

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -18,7 +18,7 @@ use std::{
 
 use datasize::DataSize;
 use prometheus::{self, Registry};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, trace};
 
 use crate::{
     components::Component,
@@ -26,14 +26,16 @@ use crate::{
         requests::{BlockProposerRequest, ProtoBlockRequest, StateStoreRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects,
     },
-    types::{chainspec::DeployConfig, Chainspec, DeployHash, DeployHeader, ProtoBlock, Timestamp},
+    types::{
+        appendable_block::{AddError, AppendableBlock},
+        chainspec::DeployConfig,
+        Chainspec, DeployHash, DeployHeader, ProtoBlock, Timestamp,
+    },
     NodeRng,
 };
-use casper_execution_engine::shared::gas::Gas;
 pub(crate) use deploy_sets::BlockProposerDeploySets;
 pub(crate) use event::{DeployType, Event};
 use metrics::BlockProposerMetrics;
-use num_traits::Zero;
 
 /// Block proposer component.
 #[derive(DataSize, Debug)]
@@ -384,20 +386,11 @@ impl BlockProposerReady {
     }
 
     /// Checks if a deploy is valid (for inclusion into the next block).
-    fn is_deploy_valid(
-        &self,
-        header: &DeployHeader,
-        block_timestamp: Timestamp,
-        deploy_config: &DeployConfig,
-        past_deploys: &HashSet<DeployHash>,
-    ) -> bool {
-        let all_deps_resolved = || {
-            header
-                .dependencies()
-                .iter()
-                .all(|dep| past_deploys.contains(dep) || self.contains_finalized(dep))
-        };
-        header.is_valid(deploy_config, block_timestamp) && all_deps_resolved()
+    fn deps_resolved(&self, header: &DeployHeader, past_deploys: &HashSet<DeployHash>) -> bool {
+        header
+            .dependencies()
+            .iter()
+            .all(|dep| past_deploys.contains(dep) || self.contains_finalized(dep))
     }
 
     /// Returns a list of candidates for inclusion into a block.
@@ -408,73 +401,68 @@ impl BlockProposerReady {
         past_deploys: HashSet<DeployHash>,
         random_bit: bool,
     ) -> ProtoBlock {
-        let max_transfers = deploy_config.block_max_transfer_count as usize;
-        let max_deploys = deploy_config.block_max_deploy_count as usize;
-        let max_block_size_bytes = deploy_config.max_block_size as usize;
-        let block_gas_limit = Gas::from(deploy_config.block_gas_limit);
+        let mut appendable_block = AppendableBlock::new(deploy_config, block_timestamp);
 
-        let mut transfers = Vec::new();
-        let mut wasm_deploys = Vec::new();
-        let mut block_gas_running_total = Gas::zero();
-        let mut block_size_running_total = 0usize;
-
-        for (hash, deploy_type) in self.sets.pending.iter() {
-            let at_max_transfers = transfers.len() == max_transfers;
-            let at_max_deploys = wasm_deploys.len() == max_deploys
-                || (deploy_type.is_wasm()
-                    && block_size_running_total + DEPLOY_APPROX_MIN_SIZE >= max_block_size_bytes);
-
-            if at_max_deploys && at_max_transfers {
-                break;
-            }
-
-            if !self.is_deploy_valid(
-                &deploy_type.header(),
-                block_timestamp,
-                &deploy_config,
-                &past_deploys,
-            ) || past_deploys.contains(hash)
-                || self.sets.finalized_deploys.contains_key(hash)
+        // We prioritize transfers over deploys, so we try to include them first.
+        for (hash, deploy_type) in &self.sets.pending {
+            if !deploy_type.is_transfer()
+                || !self.deps_resolved(&deploy_type.header(), &past_deploys)
+                || past_deploys.contains(hash)
+                || self.contains_finalized(hash)
             {
                 continue;
             }
 
-            // always include wasm-less transfers if we are under the max for them
-            if deploy_type.is_transfer() && !at_max_transfers {
-                transfers.push(*hash);
-            } else if deploy_type.is_wasm() && !at_max_deploys {
-                if block_size_running_total + deploy_type.size() > max_block_size_bytes {
-                    continue;
-                }
-                let payment_amount_gas = match Gas::from_motes(
-                    deploy_type.payment_amount(),
-                    deploy_type.header().gas_price(),
-                ) {
-                    Some(value) => value,
-                    None => {
-                        error!("payment_amount couldn't be converted from motes to gas");
-                        continue;
+            if let Err(err) = appendable_block.add(*hash, deploy_type) {
+                match err {
+                    // We added the maximum number of transfers.
+                    AddError::TransferCount | AddError::GasLimit | AddError::BlockSize => break,
+                    // The deploy is not valid in this block, but might be valid in another.
+                    AddError::InvalidDeploy => (),
+                    // These errors should never happen when adding a transfer.
+                    AddError::InvalidGasAmount | AddError::DeployCount | AddError::Duplicate => {
+                        error!(?err, "unexpected error when adding transfer")
                     }
-                };
-                let gas_running_total = if let Some(gas_running_total) =
-                    block_gas_running_total.checked_add(payment_amount_gas)
-                {
-                    gas_running_total
-                } else {
-                    warn!("block gas would overflow");
-                    continue;
-                };
-
-                if gas_running_total > block_gas_limit {
-                    continue;
                 }
-                wasm_deploys.push(*hash);
-                block_gas_running_total = gas_running_total;
-                block_size_running_total += deploy_type.size();
             }
         }
 
-        ProtoBlock::new(wasm_deploys, transfers, block_timestamp, random_bit)
+        // Now we try to add other deploys to the block.
+        for (hash, deploy_type) in &self.sets.pending {
+            if deploy_type.is_transfer()
+                || !self.deps_resolved(&deploy_type.header(), &past_deploys)
+                || past_deploys.contains(hash)
+                || self.contains_finalized(hash)
+            {
+                continue;
+            }
+
+            if let Err(err) = appendable_block.add(*hash, deploy_type) {
+                match err {
+                    // We added the maximum number of deploys.
+                    AddError::DeployCount => break,
+                    AddError::BlockSize => {
+                        if appendable_block.total_size() + DEPLOY_APPROX_MIN_SIZE
+                            >= deploy_config.block_gas_limit as usize
+                        {
+                            break; // Probably no deploy will fit in this block anymore.
+                        }
+                    }
+                    // The deploy is not valid in this block, but might be valid in another.
+                    // TODO: Do something similar to DEPLOY_APPROX_MIN_SIZE for gas.
+                    AddError::InvalidDeploy | AddError::GasLimit => (),
+                    // These errors should never happen when adding a deploy.
+                    AddError::TransferCount | AddError::Duplicate => {
+                        error!(?err, "unexpected error when adding deploy")
+                    }
+                    AddError::InvalidGasAmount => {
+                        error!("payment_amount couldn't be converted from motes to gas")
+                    }
+                }
+            }
+        }
+
+        appendable_block.into_proto_block(random_bit)
     }
 
     /// Prunes expired deploy information from the BlockProposer, returns the total deploys pruned.

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -1,4 +1,6 @@
-use casper_execution_engine::core::engine_state::executable_deploy_item::ExecutableDeployItem;
+use casper_execution_engine::{
+    core::engine_state::executable_deploy_item::ExecutableDeployItem, shared::gas::Gas,
+};
 use casper_types::{
     bytesrepr::{Bytes, ToBytes},
     runtime_args,
@@ -356,16 +358,16 @@ fn should_keep_track_of_unhandled_deploys() {
         !proposer.sets.finalized_deploys.contains_key(deploy2.id()),
         "should not yet contain deploy2"
     );
-
-    let past_deploys = HashSet::new();
     assert!(
-        proposer.is_deploy_valid(
-            deploy2.header(),
-            test_time,
-            &proposer.deploy_config,
-            &past_deploys
-        ),
-        "deploy2 should -not- be valid"
+        proposer.contains_finalized(deploy2.id()),
+        "should recognize deploy2 as finalized"
+    );
+
+    assert!(
+        deploy2
+            .header()
+            .is_valid(&proposer.deploy_config, test_time),
+        "deploy2 should be valid"
     );
 
     // Now we add Deploy2

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -54,7 +54,7 @@ pub enum Event<T, I> {
 
     /// Deploy was invalid. Unable to convert to a deploy type.
     #[display(fmt = "deploy {} invalid", _0)]
-    DeployInvalid(DeployHash),
+    CannotConvertDeploy(DeployHash),
 }
 
 /// State of the current process of block validation.
@@ -299,8 +299,8 @@ where
                     self.in_flight.inc(&deploy_hash);
                 }
             }
-            Event::DeployInvalid(deploy_hash) => {
-                info!(%deploy_hash, "deploy invalid");
+            Event::CannotConvertDeploy(deploy_hash) => {
+                info!(%deploy_hash, "cannot convert deploy to deploy type");
                 // Deploy is invalid. There's no point waiting for other in-flight requests to
                 // finish.
                 self.in_flight.dec(&deploy_hash);
@@ -343,7 +343,7 @@ where
     let validate_deploy = move |result: FetchResult<Deploy, I>| match result {
         FetchResult::FromStorage(deploy) | FetchResult::FromPeer(deploy, _) => deploy
             .deploy_type()
-            .map_or(Event::DeployInvalid(deploy_hash), |deploy_type| {
+            .map_or(Event::CannotConvertDeploy(deploy_hash), |deploy_type| {
                 Event::DeployFound {
                     deploy_hash,
                     deploy_type: Box::new(deploy_type),

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -22,15 +22,14 @@ use smallvec::{smallvec, SmallVec};
 use tracing::info;
 
 use crate::{
-    components::Component,
+    components::{block_proposer::DeployType, Component},
     effect::{
         requests::{BlockValidationRequest, FetcherRequest, StorageRequest},
         EffectBuilder, EffectExt, EffectOptionExt, Effects, Responder,
     },
-    types::{BlockLike, Chainspec, Deploy, DeployHash, Timestamp},
+    types::{appendable_block::AppendableBlock, BlockLike, Chainspec, Deploy, DeployHash},
     NodeRng,
 };
-use casper_types::bytesrepr::ToBytes;
 use keyed_counter::KeyedCounter;
 
 use super::fetcher::FetchResult;
@@ -46,14 +45,14 @@ pub enum Event<T, I> {
     #[display(fmt = "deploy {} found", deploy_hash)]
     DeployFound {
         deploy_hash: DeployHash,
-        deploy_size: usize,
+        deploy_type: Box<DeployType>,
     },
 
     /// A request to find a specific deploy, potentially from a peer, failed.
     #[display(fmt = "deploy {} missing", _0)]
     DeployMissing(DeployHash),
 
-    /// Deploy was invalid. Failed the chainspec test.
+    /// Deploy was invalid. Unable to convert to a deploy type.
     #[display(fmt = "deploy {} invalid", _0)]
     DeployInvalid(DeployHash),
 }
@@ -63,16 +62,14 @@ pub enum Event<T, I> {
 /// Tracks whether or not there are deploys still missing and who is interested in the final result.
 #[derive(DataSize, Debug)]
 pub(crate) struct BlockValidationState<T, I> {
-    /// Total running size of the deploys in the block, which is used to validate against the
-    /// chainspec's deploy.max_block_size.
-    deploy_size_running_total: usize,
+    /// Appendable block ensuring that the deploys satisfy the validity conditions.
+    appendable_block: AppendableBlock,
     /// The deploys that have not yet been "crossed off" the list of potential misses.
     missing_deploys: HashSet<DeployHash>,
     /// A list of responders that are awaiting an answer.
     responders: SmallVec<[Responder<(bool, T)>; 2]>,
     /// Peers that should have the data.
     sources: VecDeque<I>,
-    context: (Arc<Chainspec>, Timestamp),
 }
 
 impl<T, I> BlockValidationState<T, I>
@@ -191,38 +188,31 @@ where
                             entry.key().deploys().iter().map(|hash| **hash).collect();
 
                         let in_flight = &mut self.in_flight;
-                        let chainspec = Arc::clone(&self.chainspec);
                         let fetch_effects: Effects<Event<T, I>> = block_deploys
                             .iter()
                             .flat_map(|deploy_hash| {
                                 // For every request, increase the number of in-flight...
                                 in_flight.inc(deploy_hash);
                                 // ...then request it.
-                                fetch_deploy(
-                                    effect_builder,
-                                    Arc::clone(&chainspec),
-                                    block_timestamp,
-                                    *deploy_hash,
-                                    sender.clone(),
-                                )
+                                fetch_deploy(effect_builder, *deploy_hash, sender.clone())
                             })
                             .collect();
                         effects.extend(fetch_effects);
 
+                        let deploy_config = self.chainspec.deploy_config;
                         entry.insert(BlockValidationState {
-                            deploy_size_running_total: 0,
+                            appendable_block: AppendableBlock::new(deploy_config, block_timestamp),
                             missing_deploys,
                             responders: smallvec![responder],
                             sources: VecDeque::new(), /* This is empty b/c we create the first
                                                        * request using `sender`. */
-                            context: (chainspec, block_timestamp),
                         });
                     }
                 }
             }
             Event::DeployFound {
                 deploy_hash,
-                deploy_size,
+                deploy_type,
             } => {
                 // We successfully found a hash. Decrease the number of outstanding requests.
                 self.in_flight.dec(&deploy_hash);
@@ -231,23 +221,13 @@ where
                 // mark it for removal.
                 let mut invalid = Vec::new();
 
-                let max_block_size = self.chainspec.deploy_config.max_block_size as usize;
-
                 // Our first pass updates all validation states, crossing off the found deploy.
                 for (key, state) in self.validation_states.iter_mut() {
                     if state.missing_deploys.remove(&deploy_hash) {
-                        let valid_new_total = state
-                            .deploy_size_running_total
-                            .checked_add(deploy_size)
-                            .filter(|new_total| *new_total <= max_block_size);
-
-                        match valid_new_total {
-                            Some(new_total) => state.deploy_size_running_total = new_total,
-                            None => {
-                                // Notify everyone still waiting on it that all is lost.
-                                info!(block=?key, %deploy_hash, %max_block_size, "block size exceeded");
-                                invalid.push(key.clone());
-                            }
+                        if let Err(err) = state.appendable_block.add(deploy_hash, &*deploy_type) {
+                            // Notify everyone still waiting on it that all is lost.
+                            info!(block=?key, %deploy_hash, ?deploy_type, ?err, "block invalid");
+                            invalid.push(key.clone());
                         }
                     }
                 }
@@ -293,11 +273,8 @@ where
                         Some(peer) => {
                             info!(%deploy_hash, ?peer, "trying the next peer");
                             // There's still hope to download the deploy.
-                            let (chainspec, block_timestamp) = &state.context;
                             effects.extend(
                                 fetch_deploy(effect_builder,
-                                    Arc::clone(chainspec),
-                                    *block_timestamp,
                                     deploy_hash,
                                     peer,
                                 ));
@@ -351,8 +328,6 @@ where
 /// Returns effects that fetch the deploy and validate it.
 fn fetch_deploy<REv, T, I>(
     effect_builder: EffectBuilder<REv>,
-    chainspec: Arc<Chainspec>,
-    block_timestamp: Timestamp,
     deploy_hash: DeployHash,
     sender: I,
 ) -> Effects<Event<T, I>>
@@ -366,20 +341,14 @@ where
     I: Clone + Send + PartialEq + Eq + 'static,
 {
     let validate_deploy = move |result: FetchResult<Deploy, I>| match result {
-        FetchResult::FromStorage(deploy) | FetchResult::FromPeer(deploy, _) => {
-            if deploy
-                .header()
-                .is_valid(&chainspec.deploy_config, block_timestamp)
-            {
-                let deploy_size = deploy.serialized_length();
+        FetchResult::FromStorage(deploy) | FetchResult::FromPeer(deploy, _) => deploy
+            .deploy_type()
+            .map_or(Event::DeployInvalid(deploy_hash), |deploy_type| {
                 Event::DeployFound {
                     deploy_hash,
-                    deploy_size,
+                    deploy_type: Box::new(deploy_type),
                 }
-            } else {
-                Event::DeployInvalid(deploy_hash)
-            }
-        }
+            }),
     };
 
     effect_builder

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -1,5 +1,6 @@
 //! Common types used across multiple components.
 
+pub(crate) mod appendable_block;
 mod block;
 pub mod chainspec;
 mod deploy;

--- a/node/src/types/appendable_block.rs
+++ b/node/src/types/appendable_block.rs
@@ -1,0 +1,121 @@
+use std::collections::HashSet;
+
+use casper_execution_engine::shared::gas::Gas;
+use datasize::DataSize;
+use num_traits::Zero;
+use thiserror::Error;
+
+use crate::{
+    components::block_proposer::DeployType,
+    types::{chainspec::DeployConfig, DeployHash, ProtoBlock, Timestamp},
+};
+
+#[derive(Debug, Error)]
+pub(crate) enum AddError {
+    #[error("would exceed maximum transfer count per block")]
+    TransferCount,
+    #[error("would exceed maximum deploy count per block")]
+    DeployCount,
+    #[error("would exceed maximum gas per block")]
+    GasLimit,
+    #[error("would exceed maximum block size")]
+    BlockSize,
+    #[error("duplicate deploy")]
+    Duplicate,
+    #[error("payment amount could not be converted to gas")]
+    InvalidGasAmount,
+    #[error("deploy is not valid in this context")]
+    InvalidDeploy,
+}
+
+/// A block that is still being added to. It keeps track of and enforces block limits.
+#[derive(Clone, DataSize, Debug)]
+pub struct AppendableBlock {
+    deploy_config: DeployConfig,
+    deploy_hashes: Vec<DeployHash>,
+    transfer_hashes: Vec<DeployHash>,
+    deploy_and_transfer_set: HashSet<DeployHash>,
+    timestamp: Timestamp,
+    #[data_size(skip)]
+    total_gas: Gas,
+    total_size: usize,
+}
+
+impl AppendableBlock {
+    /// Creates an empty `AppendableBlock`.
+    pub(crate) fn new(deploy_config: DeployConfig, timestamp: Timestamp) -> Self {
+        AppendableBlock {
+            deploy_config,
+            deploy_hashes: Vec::new(),
+            transfer_hashes: Vec::new(),
+            timestamp,
+            deploy_and_transfer_set: HashSet::new(),
+            total_gas: Gas::zero(),
+            total_size: 0,
+        }
+    }
+
+    /// Returns the total size of all deploys so far.
+    pub(crate) fn total_size(&self) -> usize {
+        self.total_size
+    }
+
+    /// Attempts to add a deploy to the block; returns an error if that would violate a validity
+    /// condition.
+    pub(crate) fn add(
+        &mut self,
+        hash: DeployHash,
+        deploy_type: &DeployType,
+    ) -> Result<(), AddError> {
+        if self.deploy_and_transfer_set.contains(&hash) {
+            return Err(AddError::Duplicate);
+        }
+        if !deploy_type
+            .header()
+            .is_valid(&self.deploy_config, self.timestamp)
+        {
+            return Err(AddError::InvalidDeploy);
+        }
+        if deploy_type.is_transfer() {
+            if self.transfer_hashes.len() == self.deploy_config.block_max_transfer_count as usize {
+                return Err(AddError::TransferCount);
+            }
+            self.transfer_hashes.push(hash);
+        } else {
+            if self.deploy_hashes.len() == self.deploy_config.block_max_deploy_count as usize {
+                return Err(AddError::DeployCount);
+            }
+            // Only deploys count towards the size and gas limits.
+            if self.total_size
+                > (self.deploy_config.max_block_size as usize).saturating_sub(deploy_type.size())
+            {
+                return Err(AddError::BlockSize);
+            }
+            let payment_amount = deploy_type.payment_amount();
+            let gas_price = deploy_type.header().gas_price();
+            let gas =
+                Gas::from_motes(payment_amount, gas_price).ok_or(AddError::InvalidGasAmount)?;
+            let new_total_gas = self.total_gas.checked_add(gas).ok_or(AddError::GasLimit)?;
+            if new_total_gas > Gas::from(self.deploy_config.block_gas_limit) {
+                return Err(AddError::GasLimit);
+            }
+            self.deploy_hashes.push(hash);
+            self.total_gas = new_total_gas;
+            self.total_size += deploy_type.size();
+        }
+        self.deploy_and_transfer_set.insert(hash);
+        Ok(())
+    }
+
+    /// Creates a `ProtoBlock` with the `AppendableBlock`s deploys and transfers, and the given
+    /// random bit.
+    pub(crate) fn into_proto_block(self, random_bit: bool) -> ProtoBlock {
+        let AppendableBlock {
+            deploy_hashes,
+            transfer_hashes,
+            timestamp,
+            ..
+        } = self;
+        ProtoBlock::new(deploy_hashes, transfer_hashes, timestamp, random_bit)
+    }
+}


### PR DESCRIPTION
This adds the `AppendableBlock` type, which checks block validity when adding deploys and transfers, and uses that type both for proposing and validating blocks, to make sure the same criteria are applied in both cases.

Backport of https://github.com/CasperLabs/casper-node/pull/1276.

https://casperlabs.atlassian.net/browse/NDRS-1121