### PR TITLE
NDRS-1188: Metrics race condition cleanup

### DIFF
--- a/node/src/components/small_network/counting_format.rs
+++ b/node/src/components/small_network/counting_format.rs
@@ -9,7 +9,7 @@ use std::{
     convert::TryFrom,
     fmt::{self, Display, Formatter},
     pin::Pin,
-    sync::Arc,
+    sync::Weak,
 };
 
 use bytes::{Bytes, BytesMut};
@@ -64,14 +64,14 @@ pub(super) struct CountingFormat<F> {
     /// Our role in the connection.
     role: Role,
     /// Metrics to update.
-    metrics: Arc<NetworkingMetrics>,
+    metrics: Weak<NetworkingMetrics>,
 }
 
 impl<F> CountingFormat<F> {
     /// Creates a new counting formatter.
     #[inline]
     pub(super) fn new(
-        metrics: Arc<NetworkingMetrics>,
+        metrics: Weak<NetworkingMetrics>,
         connection_id: ConnectionId,
         role: Role,
         inner: F,
@@ -102,7 +102,7 @@ where
         let serialized = F::serialize(projection, item)?;
         let msg_size = serialized.len() as u64;
         let msg_kind = item.classify();
-        this.metrics.record_payload_out(msg_kind, msg_size);
+        NetworkingMetrics::record_payload_out(this.metrics, msg_kind, msg_size);
 
         let trace_id = this
             .connection_id

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -428,7 +428,7 @@ pub async fn wait_for_arc_drop<T>(arc: Arc<T>, attempts: usize, retry_delay: Dur
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::{Arc}, time::Duration};
+    use std::{sync::Arc, time::Duration};
 
     use super::{wait_for_arc_drop, xor};
 
@@ -470,13 +470,13 @@ mod tests {
 
         // Phase 1: waiting for the arc should fail, because there still is the background
         // reference.
-        assert!(! wait_for_arc_drop(arc, attempts, retry_delay).await);
+        assert!(!wait_for_arc_drop(arc, attempts, retry_delay).await);
 
         // We "restore" the arc from the background arc.
         let arc = arc_in_background.clone();
 
         // Add another "foreground" weak reference.
-        let weak =  Arc::downgrade(&arc);
+        let weak = Arc::downgrade(&arc);
 
         // Phase 2: Our background tasks drops its reference, now we should succeed.
         drop(arc_in_background);


### PR DESCRIPTION
This fixes a race condition where new metrics were being replaced before the networking component had shut down completely, resulting in a panic. As a fix `small_network` now drops its own strong reference first and waits for any stragglers.