### PR TITLE
NDRS-1190: Make sure an era is not activated twice without a unit hash file.

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -160,18 +160,6 @@ impl<C: Context> ActiveValidator<C> {
         self.own_last_unit.take()
     }
 
-    /// Cleans up the validator disk state.
-    /// Deletes all unit files.
-    pub(crate) fn cleanup(&self) -> io::Result<()> {
-        let unit_file = if let Some(file) = self.unit_file.as_ref() {
-            file
-        } else {
-            return Ok(());
-        };
-
-        fs::remove_file(unit_file)
-    }
-
     /// Sets the next round exponent to the new value.
     pub(crate) fn set_round_exp(&mut self, new_round_exp: u8) {
         self.next_round_exp = new_round_exp;

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use datasize::DataSize;
 use thiserror::Error;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use crate::{
     components::consensus::{
@@ -220,15 +220,7 @@ impl<C: Context> Highway<C> {
 
     /// Turns this instance into a passive observer, that does not create any new vertices.
     pub(crate) fn deactivate_validator(&mut self) {
-        if let Some(av) = self.active_validator.take() {
-            match av.cleanup() {
-                Ok(_) => {}
-                Err(err) => warn!(
-                    ?err,
-                    "error occurred when cleaning up active validator state"
-                ),
-            }
-        }
+        self.active_validator = None;
     }
 
     /// Switches the active validator to a new round exponent.


### PR DESCRIPTION
* Don't activate old eras on initialization: When the era supervisor starts, the validator should only actively participate in the latest era.
* Delete the unit hash file only once the era becomes obsolete.

https://casperlabs.atlassian.net/browse/NDRS-1190