### PR TITLE
NO-TICKET: Fix liveness_test_some_mute.

### DIFF
--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -235,8 +235,7 @@ impl HighwayValidator {
                 }
             }
             Some(DesFault::PermanentlyMute) => {
-                // For mute validators we add it to the state but not gossip, if the delivery time
-                // is in the interval in which they are muted.
+                // For mute validators we add it to the state but not gossip.
                 match msg {
                     HighwayMessage::NewVertex(_) => {
                         warn!("Validator is mute – won't gossip vertices in response");


### PR DESCRIPTION
When we introduced the `TemporarilyMute` variant, we accidentally made `PermanentlyMute` validators not mute at all! This re-enables simulation of permanently mute validators (i.e. offline/crashed nodes) in the Highway DES tests.