### PR TITLE
NDRS-1197: Fix flaky storage tests.

### DIFF
--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -574,8 +574,18 @@ fn different_block_at_height_is_fatal() {
     let mut storage = storage_fixture(&harness);
 
     // Create two different blocks at the same height.
-    let block_44_a = random_block_at_height(&mut harness.rng, 44);
-    let block_44_b = random_block_at_height(&mut harness.rng, 44);
+    let block_44_a = Box::new(Block::random_with_specifics(
+        &mut harness.rng,
+        EraId::new(1),
+        44,
+        false,
+    ));
+    let block_44_b = Box::new(Block::random_with_specifics(
+        &mut harness.rng,
+        EraId::new(1),
+        44,
+        false,
+    ));
 
     let was_new = put_block(&mut harness, &mut storage, block_44_a.clone());
     assert!(was_new);

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -449,9 +449,24 @@ fn can_retrieve_block_by_height() {
     let mut storage = storage_fixture(&harness);
 
     // Create a random block, load and store it.
-    let block_33 = random_block_at_height(&mut harness.rng, 33);
-    let block_14 = random_block_at_height(&mut harness.rng, 14);
-    let block_99 = random_block_at_height(&mut harness.rng, 99);
+    let block_33 = Box::new(Block::random_with_specifics(
+        &mut harness.rng,
+        EraId::new(1),
+        33,
+        true,
+    ));
+    let block_14 = Box::new(Block::random_with_specifics(
+        &mut harness.rng,
+        EraId::new(1),
+        14,
+        false,
+    ));
+    let block_99 = Box::new(Block::random_with_specifics(
+        &mut harness.rng,
+        EraId::new(2),
+        99,
+        true,
+    ));
 
     // Both block at ID and highest block should return `None` initially.
     assert!(get_block_at_height(&mut harness, &mut storage, 0).is_none());


### PR DESCRIPTION
https://casperlabs.atlassian.net/browse/NDRS-1197

Fixes random block generators used in the storage tests so that they don't lead to flaky tests.