### PR TITLE
NDRS-1079: Era Supervisor Needs to Account For Last Emergency Restart

### DIFF
--- a/node/src/components/chainspec_loader.rs
+++ b/node/src/components/chainspec_loader.rs
@@ -161,6 +161,7 @@ pub struct CurrentRunInfo {
     pub activation_point: ActivationPoint,
     pub protocol_version: ProtocolVersion,
     pub initial_state_root_hash: Digest,
+    pub last_emergency_restart: Option<EraId>,
 }
 
 #[derive(Clone, DataSize, Debug)]
@@ -565,6 +566,7 @@ impl ChainspecLoader {
             activation_point: self.chainspec.protocol_config.activation_point,
             protocol_version: self.chainspec.protocol_config.version,
             initial_state_root_hash: self.initial_state_root_hash,
+            last_emergency_restart: self.chainspec.protocol_config.last_emergency_restart,
         }
     }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1536,23 +1536,23 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Gets the correct era validators set for the given era.
-    /// Takes upgrades and emergency restarts into account based on the `initial_state_root_hash`
-    /// and `activation_era_id` parameters.
+    /// Takes emergency restarts into account based on the information from the chainspec loader.
     pub(crate) async fn get_era_validators(self, era_id: EraId) -> Option<BTreeMap<PublicKey, U512>>
     where
         REv: From<ContractRuntimeRequest> + From<StorageRequest> + From<ChainspecLoaderRequest>,
     {
         let CurrentRunInfo {
-            activation_point,
             protocol_version,
             initial_state_root_hash,
+            last_emergency_restart,
+            ..
         } = self.get_current_run_info().await;
-        let activation_era_id = activation_point.era_id();
-        if era_id < activation_era_id {
-            // we don't support getting the validators from before the last upgrade
+        let cutoff_era_id = last_emergency_restart.unwrap_or_else(|| EraId::new(0));
+        if era_id < cutoff_era_id {
+            // we don't support getting the validators from before the last emergency restart
             return None;
         }
-        if era_id == activation_era_id {
+        if era_id == cutoff_era_id {
             // in the activation era, we read the validators from the global state; we use the
             // global state hash of the first block in the era, if it exists - if we can't get it,
             // we use the initial_state_root_hash passed from the chainspec loader


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-1079

This boils down to using the last emergency restart instead of the last activation point in the `get_era_validators` effect, and that is provided by the chainspec loader.