### PR TITLE
NDRS-1173: revert to messagepack for framed transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
  "base64",
  "bincode",
  "blake2",
+ "bytes 1.0.1",
  "casper-execution-engine",
  "casper-node-macros",
  "casper-types",
@@ -818,7 +819,9 @@ dependencies = [
  "fake_instant",
  "fs2",
  "futures",
+ "futures-core",
  "futures-io",
+ "futures-sink",
  "getrandom 0.2.2",
  "hex",
  "hex-buffer-serde",
@@ -846,6 +849,7 @@ dependencies = [
  "openssl",
  "parking_lot",
  "pem",
+ "pin-project 1.0.6",
  "pnet",
  "prometheus",
  "proptest",
@@ -874,7 +878,6 @@ dependencies = [
  "thiserror",
  "tokio 1.4.0",
  "tokio-openssl",
- "tokio-serde",
  "tokio-stream",
  "tokio-util 0.6.5",
  "toml",
@@ -1663,18 +1666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "educe"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ed56329d95e524ef98177ad672881bdfe7f22f254eb6ae80deb6fdd2ab20c4"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ee-1071-regression"
 version = "0.1.0"
 dependencies = [
@@ -1899,19 +1890,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-ordinalize"
-version = "3.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d52ff39419d3e16961ecfb9e32f5042bdaacf9a4cc553d2d688057117bae49b"
-dependencies = [
- "num-bigint 0.3.2",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-executor"
@@ -2169,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
 
 [[package]]
 name = "futures-task"
@@ -3693,17 +3671,6 @@ name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -5595,21 +5562,6 @@ dependencies = [
  "openssl",
  "pin-project 1.0.6",
  "tokio 1.4.0",
-]
-
-[[package]]
-name = "tokio-serde"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
-dependencies = [
- "bincode",
- "bytes 1.0.1",
- "educe",
- "futures-core",
- "futures-sink",
- "pin-project 1.0.6",
- "serde",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -19,6 +19,7 @@ base16 = "0.2.1"
 base64 = "0.13.0"
 bincode = "1"
 blake2 = { version = "0.9.0", default-features = false }
+bytes = "1"
 casper-execution-engine = { version = "1.0.0", path = "../execution_engine" }
 casper-node-macros = { version = "1.0.0", path = "../node_macros" }
 casper-types = { version = "1.0.0", path = "../types", features = ["std", "gens"] }
@@ -31,7 +32,9 @@ either = "1"
 enum-iterator = "0.6.0"
 fs2 = "0.4.3"
 futures = "0.3.5"
+futures-core = "0.3.14"
 futures-io = "0.3.5"
+futures-sink = "0.3.14"
 getrandom = "0.2.0"
 hex = "0.4.2"
 hex-buffer-serde = "0.2.1"
@@ -58,12 +61,14 @@ once_cell = "1"
 openssl = "0.10.32"
 parking_lot = "0.11.0"
 pem = "0.8.1"
+pin-project = "1"
 prometheus = "0.12.0"
 proptest = { version = "1.0.0", optional = true }
 quanta = "0.7.2"
 rand = "0.8.3"
 rand_chacha = "0.3.0"
 regex = "1"
+rmp-serde = "0.14.4"
 schemars = { version = "0.8.0", features = ["preserve_order"] }
 sd-notify = "0.3.0"
 serde = { version = "1", features = ["derive"] }
@@ -81,7 +86,6 @@ tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-openssl = "0.6.1"
-tokio-serde = { version = "0.8.0", features = ["bincode"] }
 tokio-stream = { version = "0.1.4", features = ["sync"] }
 tokio-util = { version = "0.6.4", features = ["codec"] }
 toml = "0.5.6"

--- a/node/src/components/small_network/framed_transport.rs
+++ b/node/src/components/small_network/framed_transport.rs
@@ -1,0 +1,94 @@
+use std::{
+    io,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use bytes::{Buf, Bytes};
+use futures_core::{ready, Stream, TryStream};
+use futures_sink::Sink;
+use pin_project::pin_project;
+use serde::{Deserialize, Serialize};
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+use super::{Message, Transport};
+
+#[pin_project]
+pub(super) struct FramedTransport<P> {
+    #[pin]
+    inner: Framed<Transport, LengthDelimitedCodec>,
+    _phantom: PhantomData<P>,
+}
+
+impl<P> FramedTransport<P> {
+    /// Creates a new `FramedTransport`.
+    pub(super) fn new(stream: Transport, maximum_net_message_size: u32) -> Self {
+        let inner = Framed::new(
+            stream,
+            LengthDelimitedCodec::builder()
+                .max_frame_length(maximum_net_message_size as usize)
+                .new_codec(),
+        );
+
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<P> Stream for FramedTransport<P>
+where
+    for<'a> P: Deserialize<'a>,
+{
+    type Item = Result<Message<P>, io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match ready!(self.as_mut().project().inner.try_poll_next(context)) {
+            Some(bytes) => {
+                let message: Message<P> = rmp_serde::from_read(bytes?.reader())
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Poll::Ready(Some(Ok(message)))
+            }
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+impl<P: Serialize> Sink<Message<P>> for FramedTransport<P> {
+    type Error = io::Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_ready(context)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, message: Message<P>) -> Result<(), Self::Error> {
+        let bytes = Bytes::from(
+            rmp_serde::to_vec(&message)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+        );
+
+        self.as_mut().project().inner.start_send(bytes)?;
+
+        Ok(())
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_flush(context)
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        ready!(self.as_mut().poll_flush(context))?;
+        self.project().inner.poll_close(context)
+    }
+}


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/NDRS-1173

This PR reverts small_network to use messagepack 0.14.4 for framing network messages, in order to remain compatible with the current running mainnet nodes.

The new `FramedTransport` type is compatible with the [`impl futures_core::Stream for tokio_serde::SymmetricallyFramed`](https://github.com/carllerche/tokio-serde/blob/v0.6.1/src/lib.rs#L255-L274) and [`impl futures_sink::Sink for tokio_serde::SymmetricallyFramed`](https://github.com/carllerche/tokio-serde/blob/v0.6.1/src/lib.rs#L276-L305), and this has been tested via running an upgrade test using nctl, and seeing that a new node is able to join an upgraded network (meaning that nodes running `release-1.0.0` code are able to communicate with nodes running the code in this PR).