### PR TITLE
NDRS-1159: Add more consensus and block proposer log messages.

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -22,7 +22,7 @@ pub use config::Config;
 use datasize::DataSize;
 use itertools::Itertools;
 use prometheus::{self, Registry};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     components::Component,
@@ -230,7 +230,7 @@ impl BlockProposerReady {
         match event {
             Event::Request(BlockProposerRequest::RequestBlockPayload(request)) => {
                 if request.next_finalized > self.sets.next_finalized {
-                    info!(
+                    warn!(
                         %request.next_finalized, %self.sets.next_finalized,
                         "received request before finalization announcement"
                     );
@@ -276,9 +276,8 @@ impl BlockProposerReady {
                 let mut height = block.height();
 
                 if height > self.sets.next_finalized {
-                    info!(
-                        %height,
-                        next_finalized = %self.sets.next_finalized,
+                    warn!(
+                        %height, next_finalized = %self.sets.next_finalized,
                         "received finalized blocks out of order; queueing"
                     );
                     // safe to subtract 1 - height will never be 0 in this branch, because

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -1,3 +1,5 @@
+use tracing::trace;
+
 use super::Horizon;
 use crate::{
     components::consensus::{
@@ -81,9 +83,9 @@ fn compute_rewards_for<C: Context>(
     // Collect the block rewards for each validator who is a member of at least one summit.
     #[allow(clippy::integer_arithmetic)] // See inline comments.
     max_quorum
-        .iter()
+        .enumerate()
         .zip(state.weights())
-        .map(|(quorum, weight)| {
+        .map(|((validator_index, quorum), weight)| {
             // If the summit's quorum was not enough to finalize the block, rewards are reduced.
             // A level-1 summit with quorum  q  has FTT  q - 50%, so we need  q - 50% > f.
             let finality_factor = if *quorum > (state.total_weight() / 2).saturating_add(faulty_w) {
@@ -91,6 +93,15 @@ fn compute_rewards_for<C: Context>(
             } else {
                 state.params().reduced_block_reward()
             };
+            trace!(
+                validator_index = validator_index.0,
+                finality_factor,
+                quorum = quorum.0,
+                assigned_weight = assigned_weight.0,
+                weight = weight.0,
+                timestamp = %proposal_unit.timestamp,
+                "block reward calculation"
+            );
             // Rewards are proportional to the quorum and to the validator's weight.
             // Since  quorum <= assigned_weight  and  weight <= total_weight,  this won't overflow.
             (u128::from(finality_factor) * u128::from(*quorum) / u128::from(assigned_weight)

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -10,8 +10,9 @@ pub trait NodeIdT: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'stat
 impl<I> NodeIdT for I where I: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'static {}
 
 /// A validator identifier.
-pub trait ValidatorIdT: Eq + Ord + Clone + Debug + Hash + Send + DataSize {}
-impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash + Send + DataSize {}
+pub trait ValidatorIdT: Eq + Ord + Clone + Debug + Hash + Send + DataSize + Display {}
+impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash + Send + DataSize + Display
+{}
 
 /// The consensus value type, e.g. a list of transactions.
 pub trait ConsensusValueT:


### PR DESCRIPTION
* Log who missed their slot as a leader.
* List the individual steps of the rewards calculation: Which block got which quorum and who got rewards.
* Log when the block proposer queues a request due to the `next_finalized` value.

https://casperlabs.atlassian.net/browse/NDRS-1159