### PR TITLE
NDRS-1175: Make sure that validator has access to the correct latest block

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -18,7 +18,7 @@ use std::{
 
 use datasize::DataSize;
 use prometheus::{self, Registry};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     components::Component,
@@ -96,7 +96,7 @@ impl BlockProposer {
     where
         REv: From<Event> + From<StorageRequest> + From<StateStoreRequest> + Send + 'static,
     {
-        debug!(%next_finalized_block, "creating block proposer");
+        info!(%next_finalized_block, "creating block proposer");
         // load the state from storage or use a fresh instance if loading fails.
         let state_key = deploy_sets::create_storage_key(chainspec);
         let effects = effect_builder
@@ -227,7 +227,7 @@ impl BlockProposerReady {
         match event {
             Event::Request(BlockProposerRequest::RequestProtoBlock(request)) => {
                 if request.next_finalized > self.sets.next_finalized {
-                    debug!(
+                    warn!(
                         request_next_finalized = %request.next_finalized,
                         self_next_finalized = %self.sets.next_finalized,
                         "received request before finalization announcement"
@@ -273,7 +273,7 @@ impl BlockProposerReady {
                 deploys.extend(transfers);
 
                 if height > self.sets.next_finalized {
-                    debug!(
+                    warn!(
                         %height,
                         next_finalized = %self.sets.next_finalized,
                         "received finalized blocks out of order; queueing"

--- a/node/src/components/linear_chain_sync.rs
+++ b/node/src/components/linear_chain_sync.rs
@@ -245,8 +245,8 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
         }
     }
 
-    fn mark_done(&mut self) {
-        let latest_block = self.latest_block().cloned().map(Box::new);
+    fn mark_done(&mut self, latest_block: Option<Block>) {
+        let latest_block = latest_block.map(Box::new);
         self.state = State::Done(latest_block);
     }
 
@@ -360,7 +360,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                         era=block.header().era_id().0,
                         "downloaded recent block. finished synchronization"
                     );
-                    self.mark_done();
+                    self.mark_done(Some(*latest_block.clone()));
                     return Effects::new();
                 }
                 if self.is_currently_active_era(&maybe_switch_block) {
@@ -370,7 +370,7 @@ impl<I: Clone + PartialEq + 'static> LinearChainSync<I> {
                         era=block.header().era_id().0,
                         "downloaded switch block of a new era. finished synchronization"
                     );
-                    self.mark_done();
+                    self.mark_done(Some(*latest_block.clone()));
                     return Effects::new();
                 }
                 self.state = curr_state;
@@ -583,7 +583,7 @@ where
                                     "finished synchronizing descendants of the trusted hash. \
                                     cleaning state."
                                 );
-                                self.mark_done();
+                                self.mark_done(self.latest_block().cloned());
                                 Effects::new()
                             }
                             Some(peer) => {

--- a/node/src/reactor/joiner.rs
+++ b/node/src/reactor/joiner.rs
@@ -957,6 +957,7 @@ impl Reactor {
     /// the network, closing all incoming and outgoing connections, and frees up the listening
     /// socket.
     pub async fn into_validator_config(self) -> Result<ValidatorInitConfig, Error> {
+        let latest_block = self.linear_chain_sync.latest_block().cloned();
         // Clean the state of the linear_chain_sync before shutting it down.
         #[cfg(not(feature = "fast-sync"))]
         linear_chain_sync::clean_linear_chain_state(
@@ -969,7 +970,7 @@ impl Reactor {
             contract_runtime: self.contract_runtime,
             storage: self.storage,
             consensus: self.consensus,
-            latest_block: self.linear_chain_sync.latest_block().cloned(),
+            latest_block,
             event_stream_server: self.event_stream_server,
             small_network_identity: SmallNetworkIdentity::from(&self.small_network),
             network_identity: NetworkIdentity::from(&self.network),


### PR DESCRIPTION
Fixes a bug where a restarted node might end up with an incorrectly seeded block proposer.

https://casperlabs.atlassian.net/browse/NDRS-1175