### PR TITLE
NDRS-1175: Minor fixes in block proposer and era supervisor.

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -230,9 +230,8 @@ impl BlockProposerReady {
         match event {
             Event::Request(BlockProposerRequest::RequestBlockPayload(request)) => {
                 if request.next_finalized > self.sets.next_finalized {
-                    debug!(
-                        request_next_finalized = %request.next_finalized,
-                        self_next_finalized = %self.sets.next_finalized,
+                    info!(
+                        %request.next_finalized, %self.sets.next_finalized,
                         "received request before finalization announcement"
                     );
                     self.request_queue
@@ -277,7 +276,7 @@ impl BlockProposerReady {
                 let mut height = block.height();
 
                 if height > self.sets.next_finalized {
-                    debug!(
+                    info!(
                         %height,
                         next_finalized = %self.sets.next_finalized,
                         "received finalized blocks out of order; queueing"

--- a/node/src/components/block_proposer/deploy_sets.rs
+++ b/node/src/components/block_proposer/deploy_sets.rs
@@ -4,14 +4,13 @@ use std::{
 };
 
 use datasize::DataSize;
-use serde::{Deserialize, Serialize};
 
 use super::{event::DeployType, BlockHeight, FinalizationQueue};
-use crate::types::{Chainspec, DeployHash, DeployHeader, Timestamp};
+use crate::types::{DeployHash, DeployHeader, Timestamp};
 
 /// Stores the internal state of the BlockProposer.
-#[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
-pub struct BlockProposerDeploySets {
+#[derive(Clone, DataSize, Debug)]
+pub(super) struct BlockProposerDeploySets {
     /// The collection of deploys pending for inclusion in a block, with a timestamp of when we
     /// received them.
     pub(super) pending: HashMap<DeployHash, (DeployType, Timestamp)>,
@@ -66,18 +65,6 @@ impl Display for BlockProposerDeploySets {
             self.finalized_deploys.len()
         )
     }
-}
-
-/// Create a state storage key for block proposer deploy sets based on a chainspec.
-///
-/// We namespace based on a chainspec to prevent validators from loading data for a different chain
-/// if they forget to clear their state.
-pub fn create_storage_key(chainspec: &Chainspec) -> Vec<u8> {
-    format!(
-        "block_proposer_deploy_sets:version={},chain_name={}",
-        chainspec.protocol_config.version, chainspec.network_config.name
-    )
-    .into()
 }
 
 impl BlockProposerDeploySets {

--- a/node/src/components/block_proposer/tests.rs
+++ b/node/src/components/block_proposer/tests.rs
@@ -95,7 +95,6 @@ fn create_test_proposer(deploy_delay: TimeDiff) -> BlockProposerReady {
     BlockProposerReady {
         sets: Default::default(),
         deploy_config: Default::default(),
-        state_key: b"block-proposer-test".to_vec(),
         request_queue: Default::default(),
         unhandled_finalized: Default::default(),
         local_config: Config { deploy_delay },


### PR DESCRIPTION
This removes some code left over from when the block proposer state used to be persisted. It also fixes an issue in the era supervisor where `next_block_height` could _decrease_ (only temporarily, though), and increases log levels for the messages related to the block proposer queues.

(Related to [NDRS-1175](https://casperlabs.atlassian.net/browse/NDRS-1175).)