### PR TITLE
NDRS-1173: Fix message pack formatter to rmp-serde 0.14

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -66,6 +66,7 @@ quanta = "0.7.2"
 rand = "0.8.3"
 rand_chacha = "0.3.0"
 regex = "1"
+rmp-serde = "0.14.4"
 schemars = { version = "0.8.0", features = ["preserve_order"] }
 sd-notify = "0.3.0"
 serde = { version = "1", features = ["derive"] }
@@ -109,7 +110,6 @@ pnet = "0.27.2"
 rand_core = "0.6.2"
 rand_pcg = "0.3.0"
 reqwest = "0.10.8"
-rmp-serde = "0.14.4"
 tokio = { version = "1", features = ["test-util"] }
 
 [features]

--- a/node/src/components/small_network/message_pack_format.rs
+++ b/node/src/components/small_network/message_pack_format.rs
@@ -1,0 +1,52 @@
+//! Message pack wire format encoder.
+//!
+//! This module is used to pin the correct version of message pack used throughout the codebase to
+//! our network decoder via `Cargo.toml`; using `tokio_serde::MessagePack` would instead tie it
+//! to the dependency specified in `tokio_serde`'s `Cargo.toml`.
+//!
+//! The encoder is also specialized to `Message<P>` instead of a generic payload for simplicity.
+
+use std::{
+    io::{self, Cursor},
+    pin::Pin,
+};
+
+use bytes::{Bytes, BytesMut};
+use rmp_serde::{self};
+use serde::{Deserialize, Serialize};
+use tokio_serde::{Deserializer, Serializer};
+
+use super::Message;
+
+/// msgpack encoder/decoder for messages.
+#[derive(Debug)]
+pub(super) struct MessagePackFormat;
+
+impl<P> Serializer<Message<P>> for MessagePackFormat
+where
+    Message<P>: Serialize,
+{
+    // Note: We cast to `io::Error` because of the `Codec::Error: Into<Transport::Error>`
+    // requirement.
+    type Error = io::Error;
+
+    #[inline]
+    fn serialize(self: Pin<&mut Self>, item: &Message<P>) -> Result<Bytes, Self::Error> {
+        rmp_serde::to_vec(item)
+            .map(Into::into)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    }
+}
+
+impl<P> Deserializer<Message<P>> for MessagePackFormat
+where
+    for<'de> Message<P>: Deserialize<'de>,
+{
+    type Error = io::Error;
+
+    #[inline]
+    fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Message<P>, Self::Error> {
+        rmp_serde::from_read(Cursor::new(src))
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    }
+}


### PR DESCRIPTION
This pins the message pack version to the one used in 1.0.0