### PR TITLE
NDRS-1159: Add more consensus and block proposer log messages. 

### DIFF
--- a/node/src/components/block_proposer.rs
+++ b/node/src/components/block_proposer.rs
@@ -22,7 +22,7 @@ pub use config::Config;
 use datasize::DataSize;
 use itertools::Itertools;
 use prometheus::{self, Registry};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     components::Component,
@@ -230,7 +230,7 @@ impl BlockProposerReady {
         match event {
             Event::Request(BlockProposerRequest::RequestBlockPayload(request)) => {
                 if request.next_finalized > self.sets.next_finalized {
-                    info!(
+                    warn!(
                         %request.next_finalized, %self.sets.next_finalized,
                         "received request before finalization announcement"
                     );
@@ -276,9 +276,8 @@ impl BlockProposerReady {
                 let mut height = block.height();
 
                 if height > self.sets.next_finalized {
-                    info!(
-                        %height,
-                        next_finalized = %self.sets.next_finalized,
+                    warn!(
+                        %height, next_finalized = %self.sets.next_finalized,
                         "received finalized blocks out of order; queueing"
                     );
                     // safe to subtract 1 - height will never be 0 in this branch, because

--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -197,19 +197,17 @@ impl<C: Context> ActiveValidator<C> {
                 return effects;
             } else if timestamp == r_id + self.witness_offset(r_len) {
                 let panorama = self.panorama_at(state, timestamp);
-                if panorama.has_correct() {
-                    if let Some(witness_unit) =
-                        self.new_unit(panorama, timestamp, None, state, instance_id)
+                if let Some(witness_unit) =
+                    self.new_unit(panorama, timestamp, None, state, instance_id)
+                {
+                    if self
+                        .latest_unit(state)
+                        .map_or(true, |latest_unit| latest_unit.round_id() != r_id)
                     {
-                        if self
-                            .latest_unit(state)
-                            .map_or(true, |latest_unit| latest_unit.round_id() != r_id)
-                        {
-                            info!(round_id = %r_id, "sending witness in round with no proposal");
-                        }
-                        effects.push(Effect::NewVertex(ValidVertex(Vertex::Unit(witness_unit))));
-                        return effects;
+                        info!(round_id = %r_id, "sending witness in round with no proposal");
                     }
+                    effects.push(Effect::NewVertex(ValidVertex(Vertex::Unit(witness_unit))));
+                    return effects;
                 }
             }
         }
@@ -416,6 +414,9 @@ impl<C: Context> ActiveValidator<C> {
         state: &State<C>,
         instance_id: C::InstanceId,
     ) -> Option<SignedWireUnit<C>> {
+        if value.is_none() && !panorama.has_correct() {
+            return None; // Wait for the first proposal before creating a unit without a value.
+        }
         if !self.can_vote(state) {
             info!(?self.own_last_unit, "not voting - last own unit unknown");
             return None;

--- a/node/src/components/consensus/highway_core/finality_detector/rewards.rs
+++ b/node/src/components/consensus/highway_core/finality_detector/rewards.rs
@@ -1,3 +1,5 @@
+use tracing::trace;
+
 use super::Horizon;
 use crate::{
     components::consensus::{
@@ -81,9 +83,9 @@ fn compute_rewards_for<C: Context>(
     // Collect the block rewards for each validator who is a member of at least one summit.
     #[allow(clippy::integer_arithmetic)] // See inline comments.
     max_quorum
-        .iter()
+        .enumerate()
         .zip(state.weights())
-        .map(|(quorum, weight)| {
+        .map(|((validator_index, quorum), weight)| {
             // If the summit's quorum was not enough to finalize the block, rewards are reduced.
             // A level-1 summit with quorum  q  has FTT  q - 50%, so we need  q - 50% > f.
             let finality_factor = if *quorum > (state.total_weight() / 2).saturating_add(faulty_w) {
@@ -91,6 +93,15 @@ fn compute_rewards_for<C: Context>(
             } else {
                 state.params().reduced_block_reward()
             };
+            trace!(
+                validator_index = validator_index.0,
+                finality_factor,
+                quorum = quorum.0,
+                assigned_weight = assigned_weight.0,
+                weight = weight.0,
+                timestamp = %proposal_unit.timestamp,
+                "block reward calculation"
+            );
             // Rewards are proportional to the quorum and to the validator's weight.
             // Since  quorum <= assigned_weight  and  weight <= total_weight,  this won't overflow.
             (u128::from(finality_factor) * u128::from(*quorum) / u128::from(assigned_weight)

--- a/node/src/components/consensus/highway_core/highway.rs
+++ b/node/src/components/consensus/highway_core/highway.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use datasize::DataSize;
 use thiserror::Error;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 use crate::{
     components::consensus::{
@@ -29,6 +29,9 @@ use super::{
     endorsement::{Endorsement, EndorsementError},
     evidence::Evidence,
 };
+
+/// If a lot of rounds were skipped between two blocks, log at most this many.
+const MAX_SKIPPED_PROPOSAL_LOGS: u64 = 10;
 
 /// An error due to an invalid vertex.
 #[derive(Debug, Error, PartialEq)]
@@ -580,6 +583,7 @@ impl<C: Context> Highway<C> {
         let creator = swunit.wire_unit().creator;
         let was_honest = !self.state.is_faulty(creator);
         self.state.add_valid_unit(swunit);
+        self.log_if_missing_proposal(&unit_hash);
         let mut evidence_effects = self
             .state
             .maybe_evidence(creator)
@@ -658,6 +662,62 @@ impl<C: Context> Highway<C> {
         self.active_validator
             .as_ref()
             .map(|av| av.next_round_length())
+    }
+
+    /// Logs a message if this is a block and any previous blocks were skipped.
+    fn log_if_missing_proposal(&self, unit_hash: &C::Hash) {
+        let state = &self.state;
+        let unit = state.unit(unit_hash);
+        let r_id = unit.round_id();
+        if unit.timestamp != r_id
+            || unit.block != *unit_hash
+            || state.leader(r_id) != unit.creator
+            || state.is_faulty(unit.creator)
+        {
+            return; // Not a block by an honest validator. (Don't let faulty validators spam logs.)
+        }
+
+        // Iterate over all rounds since the parent — or since the start time, if there is none.
+        let parent_timestamp = if let Some(parent_hash) = state.block(unit_hash).parent() {
+            state.unit(parent_hash).timestamp
+        } else {
+            state.params().start_timestamp()
+        };
+        for skipped_r_id in (1..=MAX_SKIPPED_PROPOSAL_LOGS)
+            .map(|i| r_id - state.params().min_round_length() * i)
+            .take_while(|skipped_r_id| *skipped_r_id > parent_timestamp)
+        {
+            let leader_index = state.leader(skipped_r_id);
+            let leader_id = match self.validators.id(leader_index) {
+                None => {
+                    error!(?leader_index, "missing leader validator ID");
+                    return;
+                }
+                Some(leader_id) => leader_id,
+            };
+            if state.is_faulty(leader_index) {
+                trace!(
+                    ?leader_index, %leader_id, round_id = %skipped_r_id,
+                    "missing proposal: faulty leader was skipped",
+                );
+            } else {
+                let reason = state.panorama()[leader_index]
+                    .correct()
+                    .and_then(|leader_hash| {
+                        state
+                            .swimlane(leader_hash)
+                            .find(|(_, unit)| unit.timestamp <= skipped_r_id)
+                            .filter(|(_, unit)| unit.timestamp == skipped_r_id)
+                    })
+                    .map_or("the leader missed their turn", |_| {
+                        "the leader's proposal got orphaned"
+                    });
+                info!(
+                    ?leader_index, %leader_id, round_id = %skipped_r_id,
+                    "missing proposal: {}", reason,
+                );
+            }
+        }
     }
 }
 

--- a/node/src/components/consensus/highway_core/state/params.rs
+++ b/node/src/components/consensus/highway_core/state/params.rs
@@ -95,6 +95,11 @@ impl Params {
         self.max_round_exp
     }
 
+    /// Returns the minimum round length, corresponding to the minimum round exponent.
+    pub(crate) fn min_round_length(&self) -> TimeDiff {
+        round_len(self.min_round_exp)
+    }
+
     /// Returns the maximum round length, corresponding to the maximum round exponent.
     pub(crate) fn max_round_length(&self) -> TimeDiff {
         round_len(self.max_round_exp)

--- a/node/src/components/consensus/traits.rs
+++ b/node/src/components/consensus/traits.rs
@@ -10,8 +10,9 @@ pub trait NodeIdT: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'stat
 impl<I> NodeIdT for I where I: Clone + Display + Debug + Send + Eq + Hash + DataSize + 'static {}
 
 /// A validator identifier.
-pub trait ValidatorIdT: Eq + Ord + Clone + Debug + Hash + Send + DataSize {}
-impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash + Send + DataSize {}
+pub trait ValidatorIdT: Eq + Ord + Clone + Debug + Hash + Send + DataSize + Display {}
+impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash + Send + DataSize + Display
+{}
 
 /// The consensus value type, e.g. a list of transactions.
 pub trait ConsensusValueT:


### PR DESCRIPTION
* Log who missed their slot as a leader.
* List the individual steps of the rewards calculation: Which block got which quorum and who got rewards.
* Log when the block proposer queues a request due to the `next_finalized` value.

https://casperlabs.atlassian.net/browse/NDRS-1159