### PR TITLE
HWY-283: Initialize round success meter with current timestamp.

### DIFF
--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -141,7 +141,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
 
         let round_success_meter = prev_cp
             .and_then(|cp| cp.as_any().downcast_ref::<HighwayProtocol<I, C>>())
-            .map(|highway_proto| highway_proto.next_era_round_succ_meter(era_start_time))
+            .map(|highway_proto| highway_proto.next_era_round_succ_meter(now))
             .unwrap_or_else(|| {
                 RoundSuccessMeter::new(
                     highway_config.minimum_round_exponent,
@@ -407,8 +407,8 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
 
     /// Returns an instance of `RoundSuccessMeter` for the new era: resetting the counters where
     /// appropriate.
-    fn next_era_round_succ_meter(&self, era_start_timestamp: Timestamp) -> RoundSuccessMeter<C> {
-        self.round_success_meter.next_era(era_start_timestamp)
+    fn next_era_round_succ_meter(&self, now: Timestamp) -> RoundSuccessMeter<C> {
+        self.round_success_meter.next_era(now)
     }
 
     /// Returns an iterator over all the values that are in parents of the given block.

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -141,13 +141,13 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
 
         let round_success_meter = prev_cp
             .and_then(|cp| cp.as_any().downcast_ref::<HighwayProtocol<I, C>>())
-            .map(|highway_proto| highway_proto.next_era_round_succ_meter(now))
+            .map(|highway_proto| highway_proto.next_era_round_succ_meter(era_start_time.max(now)))
             .unwrap_or_else(|| {
                 RoundSuccessMeter::new(
                     highway_config.minimum_round_exponent,
                     highway_config.minimum_round_exponent,
                     highway_config.maximum_round_exponent,
-                    now,
+                    era_start_time.max(now),
                     config.into(),
                 )
             });
@@ -407,8 +407,8 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
 
     /// Returns an instance of `RoundSuccessMeter` for the new era: resetting the counters where
     /// appropriate.
-    fn next_era_round_succ_meter(&self, now: Timestamp) -> RoundSuccessMeter<C> {
-        self.round_success_meter.next_era(now)
+    fn next_era_round_succ_meter(&self, timestamp: Timestamp) -> RoundSuccessMeter<C> {
+        self.round_success_meter.next_era(timestamp)
     }
 
     /// Returns an iterator over all the values that are in parents of the given block.

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -147,7 +147,7 @@ impl<I: NodeIdT, C: Context + 'static> HighwayProtocol<I, C> {
                     highway_config.minimum_round_exponent,
                     highway_config.minimum_round_exponent,
                     highway_config.maximum_round_exponent,
-                    era_start_time,
+                    now,
                     config.into(),
                 )
             });

--- a/node/src/components/consensus/protocols/highway/round_success_meter.rs
+++ b/node/src/components/consensus/protocols/highway/round_success_meter.rs
@@ -158,10 +158,10 @@ impl<C: Context> RoundSuccessMeter<C> {
     }
 
     /// Returns an instance of `Self` for the new era: resetting the counters where appropriate.
-    pub fn next_era(&self, era_start_timestamp: Timestamp) -> Self {
+    pub fn next_era(&self, now: Timestamp) -> Self {
         Self {
             rounds: self.rounds.clone(),
-            current_round_id: state::round_id(era_start_timestamp, self.current_round_exp),
+            current_round_id: state::round_id(now, self.current_round_exp),
             proposals: Default::default(),
             min_round_exp: self.min_round_exp,
             max_round_exp: self.max_round_exp,

--- a/node/src/components/consensus/protocols/highway/round_success_meter.rs
+++ b/node/src/components/consensus/protocols/highway/round_success_meter.rs
@@ -158,10 +158,10 @@ impl<C: Context> RoundSuccessMeter<C> {
     }
 
     /// Returns an instance of `Self` for the new era: resetting the counters where appropriate.
-    pub fn next_era(&self, now: Timestamp) -> Self {
+    pub fn next_era(&self, timestamp: Timestamp) -> Self {
         Self {
             rounds: self.rounds.clone(),
-            current_round_id: state::round_id(now, self.current_round_exp),
+            current_round_id: state::round_id(timestamp, self.current_round_exp),
             proposals: Default::default(),
             min_round_exp: self.min_round_exp,
             max_round_exp: self.max_round_exp,


### PR DESCRIPTION
Initializing it with the era start time makes it likely to unnecessarily slow down after downtime, because it will count all rounds since the era's beginning as "failed".

https://casperlabs.atlassian.net/browse/HWY-283