### PR TITLE
NO-TICKET: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The status on development is reported during the Community calls and is found [h
 
 The Casper Testnet is live.
 - Transactions can be sent to: deploy.casperlabs.io via the client or via Clarity.
-- [Clarity Block Exporer](https://clarity.casperlabs.io)
+- [Clarity Block Explorer](https://clarity.casperlabs.io)
 
 ## Specification
 

--- a/client/lib/error.rs
+++ b/client/lib/error.rs
@@ -92,9 +92,9 @@ pub enum Error {
     /// Cryptographic error.
     #[error("Cryptographic error: {context}: {error}")]
     CryptoError {
-        /// Contextual text, such as callsite.
+        /// Contextual text, such as call site.
         context: &'static str,
-        /// Underlying Cryptoerror.
+        /// Underlying crypto error.
         error: CryptoError,
     },
 
@@ -109,7 +109,7 @@ pub enum Error {
     /// Conflicting arguments.
     #[error("Conflicting arguments passed '{context}' {args:?}")]
     ConflictingArguments {
-        /// Contextual text, such as callsite.
+        /// Contextual text, such as call site.
         context: &'static str,
         /// Arguments passed, with their values.
         args: Vec<String>,
@@ -119,7 +119,7 @@ pub enum Error {
     #[error("Invalid response: {0}")]
     InvalidResponse(#[from] ValidateResponseError),
 
-    /// Must call FFI's setup function prior to making ffi calls.
+    /// Must call FFI's setup function prior to making FFI calls.
     #[cfg(feature = "ffi")]
     #[error("Failed to call casper_setup_client()")]
     FFISetupNotCalled,

--- a/client/lib/ffi.rs
+++ b/client/lib/ffi.rs
@@ -39,7 +39,7 @@ pub enum casper_error_t {
     CASPER_FAILED_TO_PARSE_RESPONSE = -8,
     CASPER_FILE_ALREADY_EXISTS = -9,
     CASPER_UNSUPPORTED_ALGORITHM = -10,
-    CASPER_REPSONSE_IS_ERROR = -11,
+    CASPER_RESPONSE_IS_ERROR = -11,
     CASPER_INVALID_JSON = -12,
     CASPER_INVALID_RPC_RESPONSE = -13,
     CASPER_FAILED_SENDING = -14,
@@ -71,7 +71,7 @@ impl AsFFIError for Error {
             Error::FailedToParseResponse(_) => casper_error_t::CASPER_FAILED_TO_PARSE_RESPONSE,
             Error::FileAlreadyExists(_) => casper_error_t::CASPER_FILE_ALREADY_EXISTS,
             Error::UnsupportedAlgorithm(_) => casper_error_t::CASPER_UNSUPPORTED_ALGORITHM,
-            Error::ResponseIsError(_) => casper_error_t::CASPER_REPSONSE_IS_ERROR,
+            Error::ResponseIsError(_) => casper_error_t::CASPER_RESPONSE_IS_ERROR,
             Error::InvalidJson(_) => casper_error_t::CASPER_INVALID_JSON,
             Error::InvalidRpcResponse(_) => casper_error_t::CASPER_INVALID_RPC_RESPONSE,
             Error::FailedSending(_) => casper_error_t::CASPER_FAILED_SENDING,
@@ -91,7 +91,7 @@ impl AsFFIError for Error {
 /// Private macro for parsing arguments from c strings, (const char *, or *const c_char in rust
 /// terms). The sad path contract here is that we indicate there was an error by returning `false`,
 /// then we store the argument -name- as an Error::InvalidArgument in LAST_ERROR. The happy path is
-/// left up to callsites to define.
+/// left up to call sites to define.
 macro_rules! r#try_unsafe_arg {
     ($arg:expr) => {{
         let result = unsafe_str_arg($arg, stringify!($arg));
@@ -131,7 +131,7 @@ macro_rules! r#try_unwrap_option {
 
 /// Private macro for unwrapping our internal json-rpcs or, optionally, storing the error in
 /// LAST_ERROR and returning `false` to indicate that an error has occurred. Similar to
-/// `try_unsafe_arg!`, this handles the sad path, and the happy path is left up to callsites.
+/// `try_unsafe_arg!`, this handles the sad path, and the happy path is left up to call sites.
 macro_rules! r#try_unwrap_rpc {
     ($rpc:expr) => {{
         let rpc = try_unwrap_result!($rpc.map_err(Into::into));
@@ -144,7 +144,7 @@ macro_rules! r#try_unwrap_rpc {
 }
 
 /// Private macro to wrap TryInto implementing types with a human-readable error message describing
-/// the field name at the callsite.
+/// the field name at the call site.
 macro_rules! r#try_arg_into {
     ($arg:expr) => {{
         try_unwrap_result!(unsafe_try_into($arg, stringify!($arg)))
@@ -704,7 +704,7 @@ impl TryInto<super::PaymentStrParams<'static>> for casper_payment_params_t {
         let payment_args_simple = unsafe_vec_of_str_arg(
             self.payment_args_simple,
             self.payment_args_simple_len,
-            "caser_payment_params_t.payment_args_simple",
+            "casper_payment_params_t.payment_args_simple",
         )?;
         let payment_args_complex = unsafe_str_arg(
             self.payment_args_complex,
@@ -762,7 +762,7 @@ impl TryInto<super::SessionStrParams<'static>> for casper_session_params_t {
             unsafe_str_arg(self.session_name, "casper_session_params_t.session_name")?;
         let session_package_hash = unsafe_str_arg(
             self.session_package_hash,
-            "casper_session_params_t.sessio_package_hash",
+            "casper_session_params_t.session_package_hash",
         )?;
         let session_package_name = unsafe_str_arg(
             self.session_package_name,

--- a/execution_engine/src/core/runtime/standard_payment_internal.rs
+++ b/execution_engine/src/core/runtime/standard_payment_internal.rs
@@ -18,7 +18,7 @@ impl From<execution::Error> for Option<ApiError> {
     fn from(exec_error: execution::Error) -> Self {
         match exec_error {
             // This is used to propagate [`execution::Error::GasLimit`] to make sure
-            // [`StanadrdPayment`] contract running natively supports propagating gas limit
+            // [`StandardPayment`] contract running natively supports propagating gas limit
             // errors without a panic.
             execution::Error::GasLimit => Some(mint::Error::GasLimit.into()),
             // There are possibly other exec errors happening but such translation would be lossy.

--- a/execution_engine/src/core/runtime_context/tests.rs
+++ b/execution_engine/src/core/runtime_context/tests.rs
@@ -64,7 +64,7 @@ fn mock_tracking_copy(
 
     let new_hash = match commit_result {
         CommitResult::Success { state_root, .. } => state_root,
-        other => panic!("Commiting changes to test History failed: {:?}.", other),
+        other => panic!("Committing changes to test History failed: {:?}.", other),
     };
 
     let reader = hist
@@ -575,7 +575,7 @@ fn hash_key_addable_invalid() {
 
 #[test]
 fn manage_associated_keys() {
-    // Testing a valid case only - successfuly added a key, and successfuly removed,
+    // Testing a valid case only - successfully added a key, and successfully removed,
     // making sure `account_dirty` mutated
     let access_rights = HashMap::new();
     let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
@@ -642,7 +642,7 @@ fn manage_associated_keys() {
 
 #[test]
 fn action_thresholds_management() {
-    // Testing a valid case only - successfuly added a key, and successfuly removed,
+    // Testing a valid case only - successfully added a key, and successfully removed,
     // making sure `account_dirty` mutated
     let access_rights = HashMap::new();
     let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
@@ -683,7 +683,7 @@ fn action_thresholds_management() {
 
 #[test]
 fn should_verify_ownership_before_adding_key() {
-    // Testing a valid case only - successfuly added a key, and successfuly removed,
+    // Testing a valid case only - successfully added a key, and successfully removed,
     // making sure `account_dirty` mutated
     let access_rights = HashMap::new();
     let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
@@ -707,7 +707,7 @@ fn should_verify_ownership_before_adding_key() {
 
 #[test]
 fn should_verify_ownership_before_removing_a_key() {
-    // Testing a valid case only - successfuly added a key, and successfuly removed,
+    // Testing a valid case only - successfully added a key, and successfully removed,
     // making sure `account_dirty` mutated
     let access_rights = HashMap::new();
     let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
@@ -731,7 +731,7 @@ fn should_verify_ownership_before_removing_a_key() {
 
 #[test]
 fn should_verify_ownership_before_setting_action_threshold() {
-    // Testing a valid case only - successfuly added a key, and successfuly removed,
+    // Testing a valid case only - successfully added a key, and successfully removed,
     // making sure `account_dirty` mutated
     let access_rights = HashMap::new();
     let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {

--- a/execution_engine/src/core/tracking_copy/tests.rs
+++ b/execution_engine/src/core/tracking_copy/tests.rs
@@ -151,7 +151,7 @@ fn tracking_copy_write() {
     // write does not need to query the DB
     let db_value = counter.get();
     assert_eq!(db_value, 0);
-    // write creates a Transfrom
+    // write creates a Transform
     assert_eq!(tc.fns.len(), 1);
     assert_eq!(tc.fns.get(&k), Some(&Transform::Write(one)));
     // write creates an Op
@@ -182,7 +182,7 @@ fn tracking_copy_add_i32() {
     let add = tc.add(correlation_id, k, three.clone());
     assert_matches!(add, Ok(_));
 
-    // add creates a Transfrom
+    // add creates a Transform
     assert_eq!(tc.fns.len(), 1);
     assert_eq!(tc.fns.get(&k), Some(&Transform::AddInt32(3)));
     // add creates an Op
@@ -237,7 +237,7 @@ fn tracking_copy_add_named_key() {
     // adding correct type works
     let add = tc.add(correlation_id, k, named_key);
     assert_matches!(add, Ok(_));
-    // add creates a Transfrom
+    // add creates a Transform
     assert_eq!(tc.fns.len(), 1);
     assert_eq!(tc.fns.get(&k), Some(&Transform::AddKeys(map.clone())));
     // add creates an Op
@@ -1128,7 +1128,7 @@ fn query_with_large_depth_with_urefs_should_fail() {
     let view = global_state.checkout(root_hash).unwrap().unwrap();
     let tracking_copy = TrackingCopy::new(view);
 
-    // query for the beggining of a long chain of urefs
+    // query for the beginning of a long chain of urefs
     // (second path element of arbitrary value required to cause iteration _into_ the nested key)
     let path = vec![root_key_name, String::new()];
     let result = tracking_copy.query(correlation_id, &engine_config, contract_key, &path);

--- a/execution_engine/src/shared/account.rs
+++ b/execution_engine/src/shared/account.rs
@@ -162,7 +162,7 @@ impl Account {
         action_type: ActionType,
         weight: Weight,
     ) -> Result<(), SetThresholdFailure> {
-        // Verify if new threshold weight exceeds total weight of allassociated
+        // Verify if new threshold weight exceeds total weight of all associated
         // keys.
         self.can_set_threshold(weight)?;
         // Set new weight for given action

--- a/execution_engine/src/shared/newtypes/blake2b256.rs
+++ b/execution_engine/src/shared/newtypes/blake2b256.rs
@@ -26,7 +26,7 @@ impl Blake2bHash {
         Blake2bHash(ret)
     }
 
-    /// Returns the underlying BLKAE2b hash bytes
+    /// Returns the underlying BLAKE2b hash bytes
     pub fn value(&self) -> [u8; Blake2bHash::LENGTH] {
         self.0
     }

--- a/execution_engine/src/storage/trie_store/operations/tests/synchronize.rs
+++ b/execution_engine/src/storage/trie_store/operations/tests/synchronize.rs
@@ -117,10 +117,10 @@ where
     {
         let source_txn: R::ReadTransaction = source_environment.create_read_txn()?;
         let target_txn: R::ReadTransaction = target_environment.create_read_txn()?;
-        let soruce_keys =
+        let source_keys =
             operations::keys::<_, _, _, _>(correlation_id, &source_txn, source_store, root)
                 .collect::<Result<Vec<K>, S::Error>>()?;
-        for key in soruce_keys {
+        for key in source_keys {
             let maybe_value: ReadResult<V> = operations::read::<_, _, _, _, E>(
                 correlation_id,
                 &target_txn,

--- a/execution_engine_testing/test_support/src/internal/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/internal/wasm_test_builder.rs
@@ -73,7 +73,7 @@ use crate::internal::{
 /// This default value should give 50MiB initial map size by default.
 const DEFAULT_LMDB_PAGES: usize = 128_000;
 
-/// LDMB max readers
+/// LMDB max readers
 ///
 /// The default value is chosen to be the same as the node itself.
 const DEFAULT_MAX_READERS: u32 = 512;

--- a/execution_engine_testing/tests/benches/transfer_bench.rs
+++ b/execution_engine_testing/tests/benches/transfer_bench.rs
@@ -269,7 +269,7 @@ pub fn transfer_to_existing_purses(group: &mut BenchmarkGroup<WallTime>, should_
         |b| {
             let target_purse = purses[0];
             b.iter(|| {
-                // Execute multiple deploys with mutliple exec request
+                // Execute multiple deploys with multiple exec request
                 transfer_to_purse_multiple_execs(&mut builder, target_purse, should_commit)
             })
         },

--- a/execution_engine_testing/tests/src/test/contract_api/account/authorized_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/account/authorized_keys.rs
@@ -192,7 +192,7 @@ fn should_raise_deploy_authorization_failure() {
         .exec(exec_request_3)
         .expect_success()
         .commit()
-        // This should execute successfuly - change deploy and key management
+        // This should execute successfully - change deploy and key management
         // thresholds.
         .exec(exec_request_4)
         .expect_success()

--- a/execution_engine_testing/tests/src/test/contract_api/get_arg.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_arg.rs
@@ -44,7 +44,7 @@ fn should_use_passed_argument() {
         ARG_VALUE0 => ARG0_VALUE,
         ARG_VALUE1 => U512::from(ARG1_VALUE),
     };
-    call_get_arg(args).expect("Should successfuly call get_arg with 2 valid args");
+    call_get_arg(args).expect("Should successfully call get_arg with 2 valid args");
 }
 
 #[ignore]

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -535,7 +535,7 @@ fn should_calculate_era_validators() {
     // elements are
     let eras: Vec<_> = era_validators.keys().copied().collect();
     assert!(!era_validators.is_empty());
-    assert!(era_validators.len() >= DEFAULT_AUCTION_DELAY as usize); // definetely more than 1 element
+    assert!(era_validators.len() >= DEFAULT_AUCTION_DELAY as usize); // definitely more than 1 element
     let (first_era, _) = era_validators.iter().min().unwrap();
     let (last_era, _) = era_validators.iter().max().unwrap();
     let expected_eras: Vec<EraId> = {
@@ -1739,7 +1739,7 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         &U512::from(DELEGATOR_2_STAKE)
     );
 
-    // Process unbonding requests to verify delegators recevied their stakes
+    // Process unbonding requests to verify delegators received their stakes
     let validator_1 = builder
         .get_account(*VALIDATOR_1_ADDR)
         .expect("should have validator 1 account");

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -1438,7 +1438,7 @@ fn should_distribute_delegation_rate_half() {
     const DELEGATOR_1_STAKE: u64 = 1_000_000;
     const DELEGATOR_2_STAKE: u64 = 1_000_000;
 
-    const VALIDATOR_1_DELGATION_RATE: DelegationRate = DELEGATION_RATE_DENOMINATOR / 2;
+    const VALIDATOR_1_DELEGATION_RATE: DelegationRate = DELEGATION_RATE_DENOMINATOR / 2;
 
     // Validator share
     let validator_share = Ratio::new(U512::from(2), U512::from(3));
@@ -1493,7 +1493,7 @@ fn should_distribute_delegation_rate_half() {
         CONTRACT_ADD_BID,
         runtime_args! {
             ARG_AMOUNT => U512::from(VALIDATOR_1_STAKE),
-            ARG_DELEGATION_RATE => VALIDATOR_1_DELGATION_RATE,
+            ARG_DELEGATION_RATE => VALIDATOR_1_DELEGATION_RATE,
             ARG_PUBLIC_KEY => VALIDATOR_1.clone(),
         },
     )

--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -147,7 +147,7 @@ fn should_track_total_token_supply_in_mint() {
     let locked_funds_period = DEFAULT_LOCKED_FUNDS_PERIOD_MILLIS;
     let round_seigniorage_rate = DEFAULT_ROUND_SEIGNIORAGE_RATE;
     let unbonding_delay = DEFAULT_UNBONDING_DELAY;
-    let genesis_tiemstamp = DEFAULT_GENESIS_TIMESTAMP_MILLIS;
+    let genesis_timestamp = DEFAULT_GENESIS_TIMESTAMP_MILLIS;
     let ee_config = ExecConfig::new(
         accounts.clone(),
         wasm_config,
@@ -157,7 +157,7 @@ fn should_track_total_token_supply_in_mint() {
         locked_funds_period,
         round_seigniorage_rate,
         unbonding_delay,
-        genesis_tiemstamp,
+        genesis_timestamp,
     );
     let run_genesis_request =
         RunGenesisRequest::new(GENESIS_CONFIG_HASH.into(), protocol_version, ee_config);

--- a/node/src/components/block_validator.rs
+++ b/node/src/components/block_validator.rs
@@ -332,7 +332,7 @@ where
                     }
                 }
 
-                // Now we remove all states that have finished and notify the requestors.
+                // Now we remove all states that have finished and notify the requesters.
                 self.validation_states.retain(|key, state| {
                     if invalid.contains(key) {
                         effects.extend(state.respond(false));

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -194,7 +194,7 @@ impl<I: Debug> Display for Event<I> {
             ),
             Event::ConsensusRequest(request) => write!(
                 f,
-                "A request for consensus component hash been receieved: {:?}",
+                "A request for consensus component hash been received: {:?}",
                 request
             ),
             Event::BlockAdded(block_header) => write!(

--- a/node/src/components/consensus/consensus_protocol.rs
+++ b/node/src/components/consensus/consensus_protocol.rs
@@ -254,6 +254,6 @@ pub(crate) trait ConsensusProtocol<I, C: Context>: Send {
     /// Returns the instance ID of this instance.
     fn instance_id(&self) -> &C::InstanceId;
 
-    // TODO: Make this lees Highway-specific.
+    // TODO: Make this less Highway-specific.
     fn next_round_length(&self) -> Option<TimeDiff>;
 }

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -1053,7 +1053,7 @@ mod tests {
     }
 
     // Triggers new proposal by `validator` and verifies that it's empty – no block was proposed.
-    // Captuers the next witness timer and calls the `validator` with that to return the timer for
+    // Captures the next witness timer and calls the `validator` with that to return the timer for
     // the next proposal.
     fn assert_no_proposal(
         validator: &mut ActiveValidator<TestContext>,

--- a/node/src/components/consensus/highway_core/finality_detector/horizon.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/horizon.rs
@@ -13,7 +13,7 @@ type Committee = Vec<ValidatorIndex>;
 /// A list containing the earliest level-n messages of each member of some committee, for some n.
 ///
 /// A summit is a sequence of committees of validators, where each member of the level-n committee
-/// has produced a unit that can see level-(n-1) units by a quorum of the level-n committe.
+/// has produced a unit that can see level-(n-1) units by a quorum of the level-n committee.
 ///
 /// The level-n horizon maps each validator of a level-n committee to their earliest level-n unit.
 /// From a level-n horizon, the level-(n+1) committee and horizon can be computed.

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -382,7 +382,7 @@ impl<C: Context> Highway<C> {
         // Here we just use the timer's timestamp, and assume it's ~ Timestamp::now()
         //
         // This is because proposal units, i.e. new blocks, are
-        // supposed to thave the exact timestamp that matches the
+        // supposed to have the exact timestamp that matches the
         // beginning of the round (which we use as the "round ID").
         //
         // But at least any discrepancy here can only come from event

--- a/node/src/components/consensus/highway_core/highway/vertex.rs
+++ b/node/src/components/consensus/highway_core/highway/vertex.rs
@@ -293,7 +293,7 @@ where
 }
 
 impl<C: Context> Endorsements<C> {
-    /// Returns hash of the endorsed vode.
+    /// Returns hash of the endorsed vote.
     pub fn unit(&self) -> &C::Hash {
         &self.unit
     }

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -167,7 +167,7 @@ enum Distribution {
 }
 
 impl Distribution {
-    /// Returns vector of `count` elements of random values between `lower` and `uppwer`.
+    /// Returns vector of `count` elements of random values between `lower` and `upper`.
     fn gen_range_vec(&self, rng: &mut NodeRng, lower: u64, upper: u64, count: u8) -> Vec<u64> {
         match self {
             Distribution::Uniform => (0..count).map(|_| rng.gen_range(lower..upper)).collect(),
@@ -180,7 +180,7 @@ trait DeliveryStrategy {
         &mut self,
         rng: &mut NodeRng,
         message: &HighwayMessage,
-        distributon: &Distribution,
+        distribution: &Distribution,
         base_delivery_timestamp: Timestamp,
     ) -> DeliverySchedule;
 }
@@ -432,7 +432,7 @@ where
                         delivery_time,
                     )? {
                         Ok(msgs) => {
-                            trace!("{:?} successfuly added to the state.", v);
+                            trace!("{:?} successfully added to the state.", v);
                             msgs
                         }
                         Err((v, error)) => {
@@ -750,7 +750,7 @@ impl DeliveryStrategy for InstantDeliveryNoDropping {
         &mut self,
         _rng: &mut NodeRng,
         message: &HighwayMessage,
-        _distributon: &Distribution,
+        _distribution: &Distribution,
         base_delivery_timestamp: Timestamp,
     ) -> DeliverySchedule {
         match message {
@@ -854,7 +854,7 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
                 // At least 2 validators total and at least one faulty.
                 let faulty_num = rng.gen_range(1..self.max_faulty_validators + 1);
 
-                // Randomly (but within chosed range) assign weights to faulty nodes.
+                // Randomly (but within chosen range) assign weights to faulty nodes.
                 let faulty_weights = self
                     .weight_distribution
                     .gen_range_vec(rng, lower, upper, faulty_num);

--- a/node/src/components/consensus/highway_core/state.rs
+++ b/node/src/components/consensus/highway_core/state.rs
@@ -901,7 +901,7 @@ impl<C: Context> State<C> {
         self.incomplete_endorsements.clear();
     }
 
-    /// Validates whether a unit with the given panorama and `endorsed` set satsifies the
+    /// Validates whether a unit with the given panorama and `endorsed` set satisfies the
     /// Limited Naïveté Criterion (LNC).
     /// Returns index of the first equivocator that was cited naively in violation of the LNC, or
     /// `None` if the LNC is satisfied.
@@ -1134,7 +1134,7 @@ fn log2(x: u64) -> u32 {
         .saturating_sub(1)
 }
 
-/// Returns a pseudorandom `u64` betweend `1` and `upper` (inclusive).
+/// Returns a pseudorandom `u64` between `1` and `upper` (inclusive).
 fn leader_prng(upper: u64, seed: u64) -> u64 {
     ChaCha8Rng::seed_from_u64(seed)
         .gen_range(0..upper)

--- a/node/src/components/consensus/highway_core/state/tests.rs
+++ b/node/src/components/consensus/highway_core/state/tests.rs
@@ -559,7 +559,7 @@ fn validate_lnc_transitive_endorsement() -> Result<(), AddUnitError<TestContext>
 
 #[test]
 fn validate_lnc_cite_descendant_of_equivocation() -> Result<(), AddUnitError<TestContext>> {
-    // a0 cites a descendant b1 of an eqiuvocation vote (b0 and b0').
+    // a0 cites a descendant b1 of an equivocation vote (b0 and b0').
     // This is still detected as violation of the LNC.
     //
     // Alice                  a0<----+

--- a/node/src/components/consensus/protocols/highway/synchronizer.rs
+++ b/node/src/components/consensus/protocols/highway/synchronizer.rs
@@ -76,7 +76,7 @@ impl<I: NodeIdT, C: Context> PendingVertices<I, C> {
         Some(PendingVertex::new(sender, pvv, timestamp))
     }
 
-    /// Returns whether depedency exists in the pending vertices collection.
+    /// Returns whether dependency exists in the pending vertices collection.
     fn contains_dependency(&self, d: &Dependency<C>) -> bool {
         self.0.keys().any(|pvv| &pvv.inner().id() == d)
     }
@@ -204,7 +204,7 @@ impl<I: NodeIdT, C: Context + 'static> Synchronizer<I, C> {
         Self::remove_expired(&mut self.vertices_awaiting_deps, oldest);
     }
 
-    // Returns number of elements in the `verties_to_be_added_later` queue.
+    // Returns number of elements in the `vertices_to_be_added_later` queue.
     // Every pending vertex is counted once, even if it has multiple senders.
     fn vertices_to_be_added_later_len(&self) -> u64 {
         self.vertices_to_be_added_later

--- a/node/src/components/linear_chain_fast_sync/peers.rs
+++ b/node/src/components/linear_chain_fast_sync/peers.rs
@@ -10,7 +10,7 @@ pub struct PeersState<I> {
     // Peers we have not yet requested current block from.
     // NOTE: Maybe use a bitmask to decide which peers were tried?
     peers_to_try: Vec<I>,
-    // Peers we successfuly downloaded data from previously.
+    // Peers we successfully downloaded data from previously.
     // Have higher chance of having the next data.
     succ_peers: VecDeque<I>,
     succ_attempts: u8,

--- a/node/src/components/linear_chain_sync/event.rs
+++ b/node/src/components/linear_chain_sync/event.rs
@@ -68,7 +68,7 @@ where
             Event::GotUpgradeActivationPoint(activation_point) => {
                 write!(f, "new upgrade activation point: {:?}", activation_point)
             }
-            Event::InitUpgradeShutdown => write!(f, "shutdown for upgrade initiatied"),
+            Event::InitUpgradeShutdown => write!(f, "shutdown for upgrade initiated"),
             Event::Shutdown(upgrade) => write!(
                 f,
                 "linear chain sync is ready for shutdown. upgrade: {}",

--- a/node/src/components/linear_chain_sync/peers.rs
+++ b/node/src/components/linear_chain_sync/peers.rs
@@ -10,7 +10,7 @@ pub struct PeersState<I> {
     // Peers we have not yet requested current block from.
     // NOTE: Maybe use a bitmask to decide which peers were tried?
     peers_to_try: Vec<I>,
-    // Peers we successfuly downloaded data from previously.
+    // Peers we successfully downloaded data from previously.
     // Have higher chance of having the next data.
     succ_peers: VecDeque<I>,
     succ_attempts: u8,

--- a/node/src/components/metrics.rs
+++ b/node/src/components/metrics.rs
@@ -21,7 +21,7 @@
 //! 3. Updating metrics is done inside the `handle_event` function by simply calling methods on the
 //!    fields of `self.metrics` (`: XYZMetrics`). **Important**: Metrics should never be read to
 //!    prevent any actual logic depending on them. If a counter is being increment as a metric and
-//!    also required for busines logic, a second counter should be kept in the component's state.
+//!    also required for business logic, a second counter should be kept in the component's state.
 
 use std::convert::Infallible;
 

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -447,7 +447,14 @@ async fn server_task<REv: ReactorEventT<P>, P: PayloadT>(
                 // https://github.com/libp2p/rust-libp2p/issues/1876
                 swarm_event = swarm.next_event() => {
                     trace!("{}: {:?}", our_id(&swarm), swarm_event);
-                    handle_swarm_event(&mut swarm, event_queue, swarm_event, &known_addresses_mut, is_bootstrap_node).await;
+                    handle_swarm_event(
+                        &mut swarm,
+                        event_queue,
+                        swarm_event,
+                        &known_addresses_mut,
+                        is_bootstrap_node
+                    )
+                    .await;
                 }
 
                 // `UnboundedReceiver::recv()` is cancellation safe - see

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -434,7 +434,7 @@ async fn server_task<REv: ReactorEventT<P>, P: PayloadT>(
     mut shutdown_receiver: watch::Receiver<()>,
     mut swarm: Swarm<Behavior>,
     known_addresses_mut: Arc<Mutex<HashMap<Multiaddr, ConnectionState>>>,
-    is_bootsrap_node: bool,
+    is_bootstrap_node: bool,
     queued_messages: IntGauge,
 ) {
     //let our_id = our
@@ -447,7 +447,7 @@ async fn server_task<REv: ReactorEventT<P>, P: PayloadT>(
                 // https://github.com/libp2p/rust-libp2p/issues/1876
                 swarm_event = swarm.next_event() => {
                     trace!("{}: {:?}", our_id(&swarm), swarm_event);
-                    handle_swarm_event(&mut swarm, event_queue, swarm_event, &known_addresses_mut, is_bootsrap_node).await;
+                    handle_swarm_event(&mut swarm, event_queue, swarm_event, &known_addresses_mut, is_bootstrap_node).await;
                 }
 
                 // `UnboundedReceiver::recv()` is cancellation safe - see

--- a/node/src/components/network/behavior.rs
+++ b/node/src/components/network/behavior.rs
@@ -139,7 +139,7 @@ impl Behavior {
     fn custom_poll<T>(
         &mut self,
         _context: &mut Context,
-        _parameterss: &mut impl PollParameters,
+        _parameters: &mut impl PollParameters,
     ) -> Poll<NetworkBehaviourAction<T, SwarmBehaviorEvent>> {
         if let Some(event) = self.events.pop_back() {
             Poll::Ready(NetworkBehaviourAction::GenerateEvent(event))

--- a/node/src/components/network/tests_bulk_gossip.rs
+++ b/node/src/components/network/tests_bulk_gossip.rs
@@ -207,7 +207,7 @@ async fn send_large_message_across_network() {
         }
 
         for dummy_payload in &dummy_payloads {
-            // Calling `broadcast_message` actually triggers libp2p gossping.
+            // Calling `broadcast_message` actually triggers libp2p gossiping.
             net.process_injected_effect_on(sender, |effect_builder| {
                 effect_builder
                     .broadcast_message(dummy_payload.clone())

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -132,7 +132,7 @@ use requests::{
 use self::announcements::BlocklistAnnouncement;
 
 /// A resource that will never be available, thus trying to acquire it will wait forever.
-static UNOBTAINIUM: Lazy<Semaphore> = Lazy::new(|| Semaphore::new(0));
+static UNOBTAINABLE: Lazy<Semaphore> = Lazy::new(|| Semaphore::new(0));
 
 /// A pinned, boxed future that produces one or more events.
 pub type Effect<Ev> = BoxFuture<'static, Multiple<Ev>>;
@@ -416,8 +416,8 @@ impl<REv> EffectBuilder<REv> {
 
                 // We cannot produce any value to satisfy the request, so we just abandon this task
                 // by waiting on a resource we can never acquire.
-                let _ = UNOBTAINIUM.acquire().await;
-                panic!("should never obtain unobtainium semaphore");
+                let _ = UNOBTAINABLE.acquire().await;
+                panic!("should never obtain unobtainable semaphore");
             }
         }
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -63,7 +63,7 @@ const_assert!(_STATE_REQUEST_SIZE < 89);
 pub enum MetricsRequest {
     /// Render current node metrics as prometheus-formatted string.
     RenderNodeMetricsText {
-        /// Resopnder returning the rendered metrics or `None`, if an internal error occurred.
+        /// Responder returning the rendered metrics or `None`, if an internal error occurred.
         responder: Responder<Option<String>>,
     },
 }

--- a/node/src/testing/multi_stage_test_reactor.rs
+++ b/node/src/testing/multi_stage_test_reactor.rs
@@ -450,7 +450,7 @@ impl Reactor for MultiStageTestReactor {
                         validator_event_queue_handle,
                         rng,
                     )
-                    .expect("validator intialization failed");
+                    .expect("validator initialization failed");
 
                     *self = MultiStageTestReactor::Validator {
                         validator_reactor: Box::new(validator_reactor),

--- a/node/src/types/timestamp.rs
+++ b/node/src/types/timestamp.rs
@@ -131,14 +131,6 @@ impl Sub<TimeDiff> for Timestamp {
     }
 }
 
-impl Div<TimeDiff> for Timestamp {
-    type Output = u64;
-
-    fn div(self, rhs: TimeDiff) -> u64 {
-        self.0 / rhs.0
-    }
-}
-
 impl Rem<TimeDiff> for Timestamp {
     type Output = TimeDiff;
 

--- a/node_macros/src/gen.rs
+++ b/node_macros/src/gen.rs
@@ -280,7 +280,7 @@ pub(crate) fn generate_reactor_impl(def: &ReactorDefinition) -> TokenStream {
                 }
                 Target::Panic => {
                     announcement_dispatches.push(quote!(
-                        panic!("announcement received that was expressively declard as panic: {:?}",
+                        panic!("announcement received that was expressively declared as panic: {:?}",
                                announcement);
                     ));
                 }

--- a/node_macros/src/rust_type.rs
+++ b/node_macros/src/rust_type.rs
@@ -58,7 +58,7 @@ impl RustType {
 
     /// Returns the module name that canonically would contain the type, e.g. `small_net`.
     ///
-    /// Based on the identifier only, i.e. will discard any actualy path.
+    /// Based on the identifier only, i.e. will discard any actual path.
     pub fn module_ident(&self) -> Ident {
         to_ident(&to_snake_case(&self.ident().to_string()))
     }

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -700,7 +700,7 @@ extern "C" {
         out_ptr: *mut u8,
         out_size: usize,
     ) -> i32;
-    /// Prints data directly to stanadard output on the host.
+    /// Prints data directly to standard output on the host.
     ///
     /// # Arguments
     ///

--- a/smart_contracts/contracts/client/add-bid/src/main.rs
+++ b/smart_contracts/contracts/client/add-bid/src/main.rs
@@ -26,7 +26,7 @@ fn add_bid(public_key: PublicKey, bond_amount: U512, delegation_rate: Delegation
 
 // Bidding contract.
 //
-// Accepts a public key, amount and a delgation rate.
+// Accepts a public key, amount and a delegation rate.
 // Issues an add bid request to the auction contract.
 #[no_mangle]
 pub extern "C" fn call() {

--- a/smart_contracts/contracts/client/delegate/src/main.rs
+++ b/smart_contracts/contracts/client/delegate/src/main.rs
@@ -23,7 +23,7 @@ fn delegate(delegator: PublicKey, validator: PublicKey, amount: U512) {
 
 // Delegate contract.
 //
-// Accepts a delegator's public key, validator's public key, amount and a delgation rate.
+// Accepts a delegator's public key, validator's public key, amount and a delegation rate.
 // Issues an delegation request to the auction contract.
 #[no_mangle]
 pub extern "C" fn call() {

--- a/smart_contracts/contracts/test/groups/src/main.rs
+++ b/smart_contracts/contracts/test/groups/src/main.rs
@@ -80,7 +80,7 @@ pub extern "C" fn uncallable_contract() {}
 
 #[no_mangle]
 pub extern "C" fn call_restricted_entry_points() {
-    // We're aggresively removing exports that aren't exposed through contract header so test
+    // We're aggressively removing exports that aren't exposed through contract header so test
     // ensures that those exports are still inside WASM.
     uncallable_session();
     uncallable_contract();

--- a/smart_contracts/contracts/test/key-management-thresholds/src/main.rs
+++ b/smart_contracts/contracts/test/key-management-thresholds/src/main.rs
@@ -64,7 +64,7 @@ pub extern "C" fn call() {
             .unwrap_or_revert();
         // Removes [43;32] key created in init stage
         account::remove_associated_key(AccountHash::new([44; 32])).unwrap_or_revert();
-        // Sets action threshodl
+        // Sets action threshold
         account::set_action_threshold(ActionType::KeyManagement, Weight::new(100))
             .unwrap_or_revert();
     } else {

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -1115,7 +1115,7 @@ pub(crate) fn vec_u8_to_bytes(vec: &Vec<u8>) -> Result<Vec<u8>, Error> {
 
 /// Returns serialized length of serialized slice of bytes.
 ///
-/// This function adds a length prefix in the beggining.
+/// This function adds a length prefix in the beginning.
 #[inline(always)]
 fn u8_slice_serialized_length(bytes: &[u8]) -> usize {
     U32_SERIALIZED_LENGTH + bytes.len()

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -140,7 +140,7 @@ impl Display for FromStrError {
 }
 
 /// A (labelled) "user group". Each method of a versioned contract may be
-/// assoicated with one or more user groups which are allowed to call it.
+/// associated with one or more user groups which are allowed to call it.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(feature = "std", derive(JsonSchema))]
 pub struct Group(String);
@@ -612,7 +612,7 @@ pub struct ContractPackage {
     /// Mapping maintaining the set of URefs associated with each "user
     /// group". This can be used to control access to methods in a particular
     /// version of the contract. A method is callable by any context which
-    /// "knows" any of the URefs assoicated with the mthod's user group.
+    /// "knows" any of the URefs associated with the method's user group.
     groups: Groups,
     /// A flag that determines whether a contract is locked
     lock_status: ContractPackageStatus,
@@ -1023,7 +1023,7 @@ impl Contract {
         self.protocol_version = protocol_version;
     }
 
-    /// Determines if `Contract` is compatibile with a given `ProtocolVersion`.
+    /// Determines if `Contract` is compatible with a given `ProtocolVersion`.
     pub fn is_compatible_protocol_version(&self, protocol_version: ProtocolVersion) -> bool {
         self.protocol_version.value().major == protocol_version.value().major
     }
@@ -1119,7 +1119,7 @@ pub const DEFAULT_ENTRY_POINT_NAME: &str = "call";
 /// Default name for an installer entry point
 pub const ENTRY_POINT_NAME_INSTALL: &str = "install";
 
-/// Default name for an upgrader entry point
+/// Default name for an upgrade entry point
 pub const UPGRADE_ENTRY_POINT_NAME: &str = "upgrade";
 
 /// Collection of entry point parameters.

--- a/types/src/system/auction/bid/mod.rs
+++ b/types/src/system/auction/bid/mod.rs
@@ -146,7 +146,7 @@ impl Bid {
             .ok_or(Error::UnbondTooLarge)?;
 
         let vesting_schedule = match self.vesting_schedule.as_ref() {
-            Some(vesting_sechdule) => vesting_sechdule,
+            Some(vesting_schedule) => vesting_schedule,
             None => {
                 self.staked_amount = updated_staked_amount;
                 return Ok(updated_staked_amount);

--- a/types/src/system/auction/delegator.rs
+++ b/types/src/system/auction/delegator.rs
@@ -93,7 +93,7 @@ impl Delegator {
             .ok_or(Error::InvalidAmount)?;
 
         let vesting_schedule = match self.vesting_schedule.as_ref() {
-            Some(vesting_sechdule) => vesting_sechdule,
+            Some(vesting_schedule) => vesting_schedule,
             None => {
                 self.staked_amount = updated_staked_amount;
                 return Ok(updated_staked_amount);

--- a/types/src/system/mint/error.rs
+++ b/types/src/system/mint/error.rs
@@ -70,7 +70,7 @@ pub enum Error {
     /// Source and target purse [`crate::URef`]s are equal.
     #[cfg_attr(feature = "std", error("Invalid target purse"))]
     EqualSourceAndTarget = 17,
-    /// An arithmetic overflow has occured.
+    /// An arithmetic overflow has occurred.
     #[cfg_attr(feature = "std", error("Arithmetic overflow has occurred"))]
     ArithmeticOverflow = 18,
 


### PR DESCRIPTION
This PR is a trivial clean up:
* corrects typos
* removes the unused `impl Div<TimeDiff> for Timestamp`
* removes the empty file `consensus/era_supervisor/era_id.rs`