### PR TITLE
DEV-50: use consistent json format for block representation

### DIFF
--- a/node/src/components/event_stream_server.rs
+++ b/node/src/components/event_stream_server.rs
@@ -39,6 +39,7 @@ use casper_types::ProtocolVersion;
 use super::Component;
 use crate::{
     effect::{EffectBuilder, Effects},
+    types::JsonBlock,
     utils::{self, ListeningError},
     NodeRng,
 };
@@ -140,7 +141,7 @@ where
         match event {
             Event::BlockAdded(block) => self.broadcast(SseData::BlockAdded {
                 block_hash: *block.hash(),
-                block: Box::new(*block),
+                block: Box::new(JsonBlock::new(*block, None)),
             }),
             Event::DeployProcessed {
                 deploy_hash,

--- a/node/src/components/event_stream_server/sse_server.rs
+++ b/node/src/components/event_stream_server/sse_server.rs
@@ -19,7 +19,7 @@ use warp::{
 
 use casper_types::{EraId, ExecutionResult, ProtocolVersion, PublicKey};
 
-use crate::types::{Block, BlockHash, DeployHash, FinalitySignature, TimeDiff, Timestamp};
+use crate::types::{BlockHash, DeployHash, FinalitySignature, JsonBlock, TimeDiff, Timestamp};
 
 /// The URL path.
 pub const SSE_API_PATH: &str = "events";
@@ -37,7 +37,7 @@ pub enum SseData {
     /// The given block has been added to the linear chain and stored locally.
     BlockAdded {
         block_hash: BlockHash,
-        block: Box<Block>,
+        block: Box<JsonBlock>,
     },
     /// The given deploy has been executed, committed and forms part of the given block.
     DeployProcessed {

--- a/node/src/components/rpc_server/rpcs/chain.rs
+++ b/node/src/components/rpc_server/rpcs/chain.rs
@@ -139,7 +139,7 @@ impl RpcWithOptionalParamsExt for GetBlock {
                     Err(error) => return Ok(response_builder.error(error)?),
                 };
 
-            let json_block = JsonBlock::new(block, signatures);
+            let json_block = JsonBlock::new(block, Some(signatures));
 
             // Return the result.
             let result = Self::ResponseResult {


### PR DESCRIPTION
Ref: https://casperlabs.atlassian.net/browse/DEV-50

This PR changes the block reported in the node's event stream to match that returned by the JSON-RPC server for consistency.

Closes #1334 