### PR TITLE
NDRS-1194: OpenRPC rest endpoint

### DIFF
--- a/node/src/components/rest_server.rs
+++ b/node/src/components/rest_server.rs
@@ -47,7 +47,7 @@ use crate::{
     NodeRng,
 };
 
-use crate::effect::requests::RestRequest;
+use crate::{components::rpc_server::rpcs::docs::OPEN_RPC_SCHEMA, effect::requests::RestRequest};
 pub use config::Config;
 pub(crate) use event::Event;
 
@@ -146,6 +146,10 @@ where
                     text,
                     main_responder: responder,
                 }),
+            Event::RestRequest(RestRequest::GetOpenRpc { responder }) => {
+                let schema = OPEN_RPC_SCHEMA.clone();
+                responder.respond(schema).ignore()
+            }
             Event::GetMetricsResult {
                 text,
                 main_responder,

--- a/node/src/components/rest_server/filters.rs
+++ b/node/src/components/rest_server/filters.rs
@@ -25,6 +25,9 @@ pub const STATUS_API_PATH: &str = "status";
 /// The metrics URL path.
 pub const METRICS_API_PATH: &str = "metrics";
 
+/// The OpenRPC scehma URL path.
+pub const OPEN_RPC_API_PATH: &str = "openrpc";
+
 pub(super) fn create_status_filter<REv: ReactorEventT>(
     effect_builder: EffectBuilder<REv>,
     api_version: ProtocolVersion,
@@ -68,6 +71,24 @@ pub(super) fn create_metrics_filter<REv: ReactorEventT>(
                         )
                         .into_response())
                     }
+                })
+        })
+        .boxed()
+}
+
+pub(super) fn create_rpc_filter<REv: ReactorEventT>(
+    effect_builder: EffectBuilder<REv>,
+) -> BoxedFilter<(Response<Body>,)> {
+    warp::get()
+        .and(warp::path(OPEN_RPC_API_PATH))
+        .and_then(move || {
+            effect_builder
+                .make_request(
+                    |responder| RestRequest::GetOpenRpc { responder },
+                    QueueKind::Api,
+                )
+                .map(move |open_rpc_schema| {
+                    Ok::<_, Rejection>(reply::json(&open_rpc_schema).into_response())
                 })
         })
         .boxed()

--- a/node/src/components/rest_server/http_server.rs
+++ b/node/src/components/rest_server/http_server.rs
@@ -25,8 +25,9 @@ pub(super) async fn run<REv: ReactorEventT>(
     // REST filters.
     let rest_status = filters::create_status_filter(effect_builder, api_version);
     let rest_metrics = filters::create_metrics_filter(effect_builder);
+    let rest_open_rpc = filters::create_rpc_filter(effect_builder);
 
-    let service = warp::service(rest_status.or(rest_metrics));
+    let service = warp::service(rest_status.or(rest_metrics).or(rest_open_rpc));
 
     // Start the server, passing a oneshot receiver to allow the server to be shut down gracefully.
     let make_svc =

--- a/node/src/components/rpc_server/rpcs/docs.rs
+++ b/node/src/components/rpc_server/rpcs/docs.rs
@@ -34,7 +34,7 @@ pub(crate) const DOCS_EXAMPLE_PROTOCOL_VERSION: ProtocolVersion =
 const DEFINITIONS_PATH: &str = "#/components/schemas/";
 
 // As per https://spec.open-rpc.org/#service-discovery-method.
-static OPEN_RPC_SCHEMA: Lazy<OpenRpcSchema> = Lazy::new(|| {
+pub(crate) static OPEN_RPC_SCHEMA: Lazy<OpenRpcSchema> = Lazy::new(|| {
     let contact = OpenRpcContactField {
         name: "CasperLabs".to_string(),
         url: "https://casperlabs.io".to_string(),
@@ -103,7 +103,7 @@ pub trait DocExample {
 
 /// The main schema for the casper node's RPC server, compliant with https://spec.open-rpc.org.
 #[derive(Clone, Serialize, Deserialize, Debug)]
-struct OpenRpcSchema {
+pub struct OpenRpcSchema {
     openrpc: String,
     info: OpenRpcInfoField,
     servers: Vec<OpenRpcServerEntry>,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -44,7 +44,7 @@ use crate::{
         fetcher::FetchResult,
     },
     crypto::hash::Digest,
-    rpcs::chain::BlockIdentifier,
+    rpcs::{chain::BlockIdentifier, docs::OpenRpcSchema},
     types::{
         Block as LinearBlock, Block, BlockHash, BlockHeader, BlockPayload, BlockSignatures,
         Chainspec, ChainspecInfo, Deploy, DeployHash, DeployHeader, DeployMetadata, FinalizedBlock,
@@ -697,6 +697,11 @@ pub enum RestRequest<I> {
         /// Responder to call with the result.
         responder: Responder<Option<String>>,
     },
+    /// Returns OpenRPC compatible payload.
+    GetOpenRpc {
+        /// Responder to call with the result
+        responder: Responder<OpenRpcSchema>,
+    },
 }
 
 impl<I> Display for RestRequest<I> {
@@ -704,6 +709,7 @@ impl<I> Display for RestRequest<I> {
         match self {
             RestRequest::GetStatus { .. } => write!(formatter, "get status"),
             RestRequest::GetMetrics { .. } => write!(formatter, "get metrics"),
+            RestRequest::GetOpenRpc { .. } => write!(formatter, "get openrpc"),
         }
     }
 }


### PR DESCRIPTION
REF: https://casperlabs.atlassian.net/browse/NDRS-1194

CHANGELOG:

- Added new REST endpoint that provides an OpenRPC compatible schema for the RPC endpoints available on the node